### PR TITLE
build: bump version to 0.53.99

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.53.0',
+  version: '0.53.99',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary

Open the post-0.53.0 development cycle by bumping `project_version` in `meson.build` from `0.53.0` to `0.53.99`.

The `.99` version follows the established development-version convention and marks `main` as the in-progress cycle toward the next release. This is not a release and does not create a tag or change release notes.

## Changes

- `meson.build`: `version: '0.53.0'` → `'0.53.99'`

No code, behavior, ABI, or changelog changes.

## Validation

- `meson setup --reconfigure build`
- `meson compile -C build wirelog_cli`
- `meson test -C build version_sync cli_version --print-errorlogs`
- `build/wirelog_cli --version` → `wirelog_cli 0.53.99`
