### PR TITLE
perf(columnar): column-native batch join-hash kernel and benchmark

### DIFF
--- a/bench/bench_join_hash.c
+++ b/bench/bench_join_hash.c
@@ -1,0 +1,284 @@
+/*
+ * bench_join_hash.c - join hash-table build microbenchmark
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Decides whether col_hash_rows_batch() earns its place in the join build
+ * loops, and separates the value of the vector kernel from the value of
+ * batching at all:
+ *
+ *   perrow   The loop the join build sites use today: hash one row, mask it,
+ *            prepend to its chain, repeat.  Reproduced verbatim here because
+ *            col_join_hash_rel_keys is static.  This is the baseline -- the
+ *            question is whether the batch form beats what we have, not
+ *            whether it beats some other batch form.
+ *
+ *   batch    col_hash_rows_batch into a COL_HASH_TILE scratch, then a chain
+ *            build pass over the tile.  This is the shape the call sites
+ *            would take.
+ *
+ *   hash     The kernel alone, no chain build.  The gap between `hash` and
+ *            `batch` is the chain-write cost, which is memory-bound and
+ *            which no amount of SIMD in the hash can remove.
+ *
+ * Whether `batch` and `hash` use the AVX2 or the scalar body is a
+ * compile-time decision, so the comparison is made by building this file
+ * twice.  meson registers:
+ *
+ *   bench_join_hash          default flags  -> AVX2 kernel
+ *   bench_join_hash_scalar   -mno-avx2      -> scalar kernel
+ *
+ * A runtime switch would put a global read inside the hash loop and change
+ * the thing being measured.
+ *
+ * Every configuration checks its hashes against the per-row baseline and
+ * prints a mismatch count.  A throughput number without mismatch=0 beside it
+ * is not evidence of anything -- and for this kernel a mismatch is not a
+ * benchmark artifact but the silent join-result-loss failure that #938 is
+ * about.
+ */
+
+#include "../wirelog/columnar/internal.h"
+
+#include "bench_util.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define WARMUP  3
+#define REPEATS 7
+
+static const uint32_t NROWS_LIST[] = { 20000, 100000, 1000000 };
+#define NROWS_COUNT (sizeof(NROWS_LIST) / sizeof(NROWS_LIST[0]))
+
+static const uint32_t KC_LIST[] = { 1, 2, 4 };
+#define KC_COUNT (sizeof(KC_LIST) / sizeof(KC_LIST[0]))
+
+/* Duplicate rate: 0 means every key distinct, 10 means ~10% repeats.  Chain
+ * length changes the memory behaviour of the build pass, not the hash. */
+static const uint32_t DUP_PCT[] = { 0, 10 };
+#define DUP_COUNT (sizeof(DUP_PCT) / sizeof(DUP_PCT[0]))
+
+/*
+ * The scalar FNV-1a the join uses, reproduced because col_join_hash_rel_keys
+ * is static.  Kept structurally identical to it, including the kc == 1 and
+ * kc == 2 special cases, so `perrow` really is today's cost.
+ */
+static BENCH_NOINLINE uint32_t
+perrow_hash(const col_rel_t *rel, uint32_t row, const uint32_t *key_cols,
+    uint32_t kc)
+{
+    uint32_t h = 2166136261u;
+    for (uint32_t i = 0; i < kc; i++) {
+        uint64_t v = (uint64_t)rel->columns[key_cols[i]][row];
+        h ^= (uint32_t)(v & 0xffffffffu);
+        h *= 16777619u;
+        h ^= (uint32_t)(v >> 32);
+        h *= 16777619u;
+    }
+    return h;
+}
+
+/* Today's build loop: hash, mask, prepend, one row at a time. */
+static BENCH_NOINLINE void
+build_perrow(const col_rel_t *rel, uint32_t nrows, const uint32_t *key_cols,
+    uint32_t kc, uint32_t nbuckets, uint32_t *head, uint32_t *next)
+{
+    memset(head, 0, (size_t)nbuckets * sizeof(uint32_t));
+    for (uint32_t r = 0; r < nrows; r++) {
+        uint32_t h = perrow_hash(rel, r, key_cols, kc) & (nbuckets - 1);
+        next[r] = head[h];
+        head[h] = r + 1;
+    }
+}
+
+/* The batched shape: hash a tile, then prepend that tile's rows. */
+static BENCH_NOINLINE void
+build_batch(const col_rel_t *rel, uint32_t nrows, const uint32_t *key_cols,
+    uint32_t kc, uint32_t nbuckets, uint32_t *head, uint32_t *next,
+    uint32_t *scratch)
+{
+    memset(head, 0, (size_t)nbuckets * sizeof(uint32_t));
+    for (uint32_t base = 0; base < nrows;) {
+        uint32_t chunk = nrows - base;
+        if (chunk > COL_HASH_TILE)
+            chunk = COL_HASH_TILE;
+
+        col_hash_rows_batch(rel, base, base + chunk, key_cols, kc, scratch);
+
+        for (uint32_t j = 0; j < chunk; j++) {
+            uint32_t r = base + j;
+            uint32_t h = scratch[j] & (nbuckets - 1);
+            next[r] = head[h];
+            head[h] = r + 1;
+        }
+        base += chunk;
+    }
+}
+
+/* Kernel only, tiled the same way, no chain writes. */
+static BENCH_NOINLINE void
+hash_only(const col_rel_t *rel, uint32_t nrows, const uint32_t *key_cols,
+    uint32_t kc, uint32_t *scratch)
+{
+    for (uint32_t base = 0; base < nrows;) {
+        uint32_t chunk = nrows - base;
+        if (chunk > COL_HASH_TILE)
+            chunk = COL_HASH_TILE;
+        col_hash_rows_batch(rel, base, base + chunk, key_cols, kc, scratch);
+        base += chunk;
+    }
+}
+
+static uint32_t
+next_pow2_local(uint32_t n)
+{
+    if (n < 16)
+        return 16;
+    n--;
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    return n + 1;
+}
+
+static double
+median(double *v, uint32_t n)
+{
+    for (uint32_t i = 1; i < n; i++) {
+        double key = v[i];
+        uint32_t j = i;
+        while (j > 0 && v[j - 1] > key) {
+            v[j] = v[j - 1];
+            j--;
+        }
+        v[j] = key;
+    }
+    return v[n / 2];
+}
+
+int
+main(void)
+{
+#ifdef __AVX2__
+    const char *variant = "avx2";
+#else
+    const char *variant = "scalar";
+#endif
+    printf("bench_join_hash (kernel=%s, warmup=%d repeats=%d, tile=%u)\n",
+        variant, WARMUP, REPEATS, COL_HASH_TILE);
+    printf("%-8s %-3s %-4s %10s %10s %10s %8s %8s %8s\n", "nrows", "kc",
+        "dup%", "perrow_ms", "batch_ms", "hash_ms", "batch_x", "hash_x",
+        "mismatch");
+
+    for (uint32_t ni = 0; ni < NROWS_COUNT; ni++) {
+        const uint32_t nrows = NROWS_LIST[ni];
+        for (uint32_t ki = 0; ki < KC_COUNT; ki++) {
+            const uint32_t kc = KC_LIST[ki];
+            for (uint32_t di = 0; di < DUP_COUNT; di++) {
+                const uint32_t dup = DUP_PCT[di];
+
+                col_rel_t *rel = col_rel_new_auto("bench", 4);
+                if (!rel)
+                    return 1;
+
+                uint64_t s = 0x243F6A8885A308D3ull;
+                for (uint32_t r = 0; r < nrows; r++) {
+                    int64_t row[4];
+                    for (uint32_t c = 0; c < 4; c++) {
+                        s = s * 6364136223846793005ull
+                            + 1442695040888963407ull;
+                        int64_t v = (int64_t)(s >> 16);
+                        /* Fold a fraction of keys onto earlier values so
+                         * chains are not uniformly length 1. */
+                        if (dup && r > 0 && (s % 100u) < dup)
+                            v = rel->columns[c][r % (r > 64 ? 64 : r)];
+                        row[c] = v;
+                    }
+                    if (col_rel_append_row(rel, row) != 0)
+                        return 1;
+                }
+
+                const uint32_t KEYS[4] = { 0, 1, 2, 3 };
+                uint32_t nbuckets = next_pow2_local(nrows * 2);
+
+                uint32_t *head = (uint32_t *)malloc(
+                    (size_t)nbuckets * sizeof(uint32_t));
+                uint32_t *next_a = (uint32_t *)malloc(
+                    (size_t)nrows * sizeof(uint32_t));
+                uint32_t *next_b = (uint32_t *)malloc(
+                    (size_t)nrows * sizeof(uint32_t));
+                uint32_t *scratch = (uint32_t *)malloc(
+                    (size_t)COL_HASH_TILE * sizeof(uint32_t));
+                if (!head || !next_a || !next_b || !scratch)
+                    return 1;
+
+                double pr[REPEATS], ba[REPEATS], ha[REPEATS];
+
+                for (int rep = 0; rep < WARMUP + REPEATS; rep++) {
+                    bench_time_t t0 = bench_time_now();
+                    build_perrow(rel, nrows, KEYS, kc, nbuckets, head, next_a);
+                    bench_time_t t1 = bench_time_now();
+
+                    bench_time_t t2 = bench_time_now();
+                    build_batch(rel, nrows, KEYS, kc, nbuckets, head, next_b,
+                        scratch);
+                    bench_time_t t3 = bench_time_now();
+
+                    bench_time_t t4 = bench_time_now();
+                    hash_only(rel, nrows, KEYS, kc, scratch);
+                    bench_time_t t5 = bench_time_now();
+
+                    if (rep >= WARMUP) {
+                        int i = rep - WARMUP;
+                        pr[i] = bench_time_diff_ms(t0, t1);
+                        ba[i] = bench_time_diff_ms(t2, t3);
+                        ha[i] = bench_time_diff_ms(t4, t5);
+                    }
+                }
+
+                /* Both builds must produce identical chains, and every hash
+                 * must match the per-row baseline exactly. */
+                uint64_t mismatch = 0;
+                for (uint32_t r = 0; r < nrows; r++) {
+                    if (next_a[r] != next_b[r])
+                        mismatch++;
+                }
+                for (uint32_t base = 0; base < nrows && mismatch == 0;) {
+                    uint32_t chunk = nrows - base;
+                    if (chunk > COL_HASH_TILE)
+                        chunk = COL_HASH_TILE;
+                    col_hash_rows_batch(rel, base, base + chunk, KEYS, kc,
+                        scratch);
+                    for (uint32_t j = 0; j < chunk; j++) {
+                        if (scratch[j] != perrow_hash(rel, base + j, KEYS, kc))
+                            mismatch++;
+                    }
+                    base += chunk;
+                }
+
+                double p = median(pr, REPEATS);
+                double b = median(ba, REPEATS);
+                double h = median(ha, REPEATS);
+
+                printf("%-8u %-3u %-4u %10.3f %10.3f %10.3f %7.2fx %7.2fx"
+                    " %8" PRIu64 "\n", nrows, kc, dup, p, b, h,
+                    b > 0.0 ? p / b : 0.0, h > 0.0 ? p / h : 0.0, mismatch);
+                fflush(stdout);
+
+                free(scratch);
+                free(next_b);
+                free(next_a);
+                free(head);
+                col_rel_destroy(rel);
+            }
+        }
+    }
+    return 0;
+}

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -179,6 +179,39 @@ if host_machine.cpu_family() == 'x86_64' and cc.get_id() != 'msvc'
   )
 endif
 
+# Join hash-table build microbenchmark (Issue #938).
+#
+# Built twice for the same reason bench_filter_scan is: the kernel body is a
+# compile-time choice, and a runtime switch would sit inside the hash loop.
+bench_join_hash_srcs = [
+  files('bench_join_hash.c'),
+  bench_backend_src,
+  files(subdir_wirelog / 'intern.c'),
+  bench_arena_src,
+  bench_thread_src,
+  bench_workqueue_src,
+]
+
+bench_join_hash = executable(
+  'bench_join_hash',
+  bench_join_hash_srcs,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+  install: false,
+)
+
+if host_machine.cpu_family() == 'x86_64' and cc.get_id() != 'msvc'
+  bench_join_hash_scalar = executable(
+    'bench_join_hash_scalar',
+    bench_join_hash_srcs,
+    c_args: ['-mno-avx2'],
+    include_directories: [wirelog_inc, wirelog_src_inc],
+    dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep,
+      math_dep],
+    install: false,
+  )
+endif
+
 datagen = executable(
   'datagen',
   files('datagen.c'),

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1067,6 +1067,24 @@ test_filter_select_rows_exe = executable(
 
 test('filter_select_rows', test_filter_select_rows_exe)
 
+# Differential test for the batch join-hash kernel: the AVX2 and scalar
+# bodies must agree with col_join_hash_rel_keys bit for bit, because the
+# session-cached diff arrangement is extended incrementally and any
+# divergence loses join results silently.
+test_hash_rows_batch_exe = executable(
+  'test_hash_rows_batch',
+  files('test_hash_rows_batch.c'),
+  backend_src,
+  files(subdir_wirelog / 'intern.c'),
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('hash_rows_batch', test_hash_rows_batch_exe)
+
 # ============================================================================
 # CRDT W=1 perf-suite gate.
 #

--- a/tests/test_hash_rows_batch.c
+++ b/tests/test_hash_rows_batch.c
@@ -1,0 +1,392 @@
+/*
+ * tests/test_hash_rows_batch.c - batch join-hash kernel equivalence
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * col_hash_rows_batch() has a scalar body and, on AVX2 targets, a vectorized
+ * body that hashes 8 rows per iteration with the low and high halves of each
+ * int64_t deinterleaved into separate lanes.  The two must agree with
+ * col_join_hash_rel_keys() bit for bit.
+ *
+ * That equality is not cosmetic.  The diff arrangement is cached in the
+ * session and extended incrementally, so rows indexed in one iteration are
+ * probed in a later one, potentially through a different code path.  A single
+ * differing bit strands the earlier rows in buckets computed under the other
+ * function and loses join results with no crash and no error -- which is why
+ * these tests assert exact uint32_t equality rather than "the join returned
+ * some rows".
+ *
+ *   test_matches_oracle
+ *       Differential against an FNV-1a written here from the specification,
+ *       independent of the kernel's structure, over randomized data.
+ *
+ *   test_golden_values
+ *       Hardcoded uint32_t results.  The oracle and the kernel could in
+ *       principle drift together (a changed multiplier in both); only pinned
+ *       constants catch that, and a changed hash is exactly the silent
+ *       data-loss event above.
+ *
+ *   test_row_order
+ *       Every row hashes differently, so a lane-permutation mistake in the
+ *       deinterleave shows up as a misplaced result.  This is the detector
+ *       for the blend-cannot-swap-128-bit-halves trap.
+ *
+ *   test_lengths / test_row_begin_offset
+ *       Counts straddling the 8-row vector width, and non-zero row_begin so
+ *       the vector loop starts away from the column head.
+ *
+ *   test_kc_zero
+ *       Zero key columns must yield the bare FNV offset basis, matching the
+ *       scalar function's zero-trip loop.
+ *
+ *   test_extremes / test_repeated_and_reordered_key_cols
+ *       INT64 boundary values, and key column lists that repeat or reorder.
+ */
+
+#include "../wirelog/columnar/internal.h"
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures;
+
+#define CHECK(cond, ...)                                              \
+        do {                                                              \
+            if (!(cond)) {                                                \
+                printf("  FAIL %s:%d: ", __FILE__, __LINE__);             \
+                printf(__VA_ARGS__);                                      \
+                printf("\n");                                             \
+                failures++;                                               \
+            }                                                             \
+        } while (0)
+
+/*
+ * Reference FNV-1a, written from the specification rather than derived from
+ * the kernel: 32-bit offset basis, per 64-bit key the low word then the high
+ * word, each xored in and then multiplied by the prime.
+ */
+static uint32_t
+ref_hash_row(const col_rel_t *rel, uint32_t row, const uint32_t *key_cols,
+    uint32_t kc)
+{
+    uint32_t h = 2166136261u;
+    for (uint32_t i = 0; i < kc; i++) {
+        uint64_t v = (uint64_t)rel->columns[key_cols[i]][row];
+        h ^= (uint32_t)(v & 0xffffffffu);
+        h *= 16777619u;
+        h ^= (uint32_t)(v >> 32);
+        h *= 16777619u;
+    }
+    return h;
+}
+
+/* Build a relation with @ncols columns and @nrows rows, values from cb. */
+static col_rel_t *
+make_rel(uint32_t nrows, uint32_t ncols, int64_t (*cb)(uint32_t r, uint32_t c))
+{
+    col_rel_t *rel = col_rel_new_auto("t", ncols);
+    if (!rel)
+        return NULL;
+    int64_t row[16];
+    for (uint32_t r = 0; r < nrows; r++) {
+        for (uint32_t c = 0; c < ncols && c < 16; c++)
+            row[c] = cb(r, c);
+        if (col_rel_append_row(rel, row) != 0) {
+            col_rel_destroy(rel);
+            return NULL;
+        }
+    }
+    return rel;
+}
+
+/* Compare the batch kernel against the oracle over one range. */
+static void
+compare_range(const char *what, const col_rel_t *rel, uint32_t begin,
+    uint32_t end, const uint32_t *key_cols, uint32_t kc)
+{
+    uint32_t n = (end > begin) ? end - begin : 0;
+    uint32_t *got = (uint32_t *)malloc((n ? n : 1) * sizeof(uint32_t));
+    if (!got) {
+        printf("  FAIL %s: allocation\n", what);
+        failures++;
+        return;
+    }
+    memset(got, 0xAB, (n ? n : 1) * sizeof(uint32_t));
+
+    col_hash_rows_batch(rel, begin, end, key_cols, kc, got);
+
+    for (uint32_t j = 0; j < n; j++) {
+        uint32_t want = ref_hash_row(rel, begin + j, key_cols, kc);
+        if (got[j] != want) {
+            CHECK(false,
+                "%s [kc=%u begin=%u n=%u]: out[%u]=0x%08" PRIx32
+                ", expected 0x%08" PRIx32, what, kc, begin, n, j, got[j],
+                want);
+            break;
+        }
+    }
+    free(got);
+}
+
+static int64_t
+mix_cb(uint32_t r, uint32_t c)
+{
+    /* Deterministic, spread across the full int64 range including negatives. */
+    uint64_t s = (uint64_t)r * 6364136223846793005ull
+        + (uint64_t)c * 1442695040888963407ull + 0x9E3779B97F4A7C15ull;
+    s ^= s >> 29;
+    s *= 0xBF58476D1CE4E5B9ull;
+    s ^= s >> 32;
+    return (int64_t)s;
+}
+
+static void
+test_matches_oracle(void)
+{
+    printf("test_matches_oracle\n");
+    static const uint32_t KEYSETS[][4] = {
+        { 0 }, { 1 }, { 0, 1 }, { 2, 0 }, { 0, 1, 2 }, { 3, 2, 1, 0 },
+    };
+    static const uint32_t KCS[] = { 1, 1, 2, 2, 3, 4 };
+
+    col_rel_t *rel = make_rel(2000, 4, mix_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    for (uint32_t k = 0; k < 6; k++)
+        compare_range("oracle", rel, 0, 2000, KEYSETS[k], KCS[k]);
+    col_rel_destroy(rel);
+}
+
+/*
+ * Golden values pin the hash itself.  Computed from the FNV-1a definition:
+ * a changed multiplier or basis would move these even if kernel and oracle
+ * changed together.
+ */
+static int64_t
+golden_cb(uint32_t r, uint32_t c)
+{
+    (void)c;
+    return (int64_t)r;
+}
+
+static void
+test_golden_values(void)
+{
+    printf("test_golden_values\n");
+    col_rel_t *rel = make_rel(8, 1, golden_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    const uint32_t k0[] = { 0 };
+    uint32_t got[8];
+    col_hash_rows_batch(rel, 0, 8, k0, 1, got);
+
+    /* h = basis; h ^= lo32(v); h *= prime; h ^= hi32(v); h *= prime */
+    for (uint32_t r = 0; r < 8; r++) {
+        uint32_t h = 2166136261u;
+        h ^= r;
+        h *= 16777619u;
+        h ^= 0u;
+        h *= 16777619u;
+        CHECK(got[r] == h, "golden row %u: 0x%08" PRIx32 " != 0x%08" PRIx32,
+            r, got[r], h);
+    }
+    /*
+     * Fully hardcoded anchors, computed independently from the FNV-1a
+     * definition rather than captured from this kernel.  The loop above
+     * shares its formula with the implementation; these do not, so they are
+     * what actually pins the offset basis and the prime.
+     */
+    static const uint32_t GOLDEN[4] = {
+        0x117697CDu, 0xEB741D64u, 0x5D7B8C9Fu, 0x37791236u,
+    };
+    for (uint32_t r = 0; r < 4; r++)
+        CHECK(got[r] == GOLDEN[r],
+            "golden anchor row %u: 0x%08" PRIx32 " != 0x%08" PRIx32, r,
+            got[r], GOLDEN[r]);
+    col_rel_destroy(rel);
+}
+
+static int64_t
+distinct_cb(uint32_t r, uint32_t c)
+{
+    (void)c;
+    /* Distinct high AND low words per row, so a lane mix-up cannot alias. */
+    return (int64_t)(((uint64_t)(r + 1) << 32) | (uint64_t)(0xFEED0000u + r));
+}
+
+static void
+test_row_order(void)
+{
+    printf("test_row_order\n");
+    col_rel_t *rel = make_rel(64, 1, distinct_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    const uint32_t k0[] = { 0 };
+    uint32_t got[64];
+    col_hash_rows_batch(rel, 0, 64, k0, 1, got);
+
+    for (uint32_t r = 0; r < 64; r++) {
+        uint32_t want = ref_hash_row(rel, r, k0, 1);
+        CHECK(got[r] == want,
+            "row %u landed wrong: 0x%08" PRIx32 " != 0x%08" PRIx32, r, got[r],
+            want);
+        if (got[r] != want)
+            break;
+    }
+    col_rel_destroy(rel);
+}
+
+static void
+test_lengths(void)
+{
+    printf("test_lengths\n");
+    static const uint32_t LENGTHS[] = { 0, 1, 2, 7, 8, 9, 15, 16, 17, 31, 32,
+                                        33, 63, 64, 65, 1023, 1024, 1025 };
+    const uint32_t nlen = sizeof(LENGTHS) / sizeof(LENGTHS[0]);
+    const uint32_t k01[] = { 0, 1 };
+
+    col_rel_t *rel = make_rel(1025, 2, mix_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    for (uint32_t i = 0; i < nlen; i++) {
+        compare_range("len", rel, 0, LENGTHS[i], k01, 1);
+        compare_range("len", rel, 0, LENGTHS[i], k01, 2);
+    }
+    col_rel_destroy(rel);
+}
+
+static void
+test_row_begin_offset(void)
+{
+    printf("test_row_begin_offset\n");
+    const uint32_t k0[] = { 0 };
+    col_rel_t *rel = make_rel(600, 1, mix_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    /* Offsets that are and are not multiples of the vector width, including
+     * ranges that end exactly at nrows. */
+    static const uint32_t BEGINS[] = { 1, 3, 7, 8, 9, 16, 100, 511, 592, 599 };
+    for (uint32_t i = 0; i < sizeof(BEGINS) / sizeof(BEGINS[0]); i++) {
+        compare_range("offset", rel, BEGINS[i], 600, k0, 1);
+        compare_range("offset_mid", rel, BEGINS[i],
+            BEGINS[i] + 17 < 600 ? BEGINS[i] + 17 : 600, k0, 1);
+    }
+    /* Empty and inverted ranges must be no-ops. */
+    compare_range("empty", rel, 42, 42, k0, 1);
+    compare_range("inverted", rel, 100, 50, k0, 1);
+    col_rel_destroy(rel);
+}
+
+static void
+test_kc_zero(void)
+{
+    printf("test_kc_zero\n");
+    col_rel_t *rel = make_rel(20, 2, mix_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    uint32_t got[20];
+    memset(got, 0xAB, sizeof(got));
+    col_hash_rows_batch(rel, 0, 20, NULL, 0, got);
+    for (uint32_t r = 0; r < 20; r++)
+        CHECK(got[r] == 2166136261u,
+            "kc=0 row %u: 0x%08" PRIx32 " != offset basis", r, got[r]);
+    col_rel_destroy(rel);
+}
+
+static int64_t extreme_vals[9] = { INT64_MIN, INT64_MIN + 1, -2147483649LL, -1,
+                                   0, 1, 2147483648LL, INT64_MAX - 1,
+                                   INT64_MAX };
+
+static int64_t
+extreme_cb(uint32_t r, uint32_t c)
+{
+    return extreme_vals[(r + c * 3u) % 9u];
+}
+
+static void
+test_extremes(void)
+{
+    printf("test_extremes\n");
+    const uint32_t k01[] = { 0, 1 };
+    col_rel_t *rel = make_rel(90, 2, extreme_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    compare_range("extremes", rel, 0, 90, k01, 1);
+    compare_range("extremes", rel, 0, 90, k01, 2);
+    col_rel_destroy(rel);
+}
+
+static void
+test_repeated_and_reordered_key_cols(void)
+{
+    printf("test_repeated_and_reordered_key_cols\n");
+    static const uint32_t REPEAT[] = { 2, 2 };
+    static const uint32_t REORDER[] = { 3, 1 };
+    static const uint32_t REVERSE[] = { 3, 2, 1, 0 };
+
+    col_rel_t *rel = make_rel(300, 4, mix_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    compare_range("repeat", rel, 0, 300, REPEAT, 2);
+    compare_range("reorder", rel, 0, 300, REORDER, 2);
+    compare_range("reverse", rel, 0, 300, REVERSE, 4);
+    col_rel_destroy(rel);
+}
+
+int
+main(void)
+{
+    printf("=== col_hash_rows_batch equivalence ===\n");
+#ifdef __AVX2__
+    printf("(AVX2 kernel compiled in)\n");
+#else
+    printf("(scalar kernel only)\n");
+#endif
+
+    test_matches_oracle();
+    test_golden_values();
+    test_row_order();
+    test_lengths();
+    test_row_begin_offset();
+    test_kc_zero();
+    test_extremes();
+    test_repeated_and_reordered_key_cols();
+
+    if (failures) {
+        printf("=== %d FAILURE(S) ===\n", failures);
+        return 1;
+    }
+    printf("=== all passed ===\n");
+    return 0;
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1814,4 +1814,44 @@ col_filter_select_rows(const int64_t *col_a, const int64_t *col_b,
     int64_t const_b, uint32_t nrows, wl_plan_expr_tag_t cmp_op,
     uint32_t *out_sel);
 
+/*
+ * COL_HASH_TILE:
+ * Rows hashed per col_hash_rows_batch() call when a caller tiles a large
+ * range.  Bounds the scratch buffer a build loop needs (COL_HASH_TILE *
+ * sizeof(uint32_t)) without giving up batch width.
+ */
+#define COL_HASH_TILE 1024u
+
+/*
+ * col_hash_rows_batch:
+ * Hash rows [@row_begin, @row_end) of @rel over @kc key columns, writing
+ * @row_end - @row_begin results to @out_hashes.
+ *
+ * @out_hashes is indexed RELATIVE to @row_begin: out_hashes[j] corresponds
+ * to row row_begin + j.  Callers wanting absolute indexing pass a shifted
+ * pointer.
+ *
+ * Hashes are RAW and unmasked.  Bucket masking stays at the call site, where
+ * the table width is known and the mask folds into the loop that already
+ * reads the value.
+ *
+ * Guarantees out_hashes[j] == col_join_hash_rel_keys(rel, row_begin + j,
+ * key_cols, kc), bit for bit, including kc == 0 (every row hashes to the FNV
+ * offset basis).  That equality is load-bearing: the session-cached diff
+ * arrangement is extended incrementally, so build and probe may run through
+ * different code paths in different iterations, and any divergence would
+ * lose join results silently rather than failing.
+ *
+ * @row_end must not exceed rel->nrows; row_begin >= row_end is a no-op.
+ * Unlike col_filter_select_rows() this needs NO slack in @out_hashes -- the
+ * vector loop runs only while eight whole rows remain and writes exactly
+ * eight lanes for those eight rows.
+ *
+ * Exposed (not static) so tests and benchmarks can drive it directly.  Not
+ * public API and not exported: the library builds with hidden visibility.
+ */
+void
+col_hash_rows_batch(const col_rel_t *rel, uint32_t row_begin, uint32_t row_end,
+    const uint32_t *key_cols, uint32_t kc, uint32_t *out_hashes);
+
 #endif /* WL_COLUMNAR_INTERNAL_H */

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2951,6 +2951,89 @@ col_join_hash_rel_keys(const col_rel_t *rel, uint32_t row,
     return h;
 }
 
+/*
+ * col_hash_rows_batch:
+ * Hash a contiguous run of rows in one call.  See internal.h for the
+ * contract; the invariant that matters is bit-identity with
+ * col_join_hash_rel_keys(), which the scalar tail below guarantees
+ * structurally by calling it.
+ *
+ * Bit-identity is not a nicety here.  col_session_get_diff_arrangement()
+ * caches an arrangement in the session and extends it incrementally across
+ * iterations, so build and probe can land in different iterations and even
+ * different code paths.  A single differing bit would strand earlier rows in
+ * buckets computed under the other function and lose join results silently,
+ * with no crash and no error.
+ */
+void
+col_hash_rows_batch(const col_rel_t *rel, uint32_t row_begin, uint32_t row_end,
+    const uint32_t *key_cols, uint32_t kc, uint32_t *out_hashes)
+{
+    if (row_begin >= row_end)
+        return;
+
+    const uint32_t n = row_end - row_begin;
+    uint32_t r = 0;
+
+#ifdef __AVX2__
+    /*
+     * Eight rows per iteration, accumulating FNV-1a in eight 32-bit lanes.
+     *
+     * Each 256-bit load holds four int64_t as [l0,h0,l1,h1 | l2,h2,l3,h3].
+     * shuffle_epi32(_, 0xD8) reorders within each 128-bit half to
+     * [l0,l1,h0,h1 | l2,l3,h2,h3], after which unpacklo/unpackhi_epi64
+     * across the two loads separate the low and high words:
+     *
+     *   lo = [l0,l1,l4,l5 | l2,l3,l6,l7]
+     *   hi = [h0,h1,h4,h5 | h2,h3,h6,h7]
+     *
+     * Both carry the SAME lane permutation, sigma = [0,1,4,5,2,3,6,7].  xor
+     * and mullo are lane-wise, so accumulating in permuted order is exact;
+     * one permute at the store puts rows back in order.  sigma is its own
+     * inverse, so it doubles as the control vector.
+     *
+     * Deliberately NOT done with permutevar + blend: blend selects per lane
+     * from two sources and cannot swap the 128-bit halves, so it would pair
+     * row i's low word with row (i+4)%8's high word -- a silent wrong hash.
+     *
+     * _mm256_mullo_epi32 keeps the low 32 bits of each product, which is
+     * exactly uint32_t multiply, so this matches the scalar FNV-1a bit for
+     * bit.  kc == 0 leaves h at the broadcast offset basis, as the scalar
+     * function's zero-trip loop does.
+     */
+    const __m256i prime = _mm256_set1_epi32((int)16777619u);
+    const __m256i sigma = _mm256_setr_epi32(0, 1, 4, 5, 2, 3, 6, 7);
+
+    /* Written so the bound cannot wrap; rows past row_end are never read. */
+    for (; n >= 8 && r <= n - 8; r += 8) {
+        __m256i h = _mm256_set1_epi32((int)2166136261u);
+
+        for (uint32_t i = 0; i < kc; i++) {
+            const int64_t *col = rel->columns[key_cols[i]] + row_begin + r;
+            __m256i a0 = _mm256_loadu_si256((const __m256i *)col);
+            __m256i a1 = _mm256_loadu_si256((const __m256i *)(col + 4));
+
+            __m256i t0 = _mm256_shuffle_epi32(a0, 0xD8);
+            __m256i t1 = _mm256_shuffle_epi32(a1, 0xD8);
+            __m256i lo = _mm256_unpacklo_epi64(t0, t1);
+            __m256i hi = _mm256_unpackhi_epi64(t0, t1);
+
+            h = _mm256_mullo_epi32(_mm256_xor_si256(h, lo), prime);
+            h = _mm256_mullo_epi32(_mm256_xor_si256(h, hi), prime);
+        }
+
+        _mm256_storeu_si256((__m256i *)(out_hashes + r),
+            _mm256_permutevar8x32_epi32(h, sigma));
+    }
+#endif /* __AVX2__ */
+
+    /* Scalar tail calls the live function directly, so the two can never
+     * drift apart under maintenance. */
+    for (; r < n; r++)
+        out_hashes[r] = col_join_hash_rel_keys(rel, row_begin + r, key_cols,
+                kc);
+}
+
 static WL_OPS_ALWAYS_INLINE bool
 col_join_keys_match_rel(const col_rel_t *left, uint32_t lr,
     const uint32_t *lk, const col_rel_t *right, uint32_t rr,


### PR DESCRIPTION
Partial work on #938. **Does not close it** — see "What this deliberately does not do".

Adds the column-native batch join-hash kernel and the benchmark that measures it. The call-site wiring is **not** included, because instrumenting it showed the sites #938 names are never executed. Details below.

## The kernel

`col_hash_rows_batch()` hashes a contiguous run of rows in one call. The AVX2 body does 8 rows per iteration.

Each 256-bit load holds four `int64_t` as `[l0,h0,l1,h1 | l2,h2,l3,h3]`. `shuffle_epi32(_, 0xD8)` reorders within each 128-bit half, then `unpacklo/unpackhi_epi64` across two loads separates the low and high words:

```
lo = [l0,l1,l4,l5 | l2,l3,l6,l7]
hi = [h0,h1,h4,h5 | h2,h3,h6,h7]
```

Both come out under the *same* lane permutation σ = `[0,1,4,5,2,3,6,7]`. Since `xor` and `mullo` are lane-wise, accumulating in permuted order is exact, and one permute at the store restores row order. σ is self-inverse, so it doubles as the control vector.

Deliberately **not** built from `permutevar` + `blend`, the construction #938's body warns about: `blend` selects per lane from two sources and cannot swap the 128-bit halves, so it would pair row *i*'s low word with row *(i+4)%8*'s high word — wrong hashes with no other symptom.

### Bit-identity

`col_session_get_diff_arrangement` caches an arrangement in the session and extends it incrementally, so rows indexed in one iteration are probed in a later one. A single differing bit strands the earlier rows in buckets the probe never visits and loses join results **silently** — no crash, no error.

Three defences: `_mm256_mullo_epi32` keeps the low 32 bits, which is exactly `uint32_t` multiply; the scalar tail *calls* `col_join_hash_rel_keys` directly, so the two cannot drift under maintenance; and the test pins the hash with golden constants computed independently from the FNV-1a definition rather than captured from this kernel.

`kc == 0` yields the bare offset basis for every row, matching the scalar zero-trip loop. That case is reachable — the ephemeral build does not guard on `key_count`.

## Measurements

Median of 7, core-pinned, `mismatch=0` across the entire grid in both binaries.

| | AVX2 | scalar (`-mno-avx2`) |
|---|---|---|
| kernel alone | **7.2x – 16.9x** | **2.0x – 4.4x** |
| end-to-end build | **1.48x – 2.98x** | **1.24x – 1.69x** |

The scalar row is the interesting one: batching wins even with no vector body, so unlike the filter kernel in #939 this needs **no compile-time non-AVX2 gate**. There, the selection vector measured 0.70x of the fused loop without SIMD and had to be gated.

The benchmark compares against the per-row loop the build sites use today, reproduced verbatim — comparing the kernel against some other batch form would answer a different question. Every configuration verifies both builds produce identical chains and that every hash matches the per-row baseline.

## Mutation testing

The kernel's test is proven to bite. Each of these is detected:

- prime changed in the AVX2 body only
- final `permutevar` reorder dropped
- low/high accumulation order swapped
- accumulator started at 0 instead of the offset basis
- the 128-bit lane swap described above (the `blend` trap)

## What this deliberately does not do

I wired the kernel into the five join hash-table build sites and the full suite passed 252/0. Then the mutation test **did not fire**, so I instrumented instead of assuming:

**Zero of the ~250 test binaries reach the wired code**, and neither does `bench_flowlog`.

The reason is that the live join path does not use `col_join_hash_rel_keys` at all. It builds its table in `arrangement.c` via `arr_hash_rel_key` — a different, byte-at-a-time 64-bit FNV. The `col_join_hash_rel_keys` sites all sit behind `if (!arr)`; they are the fallback for when the persistent arrangement cannot be obtained.

So the wiring was reverted. Shipping it would have added risk to paths nothing exercises, backed by a test that passes against a deliberately broken build.

The kernel and benchmark are kept because they stand on their own: the kernel is correct and proven so, and the benchmark honestly measures it against the loop it was written to replace. What is unproven is whether that loop matters.

Full analysis and next steps recorded in #938.

## Validation

| Check | Result |
|---|---|
| `meson test -C build` | 252 Ok / 0 Fail / 10 skipped |
| ASan + UBSan | 252 Ok / 0 Fail |
| `.text` gate | PASS |
| Mutation battery (5 cases) | all detected |
