### PR TITLE
release: prepare 0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,45 @@ All notable changes to wirelog are documented in this file.
 
 ### Documentation
 
+## [0.53.0] - 2026-07-31
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- **Query-mode snapshot correctness** (#929, #930): snapshots after input
+  changes or retractions no longer reuse stale materialized derived state that
+  could emit phantom or duplicate tuples and suppress valid
+  stratified-negation results. Completed evaluation state is now tracked
+  separately, bulk inserts force full recomputation, and full recomputation
+  resets each stratum and rule frontier.
+- **Static string literal interning** (#932, #933): plan generation now
+  pre-interns static filter, projection, and aggregate literals. Those plan
+  literals now stay consistent in paired Easy read and delta sessions
+  regardless of which evaluates first, preventing downstream host-row
+  mismatches and `UNKNOWN` failures.
+- **Relation-name buffer lifetime** (#931, #934): pending insert and remove
+  evaluation now retains the session-owned canonical relation name, so callers
+  and FFI bindings can reuse or release their relation-name buffer after the
+  API call returns without silently losing `step()` or snapshot deltas.
+- **CRDT release performance gate** (#935): the gate now validates the final
+  `result` relation instead of optimizer-sensitive aggregate snapshot rows,
+  while retaining aggregate counts as diagnostics. The corrected post-#914
+  full-snapshot evaluation had a 36,303 ms nine-run median, establishing a
+  38,120 ms gate target.
+
+### Performance
+
+### Security
+
+### Documentation
+
 ## [0.52.0] - 2026-06-28
 
 ### Added

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,11 +1,32 @@
 # Migration Guide
 
-**Last Updated:** 2026-06-28
+**Last Updated:** 2026-07-31
 
 This document describes breaking changes, opt-in features, and migration
 steps for each significant Wirelog release. Entries are ordered newest first.
 
 ---
+
+## 0.52 -> 0.53
+
+Version `0.53.0` is a correctness-focused release after `0.52.0`. It does
+not change the public API, ABI, or source compatibility.
+
+- **Query-mode snapshots now discard stale derived state** (#929): input
+  changes and retractions no longer leave materialized IDB state that can
+  produce duplicate or phantom tuples. Corrected evaluation may also produce
+  stratified-negation-derived rows that a stale phantom tuple previously
+  suppressed.
+- **Static program string literals are pre-interned** (#932): applications no
+  longer need to manually pre-intern literals used by program filter,
+  projection, or aggregate expressions to keep paired Easy read and delta
+  sessions aligned. This correction is limited to those static plan literals;
+  raw symbol IDs are not a general stable contract across sessions or runs
+  when hosts intern arbitrary strings in different orders.
+- **Pending relation names are session-owned** (#931): FFI integrations no
+  longer need to cache the relation-name buffer between an insert or remove
+  call and the following `step()` or snapshot. Keeping that buffer alive
+  remains safe, but is no longer required.
 
 ## 0.51 -> 0.52
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.52.99',
+  version: '0.53.0',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary

- release the query snapshot correctness fixes from #929/#930
- release static plan-literal interning from #932/#933
- release session-owned pending relation names from #931/#934
- include the corrected and rebaselined CRDT release performance gate from #935
- set the project version to 0.53.0 and add release/migration notes

## Validation

- `meson test -C build --print-errorlogs`: 250 passed, 0 failed, 10 environment-gated skips
- `meson test -C build --suite abi --print-errorlogs`: 32/32 passed
- changelog format, version sync, and 0.53.0 changelog extraction passed
- strict CRDT gate on `752a7e3`, CPU 0 / performance governor / REQUIRE mode: result 104,851; median 36,705.0 ms; CoV 0.605%; target 38,120 ms; passed
- Implementation Skill Architect, Critic, and Reviewer: APPROVE

## Publication checklist

- [ ] Full PR CI passes
- [ ] Rebase merge and verify the merged tree matches the reviewed tree
- [ ] Confirm a GPG signer and create only a signed `v0.53.0` tag
- [ ] Resolve the absent tag-artifact workflow: explicitly approve a changelog-only release or provide and verify release artifacts
- [ ] Publish the GitHub Release with notes extracted verbatim from `CHANGELOG.md`

This remains a draft until the signing and artifact-publication requirements are resolved.
