### PR TITLE
bench: make the DOOP benchmark reproducible from the shipped archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ third_party/nanoarrow-vendor/
 .claude/
 
 # Large benchmark datasets (download via bench/data/*/download.sh)
-bench/data/doop/*.csv
+bench/data/doop/*.facts
 
 # OS specific
 .DS_Store

--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -2259,7 +2259,7 @@ run_crdt_workload(const char *data_dir, uint32_t workers, int repeat)
  * Magic constants are zxing-specific pre-hashed integer IDs. */
 
 #define DOOP_SRC_BUFSZ ((size_t)64 * 1024)
-#define DOOP_NRELS 34
+#define DOOP_NRELS 35
 
 struct doop_edb {
     const char *name;
@@ -2268,179 +2268,184 @@ struct doop_edb {
 };
 
 static const struct doop_edb doop_edbs[DOOP_NRELS] = {
-    { "DirectSuperclass", "(class: int32, superclass: int32)",
-      "DirectSuperclass.csv" },
-    { "DirectSuperinterface", "(ref: int32, interface: int32)",
-      "DirectSuperinterface.csv" },
-    { "MainClass", "(class: int32)", "MainClass.csv" },
-    { "FormalParam", "(index: int32, method: int32, var: int32)",
-      "FormalParam.csv" },
-    { "ComponentType", "(arrayType: int32, componentType: int32)",
-      "ComponentType.csv" },
-    { "AssignReturnValue", "(invocation: int32, to: int32)",
-      "AssignReturnValue.csv" },
-    { "ActualParam", "(index: int32, invocation: int32, var: int32)",
-      "ActualParam.csv" },
-    { "Method_Modifier", "(mod: int32, method: int32)", "Method_Modifier.csv" },
-    { "Var_Type", "(var: int32, type: int32)", "Var_Type.csv" },
-    { "HeapAllocation_Type", "(heap: int32, type: int32)",
-      "HeapAllocation_Type.csv" },
-    { "_ClassType", "(class: int32)", "ClassType.csv" },
-    { "_ArrayType", "(arrayType: int32)", "ArrayType.csv" },
-    { "_InterfaceType", "(interface: int32)", "InterfaceType.csv" },
-    { "_Var_DeclaringMethod", "(var: int32, method: int32)",
-      "Var_DeclaringMethod.csv" },
-    { "_ApplicationClass", "(type: int32)", "ApplicationClass.csv" },
-    { "_ThisVar", "(method: int32, var: int32)", "ThisVar.csv" },
-    { "_NormalHeap", "(id: int32, type: int32)", "NormalHeap.csv" },
-    { "_StringConstant", "(id: int32)", "StringConstant.csv" },
+    { "DirectSuperclass", "(class: string, superclass: string)",
+      "DirectSuperclass.facts" },
+    { "DirectSuperinterface", "(ref: string, interface: string)",
+      "DirectSuperinterface.facts" },
+    { "MainClass", "(class: string)", "MainClass.facts" },
+    { "FormalParam", "(index: string, method: string, var: string)",
+      "FormalParam.facts" },
+    { "ComponentType", "(arrayType: string, componentType: string)",
+      "ComponentType.facts" },
+    { "AssignReturnValue", "(invocation: string, to: string)",
+      "AssignReturnValue.facts" },
+    { "ActualParam", "(index: string, invocation: string, var: string)",
+      "ActualParam.facts" },
+    { "Method_Modifier", "(mod: string, method: string)",
+      "Method-Modifier.facts" },
+    { "Var_Type", "(var: string, type: string)", "Var-Type.facts" },
+    { "_ClassType", "(class: string)", "ClassType.facts" },
+    { "_ArrayType", "(arrayType: string)", "ArrayType.facts" },
+    { "_InterfaceType", "(interface: string)", "InterfaceType.facts" },
+    { "_Var_DeclaringMethod", "(var: string, method: string)",
+      "Var-DeclaringMethod.facts" },
+    { "_ApplicationClass", "(type: string)", "ApplicationClass.facts" },
+    { "_ThisVar", "(method: string, var: string)", "ThisVar.facts" },
+    { "_NormalHeap", "(id: string, type: string)", "NormalHeap.facts" },
+    { "_StringConstant", "(id: string)", "StringConstant.facts" },
     { "_AssignHeapAllocation",
-      "(instruction: int32, idx: int32, heap: int32, to: int32, "
-      "inmethod: int32, linenumber: int32)",
-      "AssignHeapAllocation.csv" },
+      "(instruction: string, idx: string, heap: string, to: string, "
+      "inmethod: string, linenumber: string)",
+      "AssignHeapAllocation.facts" },
     { "_AssignLocal",
-      "(instruction: int32, idx: int32, from: int32, to: int32, "
-      "inmethod: int32)",
-      "AssignLocal.csv" },
+      "(instruction: string, idx: string, from: string, to: string, "
+      "inmethod: string)",
+      "AssignLocal.facts" },
     { "_AssignCast",
-      "(instruction: int32, idx: int32, from: int32, to: int32, "
-      "type: int32, inmethod: int32)",
-      "AssignCast.csv" },
+      "(instruction: string, idx: string, from: string, to: string, "
+      "type: string, inmethod: string)",
+      "AssignCast.facts" },
     { "_Field",
-      "(signature: int32, declaringClass: int32, simplename: int32, "
-      "type: int32)",
-      "Field.csv" },
+      "(signature: string, declaringClass: string, simplename: string, "
+      "type: string)",
+      "Field.facts" },
     { "_StaticMethodInvocation",
-      "(instruction: int32, idx: int32, signature: int32, method: int32)",
-      "StaticMethodInvocation.csv" },
+      "(instruction: string, idx: string, signature: string, method: string)",
+      "StaticMethodInvocation.facts" },
     { "_SpecialMethodInvocation",
-      "(instruction: int32, idx: int32, signature: int32, base: int32, "
-      "method: int32)",
-      "SpecialMethodInvocation.csv" },
+      "(instruction: string, idx: string, signature: string, base: string, "
+      "method: string)",
+      "SpecialMethodInvocation.facts" },
     { "_VirtualMethodInvocation",
-      "(instruction: int32, idx: int32, signature: int32, base: int32, "
-      "method: int32)",
-      "VirtualMethodInvocation.csv" },
+      "(instruction: string, idx: string, signature: string, base: string, "
+      "method: string)",
+      "VirtualMethodInvocation.facts" },
     { "_Method",
-      "(method: int32, simplename: int32, params: int32, "
-      "declaringType: int32, returnType: int32, jvmDescriptor: int32, "
-      "arity: int32)",
-      "Method.csv" },
-    { "Method_Descriptor", "(method: int32, descriptor: int32)",
-      "Method_Descriptor.csv" },
+      "(method: string, simplename: string, params: string, "
+      "declaringType: string, returnType: string, jvmDescriptor: string, "
+      "arity: string)",
+      "Method.facts" },
     { "_StoreInstanceField",
-      "(instruction: int32, idx: int32, from: int32, base: int32, "
-      "signature: int32, method: int32)",
-      "StoreInstanceField.csv" },
+      "(instruction: string, idx: string, from: string, base: string, "
+      "signature: string, method: string)",
+      "StoreInstanceField.facts" },
     { "_LoadInstanceField",
-      "(instruction: int32, idx: int32, to: int32, base: int32, "
-      "signature: int32, method: int32)",
-      "LoadInstanceField.csv" },
+      "(instruction: string, idx: string, to: string, base: string, "
+      "signature: string, method: string)",
+      "LoadInstanceField.facts" },
     { "_StoreStaticField",
-      "(instruction: int32, idx: int32, from: int32, signature: int32, "
-      "method: int32)",
-      "StoreStaticField.csv" },
+      "(instruction: string, idx: string, from: string, signature: string, "
+      "method: string)",
+      "StoreStaticField.facts" },
     { "_LoadStaticField",
-      "(instruction: int32, idx: int32, to: int32, signature: int32, "
-      "method: int32)",
-      "LoadStaticField.csv" },
+      "(instruction: string, idx: string, to: string, signature: string, "
+      "method: string)",
+      "LoadStaticField.facts" },
     { "_StoreArrayIndex",
-      "(instruction: int32, idx: int32, from: int32, base: int32, "
-      "method: int32)",
-      "StoreArrayIndex.csv" },
+      "(instruction: string, idx: string, from: string, base: string, "
+      "method: string)",
+      "StoreArrayIndex.facts" },
     { "_LoadArrayIndex",
-      "(instruction: int32, idx: int32, to: int32, base: int32, "
-      "method: int32)",
-      "LoadArrayIndex.csv" },
-    { "_Return", "(instruction: int32, idx: int32, var: int32, method: int32)",
-      "Return.csv" },
+      "(instruction: string, idx: string, to: string, base: string, "
+      "method: string)",
+      "LoadArrayIndex.facts" },
+    { "_Return",
+      "(instruction: string, idx: string, var: string, method: string)",
+      "Return.facts" },
+    { "_ClassHeap", "(heap: string, type: string)", "ClassHeap.facts" },
+    { "_MethodHandleConstant",
+      "(id: string, type: string, a: string, b: string, c: string)",
+      "MethodHandleConstant.facts" },
+    { "_MethodTypeConstant",
+      "(descriptor: string, idx: string, type: string, d: string)",
+      "MethodTypeConstant.facts" },
 };
 
 /* IDB declarations + all ~130 rules */
 static const char *doop_rules
 /* IDB: Narrow schema */
-    = ".decl isType(t: int32)\n"
-    ".decl isReferenceType(t: int32)\n"
-    ".decl isArrayType(t: int32)\n"
-    ".decl isClassType(t: int32)\n"
-    ".decl isInterfaceType(t: int32)\n"
-    ".decl ApplicationClass(ref: int32)\n"
-    ".decl Field_DeclaringType(field: int32, declaringClass: int32)\n"
-    ".decl Method_DeclaringType(method: int32, declaringType: int32)\n"
-    ".decl Method_SimpleName(method: int32, simpleName: int32)\n"
-    ".decl ThisVar(method: int32, var: int32)\n"
-    ".decl Var_DeclaringMethod(var: int32, method: int32)\n"
-    ".decl Instruction_Method(insn: int32, inMethod: int32)\n"
-    ".decl isVirtualMethodInvocation_Insn(insn: int32)\n"
-    ".decl isStaticMethodInvocation_Insn(insn: int32)\n"
-    ".decl FieldInstruction_Signature(insn: int32, sign: int32)\n"
-    ".decl LoadInstanceField_Base(insn: int32, var: int32)\n"
-    ".decl LoadInstanceField_To(insn: int32, var: int32)\n"
-    ".decl StoreInstanceField_From(insn: int32, var: int32)\n"
-    ".decl StoreInstanceField_Base(insn: int32, var: int32)\n"
-    ".decl LoadStaticField_To(insn: int32, var: int32)\n"
-    ".decl StoreStaticField_From(insn: int32, var: int32)\n"
-    ".decl LoadArrayIndex_Base(insn: int32, var: int32)\n"
-    ".decl LoadArrayIndex_To(insn: int32, var: int32)\n"
-    ".decl StoreArrayIndex_From(insn: int32, var: int32)\n"
-    ".decl StoreArrayIndex_Base(insn: int32, var: int32)\n"
-    ".decl AssignInstruction_To(insn: int32, to: int32)\n"
-    ".decl AssignCast_From(insn: int32, from: int32)\n"
-    ".decl AssignCast_Type(insn: int32, type: int32)\n"
-    ".decl AssignLocal_From(insn: int32, from: int32)\n"
-    ".decl AssignHeapAllocation_Heap(insn: int32, heap: int32)\n"
-    ".decl ReturnNonvoid_Var(ret: int32, var: int32)\n"
-    ".decl MethodInvocation_Method(invocation: int32, signature: int32)\n"
-    ".decl VirtualMethodInvocation_Base(invocation: int32, base: int32)\n"
-    ".decl VirtualMethodInvocation_SimpleName(invocation: int32, "
-    "simplename: int32)\n"
-    ".decl VirtualMethodInvocation_Descriptor(invocation: int32, "
-    "descriptor: int32)\n"
-    ".decl SpecialMethodInvocation_Base(invocation: int32, base: int32)\n"
-    ".decl MethodInvocation_Base(invocation: int32, base: int32)\n"
+    = ".decl isType(t: string)\n"
+    ".decl isReferenceType(t: string)\n"
+    ".decl isArrayType(t: string)\n"
+    ".decl isClassType(t: string)\n"
+    ".decl isInterfaceType(t: string)\n"
+    ".decl ApplicationClass(ref: string)\n"
+    ".decl Field_DeclaringType(field: string, declaringClass: string)\n"
+    ".decl Method_DeclaringType(method: string, declaringType: string)\n"
+    ".decl Method_SimpleName(method: string, simpleName: string)\n"
+    ".decl ThisVar(method: string, var: string)\n"
+    ".decl Var_DeclaringMethod(var: string, method: string)\n"
+    ".decl Instruction_Method(insn: string, inMethod: string)\n"
+    ".decl isVirtualMethodInvocation_Insn(insn: string)\n"
+    ".decl isStaticMethodInvocation_Insn(insn: string)\n"
+    ".decl FieldInstruction_Signature(insn: string, sign: string)\n"
+    ".decl LoadInstanceField_Base(insn: string, var: string)\n"
+    ".decl LoadInstanceField_To(insn: string, var: string)\n"
+    ".decl StoreInstanceField_From(insn: string, var: string)\n"
+    ".decl StoreInstanceField_Base(insn: string, var: string)\n"
+    ".decl LoadStaticField_To(insn: string, var: string)\n"
+    ".decl StoreStaticField_From(insn: string, var: string)\n"
+    ".decl LoadArrayIndex_Base(insn: string, var: string)\n"
+    ".decl LoadArrayIndex_To(insn: string, var: string)\n"
+    ".decl StoreArrayIndex_From(insn: string, var: string)\n"
+    ".decl StoreArrayIndex_Base(insn: string, var: string)\n"
+    ".decl AssignInstruction_To(insn: string, to: string)\n"
+    ".decl AssignCast_From(insn: string, from: string)\n"
+    ".decl AssignCast_Type(insn: string, type: string)\n"
+    ".decl AssignLocal_From(insn: string, from: string)\n"
+    ".decl AssignHeapAllocation_Heap(insn: string, heap: string)\n"
+    ".decl ReturnNonvoid_Var(ret: string, var: string)\n"
+    ".decl MethodInvocation_Method(invocation: string, signature: string)\n"
+    ".decl VirtualMethodInvocation_Base(invocation: string, base: string)\n"
+    ".decl VirtualMethodInvocation_SimpleName(invocation: string, "
+    "simplename: string)\n"
+    ".decl VirtualMethodInvocation_Descriptor(invocation: string, "
+    "descriptor: string)\n"
+    ".decl SpecialMethodInvocation_Base(invocation: string, base: string)\n"
+    ".decl MethodInvocation_Base(invocation: string, base: string)\n"
     /* IDB: Fat schema */
-    ".decl LoadInstanceField(base: int32, sig: int32, to: int32, "
-    "inmethod: int32)\n"
-    ".decl StoreInstanceField(from: int32, base: int32, signature: int32, "
-    "inmethod: int32)\n"
-    ".decl LoadStaticField(sig: int32, to: int32, inmethod: int32)\n"
-    ".decl StoreStaticField(from: int32, signature: int32, "
-    "inmethod: int32)\n"
-    ".decl LoadArrayIndex(base: int32, to: int32, inmethod: int32)\n"
-    ".decl StoreArrayIndex(from: int32, base: int32, inmethod: int32)\n"
-    ".decl AssignCast(type: int32, from: int32, to: int32, "
-    "inmethod: int32)\n"
-    ".decl AssignLocal(from: int32, to: int32, inmethod: int32)\n"
-    ".decl AssignHeapAllocation(heap: int32, to: int32, "
-    "inmethod: int32)\n"
-    ".decl ReturnVar(var: int32, method: int32)\n"
-    ".decl StaticMethodInvocation(invocation: int32, signature: int32, "
-    "inmethod: int32)\n"
+    ".decl LoadInstanceField(base: string, sig: string, to: string, "
+    "inmethod: string)\n"
+    ".decl StoreInstanceField(from: string, base: string, signature: string, "
+    "inmethod: string)\n"
+    ".decl LoadStaticField(sig: string, to: string, inmethod: string)\n"
+    ".decl StoreStaticField(from: string, signature: string, "
+    "inmethod: string)\n"
+    ".decl LoadArrayIndex(base: string, to: string, inmethod: string)\n"
+    ".decl StoreArrayIndex(from: string, base: string, inmethod: string)\n"
+    ".decl AssignCast(type: string, from: string, to: string, "
+    "inmethod: string)\n"
+    ".decl AssignLocal(from: string, to: string, inmethod: string)\n"
+    ".decl AssignHeapAllocation(heap: string, to: string, "
+    "inmethod: string)\n"
+    ".decl ReturnVar(var: string, method: string)\n"
+    ".decl StaticMethodInvocation(invocation: string, signature: string, "
+    "inmethod: string)\n"
     /* IDB: Type hierarchy */
-    ".decl MethodLookup(simplename: int32, descriptor: int32, "
-    "type: int32, method: int32)\n"
-    ".decl MethodImplemented(simplename: int32, descriptor: int32, "
-    "type: int32, method: int32)\n"
-    ".decl DirectSubclass(a: int32, c: int32)\n"
-    ".decl Subclass(c: int32, a: int32)\n"
-    ".decl Superclass(c: int32, a: int32)\n"
-    ".decl Superinterface(k: int32, c: int32)\n"
-    ".decl SubtypeOf(subtype: int32, type: int32)\n"
-    ".decl SupertypeOf(supertype: int32, type: int32)\n"
-    ".decl SubtypeOfDifferent(subtype: int32, type: int32)\n"
-    ".decl MainMethodDeclaration(method: int32)\n"
+    ".decl MethodLookup(simplename: string, descriptor: string, "
+    "type: string, method: string)\n"
+    ".decl MethodImplemented(simplename: string, descriptor: string, "
+    "type: string, method: string)\n"
+    ".decl DirectSubclass(a: string, c: string)\n"
+    ".decl Subclass(c: string, a: string)\n"
+    ".decl Superclass(c: string, a: string)\n"
+    ".decl Superinterface(k: string, c: string)\n"
+    ".decl SubtypeOf(subtype: string, type: string)\n"
+    ".decl SupertypeOf(supertype: string, type: string)\n"
+    ".decl SubtypeOfDifferent(subtype: string, type: string)\n"
+    ".decl MainMethodDeclaration(method: string)\n"
     /* IDB: Class initialization */
-    ".decl ClassInitializer(type: int32, method: int32)\n"
-    ".decl InitializedClass(classOrInterface: int32)\n"
+    ".decl ClassInitializer(type: string, method: string)\n"
+    ".decl InitializedClass(classOrInterface: string)\n"
     /* IDB: Main analysis */
-    ".decl Assign(to: int32, from: int32)\n"
-    ".decl VarPointsTo(heap: int32, var: int32)\n"
-    ".decl InstanceFieldPointsTo(heap: int32, fld: int32, "
-    "baseheap: int32)\n"
-    ".decl StaticFieldPointsTo(heap: int32, fld: int32)\n"
-    ".decl CallGraphEdge(invocation: int32, meth: int32)\n"
-    ".decl ArrayIndexPointsTo(baseheap: int32, heap: int32)\n"
-    ".decl Reachable(method: int32)\n"
+    ".decl Assign(to: string, from: string)\n"
+    ".decl VarPointsTo(heap: string, var: string)\n"
+    ".decl InstanceFieldPointsTo(heap: string, fld: string, "
+    "baseheap: string)\n"
+    ".decl StaticFieldPointsTo(heap: string, fld: string)\n"
+    ".decl CallGraphEdge(invocation: string, meth: string)\n"
+    ".decl ArrayIndexPointsTo(baseheap: string, heap: string)\n"
+    ".decl Reachable(method: string)\n"
     /* Phase 1: EDB staging & decomposition */
     "isType(class) :- _ClassType(class).\n"
     "isReferenceType(class) :- _ClassType(class).\n"
@@ -2594,12 +2599,11 @@ static const char *doop_rules
     "MethodLookup(sn, d, st, m), !MethodImplemented(sn, d, t, _).\n"
     "MethodImplemented(sn, d, t, m) :- Method_SimpleName(m, sn), "
     "Method_Descriptor(m, d), Method_DeclaringType(m, t), "
-    "!Method_Modifier(1928492, m).\n"
+    "!Method_Modifier(\"abstract\", m).\n"
     "MainMethodDeclaration(m) :- MainClass(t), "
-    "Method_DeclaringType(m, t), m != 536048, m != 1057660, "
-    "m != 796639, Method_SimpleName(m, 2648290), "
-    "Method_Descriptor(m, 2671384), Method_Modifier(760051, m), "
-    "Method_Modifier(841804, m).\n"
+    "Method_DeclaringType(m, t), Method_SimpleName(m, \"main\"), "
+    "Method_Descriptor(m, \"java.lang.String[]\"), Method_Modifier(\"public\", m), "
+    "Method_Modifier(\"static\", m).\n"
     "DirectSubclass(a, c) :- DirectSuperclass(a, c).\n"
     "Subclass(c, a) :- DirectSubclass(a, c).\n"
     "Subclass(c, a) :- Subclass(b, a), DirectSubclass(b, c).\n"
@@ -2614,20 +2618,20 @@ static const char *doop_rules
     "SubtypeOf(s, t) :- Subclass(t, s).\n"
     "SubtypeOf(s, s) :- isInterfaceType(s).\n"
     "SubtypeOf(s, t) :- isClassType(s), Superinterface(t, s).\n"
-    "SubtypeOf(s, t) :- isInterfaceType(s), isType(t), t = 613907.\n"
-    "SubtypeOf(s, t) :- isArrayType(s), isType(t), t = 613907.\n"
+    "SubtypeOf(s, t) :- isInterfaceType(s), isType(t), t = \"java.lang.Object\".\n"
+    "SubtypeOf(s, t) :- isArrayType(s), isType(t), t = \"java.lang.Object\".\n"
     "SubtypeOf(s, t) :- isInterfaceType(s), Superinterface(t, s).\n"
     "SubtypeOf(s, t) :- SubtypeOf(sc, tc), ComponentType(s, sc), "
     "ComponentType(t, tc), isReferenceType(sc), "
     "isReferenceType(tc).\n"
     "SubtypeOf(s, t) :- isArrayType(s), isInterfaceType(t), "
-    "isType(t), t = 935673.\n"
+    "isType(t), t = \"java.lang.Cloneable\".\n"
     "SubtypeOf(s, t) :- isArrayType(s), isInterfaceType(t), "
-    "isType(t), t = 619327.\n"
+    "isType(t), t = \"java.io.Serializable\".\n"
     "SupertypeOf(s, t) :- SubtypeOf(t, s).\n"
     "SubtypeOfDifferent(s, t) :- SubtypeOf(s, t), s != t.\n"
     /* Phase 3: Class initialization */
-    "ClassInitializer(t, m) :- MethodImplemented(777634, 2670449, t, m).\n"
+    "ClassInitializer(t, m) :- MethodImplemented(\"<clinit>\", \"\", t, m).\n"
     "InitializedClass(sc) :- InitializedClass(c), "
     "DirectSuperclass(c, sc).\n"
     "InitializedClass(si) :- InitializedClass(ci), "
@@ -2721,7 +2725,31 @@ static const char *doop_rules
     "SpecialMethodInvocation_Base(inv, base), "
     "VarPointsTo(h, base), "
     "MethodInvocation_Method(inv, tm), ThisVar(tm, this).\n"
-    "Reachable(m) :- MainMethodDeclaration(m).\n";
+    "Reachable(m) :- MainMethodDeclaration(m).\n"
+    /* Issue #950: HeapAllocation_Type and Method_Descriptor used to be
+     * shipped as pre-computed CSV files.  The upstream artifact no longer
+     * contains them -- FlowLog's own zxing.dl notes HeapAllocation_Type was
+     * "modified to be an EDB now", i.e. materialised from a fuller DOOP run.
+     * Both are derived here instead, so the benchmark needs only the raw
+     * .facts the archive actually ships.
+     *
+     * The heap rules are the ones zxing.dl carries commented out, plus the
+     * three heap kinds it dropped when it switched to the materialised file.
+     * Verified against the archive: these five rules cover all 75,106
+     * distinct heaps _AssignHeapAllocation references, with none left over.
+     * Method-type heaps are the one case whose id must be synthesised --
+     * DOOP names them "<method type D>" for descriptor D. */
+    ".decl HeapAllocation_Type(heap: string, type: string)\n"
+    "HeapAllocation_Type(h, t) :- _NormalHeap(h, t).\n"
+    "HeapAllocation_Type(h, \"java.lang.String\") :- _StringConstant(h).\n"
+    "HeapAllocation_Type(h, t) :- _ClassHeap(h, t).\n"
+    "HeapAllocation_Type(h, t) :- _MethodHandleConstant(h, t, _, _, _).\n"
+    "HeapAllocation_Type(cat(cat(\"<method type \", d), \">\"), t) :- "
+    "_MethodTypeConstant(d, _, t, _).\n"
+    /* Method.facts column 3 is the Java-style descriptor (main ->
+     * java.lang.String[]); column 6 is the JVM one. */
+    ".decl Method_Descriptor(method: string, descriptor: string)\n"
+    "Method_Descriptor(m, d) :- _Method(m, _, d, _, _, _, _).\n";
 
 static int
 run_doop_workload(const char *data_dir, uint32_t workers, int repeat)
@@ -2735,7 +2763,7 @@ run_doop_workload(const char *data_dir, uint32_t workers, int repeat)
     for (int i = 0; i < DOOP_NRELS; i++) {
         int n = snprintf(source + pos, DOOP_SRC_BUFSZ - pos,
                 ".decl %s%s\n"
-                ".input %s(filename=\"%s/%s\", delimiter=\",\")\n",
+                ".input %s(filename=\"%s/%s\", delimiter=\"\\t\")\n",
                 doop_edbs[i].name, doop_edbs[i].cols,
                 doop_edbs[i].name, data_dir, doop_edbs[i].csv);
         if (n < 0 || pos + (size_t)n >= DOOP_SRC_BUFSZ) {
@@ -2754,19 +2782,35 @@ run_doop_workload(const char *data_dir, uint32_t workers, int repeat)
         return -1;
     }
 
-    /* Count total input facts across all 34 CSV files */
+    /* Count total input facts across every EDB file.
+     *
+     * Counts newlines rather than fgets() calls: DOOP method signatures run
+     * well past any fixed line buffer, and a short buffer would count one
+     * long row several times.  A missing file is an error -- silently
+     * skipping it would under-report the fact count for a run that is also
+     * about to produce wrong results. */
     int32_t total_facts = 0;
     {
         char path[1024];
-        char line[256];
+        char buf[65536];
         for (int i = 0; i < DOOP_NRELS; i++) {
             snprintf(path, sizeof(path), "%s/%s", data_dir, doop_edbs[i].csv);
             FILE *f = fopen(path, "r");
-            if (f) {
-                while (fgets(line, sizeof(line), f))
-                    total_facts++;
-                fclose(f);
+            if (!f) {
+                fprintf(stderr,
+                    "error: DOOP input file missing: %s\n"
+                    "       run bench/data/doop/download.sh\n", path);
+                free(source);
+                return -1;
             }
+            size_t got;
+            while ((got = fread(buf, 1, sizeof(buf), f)) > 0) {
+                for (size_t k = 0; k < got; k++) {
+                    if (buf[k] == '\n')
+                        total_facts++;
+                }
+            }
+            fclose(f);
         }
     }
 

--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -2253,10 +2253,12 @@ run_crdt_workload(const char *data_dir, uint32_t workers, int repeat)
  * DOOP - Java Points-to Analysis (zxing dataset)
  * ---------------------------------------------------------------- */
 
-/* DOOP uses .input directives to load 34 CSV files (~3.5M tuples).
+/* DOOP uses .input directives to load 35 DOOP .facts files (~3.9M tuples).
  * EDB definitions are generated programmatically; rules are a static string.
  * Dataset: zxing (smallest FlowLog DOOP artifact, 83MB).
- * Magic constants are zxing-specific pre-hashed integer IDs. */
+ * Columns are string-typed and the facts are read as shipped, so the
+ * benchmark no longer depends on any particular integer encoding
+ * (Issue #950). */
 
 #define DOOP_SRC_BUFSZ ((size_t)64 * 1024)
 #define DOOP_NRELS 35
@@ -2352,12 +2354,15 @@ static const struct doop_edb doop_edbs[DOOP_NRELS] = {
     { "_Return",
       "(instruction: string, idx: string, var: string, method: string)",
       "Return.facts" },
-    { "_ClassHeap", "(heap: string, type: string)", "ClassHeap.facts" },
+    { "_ClassHeap", "(heap: string, instanceType: string)",
+      "ClassHeap.facts" },
     { "_MethodHandleConstant",
-      "(id: string, type: string, a: string, b: string, c: string)",
+      "(id: string, method: string, retType: string, paramTypes: string, "
+      "arity: string)",
       "MethodHandleConstant.facts" },
     { "_MethodTypeConstant",
-      "(descriptor: string, idx: string, type: string, d: string)",
+      "(descriptor: string, arity: string, retType: string, "
+      "paramTypes: string)",
       "MethodTypeConstant.facts" },
 };
 
@@ -2742,10 +2747,11 @@ static const char *doop_rules
     ".decl HeapAllocation_Type(heap: string, type: string)\n"
     "HeapAllocation_Type(h, t) :- _NormalHeap(h, t).\n"
     "HeapAllocation_Type(h, \"java.lang.String\") :- _StringConstant(h).\n"
-    "HeapAllocation_Type(h, t) :- _ClassHeap(h, t).\n"
-    "HeapAllocation_Type(h, t) :- _MethodHandleConstant(h, t, _, _, _).\n"
-    "HeapAllocation_Type(cat(cat(\"<method type \", d), \">\"), t) :- "
-    "_MethodTypeConstant(d, _, t, _).\n"
+    "HeapAllocation_Type(h, \"java.lang.Class\") :- _ClassHeap(h, _).\n"
+    "HeapAllocation_Type(h, \"java.lang.invoke.MethodHandle\") :- "
+    "_MethodHandleConstant(h, _, _, _, _).\n"
+    "HeapAllocation_Type(cat(cat(\"<method type \", d), \">\"), "
+    "\"java.lang.invoke.MethodType\") :- _MethodTypeConstant(d, _, _, _).\n"
     /* Method.facts column 3 is the Java-style descriptor (main ->
      * java.lang.String[]); column 6 is the JVM one. */
     ".decl Method_Descriptor(method: string, descriptor: string)\n"
@@ -3073,7 +3079,7 @@ usage(const char *prog)
         "CSVs\n"
         "  --data-ddisasm DIR    Directory with DDISASM disassembly CSVs\n"
         "  --data-crdt DIR       Directory with CRDT Insert/Remove CSVs\n"
-        "  --data-doop DIR       Directory with DOOP zxing CSVs\n",
+        "  --data-doop DIR       Directory with DOOP zxing .facts\n",
         prog);
 }
 

--- a/bench/data/doop/download.sh
+++ b/bench/data/doop/download.sh
@@ -22,21 +22,37 @@ if ! unzip -tq "$TMPZIP" > /dev/null 2>&1; then
     exit 1
 fi
 
-echo "Extracting required CSV files..."
+echo "Extracting required fact files..."
 mkdir -p "$TMPDIR"
 unzip -o "$TMPZIP" -d "$TMPDIR" > /dev/null
 
+# The archive ships DOOP .facts (tab-separated, string-valued).  They are
+# copied verbatim: the benchmark reads them directly, so there is no encoding
+# step that could drift between refreshes.  Issue #950.
 REQUIRED="DirectSuperclass DirectSuperinterface MainClass FormalParam
-ComponentType AssignReturnValue ActualParam Method_Modifier Var_Type
-HeapAllocation_Type ClassType ArrayType InterfaceType Var_DeclaringMethod
-ApplicationClass ThisVar NormalHeap StringConstant AssignHeapAllocation
-AssignLocal AssignCast Field StaticMethodInvocation SpecialMethodInvocation
-VirtualMethodInvocation Method Method_Descriptor StoreInstanceField
-LoadInstanceField StoreStaticField LoadStaticField StoreArrayIndex
-LoadArrayIndex Return"
+ComponentType AssignReturnValue ActualParam Method-Modifier Var-Type
+ClassType ArrayType InterfaceType Var-DeclaringMethod ApplicationClass
+ThisVar NormalHeap StringConstant AssignHeapAllocation AssignLocal AssignCast
+Field StaticMethodInvocation SpecialMethodInvocation VirtualMethodInvocation
+Method StoreInstanceField LoadInstanceField StoreStaticField LoadStaticField
+StoreArrayIndex LoadArrayIndex Return ClassHeap MethodHandleConstant
+MethodTypeConstant"
+
+missing=""
+for f in $REQUIRED; do
+    [ -f "$TMPDIR/zxing/${f}.facts" ] || missing="$missing $f"
+done
+if [ -n "$missing" ]; then
+    echo "ERROR: the archive is missing required relations:" >&2
+    for f in $missing; do echo "         ${f}.facts" >&2; done
+    echo "       Downloaded from: $URL" >&2
+    echo "       The upstream artifact may have changed; see issue #950." >&2
+    exit 1
+fi
 
 for f in $REQUIRED; do
-    cp "$TMPDIR/zxing/${f}.csv" "$SCRIPT_DIR/"
+    cp "$TMPDIR/zxing/${f}.facts" "$SCRIPT_DIR/"
 done
 
-echo "Done. 34 CSV files copied to $SCRIPT_DIR/"
+echo "Done. $(echo $REQUIRED | wc -w) fact files copied to $SCRIPT_DIR/"
+echo "Archive sha256: $(sha256sum "$TMPZIP" | cut -d" " -f1)"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1049,6 +1049,27 @@ test_option2_doop_exe = executable(
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
 
+# Issue #950: pins what each DOOP rule constant MEANS, on a hand-written
+# miniature dataset.  The real 68 MB archive cannot be fetched in CI (and has
+# already disappeared once), so these semantics have to be fixed independently
+# of it.  Each case carries the negative that makes it non-vacuous.
+test_doop_strings_exe = executable(
+  'test_doop_strings',
+  files('test_doop_strings.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('doop_strings', test_doop_strings_exe)
+
 test('option2_doop', test_option2_doop_exe,
   env: ['DOOP_DATA_DIR=' + meson.project_source_root() / 'bench/data/doop'],
 )

--- a/tests/test_doop_strings.c
+++ b/tests/test_doop_strings.c
@@ -1,0 +1,415 @@
+/*
+ * tests/test_doop_strings.c - string-typed DOOP rule semantics (Issue #950)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * The DOOP workload's rules used to carry thirteen bare integer IDs from the
+ * dataset's original encoding, e.g.
+ *
+ *     Method_Descriptor(m, 2671384), Method_Modifier(760051, m)
+ *     SubtypeOf(s, t) :- isInterfaceType(s), isType(t), t = 613907.
+ *
+ * Those IDs only meant anything relative to one encoder run, so the
+ * benchmark could not be reproduced from a re-downloaded dataset: any
+ * re-encoding assigns different numbers and silently changes the result.
+ * They are now string constants, which are legible in review and stable
+ * across any encoding.
+ *
+ * This test pins what each constant MEANS, on a miniature hand-written
+ * dataset, so the meanings are fixed independently of the 68 MB archive --
+ * which has already disappeared once and cannot be re-fetched in CI.
+ *
+ * Ten of the thirteen are covered here.  The other three appear only as
+ * identity exclusions in MainMethodDeclaration:
+ *
+ *     m != 536048, m != 1057660, m != 796639
+ *
+ * Those are opaque method IDs, not names or types, so unlike the rest they
+ * carry no recoverable meaning -- there is nothing to pin.  They exist to
+ * keep MainMethodDeclaration a singleton, and that property is asserted
+ * directly here and enforced against the real dataset, which is the
+ * guarantee they were standing in for.  They are dropped rather than
+ * translated; see Issue #950.
+ *
+ * Each case includes the negative that makes it non-vacuous. Asserting only
+ * "the expected tuple appears" would pass against a rule that matches
+ * everything, which is exactly how a constant could be wrong and unnoticed.
+ *
+ *   test_method_implemented_excludes_abstract
+ *       !Method_Modifier("abstract", m) -- a method with a body is
+ *       implemented; an abstract one is not.
+ *
+ *   test_main_method_declaration
+ *       The conjunction of MainClass, simple name "main", descriptor
+ *       "java.lang.String[]", and modifiers "public" and "static".  Five
+ *       negatives: wrong class, wrong name, wrong descriptor, missing
+ *       static, missing public.  Both modifier negatives are needed --
+ *       with only one, the other conjunct could be dropped or duplicated
+ *       and nothing would notice.  The two conjuncts are symmetric, so
+ *       this pins the SET {public, static} and not which literal was
+ *       which; nothing can distinguish that, and nothing needs to.
+ *
+ *   test_class_initializer
+ *       MethodImplemented("<clinit>", "", t, m) -- the class initializer is
+ *       matched by simple name AND empty descriptor.  Negative: a same-named
+ *       method with a non-empty descriptor must not match.
+ *
+ *   test_subtype_of_object_and_array_interfaces
+ *       Every interface and every array type is a subtype of
+ *       "java.lang.Object"; array types are also subtypes of
+ *       "java.lang.Cloneable" and "java.io.Serializable".  Those last two
+ *       rules are structurally identical, so again this pins the set.
+ */
+
+#include "../wirelog/backend.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/intern.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int test_count;
+static int pass_count;
+static int fail_count;
+
+#define TEST(name)                                      \
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
+
+#define PASS()            \
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                    \
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
+
+#define ASSERT(cond, msg) \
+        do {                  \
+            if (!(cond))      \
+            FAIL(msg);    \
+        } while (0)
+
+#define MAX_SEEN 32
+
+typedef struct {
+    const char *rel;
+    uint32_t count;
+    const wirelog_intern_t *intern;
+    /* Interned values of the row, joined with '|', for the first MAX_SEEN
+     * rows.  Counting alone is not enough: swapping one rule constant for
+     * another that happens to select a different-but-equally-sized set
+     * leaves the count identical, so the test must look at what was
+     * actually selected. */
+    char seen[MAX_SEEN][256];
+} collect_t;
+
+static void
+collect_cb(const char *relation, const int64_t *row, uint32_t ncols, void *user)
+{
+    collect_t *c = (collect_t *)user;
+    if (!c->rel || !relation || strcmp(relation, c->rel) != 0)
+        return;
+    if (c->count < MAX_SEEN) {
+        char *dst = c->seen[c->count];
+        size_t pos = 0;
+        dst[0] = '\0';
+        for (uint32_t i = 0; i < ncols && pos + 1 < sizeof(c->seen[0]); i++) {
+            const char *v = c->intern
+                ? wl_intern_reverse(c->intern, row[i]) : NULL;
+            int n = snprintf(dst + pos, sizeof(c->seen[0]) - pos, "%s%s",
+                    i ? "|" : "", v ? v : "?");
+            if (n < 0)
+                break;
+            pos += (size_t)n;
+        }
+    }
+    c->count++;
+}
+
+/* True if any collected row equals @want. */
+static bool
+saw(const collect_t *c, const char *want)
+{
+    uint32_t n = c->count < MAX_SEEN ? c->count : MAX_SEEN;
+    for (uint32_t i = 0; i < n; i++) {
+        if (strcmp(c->seen[i], want) == 0)
+            return true;
+    }
+    return false;
+}
+
+/* Evaluate @src, filling @out with @relation's tuples.  Returns 0 on
+ * success. */
+static int
+eval_relation(const char *src, const char *relation, collect_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    out->rel = relation;
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        fprintf(stderr, "  parse error: %d\n", (int)err);
+        return -1;
+    }
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_session_t *sess = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    out->intern = wirelog_program_get_intern(prog);
+
+    int result = -1;
+    if (wl_session_load_facts(sess, prog) == 0
+        && wl_session_snapshot(sess, collect_cb, out) == 0)
+        result = 0;
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return result;
+}
+
+/*
+ * MethodImplemented is "declared, and not abstract".  The abstract method
+ * must be excluded; without the negation both would appear.
+ */
+static void
+test_method_implemented_excludes_abstract(void)
+{
+    TEST("MethodImplemented excludes abstract methods");
+
+    const char *src =
+        ".decl Method_SimpleName(m: string, sn: string)\n"
+        ".decl Method_Descriptor(m: string, d: string)\n"
+        ".decl Method_DeclaringType(m: string, t: string)\n"
+        ".decl Method_Modifier(mod: string, m: string)\n"
+        "Method_SimpleName(\"<A: void f()>\", \"f\").\n"
+        "Method_SimpleName(\"<A: void g()>\", \"g\").\n"
+        "Method_Descriptor(\"<A: void f()>\", \"\").\n"
+        "Method_Descriptor(\"<A: void g()>\", \"\").\n"
+        "Method_DeclaringType(\"<A: void f()>\", \"A\").\n"
+        "Method_DeclaringType(\"<A: void g()>\", \"A\").\n"
+        "Method_Modifier(\"abstract\", \"<A: void g()>\").\n"
+        ".decl MethodImplemented(sn: string, d: string, t: string, m: string)\n"
+        "MethodImplemented(sn, d, t, m) :- Method_SimpleName(m, sn), "
+        "Method_Descriptor(m, d), Method_DeclaringType(m, t), "
+        "!Method_Modifier(\"abstract\", m).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "MethodImplemented", &c) == 0,
+        "evaluation failed");
+    ASSERT(c.count == 1, "expected exactly the non-abstract method");
+    ASSERT(saw(&c, "f||A|<A: void f()>"),
+        "expected f(), the method with a body");
+    PASS();
+}
+
+/* Shared prelude for the MainMethodDeclaration cases. */
+#define MAIN_DECLS                                                       \
+        ".decl MainClass(t: string)\n"                                       \
+        ".decl Method_DeclaringType(m: string, t: string)\n"                 \
+        ".decl Method_SimpleName(m: string, sn: string)\n"                   \
+        ".decl Method_Descriptor(m: string, d: string)\n"                    \
+        ".decl Method_Modifier(mod: string, m: string)\n"
+
+#define MAIN_RULE                                                        \
+        ".decl MainMethodDeclaration(m: string)\n"                           \
+        "MainMethodDeclaration(m) :- MainClass(t), "                         \
+        "Method_DeclaringType(m, t), Method_SimpleName(m, \"main\"), "       \
+        "Method_Descriptor(m, \"java.lang.String[]\"), "                     \
+        "Method_Modifier(\"public\", m), Method_Modifier(\"static\", m).\n"
+
+static void
+test_main_method_declaration(void)
+{
+    TEST("MainMethodDeclaration pins name, descriptor and modifier set");
+
+    /* The real entry point, plus four near-misses that must all be rejected:
+     * wrong declaring class, wrong simple name, wrong descriptor, and no
+     * static modifier. */
+    const char *src =
+        MAIN_DECLS
+        "MainClass(\"App\").\n"
+        "Method_DeclaringType(\"<App: void main(String[])>\", \"App\").\n"
+        "Method_SimpleName(\"<App: void main(String[])>\", \"main\").\n"
+        "Method_Descriptor(\"<App: void main(String[])>\", "
+        "\"java.lang.String[]\").\n"
+        "Method_Modifier(\"public\", \"<App: void main(String[])>\").\n"
+        "Method_Modifier(\"static\", \"<App: void main(String[])>\").\n"
+        /* not the main class */
+        "Method_DeclaringType(\"<Other: void main(String[])>\", \"Other\").\n"
+        "Method_SimpleName(\"<Other: void main(String[])>\", \"main\").\n"
+        "Method_Descriptor(\"<Other: void main(String[])>\", "
+        "\"java.lang.String[]\").\n"
+        "Method_Modifier(\"public\", \"<Other: void main(String[])>\").\n"
+        "Method_Modifier(\"static\", \"<Other: void main(String[])>\").\n"
+        /* right class, wrong simple name */
+        "Method_DeclaringType(\"<App: void run(String[])>\", \"App\").\n"
+        "Method_SimpleName(\"<App: void run(String[])>\", \"run\").\n"
+        "Method_Descriptor(\"<App: void run(String[])>\", "
+        "\"java.lang.String[]\").\n"
+        "Method_Modifier(\"public\", \"<App: void run(String[])>\").\n"
+        "Method_Modifier(\"static\", \"<App: void run(String[])>\").\n"
+        /* right name, wrong descriptor */
+        "Method_DeclaringType(\"<App: void main(int)>\", \"App\").\n"
+        "Method_SimpleName(\"<App: void main(int)>\", \"main\").\n"
+        "Method_Descriptor(\"<App: void main(int)>\", \"int\").\n"
+        "Method_Modifier(\"public\", \"<App: void main(int)>\").\n"
+        "Method_Modifier(\"static\", \"<App: void main(int)>\").\n"
+        /* right name and descriptor and static, but not public: this is
+         * what constrains the "public" literal.  Without it every method
+         * carrying static also carried public, so dropping or swapping the
+         * public conjunct changed nothing. */
+        "Method_DeclaringType(\"<App: void main3(String[])>\", \"App\").\n"
+        "Method_SimpleName(\"<App: void main3(String[])>\", \"main\").\n"
+        "Method_Descriptor(\"<App: void main3(String[])>\", "
+        "\"java.lang.String[]\").\n"
+        "Method_Modifier(\"static\", \"<App: void main3(String[])>\").\n"
+        /* right name and descriptor, but not static */
+        "Method_DeclaringType(\"<App: void main2(String[])>\", \"App\").\n"
+        "Method_SimpleName(\"<App: void main2(String[])>\", \"main\").\n"
+        "Method_Descriptor(\"<App: void main2(String[])>\", "
+        "\"java.lang.String[]\").\n"
+        "Method_Modifier(\"public\", \"<App: void main2(String[])>\").\n"
+        MAIN_RULE;
+
+    collect_t c;
+    ASSERT(eval_relation(src, "MainMethodDeclaration", &c) == 0,
+        "evaluation failed");
+    ASSERT(c.count == 1, "expected exactly one entry point");
+    /* Naming the method is what makes each constant load-bearing: swapping
+     * "main" for "run", or the descriptor for "int", selects a different
+     * near-miss and keeps the count at 1. */
+    ASSERT(saw(&c, "<App: void main(String[])>"),
+        "expected the real entry point, not a near-miss");
+    PASS();
+}
+
+/*
+ * The class initializer is matched by simple name AND empty descriptor.  A
+ * same-named method taking arguments must not match, which is what makes the
+ * descriptor constant load-bearing rather than decorative.
+ */
+static void
+test_class_initializer(void)
+{
+    TEST("ClassInitializer matches <clinit> with the empty descriptor");
+
+    const char *src =
+        ".decl MethodImplemented(sn: string, d: string, t: string, m: string)\n"
+        "MethodImplemented(\"<clinit>\", \"\", \"A\", \"<A: void clinit()>\").\n"
+        "MethodImplemented(\"<clinit>\", \"int\", \"A\", "
+        "\"<A: void clinit(int)>\").\n"
+        "MethodImplemented(\"<init>\", \"\", \"A\", \"<A: void init()>\").\n"
+        ".decl ClassInitializer(t: string, m: string)\n"
+        "ClassInitializer(t, m) :- "
+        "MethodImplemented(\"<clinit>\", \"\", t, m).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "ClassInitializer", &c) == 0,
+        "evaluation failed");
+    ASSERT(c.count == 1, "expected only the zero-argument <clinit>");
+    ASSERT(saw(&c, "A|<A: void clinit()>"),
+        "expected the no-argument <clinit>, not the int overload");
+    PASS();
+}
+
+/*
+ * Every interface and every array type is a subtype of java.lang.Object, and
+ * array types are additionally subtypes of the two interfaces arrays
+ * implement.  The two array-interface rules are structurally identical, so
+ * this pins the set {java.lang.Cloneable, java.io.Serializable}.
+ */
+static void
+test_subtype_of_object_and_array_interfaces(void)
+{
+    TEST("SubtypeOf relates interfaces and arrays to Object and array ifaces");
+
+    const char *src =
+        ".decl isInterfaceType(t: string)\n"
+        ".decl isArrayType(t: string)\n"
+        ".decl isType(t: string)\n"
+        "isInterfaceType(\"I\").\n"
+        "isArrayType(\"A[]\").\n"
+        "isType(\"java.lang.Object\").\n"
+        "isType(\"java.lang.Cloneable\").\n"
+        "isType(\"java.io.Serializable\").\n"
+        "isType(\"Unrelated\").\n"
+        "isInterfaceType(\"java.lang.Cloneable\").\n"
+        "isInterfaceType(\"java.io.Serializable\").\n"
+        ".decl SubtypeOf(s: string, t: string)\n"
+        "SubtypeOf(s, t) :- isInterfaceType(s), isType(t), "
+        "t = \"java.lang.Object\".\n"
+        "SubtypeOf(s, t) :- isArrayType(s), isType(t), "
+        "t = \"java.lang.Object\".\n"
+        "SubtypeOf(s, t) :- isArrayType(s), isInterfaceType(t), isType(t), "
+        "t = \"java.lang.Cloneable\".\n"
+        "SubtypeOf(s, t) :- isArrayType(s), isInterfaceType(t), isType(t), "
+        "t = \"java.io.Serializable\".\n";
+
+    /* isInterfaceType = {I, Cloneable, Serializable}, isArrayType = {A[]}.
+     * Object rules give 3 + 1 = 4; the two array-interface rules give 1 each.
+     * "Unrelated" is in isType but must never appear as a supertype. */
+    collect_t c;
+    ASSERT(eval_relation(src, "SubtypeOf", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 6,
+        "expected 4 Object pairs plus 2 array-interface pairs");
+    ASSERT(saw(&c, "I|java.lang.Object"), "interface must subtype Object");
+    ASSERT(saw(&c, "A[]|java.lang.Object"), "array must subtype Object");
+    ASSERT(saw(&c, "A[]|java.lang.Cloneable"), "array must subtype Cloneable");
+    ASSERT(saw(&c, "A[]|java.io.Serializable"),
+        "array must subtype Serializable");
+    ASSERT(!saw(&c, "I|Unrelated"), "Unrelated must never be a supertype");
+    PASS();
+}
+
+int
+main(void)
+{
+    printf("=== DOOP string-constant rule semantics (Issue #950) ===\n");
+
+    test_method_implemented_excludes_abstract();
+    test_main_method_declaration();
+    test_class_initializer();
+    test_subtype_of_object_and_array_interfaces();
+
+    printf("\n--- Results: %d/%d passed", pass_count, test_count);
+    if (fail_count > 0)
+        printf(", %d FAILED", fail_count);
+    printf(" ---\n");
+    return (fail_count > 0) ? 1 : 0;
+}

--- a/tests/test_option2_doop.c
+++ b/tests/test_option2_doop.c
@@ -11,10 +11,10 @@
  * Validates DOOP (Java points-to analysis) infrastructure for Option 2.
  * This file covers US-009 preparation tasks:
  *
- *   1. Verify DOOP data directory has all 34 expected CSV files.
+ *   1. Verify DOOP data directory has all 35 expected fact files.
  *   2. Verify DOOP declarations parse without error (syntax check).
  *   3. Verify 8-way virtual-dispatch join produces correct results
- *      using synthetic inline data (avoids loading 83MB dataset).
+ *      using synthetic inline data (avoids loading the full dataset).
  *
  * Full DOOP benchmark execution (US-010) uses the shell script:
  *   scripts/run_doop_validation.sh
@@ -23,7 +23,7 @@
  * DATA DIRECTORY
  * ========================================================================
  *
- * The DOOP zxing CSV dataset lives at bench/data/doop/ relative to the
+ * The DOOP zxing fact dataset lives at bench/data/doop/ relative to the
  * project root.  When running under meson test the CWD is the build
  * directory, so we try "../bench/data/doop" first and fall back to the
  * DOOP_DATA_DIR environment variable.
@@ -108,47 +108,53 @@ static int skip_count = 0;
 /* *INDENT-ON* */
 
 /* ========================================================================
- * DOOP EDB catalogue: the 34 CSV files expected in the data directory.
+ * DOOP EDB catalogue: the 35 .facts files expected in the data
+ * directory.  Issue #950: the benchmark reads DOOP's own fact files
+ * directly, so this list must track doop_edbs[] in bench_flowlog.c --
+ * if it drifts, this test skips instead of failing and the only
+ * end-to-end check against real data silently stops running.
  * ======================================================================== */
 
-static const char *doop_csv_files[] = {
-    "ActualParam.csv",
-    "ApplicationClass.csv",
-    "ArrayType.csv",
-    "AssignCast.csv",
-    "AssignHeapAllocation.csv",
-    "AssignLocal.csv",
-    "AssignReturnValue.csv",
-    "ClassType.csv",
-    "ComponentType.csv",
-    "DirectSuperclass.csv",
-    "DirectSuperinterface.csv",
-    "Field.csv",
-    "FormalParam.csv",
-    "HeapAllocation_Type.csv",
-    "InterfaceType.csv",
-    "LoadArrayIndex.csv",
-    "LoadInstanceField.csv",
-    "LoadStaticField.csv",
-    "MainClass.csv",
-    "Method.csv",
-    "Method_Descriptor.csv",
-    "Method_Modifier.csv",
-    "NormalHeap.csv",
-    "Return.csv",
-    "SpecialMethodInvocation.csv",
-    "StaticMethodInvocation.csv",
-    "StoreArrayIndex.csv",
-    "StoreInstanceField.csv",
-    "StoreStaticField.csv",
-    "StringConstant.csv",
-    "ThisVar.csv",
-    "Var_DeclaringMethod.csv",
-    "Var_Type.csv",
-    "VirtualMethodInvocation.csv",
+static const char *doop_fact_files[] = {
+    "ActualParam.facts",
+    "ApplicationClass.facts",
+    "ArrayType.facts",
+    "AssignCast.facts",
+    "AssignHeapAllocation.facts",
+    "AssignLocal.facts",
+    "AssignReturnValue.facts",
+    "ClassHeap.facts",
+    "ClassType.facts",
+    "ComponentType.facts",
+    "DirectSuperclass.facts",
+    "DirectSuperinterface.facts",
+    "Field.facts",
+    "FormalParam.facts",
+    "InterfaceType.facts",
+    "LoadArrayIndex.facts",
+    "LoadInstanceField.facts",
+    "LoadStaticField.facts",
+    "MainClass.facts",
+    "Method.facts",
+    "Method-Modifier.facts",
+    "MethodHandleConstant.facts",
+    "MethodTypeConstant.facts",
+    "NormalHeap.facts",
+    "Return.facts",
+    "SpecialMethodInvocation.facts",
+    "StaticMethodInvocation.facts",
+    "StoreArrayIndex.facts",
+    "StoreInstanceField.facts",
+    "StoreStaticField.facts",
+    "StringConstant.facts",
+    "ThisVar.facts",
+    "Var-DeclaringMethod.facts",
+    "Var-Type.facts",
+    "VirtualMethodInvocation.facts",
 };
 
-#define DOOP_NCSV ((int)(sizeof(doop_csv_files) / sizeof(doop_csv_files[0])))
+#define DOOP_NFACTS ((int)(sizeof(doop_fact_files) / \
+        sizeof(doop_fact_files[0])))
 
 /* ========================================================================
  * Helper: resolve DOOP data directory
@@ -382,7 +388,7 @@ run_program_count_rel_with_jpp(const char *src, uint32_t num_workers,
 /*
  * Test 1: DOOP data directory is accessible.
  *
- * Resolves the DOOP CSV directory via env var or relative path.
+ * Resolves the DOOP fact directory via env var or relative path.
  * SKIP if not found (no DOOP data installed — CI without large assets).
  */
 static void
@@ -400,15 +406,15 @@ test_doop_data_dir_accessible(void)
 }
 
 /*
- * Test 2: All 34 DOOP CSV files exist and are non-empty.
+ * Test 2: All 35 DOOP fact files exist and are non-empty.
  *
- * Spot-checks 5 representative files from the 34-file EDB.
+ * Spot-checks 5 representative files from the 35-file EDB.
  * SKIP if data dir not found.
  */
 static void
-test_doop_all_csv_files_exist(void)
+test_doop_all_fact_files_exist(void)
 {
-    TEST("doop_infra: all 34 CSV files exist and are non-empty");
+    TEST("doop_infra: all 35 fact files exist and are non-empty");
 
     const char *dir = resolve_doop_data_dir();
     if (!dir)
@@ -418,49 +424,53 @@ test_doop_all_csv_files_exist(void)
     int missing = 0;
     int empty = 0;
 
-    for (int i = 0; i < DOOP_NCSV; i++) {
-        snprintf(path, sizeof(path), "%s/%s", dir, doop_csv_files[i]);
+    for (int i = 0; i < DOOP_NFACTS; i++) {
+        snprintf(path, sizeof(path), "%s/%s", dir, doop_fact_files[i]);
         struct stat st;
         if (stat(path, &st) != 0) {
-            fprintf(stderr, "\n  missing: %s", doop_csv_files[i]);
+            fprintf(stderr, "\n  missing: %s", doop_fact_files[i]);
             missing++;
         } else if (st.st_size == 0) {
-            fprintf(stderr, "\n  empty: %s", doop_csv_files[i]);
+            fprintf(stderr, "\n  empty: %s", doop_fact_files[i]);
             empty++;
         }
     }
 
     char msg[128];
-    if (missing == DOOP_NCSV) {
-        SKIP("DOOP CSV data files not installed");
+    if (missing == DOOP_NFACTS) {
+        SKIP("DOOP .facts data files not installed; "
+            "run bench/data/doop/download.sh");
         return;
     }
     if (missing > 0) {
-        snprintf(msg, sizeof(msg), "%d of %d CSV files missing", missing,
-            DOOP_NCSV);
+        snprintf(msg, sizeof(msg), "%d of %d fact files missing", missing,
+            DOOP_NFACTS);
         FAIL(msg);
         return;
     }
     if (empty > 0) {
-        snprintf(msg, sizeof(msg), "%d CSV files are empty", empty);
+        snprintf(msg, sizeof(msg), "%d fact files are empty", empty);
         FAIL(msg);
         return;
     }
 
-    printf("[%d files OK] ", DOOP_NCSV);
+    printf("[%d files OK] ", DOOP_NFACTS);
     PASS();
 }
 
 /*
- * Test 3: Total dataset size is in the expected range (70–100 MB).
+ * Test 3: Total dataset size is in the expected range.
  *
- * The zxing DOOP dataset is documented as ~83MB.  A significant
- * deviation indicates a corrupted or wrong dataset.
+ * Issue #950: the benchmark reads DOOP's .facts directly rather than a
+ * pre-encoded integer CSV set, so the on-disk size is dominated by fully
+ * qualified Java signatures -- about 740 MB, against ~83 MB for the
+ * integer encoding this replaced.  A large deviation still indicates a
+ * corrupted or wrong dataset.
  */
 static void
 test_doop_dataset_size_in_range(void)
 {
-    TEST("doop_infra: total dataset size is 70–100 MB");
+    TEST("doop_infra: total dataset size is 600–900 MB");
 
     const char *dir = resolve_doop_data_dir();
     if (!dir)
@@ -469,8 +479,8 @@ test_doop_dataset_size_in_range(void)
     char path[1024];
     off_t total = 0;
 
-    for (int i = 0; i < DOOP_NCSV; i++) {
-        snprintf(path, sizeof(path), "%s/%s", dir, doop_csv_files[i]);
+    for (int i = 0; i < DOOP_NFACTS; i++) {
+        snprintf(path, sizeof(path), "%s/%s", dir, doop_fact_files[i]);
         struct stat st;
         if (stat(path, &st) == 0)
             total += st.st_size;
@@ -480,11 +490,12 @@ test_doop_dataset_size_in_range(void)
     printf("[%lld MB] ", mb);
 
     if (total == 0)
-        SKIP("DOOP CSV data files not installed");
+        SKIP("DOOP .facts data files not installed; "
+            "run bench/data/doop/download.sh");
 
     char msg[128];
-    snprintf(msg, sizeof(msg), "expected 70–100 MB, got %lld MB", mb);
-    ASSERT(mb >= 70 && mb <= 100, msg);
+    snprintf(msg, sizeof(msg), "expected 600–900 MB, got %lld MB", mb);
+    ASSERT(mb >= 600 && mb <= 900, msg);
 
     PASS();
 }
@@ -1222,7 +1233,7 @@ main(void)
     /* --- Infrastructure: data files --- */
     printf("--- Infrastructure: Data Files ---\n");
     test_doop_data_dir_accessible();
-    test_doop_all_csv_files_exist();
+    test_doop_all_fact_files_exist();
     test_doop_dataset_size_in_range();
 
     /* --- Infrastructure: parser --- */


### PR DESCRIPTION
Makes the DOOP benchmark runnable from a freshly downloaded dataset. Does not close #950 on its own — the baseline documentation (README row, `scripts/run_doop_validation.sh`) follows once the number is agreed.

## What was broken

Three things, and only the first was visible:

1. `download.sh` expects `zxing/*.csv`; the archive ships `zxing/*.facts`. It died on a `cp`.
2. Two required relations — `HeapAllocation_Type`, `Method_Descriptor` — are absent from the archive entirely.
3. `doop_rules` hardcoded **13 integer IDs** from the original encoding. So even a working download could not have reproduced the benchmark: any re-encoding assigns different numbers and silently changes the result.

Measured: encoding *every* `.facts` file in the archive yields 2,572,546 distinct strings, while the rules reference ID 2,671,384. No re-encoding can reproduce them.

## What FlowLog's own program told us

`program/flowlog_interpreter/zxing.dl` on the same mirror is the reference this workload was ported from, and it answers both open questions:

```
.decl HeapAllocation_Type(heap:number, type:number)
.input HeapAllocation_Type.csv # modified to be an EDB now
```

That relation was **derived and then materialised into a file**, which is why no such file exists to download. The original rules survive commented out. All 13 literals appear there with identical values, confirming this port is faithful — and `java.lang.String[]` carries different ids as a descriptor and as a type, showing the original encoding was per-domain rather than global. Another reason it cannot be regenerated.

## The fix: remove the encoding rather than repair it

- **EDB columns become `string`.** The language supports it, the CSV adapter interns strings, and its delimiter already defaults to tab — which is what `.facts` uses. No transformation step remains that could drift between refreshes.
- **The 13 literals become string constants**: `abstract`, `public`, `static`, `main`, `java.lang.String[]`, `<clinit>` with its empty descriptor, `java.lang.Object`, `java.lang.Cloneable`, `java.io.Serializable`. Their meanings were pinned *first*, in `7db875e`, on a synthetic dataset — so they survive the archive disappearing again, which it already has once.
- **Three literals are dropped, not translated.** They were identity exclusions on opaque method ids with no recoverable meaning. They existed to keep `MainMethodDeclaration` a singleton; it measures exactly 1, and the survivor is identified as the real zxing entry point (`CommandLineRunner`; `java.util.prefs.Base64` also declares a `main` and is excluded by `MainClass` alone).
- **The two missing relations are derived.** `Method_Descriptor` projects `_Method` column 3 (the Java-style descriptor; column 6 is the JVM one). `HeapAllocation_Type` is five rules: the reference's commented ones, plus the three heap kinds it dropped when it switched to the materialised file, plus method-type heaps whose ids DOOP synthesises as `<method type D>`. Measured: covers all **75,106** heaps `_AssignHeapAllocation` references with none left over — `_NormalHeap` alone misses 26,457.
- **`download.sh` extracts and verifies only.** It names every missing relation instead of dying on a `cp`, and prints the archive sha256 so an upstream change is announced rather than absorbed.
- **`total_facts`** counted with a 256-byte line buffer, which would have counted long method signatures several times, and skipped missing files silently. Now counts newlines and errors on a missing file.

## Results

| | |
|---|---|
| tuples | 6,069,774 |
| iterations | **28** |
| wall | 92.8s |
| peak RSS | 32.4 GB |

Identical tuples and iterations at W=1, W=2, W=4. `download.sh` succeeds: 35 files, archive sha256 `154593343fefd18306d4098ba9f6286947b134b56ebcf83d8e8eae368d5867e7`.

## What review caught

Worth recording, because both were the same failure mode this issue is about.

**The heap rules bound a column where upstream DOOP binds a fixed type constant.** 8,301 class-literal heaps were typed as the class they *denote* rather than `java.lang.Class`, so every `<class X>` masqueraded as an instance of `X` and manufactured `VarPointsTo` / `Reachable` / `CallGraphEdge` tuples. Of the other 568, 379 handle heaps got a type absent from `isType` and so suppressed dispatch, while 111 method-type heaps got a *real* type and manufactured plausible-but-wrong dispatch — the least visible half.

Before: 6,238,352 / **70 iterations**. After: 6,069,774 / **28**. Twenty-eight is the README's iteration count, so that discrepancy was this bug, not dataset drift as an earlier commit message claimed.

**`test_option2_doop.c` had gone permanently vacuous.** It still listed 34 `.csv` names, so after the format switch it skipped its two real-dataset cases and would have stayed green forever — `256 Ok / 0 Fail` was not evidence the dataset path worked. Now 13 of 13 with nothing skipped, and removing a fact file makes it **fail** rather than skip. Its checks are file presence and size, so it would not have caught the heap defect; fixing the silent-skip rot is justified on its own.

## Not the README's 6,276,657, and why

The iteration count now matches, so the semantics line up. The remaining tuple gap has two named parts:

- **157,097 exactly**: `Method_Descriptor` (73,303) and `HeapAllocation_Type` (83,794) are now derived, and a snapshot reports IDB rows only, so their rows enter a total that never counted them.
- **The dataset**, which is demonstrably not the one the README row was measured on.

The README table is left untouched — it also predates `61e2530` (#914), which changed several workloads' output. The new measurement should get its own identity (archive sha256, date, schema note) rather than overwriting a row measured on a vanished artifact. Cost changed too: 33.18s → ~93s and 12.0 GB → 32.4 GB, the latter a real barrier for anyone following the reproduction block in the README.

## Validation

`meson test -C build` 256 Ok / 0 Fail. `test_doop_strings` (new) mutation-tested with 12 cases, each of which must fail it. `test_option2_doop` mutation-tested for the skip-rot property.
