### PR TITLE
test(perf): rebaseline CRDT gate after correctness fix

### DIFF
--- a/bench/bench_crdt_workload.h
+++ b/bench/bench_crdt_workload.h
@@ -29,10 +29,10 @@
  * leaves headroom and matches the historical CRDT_SRC_BUFSZ. */
 #define WL_BENCH_CRDT_SRC_BUFSZ ((size_t)8 * 1024)
 
-/* Gold output cardinality for the CRDT result relation on the shipped
- * bench/data/crdt fixtures.  Exposed as a header constant so the perf
- * gate can assert correctness without re-deriving the number. */
-#define WL_BENCH_CRDT_GOLD_TUPLES ((int64_t)1301914)
+/* Expected cardinality of the CRDT result relation on the shipped
+ * bench/data/crdt fixtures.  This is not the aggregate number of rows
+ * emitted for all relations by a full-session snapshot. */
+#define WL_BENCH_CRDT_RESULT_TUPLES ((int64_t)104851)
 
 static const char wl_bench_crdt_template[]
     = ".decl Insert_input(ctr: int32, node: int32, parent_ctr: int32, "

--- a/docs/CRDT_PERF_BASELINE.md
+++ b/docs/CRDT_PERF_BASELINE.md
@@ -1,0 +1,128 @@
+# CRDT Performance Baseline
+
+**Last Updated:** 2026-07-31
+
+This document records the correctness sentinel and wall-time provenance for
+the `crdt_perf_gate` test. The gate evaluates the complete Kleppmann sequence
+CRDT workload with one worker and measures a full-session snapshot.
+
+## Correctness boundary
+
+Issue #914 fixed iteration state leaking from recursive strata into later
+non-recursive strata. The fix, commit `61e2530`, changed the work performed
+and the rows observable through a full snapshot, so measurements from before
+that commit are not comparable to this baseline.
+
+The old `1,301,914` sentinel counted callback rows aggregated across every
+relation in the snapshot. It was not the cardinality of the user-facing
+`result` relation. The gate now asserts only the `result` cardinality and
+prints the aggregate snapshot count as a diagnostic. The aggregate was
+`2,156,530` in the calibration below, but it is deliberately not a correctness
+contract.
+
+The shipped fixtures prove the expected result cardinality:
+
+- `Insert_input.csv` has 182,315 insertion records and SHA-256
+  `9147f2b44d4cb291336da9aa6c39c27feac8630361f2b36875474e5c30602b05`.
+- `Remove_input.csv` has 77,463 removal records and SHA-256
+  `b83fba0709b37259cd6ad00bfe3434abc3df3fec3dbccd3f5eedf273e9c921dc`.
+- All 182,315 insertion `(ctr, node)` keys are unique, all 77,463 removal
+  keys are unique, and every removal key occurs in the insertion key set.
+  The fixture therefore has `182,315 - 77,463 = 104,852` visible sequence
+  elements. An independent traversal check confirms that the insertion graph
+  forms one rooted traversal and all 104,852 visible elements participate in
+  one visible sequence. The `result` relation represents adjacent
+  visible-element pairs, so its cardinality is `104,852 - 1 = 104,851`.
+
+## Measurement environment
+
+The 2026-07-31 calibration used:
+
+- Linux `7.1.4-arch1-1`, x86-64.
+- Intel Xeon E5-2696 v4 at 2.20 GHz.
+- GCC `16.1.1 20260728`, Meson `1.11.2`, and Ninja `1.13.2`.
+- Source base `623e8cf` (`origin/main`) plus the gate instrumentation in this
+  change.
+- Meson options `buildtype=release`, `optimization=s`, `b_lto=true`,
+  `wirelog_log_max_level=error`, and `tests=true`.
+- Native threading, one Wirelog worker, CPU affinity fixed to CPU 0 with
+  `taskset -c 0`, and cpufreq policy 0 fixed to the `performance` governor.
+- `WIRELOG_PERF_GATE=1`, `WIRELOG_PERF_REQUIRE=1`, and
+  `WIRELOG_CRDT_DATA_DIR=<source>/bench/data/crdt`.
+- The canonical Meson test runner injected `MALLOC_PERTURB_=12` for the
+  calibration and `MALLOC_PERTURB_=110` for verification. These runs should
+  not be compared directly with a hand-run benchmark that omits Meson's test
+  environment.
+
+The dedicated build and strict gate were run as follows:
+
+```sh
+source .venv/bin/activate
+meson setup build-crdt-perf \
+  -Dbuildtype=release \
+  -Doptimization=s \
+  -Db_lto=true \
+  -Dwirelog_log_max_level=error \
+  -Dtests=true
+meson compile -C build-crdt-perf test_crdt_perf_gate
+governor_path=/sys/devices/system/cpu/cpufreq/policy0/scaling_governor
+old_governor=$(tr -d '\n' < "$governor_path")
+restore_governor() {
+  printf '%s\n' "$old_governor" | sudo tee "$governor_path" >/dev/null
+}
+trap restore_governor EXIT INT TERM
+printf '%s\n' performance |
+  sudo tee "$governor_path"
+taskset -c 0 env \
+  WIRELOG_PERF_GATE=1 \
+  WIRELOG_PERF_REQUIRE=1 \
+  meson test -C build-crdt-perf crdt_perf_gate --verbose
+restore_governor
+trap - EXIT INT TERM
+```
+
+The previous governor was `schedutil` and was restored immediately after each
+measurement.
+
+## Calibration and target
+
+The final instrumentation recorded one untimed warm-up and nine timed full
+snapshots:
+
+- Warm-up: `36,280.7 ms`.
+- Raw timed samples, in run order:
+  `36,189.0`, `36,251.7`, `36,303.0`, `36,257.8`, `36,372.9`,
+  `36,529.4`, `36,455.5`, `36,223.9`, `36,462.9` ms.
+- Median: `36,303.0 ms`.
+- Mean: `36,338.5 ms`.
+- Population standard deviation: `114.30 ms`.
+- Coefficient of variation: `0.315%`.
+
+The target is a 5% envelope over the median, rounded up to the next 10 ms:
+
+```text
+ceil((36,303.0 * 1.05) / 10) * 10 = 38,120 ms
+```
+
+The test skips rather than gates when CoV exceeds 3%. A stable run fails when
+its median exceeds `38,120 ms`.
+
+## Strict target verification
+
+After rebuilding with the final `38,120 ms` target, a second strict run under
+the same governor and CPU-affinity conditions passed:
+
+- Warm-up: `36,413.0 ms`.
+- Raw timed samples, in run order:
+  `36,200.0`, `36,181.0`, `36,310.8`, `36,464.0`, `36,506.9`,
+  `36,483.7`, `36,378.1`, `36,248.0`, `36,374.4` ms.
+- Median: `36,374.4 ms`.
+- Mean: `36,349.7 ms`.
+- Population standard deviation: `115.40 ms`.
+- Coefficient of variation: `0.317%`.
+- Snapshot aggregate: `2,156,530` (diagnostic only).
+- Result cardinality: `104,851` (expected).
+- Iterations: `14,148`.
+
+The test exited successfully, and policy 0 was restored from `performance` to
+`schedutil`.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1054,9 +1054,10 @@ test('option2_doop', test_option2_doop_exe,
 # CRDT W=1 perf-suite gate.
 #
 # Drives the same Datalog source as bench_flowlog --workload crdt and
-# asserts median wall <= TARGET_MS (currently 19,840 ms = baseline
-# 18,890 ms x 1.05).  Default-suite invocation skips this entry
-# (suite is 'perf').  Registered here, after backend_src/arena_src/
+# asserts the corrected result relation cardinality before enforcing the
+# full-snapshot median wall-time target (currently 38,120 ms) documented
+# in docs/CRDT_PERF_BASELINE.md.  Default-suite invocation skips this
+# entry (suite is 'perf').  Registered here, after backend_src/arena_src/
 # workqueue_src are defined, so it can link the full evaluator.
 #
 #   Linux:   echo performance | sudo tee /sys/.../scaling_governor

--- a/tests/test_crdt_perf_gate.c
+++ b/tests/test_crdt_perf_gate.c
@@ -31,11 +31,11 @@
  *                                           runner where the operator
  *                                           is asserting the host is
  *                                           configured)
- *   - tuple count != gold (1,301,914)    -> FAIL (correctness sentinel
- *                                           checked BEFORE the timing
- *                                           assertion so a wrong-output
- *                                           bug never trips the timing
- *                                           gate spuriously)
+ *   - result count != expected (104,851) -> FAIL (correctness sentinel
+ *                                            checked BEFORE the timing
+ *                                            assertion so a wrong-output
+ *                                            bug never trips the timing
+ *                                            gate spuriously)
  *   - baseline CoV > 3%                  -> SKIP (measurement noise
  *                                           exceeds the budget)
  *   - median wall > target               -> FAIL (the gate fires)
@@ -78,33 +78,32 @@ enum {
     SKIP_EXIT = 77,
 };
 
-/* Median budget, in milliseconds.  Provenance: baseline median 18,890 ms
- * captured on the dev box with W=1, repeat=1, governor=NOT-asserted.
- * 1.05 envelope accounts for run-to-run variance + the tighter governor
- * pinning the perf-gate runner uses.  See .omc/perf/CRDT_BASELINE.md
- * section 1.  Tighten this when post-optimization commits land: each
- * commit's PR records a fresh n=9 median and the gate ratchets down. */
-#define WL_CRDT_PERF_GATE_TARGET_MS 19840
+/* Median budget, in milliseconds.  The post-#914 n=9 baseline median is
+* 36,303.0 ms; a 5% envelope rounded up to the next 10 ms gives 38,120 ms.
+* See docs/CRDT_PERF_BASELINE.md for the fixture and host provenance. */
+#define WL_CRDT_PERF_GATE_TARGET_MS 38120
 
 /* Coefficient-of-variation ceiling for the trial buffer.  3% mirrors
- * the WL_LOG perf gate's tolerance; CRDT runs ~19 s per trial so even
- * 3% is ~570 ms of jitter, well within "still meaningful" if the
+ * the WL_LOG perf gate's tolerance; CRDT runs ~36 s per trial so even
+ * 3% is ~1.1 s of jitter, well within "still meaningful" if the
  * cpufreq governor is pinned. */
 #define MAX_BASELINE_COV 0.03
 
 struct count_ctx {
-    int64_t total;
+    int64_t aggregate;
+    int64_t result;
 };
 
 static void
 count_cb(const char *relation, const int64_t *row, uint32_t ncols,
     void *user_data)
 {
-    (void)relation;
     (void)row;
     (void)ncols;
     struct count_ctx *ctx = (struct count_ctx *)user_data;
-    ctx->total++;
+    ctx->aggregate++;
+    if (relation && strcmp(relation, "result") == 0)
+        ctx->result++;
 }
 
 /* Resolve the CRDT data directory.  Order:
@@ -151,13 +150,14 @@ parse_bool_env_(const char *name, int default_val)
 }
 
 /* Run the CRDT pipeline once.  Returns 0 on success and writes the
- * tuple count and iteration count to the out-pointers; -1 on any
- * pipeline error.  Mirrors run_pipeline_count() in
+ * aggregate snapshot count, result-relation count, and iteration count
+ * to the out-pointers; -1 on any pipeline error.  Mirrors
+ * run_pipeline_count() in
  * bench/bench_flowlog.c, kept independent so this test does not depend
  * on the bench driver as a library. */
 static int
 run_crdt_once_(const char *source, uint32_t num_workers,
-    int64_t *out_count, uint32_t *out_iters)
+    int64_t *out_aggregate, int64_t *out_result, uint32_t *out_iters)
 {
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(source, &err);
@@ -210,8 +210,10 @@ run_crdt_once_(const char *source, uint32_t num_workers,
     if (rc != 0)
         return -1;
 
-    if (out_count)
-        *out_count = ctx.total;
+    if (out_aggregate)
+        *out_aggregate = ctx.aggregate;
+    if (out_result)
+        *out_result = ctx.result;
     if (out_iters)
         *out_iters = iters;
     return 0;
@@ -285,33 +287,41 @@ main(void)
     /* One untimed warm-up to amortize page cache + first-run engine
      * lazy init.  CRDT is too long to median-of-9 with no warm-up
      * without paying it as the worst trial. */
-    int64_t warm_count = 0;
+    int64_t warm_aggregate = 0;
+    int64_t warm_result = 0;
     uint32_t warm_iters = 0;
-    if (run_crdt_once_(source, 1, &warm_count, &warm_iters) != 0) {
+    wl_perf_ns_t warm_t0 = wl_perf_now_ns();
+    int warm_rc = run_crdt_once_(source, 1, &warm_aggregate, &warm_result,
+            &warm_iters);
+    wl_perf_ns_t warm_t1 = wl_perf_now_ns();
+    double warmup_ms = (double)(warm_t1 - warm_t0) / 1.0e6;
+    if (warm_rc != 0) {
         fprintf(stderr,
             "test_crdt_perf_gate: FAIL: CRDT pipeline error on warm-up\n");
         free(source);
         return 1;
     }
-    if (warm_count != WL_BENCH_CRDT_GOLD_TUPLES) {
+    if (warm_result != WL_BENCH_CRDT_RESULT_TUPLES) {
         fprintf(stderr,
-            "test_crdt_perf_gate: FAIL: warm-up tuple count %" PRId64
-            " != gold %" PRId64
+            "test_crdt_perf_gate: FAIL: warm-up result count %" PRId64
+            " != expected %" PRId64
             " (correctness regression; refusing to time)\n",
-            warm_count, WL_BENCH_CRDT_GOLD_TUPLES);
+            warm_result, WL_BENCH_CRDT_RESULT_TUPLES);
         free(source);
         return 1;
     }
 
     double trials_ms[TRIALS];
-    int64_t last_count = 0;
+    int64_t last_aggregate = 0;
+    int64_t last_result = 0;
     uint32_t last_iters = 0;
 
     for (int i = 0; i < TRIALS; i++) {
         wl_perf_ns_t t0 = wl_perf_now_ns();
-        int64_t count = 0;
+        int64_t aggregate = 0;
+        int64_t result = 0;
         uint32_t iters = 0;
-        int rc = run_crdt_once_(source, 1, &count, &iters);
+        int rc = run_crdt_once_(source, 1, &aggregate, &result, &iters);
         wl_perf_ns_t t1 = wl_perf_now_ns();
 
         if (rc != 0) {
@@ -321,16 +331,17 @@ main(void)
             free(source);
             return 1;
         }
-        if (count != WL_BENCH_CRDT_GOLD_TUPLES) {
+        if (result != WL_BENCH_CRDT_RESULT_TUPLES) {
             fprintf(stderr,
-                "test_crdt_perf_gate: FAIL: trial %d tuple count %" PRId64
-                " != gold %" PRId64 "\n",
-                i, count, WL_BENCH_CRDT_GOLD_TUPLES);
+                "test_crdt_perf_gate: FAIL: trial %d result count %" PRId64
+                " != expected %" PRId64 "\n",
+                i, result, WL_BENCH_CRDT_RESULT_TUPLES);
             free(source);
             return 1;
         }
         trials_ms[i] = (double)(t1 - t0) / 1.0e6;
-        last_count = count;
+        last_aggregate = aggregate;
+        last_result = result;
         last_iters = iters;
     }
     free(source);
@@ -338,18 +349,26 @@ main(void)
     double mean = wl_perf_mean_ms(trials_ms, (size_t)TRIALS);
     double stdev = wl_perf_stdev_ms(trials_ms, (size_t)TRIALS, mean);
     double cov = (mean > 0.0) ? stdev / mean : 0.0;
+    fprintf(stderr, "test_crdt_perf_gate: raw_ms =");
+    for (int i = 0; i < TRIALS; i++)
+        fprintf(stderr, " %.1f", trials_ms[i]);
+    fputc('\n', stderr);
     double median = wl_perf_median_ms_inplace(trials_ms, (size_t)TRIALS);
 
     fprintf(stderr,
         "test_crdt_perf_gate: trials=%d workers=1\n"
         "  data_dir   = %s\n"
-        "  tuples     = %" PRId64 " (gold %" PRId64 ")\n"
+        "  warmup_ms  = %.1f\n"
+        "  aggregate  = %" PRId64 " (diagnostic only)\n"
+        "  result     = %" PRId64 " (expected %" PRId64 ")\n"
         "  iterations = %" PRIu32 "\n"
         "  mean_ms    = %.1f\n"
         "  stdev_ms   = %.2f (CoV %.3f%%)\n"
         "  median_ms  = %.1f (target %d)\n",
         TRIALS, data_dir,
-        last_count, WL_BENCH_CRDT_GOLD_TUPLES,
+        warmup_ms,
+        last_aggregate,
+        last_result, WL_BENCH_CRDT_RESULT_TUPLES,
         last_iters, mean, stdev, cov * 100.0,
         median, WL_CRDT_PERF_GATE_TARGET_MS);
 


### PR DESCRIPTION
## Summary

- validate the semantic `result` relation (`104,851` rows) instead of treating aggregate snapshot callback rows as the correctness gold
- retain aggregate snapshot cardinality as a diagnostic so the gate remains observable alongside `bench_flowlog`
- rebaseline the complete post-#914 workload at `38,120 ms` and record reproducible fixture, host, raw-sample, CoV, and threshold provenance

## Root cause

The CRDT gate was introduced with an aggregate callback count of `1,301,914`, while its shared-header comment described that number as the `result` cardinality. Commit `61e2530` (#914) later fixed a leaked iteration context that had incorrectly skipped non-recursive strata after recursion. That correctness fix restored the final `result` output and increased the aggregate snapshot work, but the opt-in gate remained stale through v0.52.0.

The shipped fixture has 182,315 unique inserts and 77,463 unique removals (all removals are inserted), yielding 104,852 visible elements and 104,851 adjacent visible pairs. The corrected engine output matches that independent result cardinality.

## Impact

This changes no installed API or ABI. The perf gate now fails on an incorrect user-facing CRDT result while allowing optimizer-equivalent intermediate materialization changes. Timing still covers the complete snapshot and reports aggregate rows diagnostically.

## Validation

- strict release/LTO/error-log perf calibration, CPU 0 + performance governor: median `36,303.0 ms`, CoV `0.315%`
- final strict `WIRELOG_PERF_GATE=1 WIRELOG_PERF_REQUIRE=1` verification: median `36,374.4 ms` <= target `38,120 ms`, CoV `0.317%`, result `104,851`, aggregate `2,156,530`
- default suite: 250 passed, 0 failed, 10 environment-dependent skips
- ABI suite: 32/32 passed
- independent Architect, Critic, and Reviewer consensus: APPROVE

This is a prerequisite for the 0.53.0 release.
