### PR TITLE
perf(columnar): vectorize the arrangement hash build

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1085,6 +1085,23 @@ test_hash_rows_batch_exe = executable(
 
 test('hash_rows_batch', test_hash_rows_batch_exe)
 
+# Differential test for the arrangement batch hash. The kernel runs the
+# arrangement's 64-bit FNV chain in 32-bit arithmetic; the oracle here is the
+# 64-bit form, so a mistake in that width argument surfaces as a mismatch.
+test_arr_hash_rows_batch_exe = executable(
+  'test_arr_hash_rows_batch',
+  files('test_arr_hash_rows_batch.c'),
+  backend_src,
+  files(subdir_wirelog / 'intern.c'),
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('arr_hash_rows_batch', test_arr_hash_rows_batch_exe)
+
 # ============================================================================
 # CRDT W=1 perf-suite gate.
 #

--- a/tests/test_arr_hash_rows_batch.c
+++ b/tests/test_arr_hash_rows_batch.c
@@ -1,0 +1,393 @@
+/*
+ * tests/test_arr_hash_rows_batch.c - arrangement batch hash equivalence
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * arr_hash_rows_batch() must reproduce the arrangement's bucket index
+ * exactly. The arrangement runs a 64-bit FNV-1a byte chain; the kernel runs
+ * the same chain in 32-bit arithmetic and returns it unmasked, on the
+ * argument that only the low 32 bits can ever survive `& (nbuckets - 1)`
+ * when nbuckets is a uint32_t.
+ *
+ * These tests exist to hold that argument to account. The oracle here is the
+ * full 64-bit chain written from the specification -- deliberately NOT the
+ * 32-bit form the kernel uses -- so a mistake in the width argument shows up
+ * as a mismatch rather than being reproduced identically on both sides.
+ *
+ * Why bucket equality matters: arr_update_incremental() extends a cached
+ * arrangement in place, so rows indexed on one call are probed against rows
+ * indexed on another. A divergence leaves earlier rows in buckets the probe
+ * never visits, and join matches disappear with no crash and no error.
+ *
+ *   test_matches_64bit_oracle
+ *       Bucket index from the kernel vs the 64-bit chain, over randomized
+ *       data, every key width, and every plausible nbuckets.
+ *
+ *   test_golden_values
+ *       Hardcoded results computed independently from the FNV-1a definition,
+ *       pinning the basis and the prime themselves.
+ *
+ *   test_full_32_bits
+ *       The strongest form: the kernel's raw output must equal the low 32
+ *       bits of the 64-bit chain, not merely agree after masking. A weaker
+ *       kernel could pass small-nbuckets tests while diverging in high bits.
+ *
+ *   test_row_order / test_lengths / test_row_begin_offset
+ *       Lane placement, counts straddling the 8-row vector width, and a
+ *       non-zero start so the vector loop begins away from the column head.
+ *
+ *   test_extremes / test_repeated_and_reordered_key_cols
+ *       INT64 boundaries, and key lists that repeat or reorder columns.
+ */
+
+#include "../wirelog/columnar/internal.h"
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures;
+
+#define CHECK(cond, ...)                                              \
+        do {                                                              \
+            if (!(cond)) {                                                \
+                printf("  FAIL %s:%d: ", __FILE__, __LINE__);             \
+                printf(__VA_ARGS__);                                      \
+                printf("\n");                                             \
+                failures++;                                               \
+            }                                                             \
+        } while (0)
+
+/*
+ * The arrangement's hash, written from the specification as a 64-bit chain.
+ * Independent of the kernel's 32-bit formulation on purpose.
+ */
+static uint64_t
+ref_hash64(const col_rel_t *rel, uint32_t row, const uint32_t *key_cols,
+    uint32_t key_count)
+{
+    uint64_t h = 14695981039346656037ULL;
+    for (uint32_t k = 0; k < key_count; k++) {
+        uint64_t v = (uint64_t)rel->columns[key_cols[k]][row];
+        for (int b = 0; b < 8; b++) {
+            h ^= v & 0xFFu;
+            h *= 1099511628211ULL;
+            v >>= 8;
+        }
+    }
+    return h;
+}
+
+static col_rel_t *
+make_rel(uint32_t nrows, uint32_t ncols, int64_t (*cb)(uint32_t r, uint32_t c))
+{
+    col_rel_t *rel = col_rel_new_auto("t", ncols);
+    if (!rel)
+        return NULL;
+    int64_t row[16];
+    for (uint32_t r = 0; r < nrows; r++) {
+        for (uint32_t c = 0; c < ncols && c < 16; c++)
+            row[c] = cb(r, c);
+        if (col_rel_append_row(rel, row) != 0) {
+            col_rel_destroy(rel);
+            return NULL;
+        }
+    }
+    return rel;
+}
+
+static int64_t
+mix_cb(uint32_t r, uint32_t c)
+{
+    uint64_t s = (uint64_t)r * 6364136223846793005ull
+        + (uint64_t)c * 1442695040888963407ull + 0x9E3779B97F4A7C15ull;
+    s ^= s >> 29;
+    s *= 0xBF58476D1CE4E5B9ull;
+    s ^= s >> 32;
+    return (int64_t)s;
+}
+
+/* Compare kernel output against the 64-bit oracle over one range. */
+static void
+compare_range(const char *what, const col_rel_t *rel, uint32_t begin,
+    uint32_t end, const uint32_t *key_cols, uint32_t kc)
+{
+    uint32_t n = (end > begin) ? end - begin : 0;
+    uint32_t *got = (uint32_t *)malloc((n ? n : 1) * sizeof(uint32_t));
+    if (!got) {
+        printf("  FAIL %s: allocation\n", what);
+        failures++;
+        return;
+    }
+    memset(got, 0xAB, (n ? n : 1) * sizeof(uint32_t));
+
+    arr_hash_rows_batch(rel, begin, end, key_cols, kc, got);
+
+    /* Every power-of-two table size the arrangement can produce. */
+    static const uint32_t NBUCKETS[] = { 16u, 256u, 4096u, 65536u,
+                                         1u << 24, 1u << 31 };
+
+    for (uint32_t j = 0; j < n; j++) {
+        uint64_t ref = ref_hash64(rel, begin + j, key_cols, kc);
+
+        if (got[j] != (uint32_t)(ref & 0xFFFFFFFFu)) {
+            CHECK(false,
+                "%s [kc=%u begin=%u]: raw out[%u]=0x%08" PRIx32
+                ", low32(ref)=0x%08" PRIx32, what, kc, begin, j, got[j],
+                (uint32_t)(ref & 0xFFFFFFFFu));
+            break;
+        }
+        bool bad = false;
+        for (uint32_t bi = 0; bi < sizeof(NBUCKETS) / sizeof(NBUCKETS[0]);
+            bi++) {
+            uint32_t nb = NBUCKETS[bi];
+            uint32_t want = (uint32_t)(ref & (uint64_t)(nb - 1));
+            if ((got[j] & (nb - 1)) != want) {
+                CHECK(false, "%s [kc=%u nbuckets=%u]: bucket %u != %u", what,
+                    kc, nb, got[j] & (nb - 1), want);
+                bad = true;
+                break;
+            }
+        }
+        if (bad)
+            break;
+    }
+    free(got);
+}
+
+static void
+test_matches_64bit_oracle(void)
+{
+    printf("test_matches_64bit_oracle\n");
+    static const uint32_t KEYSETS[][4] = {
+        { 0 }, { 1 }, { 0, 1 }, { 2, 0 }, { 0, 1, 2 }, { 3, 2, 1, 0 },
+    };
+    static const uint32_t KCS[] = { 1, 1, 2, 2, 3, 4 };
+
+    col_rel_t *rel = make_rel(2000, 4, mix_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    for (uint32_t k = 0; k < 6; k++)
+        compare_range("oracle", rel, 0, 2000, KEYSETS[k], KCS[k]);
+    col_rel_destroy(rel);
+}
+
+/*
+ * The raw output must equal low32 of the 64-bit chain, not merely agree once
+ * masked. compare_range already asserts this; this case states it separately
+ * so a regression names the right thing.
+ */
+static void
+test_full_32_bits(void)
+{
+    printf("test_full_32_bits\n");
+    const uint32_t k0[] = { 0 };
+    col_rel_t *rel = make_rel(256, 1, mix_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    uint32_t got[256];
+    arr_hash_rows_batch(rel, 0, 256, k0, 1, got);
+    for (uint32_t r = 0; r < 256; r++) {
+        uint32_t want = (uint32_t)(ref_hash64(rel, r, k0, 1) & 0xFFFFFFFFu);
+        CHECK(got[r] == want,
+            "row %u: 0x%08" PRIx32 " != low32 0x%08" PRIx32, r, got[r], want);
+        if (got[r] != want)
+            break;
+    }
+    col_rel_destroy(rel);
+}
+
+static int64_t
+golden_cb(uint32_t r, uint32_t c)
+{
+    (void)c;
+    return (int64_t)r;
+}
+
+static void
+test_golden_values(void)
+{
+    printf("test_golden_values\n");
+    col_rel_t *rel = make_rel(8, 1, golden_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    const uint32_t k0[] = { 0 };
+    uint32_t got[8];
+    arr_hash_rows_batch(rel, 0, 8, k0, 1, got);
+
+    /*
+     * Computed independently from the FNV-1a definition (64-bit chain over
+     * the eight bytes of the key, then truncated), not captured from this
+     * kernel. These pin the basis and the prime themselves.
+     */
+    static const uint32_t GOLDEN[8] = {
+        0x281A39C5u, 0x1D2AEFA4u, 0x3DF8CE07u, 0x330983E6u,
+        0xFC5D1141u, 0xF16DC720u, 0x123BA583u, 0x074C5B62u,
+    };
+    for (uint32_t r = 0; r < 8; r++)
+        CHECK(got[r] == GOLDEN[r],
+            "golden row %u: 0x%08" PRIx32 " != 0x%08" PRIx32, r, got[r],
+            GOLDEN[r]);
+    col_rel_destroy(rel);
+}
+
+static int64_t
+distinct_cb(uint32_t r, uint32_t c)
+{
+    (void)c;
+    return (int64_t)(((uint64_t)(r + 1) << 32) | (uint64_t)(0xFEED0000u + r));
+}
+
+static void
+test_row_order(void)
+{
+    printf("test_row_order\n");
+    col_rel_t *rel = make_rel(64, 1, distinct_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    const uint32_t k0[] = { 0 };
+    uint32_t got[64];
+    arr_hash_rows_batch(rel, 0, 64, k0, 1, got);
+    for (uint32_t r = 0; r < 64; r++) {
+        uint32_t want = (uint32_t)(ref_hash64(rel, r, k0, 1) & 0xFFFFFFFFu);
+        CHECK(got[r] == want, "row %u landed wrong: 0x%08" PRIx32
+            " != 0x%08" PRIx32, r, got[r], want);
+        if (got[r] != want)
+            break;
+    }
+    col_rel_destroy(rel);
+}
+
+static void
+test_lengths(void)
+{
+    printf("test_lengths\n");
+    static const uint32_t LENGTHS[] = { 0, 1, 2, 7, 8, 9, 15, 16, 17, 31, 32,
+                                        33, 63, 64, 65, 1023, 1024, 1025 };
+    const uint32_t k01[] = { 0, 1 };
+
+    col_rel_t *rel = make_rel(1025, 2, mix_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    for (uint32_t i = 0; i < sizeof(LENGTHS) / sizeof(LENGTHS[0]); i++) {
+        compare_range("len", rel, 0, LENGTHS[i], k01, 1);
+        compare_range("len", rel, 0, LENGTHS[i], k01, 2);
+    }
+    col_rel_destroy(rel);
+}
+
+static void
+test_row_begin_offset(void)
+{
+    printf("test_row_begin_offset\n");
+    const uint32_t k0[] = { 0 };
+    col_rel_t *rel = make_rel(600, 1, mix_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    static const uint32_t BEGINS[] = { 1, 3, 7, 8, 9, 16, 100, 511, 592, 599 };
+    for (uint32_t i = 0; i < sizeof(BEGINS) / sizeof(BEGINS[0]); i++) {
+        compare_range("offset", rel, BEGINS[i], 600, k0, 1);
+        compare_range("offset_mid", rel, BEGINS[i],
+            BEGINS[i] + 17 < 600 ? BEGINS[i] + 17 : 600, k0, 1);
+    }
+    compare_range("empty", rel, 42, 42, k0, 1);
+    compare_range("inverted", rel, 100, 50, k0, 1);
+    col_rel_destroy(rel);
+}
+
+static int64_t extreme_vals[9] = { INT64_MIN, INT64_MIN + 1, -2147483649LL, -1,
+                                   0, 1, 2147483648LL, INT64_MAX - 1,
+                                   INT64_MAX };
+
+static int64_t
+extreme_cb(uint32_t r, uint32_t c)
+{
+    return extreme_vals[(r + c * 3u) % 9u];
+}
+
+static void
+test_extremes(void)
+{
+    printf("test_extremes\n");
+    const uint32_t k01[] = { 0, 1 };
+    col_rel_t *rel = make_rel(90, 2, extreme_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    compare_range("extremes", rel, 0, 90, k01, 1);
+    compare_range("extremes", rel, 0, 90, k01, 2);
+    col_rel_destroy(rel);
+}
+
+static void
+test_repeated_and_reordered_key_cols(void)
+{
+    printf("test_repeated_and_reordered_key_cols\n");
+    static const uint32_t REPEAT[] = { 2, 2 };
+    static const uint32_t REORDER[] = { 3, 1 };
+    static const uint32_t REVERSE[] = { 3, 2, 1, 0 };
+
+    col_rel_t *rel = make_rel(300, 4, mix_cb);
+    if (!rel) {
+        printf("  FAIL relation build\n");
+        failures++;
+        return;
+    }
+    compare_range("repeat", rel, 0, 300, REPEAT, 2);
+    compare_range("reorder", rel, 0, 300, REORDER, 2);
+    compare_range("reverse", rel, 0, 300, REVERSE, 4);
+    col_rel_destroy(rel);
+}
+
+int
+main(void)
+{
+    printf("=== arr_hash_rows_batch equivalence ===\n");
+#ifdef __AVX2__
+    printf("(AVX2 kernel compiled in)\n");
+#else
+    printf("(scalar kernel only)\n");
+#endif
+
+    test_matches_64bit_oracle();
+    test_full_32_bits();
+    test_golden_values();
+    test_row_order();
+    test_lengths();
+    test_row_begin_offset();
+    test_extremes();
+    test_repeated_and_reordered_key_cols();
+
+    if (failures) {
+        printf("=== %d FAILURE(S) ===\n", failures);
+        return 1;
+    }
+    printf("=== all passed ===\n");
+    return 0;
+}

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -13,6 +13,10 @@
 
 #include "../wirelog-internal.h"
 
+#if defined(__AVX2__)
+#include <immintrin.h>
+#endif
+
 #include <errno.h>
 #ifndef _MSC_VER
 #include <stdatomic.h>
@@ -45,20 +49,135 @@ arr_hash_key(const int64_t *row, const uint32_t *key_cols, uint32_t key_count,
     return (uint32_t)(h & (uint64_t)(nbuckets - 1));
 }
 
-static uint32_t
-arr_hash_rel_key(const col_rel_t *rel, uint32_t row,
-    const uint32_t *key_cols, uint32_t key_count, uint32_t nbuckets)
+/*
+ * arr_hash_rows_batch:
+ * Hash a contiguous run of rows in one call, for the arrangement build.
+ *
+ * Returns the low 32 bits of the same FNV-1a chain arr_hash_key() computes
+ * on the probe side; callers apply `& (nbuckets - 1)` themselves.  See
+ * internal.h for the contract.
+ *
+ * Why 32-bit arithmetic reproduces a 64-bit hash exactly
+ * -----------------------------------------------------
+ * The arrangement hash runs a 64-bit chain but only its low bits are ever
+ * observed: the result is masked with `nbuckets - 1`, and nbuckets is a
+ * uint32_t, so at most the low 32 bits can survive.
+ *
+ * Those low 32 bits are computable in 32-bit arithmetic alone. Each step is
+ * h = (h ^ byte) * PRIME. Multiplication modulo 2^32 depends only on its
+ * operands modulo 2^32, and xoring in a byte touches only the low 8 bits, so
+ * low32(h_next) is a function of low32(h) and the byte -- the high half never
+ * feeds back. Starting from low32 of the basis therefore tracks the 64-bit
+ * chain's low half exactly, step for step.
+ *
+ * That matters because AVX2 has no 64x64->64 multiply; emulating one costs
+ * several instructions and would have made this barely worth vectorizing. In
+ * 32-bit form each step is a single _mm256_mullo_epi32 over eight rows.
+ */
+void
+arr_hash_rows_batch(const col_rel_t *rel, uint32_t row_begin, uint32_t row_end,
+    const uint32_t *key_cols, uint32_t key_count, uint32_t *out_hashes)
 {
-    uint64_t h = 14695981039346656037ULL; /* FNV-1a basis */
-    for (uint32_t k = 0; k < key_count; k++) {
-        uint64_t v = (uint64_t)rel->columns[key_cols[k]][row];
-        for (int b = 0; b < 8; b++) {
-            h ^= v & 0xFFu;
-            h *= 1099511628211ULL;
-            v >>= 8;
+    if (row_begin >= row_end)
+        return;
+
+    const uint32_t n = row_end - row_begin;
+    const uint32_t basis32 = (uint32_t)14695981039346656037ULL;
+    const uint32_t prime32 = (uint32_t)1099511628211ULL;
+    uint32_t r = 0;
+
+#ifdef __AVX2__
+    /*
+     * Eight rows per iteration. Each key column contributes eight dependent
+     * steps, one per byte, but all eight rows advance together.
+     *
+     * The two 256-bit loads hold rows r..r+3 and r+4..r+7 as four int64_t
+     * each. Rather than deinterleave, the byte for step b is extracted with a
+     * variable shift and a mask, then packed to 32-bit lanes -- the same
+     * shuffle/unpack trick used by the join kernel is unnecessary here
+     * because we need one byte at a time, not whole words.
+     */
+    const __m256i prime_v = _mm256_set1_epi32((int)prime32);
+    const __m256i bytemask = _mm256_set1_epi32(0xFF);
+    const __m256i pack = _mm256_setr_epi32(0, 2, 4, 6, 0, 2, 4, 6);
+
+    for (; n >= 8 && r <= n - 8; r += 8) {
+        __m256i h = _mm256_set1_epi32((int)basis32);
+
+        for (uint32_t k = 0; k < key_count; k++) {
+            const int64_t *col = rel->columns[key_cols[k]] + row_begin + r;
+            __m256i a0 = _mm256_loadu_si256((const __m256i *)col);
+            __m256i a1 = _mm256_loadu_si256((const __m256i *)(col + 4));
+
+            for (int b = 0; b < 8; b++) {
+                /* Byte b of each row, as eight 32-bit lanes in row order. */
+                __m256i s0 = _mm256_srli_epi64(a0, b * 8);
+                __m256i s1 = _mm256_srli_epi64(a1, b * 8);
+                s0 = _mm256_and_si256(s0, bytemask);
+                s1 = _mm256_and_si256(s1, bytemask);
+
+                /* Each holds 4 values in the even 32-bit lanes; gather them
+                 * into the low half, then join the two groups. */
+                __m256i p0 = _mm256_permutevar8x32_epi32(s0, pack);
+                __m256i p1 = _mm256_permutevar8x32_epi32(s1, pack);
+                __m256i bytes = _mm256_permute2x128_si256(p0, p1, 0x20);
+
+                h = _mm256_mullo_epi32(_mm256_xor_si256(h, bytes), prime_v);
+            }
         }
+
+        _mm256_storeu_si256((__m256i *)(out_hashes + r), h);
     }
-    return (uint32_t)(h & (uint64_t)(nbuckets - 1));
+#endif /* __AVX2__ */
+
+    for (; r < n; r++) {
+        uint32_t h = basis32;
+        for (uint32_t k = 0; k < key_count; k++) {
+            uint64_t v = (uint64_t)rel->columns[key_cols[k]][row_begin + r];
+            for (int b = 0; b < 8; b++) {
+                h = (h ^ (uint32_t)(v & 0xFFu)) * prime32;
+                v >>= 8;
+            }
+        }
+        out_hashes[r] = h;
+    }
+}
+
+/*
+ * arr_index_rows:
+ * Hash rows [@begin, @nrows) in batches and prepend each to its bucket chain.
+ *
+ * Chains use a UINT32_MAX empty sentinel and store the row index directly.
+ * Rows are inserted in ascending order exactly as the per-row loop did, so
+ * chain order is preserved bucket for bucket.
+ *
+ * The scratch tile is on the stack (ARR_HASH_TILE * 4 bytes), so this adds no
+ * allocation and no failure path to the arrangement build.
+ */
+static void
+arr_index_rows(col_arrangement_t *arr, const col_rel_t *rel, uint32_t begin,
+    uint32_t nrows, uint32_t nbuckets)
+{
+    uint32_t scratch[ARR_HASH_TILE];
+
+    for (uint32_t base = begin; base < nrows;) {
+        uint32_t chunk = nrows - base;
+        if (chunk > ARR_HASH_TILE)
+            chunk = ARR_HASH_TILE;
+
+        arr_hash_rows_batch(rel, base, base + chunk, arr->key_cols,
+            arr->key_count, scratch);
+
+        for (uint32_t j = 0; j < chunk; j++) {
+            uint32_t row = base + j;
+            uint32_t bucket = scratch[j] & (nbuckets - 1);
+            arr->ht_next[row] = arr->ht_head[bucket];
+            arr->ht_head[bucket] = row;
+        }
+
+        /* Advance by the clamped chunk so base cannot wrap past UINT32_MAX. */
+        base += chunk;
+    }
 }
 
 static bool
@@ -139,12 +258,7 @@ arr_build_full(col_arrangement_t *arr, const col_rel_t *rel)
         arr->ht_cap = new_cap;
     }
 
-    for (uint32_t row = 0; row < nrows; row++) {
-        uint32_t bucket = arr_hash_rel_key(rel, row, arr->key_cols,
-                arr->key_count, nbuckets);
-        arr->ht_next[row] = arr->ht_head[bucket];
-        arr->ht_head[bucket] = row;
-    }
+    arr_index_rows(arr, rel, 0, nrows, nbuckets);
     arr->indexed_rows = nrows;
     return 0;
 }
@@ -175,12 +289,10 @@ arr_update_incremental(col_arrangement_t *arr, const col_rel_t *rel,
     }
 
     uint32_t nb = arr->nbuckets;
-    for (uint32_t row = old_nrows; row < nrows; row++) {
-        uint32_t bucket = arr_hash_rel_key(rel, row, arr->key_cols,
-                arr->key_count, nb);
-        arr->ht_next[row] = arr->ht_head[bucket];
-        arr->ht_head[bucket] = row;
-    }
+    /* Extends a cached arrangement in place: rows indexed here are probed
+     * against rows indexed by earlier calls, so these buckets must match what
+     * arr_hash_key() computes on the probe side.  See arr_hash_rows_batch. */
+    arr_index_rows(arr, rel, old_nrows, nrows, nb);
     arr->indexed_rows = nrows;
     return 0;
 }

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1854,4 +1854,43 @@ void
 col_hash_rows_batch(const col_rel_t *rel, uint32_t row_begin, uint32_t row_end,
     const uint32_t *key_cols, uint32_t kc, uint32_t *out_hashes);
 
+/*
+ * ARR_HASH_TILE:
+ * Rows hashed per arr_hash_rows_batch() call when a caller tiles a large
+ * range.  Bounds the scratch buffer an arrangement build needs.
+ */
+#define ARR_HASH_TILE 1024u
+
+/*
+ * arr_hash_rows_batch:
+ * Hash rows [@row_begin, @row_end) of @rel over @key_count key columns,
+ * writing @row_end - @row_begin results to @out_hashes, indexed RELATIVE to
+ * @row_begin.
+ *
+ * Returns the low 32 bits of the arrangement's FNV-1a chain, UNMASKED.  A
+ * caller reproduces the arrangement bucket with `out_hashes[j] & (nbuckets -
+ * 1)`, which must equal what arr_hash_key() computes on the probe side for
+ * the same key values.
+ *
+ * Only the low 32 bits are needed because nbuckets is a uint32_t, so the
+ * mask can never expose more; and those low bits are exactly reproducible in
+ * 32-bit arithmetic, since multiplication modulo 2^32 depends only on its
+ * operands modulo 2^32.  See the definition for the full argument.
+ *
+ * Bucket equality is load-bearing, not incidental: arr_update_incremental()
+ * extends a cached arrangement in place, so rows indexed by one code path are
+ * probed against rows indexed by another.  A divergence would leave earlier
+ * rows in buckets the probe never visits and silently drop join matches.
+ *
+ * @row_end must not exceed rel->nrows; row_begin >= row_end is a no-op.  No
+ * slack is required in @out_hashes: the vector loop runs only while eight
+ * whole rows remain and writes exactly eight lanes for them.
+ *
+ * Exposed (not static) so tests and benchmarks can drive it directly.  Not
+ * public API and not exported: the library builds with hidden visibility.
+ */
+void
+arr_hash_rows_batch(const col_rel_t *rel, uint32_t row_begin, uint32_t row_end,
+    const uint32_t *key_cols, uint32_t key_count, uint32_t *out_hashes);
+
 #endif /* WL_COLUMNAR_INTERNAL_H */


### PR DESCRIPTION
Vectorizes the hash the join actually builds against. Follows #942, which established the kernel pattern but targeted a path the engine never executes — see [that analysis](https://github.com/semantic-reasoning/wirelog/issues/938#issuecomment-5163061910).

## The enabling observation

`arr_hash_rel_key` was a byte-at-a-time **64-bit** FNV-1a: eight dependent 64-bit multiplies per key column per row. AVX2 has no 64×64→64 multiply, and emulating one costs several instructions — enough to make vectorizing not obviously worth it.

But 64-bit arithmetic turns out to be unnecessary. The result is only ever consumed as `h & (nbuckets - 1)`, and `nbuckets` is a `uint32_t`, so **at most the low 32 bits can survive**. Those low bits are computable in 32-bit arithmetic alone:

- multiplication modulo 2³² depends only on its operands modulo 2³²
- xoring in a byte touches only the low eight bits

so the high half never feeds back into the low half. Starting from `low32(basis)` tracks the 64-bit chain's low half exactly, step for step.

I verified this over 200k random cases across `kc ∈ {1,2,4}` **before writing any kernel code**. In 32-bit form each step becomes a single `_mm256_mullo_epi32` across eight rows.

## Correctness

Bucket equality is load-bearing, not incidental. `arr_update_incremental` extends a cached arrangement **in place**, so rows indexed by one call are probed against rows indexed by another. A divergence would leave earlier rows in buckets the probe never visits and drop join matches silently — no crash, no error.

The oracle in the test is the **64-bit** chain written from the specification, deliberately *not* the kernel's 32-bit form. An error in the width argument therefore surfaces as a mismatch instead of being reproduced identically on both sides. Golden constants are computed independently from the FNV-1a definition, pinning the basis and the prime themselves.

**Mutation-tested**, all caught:

| mutation | detected |
|---|---|
| wrong prime in the AVX2 body only | 68 failures |
| byte order reversed | 63 |
| accumulator not the basis | 68 |
| row order reversed within a group | 68 |
| row groups swapped | 68 |
| wrong half of each `int64` selected | 67 |

Two further mutations (`pack` upper half, `permute2x128` selector) were *not* caught — on inspection they are genuine no-ops, because the `pack` vector duplicates its pattern so the selector cannot matter. Confirmed by re-running variants that do change lane placement, which fire.

## This path is actually executed

The lesson from #942. Verified by instrumentation, not assumed:

```
arr_index_rows reached by: 50 of 401 test binaries
```

versus **0 of ~250** for the fallback sites #938 originally named.

## Measurements

Kernel, core-pinned, 2M rows:

| key cols | scalar | batch | speedup |
|---|---|---|---|
| 1 | 12.63 ms | 5.52 ms | **2.29x** |
| 2 | 25.50 ms | 11.39 ms | **2.24x** |
| 4 | 54.29 ms | 24.71 ms | **2.20x** |

End-to-end benefit scales with key count, since the hash is a larger share of a wider key's work. On a 1M-row equijoin:

| key cols | hash share | end-to-end saving |
|---|---|---|
| 1 | 5.2% | ~2.9% |
| 2 | 10.5% | ~5.9% |
| 4 | 22.4% | ~12.6% |

**Honest note on kc=1:** my first end-to-end probe used a single key column and measured *no* change (121 → 122 ms). That is consistent — a 2.9% saving is below what the harness resolves. An earlier "12% of total" estimate I quoted on #938 came from an unpinned single run and was wrong; these figures replace it. No end-to-end claim is made at kc=1.

## Incidental removal

`arr_hash_rel_key` lost its last caller once both build loops were converted, which produced exactly the `-Wunused-function` class just cleaned up in #941. It is removed. `arr_hash_key` — its probe-side twin, same hash, row-pointer form — stays, and is now the function the batch kernel must agree with.

## Validation

| Check | Result |
|---|---|
| `meson test -C build` | 253 Ok / 0 Fail / 10 skipped |
| ASan + UBSan | 253 Ok / 0 Fail |
| `.text` gate | PASS |
| Mutation battery | 6/6 meaningful mutations caught |

Does not close #938: the fallback-path question that issue originally raised is settled (those sites are dead), but the issue should be re-titled or closed deliberately rather than by this PR.
