### PR TITLE
docs: correct the SIMD claim in the columnar rationale

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -213,7 +213,7 @@ Timely-Differential provides:
 
 ### Why Columnar (not row-major)?
 
-- **SIMD acceleration**: Vectorized comparison, hash, join operations
+- **SIMD acceleration**: Vectorized row comparison and filter scan kernels
 - **Cache efficiency**: Sequential column access improves L1/L2 hit rate
 - **Arrow ecosystem**: Direct mapping to Apache Arrow format
 


### PR DESCRIPTION
`docs/ARCHITECTURE.md:216` claimed vectorized **"comparison, hash, join"** operations. Two thirds of that has been false since #939 removed the unreachable per-key-column kernels — their dispatcher macros (`col_filter_fast`, `hash_int64_keys_fast`, `keys_match_fast`) had zero call sites, so nothing vectorized the join hash or the key match on any target.

## What is actually vectorized today

| | kernel | reached from |
|---|---|---|
| row comparison | `row_cmp_simd_avx2` / `row_cmp_simd_neon` | `row_cmp_dispatch`, called from the consolidate and merge paths (`ops.c:4099`, `ops.c:5358`) |
| filter scan | `col_filter_select_rows` | `col_op_filter`'s simple-comparison fast path (`ops.c:2055`), AVX2 builds |

`col_hash_rows_batch` landed in #942 but has **no production caller**, so it is deliberately not claimed here.

Verified by grep rather than assumed — each of the two above traces to a live call site, and the batch hash traces only to its own definition.

## Why this was not fixed earlier

I deliberately left this line untouched in #941, on the assumption that the join half of the SIMD work would make "hash" and "join" true again.

That assumption is dead. #942 found the join hash sites #938 targets are a fallback path behind `if (!arr)` that the engine never executes — zero calls across ~250 test binaries. The live join hash is `arr_hash_rel_key` in `arrangement.c`, and its observed geometry (median 1 row, max 4) is below the vector width. Details on #938.

So the line needed correcting on its own rather than riding along with work that is not going to happen as scoped.

Line 87 (`SIMD-friendly: Column-major enables vectorized operations on homogeneous data types`) is a property of the layout, not a capability claim, and is left as is.

Documentation only; no code, no build files. `--suite abi` 32/32.