### PR TITLE
fix: SEMIJOIN/ANTIJOIN plan layout, DOOP Method_Descriptor, and the DOOP baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ All notable changes to wirelog are documented in this file.
   `ActualParam.csv`, so after the archive switched to 35 string-valued
   `.facts` (#950) it failed for every user with `expected 34 CSV files,
   found 0`. It now counts `.facts`, points at the download script when the
-  dataset is absent, and carries the reconciled tuple oracle 6,070,090 --
+  dataset is absent, and carries the reconciled tuple oracle
+  (14,096,448 after #955) --
   the previous 6276338 matched neither the measurement nor the README's
   6,276,657, so the two in-tree "expected" values for one workload had
   disagreed by 319 for some time. The default is W=1-specific and is not
@@ -59,6 +60,32 @@ All notable changes to wirelog are documented in this file.
   rows, so a matching iteration count proves nothing on its own.
   `--help` printed a fixed `head -40` window and had silently begun
   truncating its own options list.
+
+- **SEMIJOIN/ANTIJOIN widened the plan's output layout** (#955):
+  `collect_output_columns` grouped them with JOIN and concatenated the right
+  child's columns, but both operators only filter and emit the left side.
+  Every SIP-inserted semijoin therefore inflated the reported layout by the
+  right relation's arity, shifting every join key and fused projection
+  resolved above it; `col_rel_col_idx` returned -1 for the out-of-range
+  `colN` and the resolution sites silently fell back to column 0.  A plan
+  bug became a wrong answer instead of an error.
+
+  The engine's output stopped being a model of its own program.  In DOOP a
+  `VarPointsTo` rule generated `col7=col0` over a six-column left input, so
+  it compared `inv` against `sn`; 354 immediate consequences of that one
+  rule were missing from the final fixpoint with every body atom present,
+  and `ArrayIndexPointsTo` derived nothing at all.  Against the full-DOOP
+  reference outputs in the recovered archive, `VarPointsTo` measured 5,266
+  where the reference has 4,455,314.  After the fix: 4,121,488.
+
+  SIP is on by default, so this reached user programs with a rule of this
+  shape, not only benchmarks.  Among the 15 shipped workloads only DOOP's
+  plan changes; out-of-range resolutions go 47 to 0 there and are 0
+  everywhere else both before and after.
+
+  DOOP's cost changes accordingly -- 94 s to about 23 minutes at W=1, 28 to
+  153 iterations, 39 GB peak -- and it no longer completes at W>1 (#959).
+  The old speed was under-derivation.
 
 - **DOOP `Method_Descriptor` derived from the wrong column** (#956): #951
   reconstructed the relation (the archive stopped shipping it) by projecting
@@ -133,9 +160,10 @@ All notable changes to wirelog are documented in this file.
   a pinned revision of the same git-backed mirror, and building the
   benchmark at `70f4d84` against it reproduces the old row exactly
   (6,276,657 tuples, 28 iterations, 11.8 GB). On a basis excluding the two
-  now-derived relations, the archive change accounts for -482,759 and all
-  engine and rule changes since for +119,095; `AssignLocal` alone dropped
-  306,227 -> 144,124 rows.
+  now-derived relations the archive change was the smaller term; after
+  #955 landed, the engine change dominates and no tuple-level
+  decomposition against the old row is meaningful.  `AssignLocal` alone
+  dropped 306,227 -> 144,124 rows between the two archives.
 
 ## [0.53.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,14 +47,46 @@ All notable changes to wirelog are documented in this file.
   `ActualParam.csv`, so after the archive switched to 35 string-valued
   `.facts` (#950) it failed for every user with `expected 34 CSV files,
   found 0`. It now counts `.facts`, points at the download script when the
-  dataset is absent, and carries the reconciled tuple oracle 6,069,774 --
+  dataset is absent, and carries the reconciled tuple oracle 6,070,090 --
   the previous 6276338 matched neither the measurement nor the README's
   6,276,657, so the two in-tree "expected" values for one workload had
-  disagreed by 319 for some time. It also gained an iteration oracle,
-  because iteration count is the more sensitive signal: the heap-typing
-  defect fixed in #951 ran 70 iterations while its tuple total stayed
-  within 3% of the correct one. `--help` printed a fixed `head -40` window
-  and had silently begun truncating its own options list.
+  disagreed by 319 for some time. The default is W=1-specific and is not
+  applied at W>1, which is not reproducible (#958). It also gained an
+  iteration oracle as a cheap second signal -- it does catch defects the
+  tuple total hides (the heap-typing bug fixed in #951 ran 70 iterations
+  while its total stayed within 3% of correct), but not the converse: 28
+  survives configurations where the whole type hierarchy derives zero
+  rows, so a matching iteration count proves nothing on its own.
+  `--help` printed a fixed `head -40` window and had silently begun
+  truncating its own options list.
+
+- **DOOP `Method_Descriptor` derived from the wrong column** (#956): #951
+  reconstructed the relation (the archive stopped shipping it) by projecting
+  `Method.facts` column 3, the parameter list.  DOOP's convention is
+  `?returnType "(" ?paramTypes ")"`.  Confirmed against the recovered
+  2026-05-24 archive's own `Method_Descriptor.csv`: the descriptor form
+  matches all 70,373 rows, the params form matches none.
+
+  Two consequences.  562 `MethodLookup` rows were lost to the
+  `!MethodImplemented` antijoin, and -- less visibly -- the coarser key
+  merged covariant overrides and bridge methods, leaving 1,829 ambiguous
+  virtual-dispatch keys where the correct reading leaves 625.  Wrong
+  dispatch targets, not just missing rows.
+
+  The constant sites move with it: `MainMethodDeclaration` from
+  `"java.lang.String[]"` to `"void(java.lang.String[])"`, and
+  `ClassInitializer` from `""` to `"void()"`.  Missing the second would
+  have silently emptied `ClassInitializer` -- all 1,900 `<clinit>` rows
+  carry the empty parameter list, and no `rt(params)` descriptor can be
+  empty.
+
+  Every existing test supplied `Method_Descriptor` as EDB facts, so none
+  reached the derivation and no amount of constant-pinning could have
+  caught this.  Two tests now derive it, and the assertions include a
+  method with non-empty parameters -- with only no-argument methods,
+  `cat(rt, p)` without parentheses and the arguments transposed both
+  produce the same partition as the correct rule and survive a
+  count-only test.
 
 - **Unbounded source construction in a filter test** (#939, #940): a test-source
   builder accumulated `snprintf` return values, which report the length that
@@ -101,8 +133,8 @@ All notable changes to wirelog are documented in this file.
   a pinned revision of the same git-backed mirror, and building the
   benchmark at `70f4d84` against it reproduces the old row exactly
   (6,276,657 tuples, 28 iterations, 11.8 GB). On a basis excluding the two
-  now-derived relations, the archive change accounts for -482,761 and all
-  engine and rule changes since for +118,781; `AssignLocal` alone dropped
+  now-derived relations, the archive change accounts for -482,759 and all
+  engine and rule changes since for +119,095; `AssignLocal` alone dropped
   306,227 -> 144,124 rows.
 
 ## [0.53.0] - 2026-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **DOOP fact-catalogue drift gate** (#952): the set of DOOP `.facts` files is
+  written down in four places -- `download.sh`, `doop_edbs[]`,
+  `doop_fact_files[]`, and the file count in `run_doop_validation.sh`. They
+  drifted apart silently once (#950) and the test that should have caught it
+  skipped itself instead. `scripts/ci/check-doop-catalogue.sh` now compares
+  all four and fails the `abi` suite on disagreement. It parses sources only,
+  so it runs on hosts that will never fetch the 740 MB archive, and it refuses
+  to compare catalogues it could not parse -- a parser returning nothing would
+  otherwise make every set trivially equal, which is the exact shape of
+  failure it exists to catch.
+
 ### Changed
 
 - **Warning-clean library build** (#940): the last three `-Wunused-function`
@@ -31,6 +42,20 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **`scripts/run_doop_validation.sh` no longer expects the vanished CSV
+  layout** (#952): it counted 34 `*.csv` files and spot-checked
+  `ActualParam.csv`, so after the archive switched to 35 string-valued
+  `.facts` (#950) it failed for every user with `expected 34 CSV files,
+  found 0`. It now counts `.facts`, points at the download script when the
+  dataset is absent, and carries the reconciled tuple oracle 6,069,774 --
+  the previous 6276338 matched neither the measurement nor the README's
+  6,276,657, so the two in-tree "expected" values for one workload had
+  disagreed by 319 for some time. It also gained an iteration oracle,
+  because iteration count is the more sensitive signal: the heap-typing
+  defect fixed in #951 ran 70 iterations while its tuple total stayed
+  within 3% of the correct one. `--help` printed a fixed `head -40` window
+  and had silently begun truncating its own options list.
+
 - **Unbounded source construction in a filter test** (#939, #940): a test-source
   builder accumulated `snprintf` return values, which report the length that
   would have been written rather than the length written, so the write cursor
@@ -55,6 +80,25 @@ All notable changes to wirelog are documented in this file.
 ### Security
 
 ### Documentation
+
+- **Benchmark table re-measured** (#952): the README portfolio was last
+  measured 2026-05-24 and four workloads' *output* had changed since. CRDT
+  (1,301,914 -> 2,156,530 tuples), DDISASM (531 -> 900) and Polonius
+  (1,807 -> 1,999) moved under `61e2530` (#914); this was confirmed rather
+  than assumed by building both sides of that commit, which reproduce the
+  old and new values exactly. DOOP moved under #950/#951.
+
+  Each workload is now measured in its own process. Peak RSS is a
+  process-wide high-water mark, so the convenient single `--workload all`
+  invocation reports the largest workload's footprint for everything that
+  follows it -- CSPA's 325 MB was being attributed to five later rows.
+
+  The DOOP row carries the archive sha256 it describes and its ~33 GB
+  memory requirement, which is a barrier for anyone following the
+  reproduction block. Its remaining 363,980-tuple difference from the old
+  row is stated as unexplained rather than presented as a refresh, and
+  #914 is ruled out as the cause by direct measurement: reverting only its
+  `eval.c` hunk *lowers* DOOP to 5,857,332, so it widens the gap.
 
 ## [0.53.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,10 +95,15 @@ All notable changes to wirelog are documented in this file.
 
   The DOOP row carries the archive sha256 it describes and its ~33 GB
   memory requirement, which is a barrier for anyone following the
-  reproduction block. Its remaining 363,980-tuple difference from the old
-  row is stated as unexplained rather than presented as a refresh, and
-  #914 is ruled out as the cause by direct measurement: reverting only its
-  `eval.c` hunk *lowers* DOOP to 5,857,332, so it widens the gap.
+  reproduction block. Its difference from the old row is accounted for
+  rather than presented as a refresh: upstream replaced the archive 51
+  minutes after the old row was measured, the original is still served at
+  a pinned revision of the same git-backed mirror, and building the
+  benchmark at `70f4d84` against it reproduces the old row exactly
+  (6,276,657 tuples, 28 iterations, 11.8 GB). On a basis excluding the two
+  now-derived relations, the archive change accounts for -482,761 and all
+  engine and rule changes since for +118,781; `AssignLocal` alone dropped
+  306,227 -> 144,124 rows.
 
 ## [0.53.0] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -89,16 +89,18 @@ block below runs them separately for the same reason.
 | Borrow Check | Polonius | 4.4ms | 3.8ms | 3.6ms | 1,999 | 23 / 25 / 25 | 3.5MB / 3.4MB / 3.5MB |
 | Disassembly | DDISASM | 2.4ms | 3.8ms | 3.3ms | 900 | 0 / 19 / 19 | 3.5MB / 3.7MB / 3.7MB |
 | CRDT | CRDT | 23.36s | 24.01s | 23.65s | 2,156,530 | 14,148 | 108MB / 345MB / 462MB |
-| Program Analysis | DOOP (zxing) | 91.31s | 50.72s | 44.02s | 6,070,090 [^doop] | 28 | 31.1GB / 32.8GB / 32.8GB |
+| Program Analysis | DOOP (zxing) | 1368.4s | FAIL | FAIL | 14,096,448 [^doop] | 153 | 39.1GB / -- / -- |
 
-[^doop]: DOOP's tuple total is the **W=1** figure and is reproducible only
-    there. At W>1 it varies run to run -- 6,070,123 / 6,070,238 / 6,070,274
-    across three W=8 runs of the same binary (#958). The W=8 and W=16
-    timings in this row are still meaningful; the tuple count is not.
-    Two further open defects ride on this number: the fixpoint is not
-    closed under its own rules (#955), and the total counts duplicate
-    rows rather than distinct tuples (#957). Treat it as a fingerprint of
-    current code, not as a statement about what DOOP should compute.
+[^doop]: DOOP is the one row measured with `--repeat 1`, not a 5-trial
+    median: at 23 minutes a run, three widths at `--repeat 5` is six hours.
+    **W=8 and W=16 do not complete** -- they hit the per-worker join-output
+    cap, which is the session cap divided by the worker count (#959), so
+    parallelism currently lowers the capacity of the run. W=1 is
+    deterministic; the W>1 tuple counts recorded in an earlier revision of
+    this table came from runs that varied between invocations (#958).
+    The total counts duplicate rows rather than distinct tuples (#957), so
+    treat it as a fingerprint of current code rather than a statement
+    about what DOOP should compute.
 
 Numbers are 5-trial medians (`--repeat 5`) on a single dev host with
 cpufreq governor `schedutil`; treat them as descriptive, not gated.
@@ -127,19 +129,23 @@ are result-set changes, not timing noise, and they have separate causes:
   commit: at W=1, `61e2530^` reproduces the previous table's three values
   exactly and `61e2530` reproduces the current ones exactly. CRDT's
   iteration count moves with it, 0 -> 14,148.
-- **DOOP** changed under #950/#951, which converted the benchmark to read
-  the archive's string-valued `.facts` as shipped instead of a vanished
-  integer encoding, and derived two relations the archive does not ship.
-  The tuple total is therefore not comparable to the previous row: 157,097
-  of it is `Method_Descriptor` and `HeapAllocation_Type`, which are now IDBs
-  and so enter a count that never included them.
+- **DOOP** changed under #950/#951 (reading the archive's string-valued
+  `.facts` as shipped, and deriving two relations it does not ship), #956
+  (`Method_Descriptor` was projecting the parameter list instead of
+  `returnType(params)`), and above all **#955**, a plan-generation defect
+  that made the evaluator drop most of its own derivations. The total is
+  not comparable to the previous row in any tuple-level sense; see below.
 
 **The DOOP row describes a specific artifact**: the FlowLog zxing archive
 with sha256
 `154593343fefd18306d4098ba9f6286947b134b56ebcf83d8e8eae368d5867e7`
 (35 `.facts` files, ~740 MB unpacked), fetched by
-`bench/data/doop/download.sh`. **It needs roughly 33 GB of RAM** -- the
-2026-05-24 row's 12 GB no longer describes what running this costs.
+`bench/data/doop/download.sh`. **It needs roughly 40 GB of RAM and takes
+about 23 minutes** at W=1 -- the 2026-05-24 row's 12 GB and 33 s do not
+describe what running this costs. That row was measured before #955, when
+the evaluator was dropping most of its own derivations: `VarPointsTo`
+measured 5,266 against a true value near 4.1 million. The old speed was
+under-derivation, not performance.
 
 **The difference from the 2026-05-24 row is accounted for.** Upstream
 replaced the archive at that URL on 2026-05-24, 51 minutes after the old
@@ -151,21 +157,34 @@ Building the benchmark at `70f4d84` and running it against that recovered
 archive reproduces the old row exactly: **6,276,657 tuples, 28 iterations,
 11.8 GB**.
 
-With both endpoints measured, on a basis that excludes the two relations
-that are now derived:
+Running today's engine against both archives separates the two causes:
 
-| | comparable total |
-|---|---|
-| `70f4d84` engine, old archive (the old row) | 6,276,657 |
-| today's engine and rules, old archive | 6,395,752 |
-| today's engine and rules, current archive | 5,912,993 |
+| | tuples | iterations |
+|---|---|---|
+| `70f4d84` engine, old archive (the old row) | 6,276,657 | 28 |
+| today's engine, old archive | 14,470,301 | 160 |
+| today's engine, current archive | 14,096,448 | 153 |
 
-So the archive change accounts for **-482,759** and everything else since
-`70f4d84` for **+119,095**. The dominant single input change is
-`AssignLocal`, 306,227 -> 144,124 rows: it is the main source of `Assign`,
-and `VarPointsTo` closure over `Assign` dominates the total. 32 of the 34
-shared relations changed; only `MainClass` and `ApplicationClass` did not.
-See #952.
+**The engine change dominates.** #955 -- a plan-generation defect that
+shifted join keys past a semijoin and silently resolved them to column 0 --
+had the evaluator dropping most of its own derivations, so the old row was
+not a smaller-but-correct answer, it was a different and wrong one. No
+tuple-level decomposition against it is meaningful.
+
+The archive change is the smaller term and still real: upstream replaced
+the artifact 51 minutes after the old row was measured, with a regenerated
+Soot fact dump rather than a re-encoding. The dominant single input change
+is `AssignLocal`, 306,227 -> 144,124 rows: it is the main source of
+`Assign`, and `VarPointsTo` closure over `Assign` dominates the total. 32
+of the 34 shared relations changed; only `MainClass` and `ApplicationClass`
+did not. See #952.
+
+The recovered archive also ships full-DOOP reference outputs, which is the
+first external check this benchmark has had. Post-#955, on the current
+archive, against the reference (a different dataset, so exact agreement is
+not expected): `Reachable` 6,127 vs 6,167, `ArrayIndexPointsTo` 32,859 vs
+33,018, `InstanceFieldPointsTo` 3,792,166 vs 3,837,529, `VarPointsTo`
+4,121,488 vs 4,455,314. Before #955 those measured 498, 0, and 5,266.
 
 **Incremental evaluation** (CSPA, delta-seeded): W=1 baseline 1.31s
 -> incremental re-eval 15.3ms (**86.0x faster**); W=8 baseline 691.3ms

--- a/README.md
+++ b/README.md
@@ -60,31 +60,36 @@ For fine-grained control over plans, backends, or worker counts, use the `wirelo
 ## Performance
 
 15-workload static benchmark portfolio plus CSPA incremental check
-(2026-05-24, `chore/0.43.99-dev-bench` at `70f4d84`,
-release/LTO build, GCC 16.1.1, `--repeat 5` medians):
+(2026-08-04, `main` at `7e498e7`, release/LTO build, GCC 16.1.1,
+`--repeat 5` medians):
 
-**Test environment**: Intel Xeon E5-2696 v4 (2 sockets, 44C/88T), Linux 7.0.9
-(Arch), 88 logical CPUs across two NUMA nodes. Measurements were collected
-from `./build-readme-bench/bench/bench_flowlog`; wall-clock results vary
-with CPU governor, thermal state, and memory pressure.
+**Test environment**: Intel Xeon E5-2696 v4 (2 sockets, 44C/88T), Linux 7.1.5
+(Arch), 88 logical CPUs across two NUMA nodes, 125 GB RAM. Measurements were
+collected from `./build-readme-bench/bench/bench_flowlog`; wall-clock results
+vary with CPU governor, thermal state, and memory pressure.
+
+Each workload was run in its own process. Peak RSS is a process-wide
+high-water mark, so a single `--workload all` invocation reports the largest
+workload's footprint for every workload that follows it -- the reproduction
+block below runs them separately for the same reason.
 
 | Category | Workload | W=1 median | W=8 median | W=16 median | Tuples | Iterations | Peak RSS (W=1 / W=8 / W=16) |
 |----------|----------|------------|------------|-------------|--------|------------|-------------------------------|
-| Graph | TC (Transitive Closure) | 7.9ms | 5.9ms | 5.9ms | 4,950 | 98 | 3.1MB / 3.3MB / 3.3MB |
-| Graph | Reach | 0.6ms | 0.4ms | 0.4ms | 100 | 98 | 2.7MB / 2.8MB / 2.7MB |
-| Graph | CC (Connected Components) | 8.6ms | 8.8ms | 11.0ms | 100 | 99 | 3.2MB / 3.1MB / 3.1MB |
-| Graph | SSSP (Shortest Path) | 0.6ms | 0.6ms | 0.8ms | 100 | 98 | 2.8MB / 2.8MB / 2.8MB |
-| Graph | SG (Subgraph) | 0.3ms | 0.4ms | 0.4ms | 0 | 0 | 2.8MB / 2.7MB / 2.8MB |
-| Graph | Bipartite | 0.6ms | 0.9ms | 0.8ms | 100 | 73 | 2.9MB / 2.9MB / 2.9MB |
-| Pointer Analysis | Andersen | 1.8ms | 2.9ms | 3.2ms | 155 | 8 | 4.8MB / 6.5MB / 3.4MB |
-| Pointer Analysis | Dyck-2 | 10.0ms | 9.8ms | 9.2ms | 2,120 | 8 | 5.6MB / 9.1MB / 9.2MB |
-| Pointer Analysis | CSPA | 1.16s | 588.6ms | 583.2ms | 20,381 | 6 | 339MB / 456MB / 482MB |
-| Data Flow | CSDA | 2.7ms | 2.7ms | 2.7ms | 2,986 | 29 | 3.1MB / 3.2MB / 3.2MB |
-| Ontology | Galen | 21.7ms | 28.8ms | 32.4ms | 5,568 | 23 | 6.1MB / 24MB / 24MB |
-| Borrow Check | Polonius | 3.7ms | 4.5ms | 3.6ms | 1,807 | 23 | 5.2MB / 5.2MB / 5.2MB |
-| Disassembly | DDISASM | 3.3ms | 3.9ms | 3.8ms | 531 | 0 / 16 / 16 | 5.0MB / 5.1MB / 5.1MB |
-| CRDT | CRDT | 12.78s | 12.87s | 12.73s | 1,301,914 | 0 / 7,603 / 7,603 | 79MB / 281MB / 322MB |
-| Program Analysis | DOOP (zxing) | 33.18s | 19.31s | 17.01s | 6,276,657 | 28 | 12.0GB / 12.7GB / 12.9GB |
+| Graph | TC (Transitive Closure) | 6.1ms | 6.0ms | 7.6ms | 4,950 | 98 | 3.2MB / 3.5MB / 3.4MB |
+| Graph | Reach | 0.6ms | 0.6ms | 0.4ms | 100 | 98 | 2.9MB / 2.9MB / 2.9MB |
+| Graph | CC (Connected Components) | 8.7ms | 8.4ms | 12.7ms | 100 | 99 | 3.2MB / 3.1MB / 3.2MB |
+| Graph | SSSP (Shortest Path) | 0.8ms | 0.6ms | 0.8ms | 100 | 98 | 2.8MB / 2.8MB / 2.8MB |
+| Graph | SG (Subgraph) | 0.5ms | 0.4ms | 0.5ms | 0 | 0 | 2.8MB / 2.9MB / 2.8MB |
+| Graph | Bipartite | 0.9ms | 0.7ms | 0.8ms | 100 | 73 | 3.0MB / 2.9MB / 2.9MB |
+| Pointer Analysis | Andersen | 2.4ms | 3.1ms | 3.2ms | 155 | 8 | 3.1MB / 3.4MB / 3.5MB |
+| Pointer Analysis | Dyck-2 | 10.2ms | 10.3ms | 9.5ms | 2,120 | 8 | 3.5MB / 7.2MB / 7.3MB |
+| Pointer Analysis | CSPA | 1.32s | 716.9ms | 695.9ms | 20,381 | 6 | 325MB / 459MB / 453MB |
+| Data Flow | CSDA | 2.7ms | 2.3ms | 2.3ms | 2,986 | 29 | 3.2MB / 3.4MB / 3.3MB |
+| Ontology | Galen | 21.1ms | 31.0ms | 33.9ms | 5,568 | 23 | 4.2MB / 8.8MB / 9.0MB |
+| Borrow Check | Polonius | 4.4ms | 3.8ms | 3.6ms | 1,999 | 23 / 25 / 25 | 3.5MB / 3.4MB / 3.5MB |
+| Disassembly | DDISASM | 2.4ms | 3.8ms | 3.3ms | 900 | 0 / 19 / 19 | 3.5MB / 3.7MB / 3.7MB |
+| CRDT | CRDT | 23.36s | 24.01s | 23.65s | 2,156,530 | 14,148 | 108MB / 345MB / 462MB |
+| Program Analysis | DOOP (zxing) | 92.77s | 51.14s | 44.05s | 6,069,774 | 28 | 31.1GB / 32.7GB / 32.8GB |
 
 Numbers are 5-trial medians (`--repeat 5`) on a single dev host with
 cpufreq governor `schedutil`; treat them as descriptive, not gated.
@@ -93,22 +98,53 @@ under `-Dwirelog_log_max_level=error` plus a `performance` governor
 (see `tests/test_crdt_perf_gate.c`).
 
 The CSPA table row is the static `cspa-fast` workload. The separate
-incremental CSPA check exercises `--workload cspa`. Galen W=8 had one
-outlier pass during regression triage and was rerun before documenting
-the confirmed 28.8ms median.
+incremental CSPA check exercises `--workload cspa`, which runs *only* the
+incremental variant -- the two are different entry points, not two
+reports from one run.
 
 Historic single-trial numbers from pre-2026-05-09 README revisions
 (before commit `1e6af00`) used `--repeat 1` and are not directly
-comparable to the current 5-trial medians. The previous repeat-5 README
-baseline reported CSPA W=1 at 1.95s on the 2026-05-06 host; this refresh
-reports 1.16s on the 2026-05-24 host/environment, so the delta is
-descriptive and should not be read as an isolated algorithmic speedup or
-regression.
+comparable to the current 5-trial medians. Wall-clock deltas between
+successive refreshes on this host are descriptive and should not be read
+as isolated algorithmic speedups or regressions.
 
-**Incremental evaluation** (CSPA, delta-seeded): W=1 baseline 1.11s
--> incremental re-eval 15.4ms (**71.9x faster**); W=8 baseline 594.1ms
--> incremental re-eval 29.1ms (**20.4x faster**); W=16 baseline 608.1ms
--> incremental re-eval 29.9ms (**20.3x faster**). Each run inserted one
+**Output changed for four workloads since the 2026-05-24 revision.** These
+are result-set changes, not timing noise, and they have separate causes:
+
+- **CRDT** (1,301,914 -> 2,156,530 tuples), **DDISASM** (531 -> 900), and
+  **Polonius** (1,807 -> 1,999) changed under `61e2530` (#914), which reset
+  the iteration context for non-recursive strata; the previous table was
+  never re-measured afterwards. Confirmed by building both sides of that
+  commit: at W=1, `61e2530^` reproduces the previous table's three values
+  exactly and `61e2530` reproduces the current ones exactly. CRDT's
+  iteration count moves with it, 0 -> 14,148.
+- **DOOP** changed under #950/#951, which converted the benchmark to read
+  the archive's string-valued `.facts` as shipped instead of a vanished
+  integer encoding, and derived two relations the archive does not ship.
+  The tuple total is therefore not comparable to the previous row: 157,097
+  of it is `Method_Descriptor` and `HeapAllocation_Type`, which are now IDBs
+  and so enter a count that never included them.
+
+**The DOOP row describes a specific artifact**: the FlowLog zxing archive
+with sha256
+`154593343fefd18306d4098ba9f6286947b134b56ebcf83d8e8eae368d5867e7`
+(35 `.facts` files, ~740 MB unpacked), fetched by
+`bench/data/doop/download.sh`. **It needs roughly 33 GB of RAM** -- the
+2026-05-24 row's 12 GB no longer describes what running this costs.
+
+After subtracting the 157,097 schema tuples, this run is still 363,980
+(5.8%) short of the previous row, and that gap is **not** explained by
+#914: reverting only its `eval.c` hunk and re-running DOOP on today's
+dataset gives 5,857,332 tuples, so #914 *adds* 212,442 here and correcting
+for it widens the gap rather than closing it. What remains is the dataset
+itself, the fidelity of the two reconstructed relations, or both -- neither
+is decidable without the artifact the old row was measured on, which is no
+longer available at its original host. Tracked in #952.
+
+**Incremental evaluation** (CSPA, delta-seeded): W=1 baseline 1.31s
+-> incremental re-eval 15.3ms (**86.0x faster**); W=8 baseline 691.3ms
+-> incremental re-eval 27.5ms (**25.1x faster**); W=16 baseline 673.9ms
+-> incremental re-eval 27.1ms (**24.9x faster**). Each run inserted one
 fact and changed the result from 20,381 to 21,063 tuples.
 
 `--workers N` means "use up to N workers", not "force exactly N workers for
@@ -167,7 +203,7 @@ done
 ```bash
 meson setup build
 meson compile -C build
-meson test -C build --print-errorlogs    # 126 tests
+meson test -C build --print-errorlogs    # 268 tests
 
 # Sanitizer build (optional)
 meson setup build-san -Db_sanitize=address,undefined

--- a/README.md
+++ b/README.md
@@ -89,7 +89,16 @@ block below runs them separately for the same reason.
 | Borrow Check | Polonius | 4.4ms | 3.8ms | 3.6ms | 1,999 | 23 / 25 / 25 | 3.5MB / 3.4MB / 3.5MB |
 | Disassembly | DDISASM | 2.4ms | 3.8ms | 3.3ms | 900 | 0 / 19 / 19 | 3.5MB / 3.7MB / 3.7MB |
 | CRDT | CRDT | 23.36s | 24.01s | 23.65s | 2,156,530 | 14,148 | 108MB / 345MB / 462MB |
-| Program Analysis | DOOP (zxing) | 92.77s | 51.14s | 44.05s | 6,069,774 | 28 | 31.1GB / 32.7GB / 32.8GB |
+| Program Analysis | DOOP (zxing) | 91.31s | 50.72s | 44.02s | 6,070,090 [^doop] | 28 | 31.1GB / 32.8GB / 32.8GB |
+
+[^doop]: DOOP's tuple total is the **W=1** figure and is reproducible only
+    there. At W>1 it varies run to run -- 6,070,123 / 6,070,238 / 6,070,274
+    across three W=8 runs of the same binary (#958). The W=8 and W=16
+    timings in this row are still meaningful; the tuple count is not.
+    Two further open defects ride on this number: the fixpoint is not
+    closed under its own rules (#955), and the total counts duplicate
+    rows rather than distinct tuples (#957). Treat it as a fingerprint of
+    current code, not as a statement about what DOOP should compute.
 
 Numbers are 5-trial medians (`--repeat 5`) on a single dev host with
 cpufreq governor `schedutil`; treat them as descriptive, not gated.
@@ -148,11 +157,11 @@ that are now derived:
 | | comparable total |
 |---|---|
 | `70f4d84` engine, old archive (the old row) | 6,276,657 |
-| today's engine and rules, old archive | 6,395,438 |
-| today's engine and rules, current archive | 5,912,677 |
+| today's engine and rules, old archive | 6,395,752 |
+| today's engine and rules, current archive | 5,912,993 |
 
-So the archive change accounts for **-482,761** and everything else since
-`70f4d84` for **+118,781**. The dominant single input change is
+So the archive change accounts for **-482,759** and everything else since
+`70f4d84` for **+119,095**. The dominant single input change is
 `AssignLocal`, 306,227 -> 144,124 rows: it is the main source of `Assign`,
 and `VarPointsTo` closure over `Assign` dominates the total. 32 of the 34
 shared relations changed; only `MainClass` and `ApplicationClass` did not.

--- a/README.md
+++ b/README.md
@@ -132,14 +132,31 @@ with sha256
 `bench/data/doop/download.sh`. **It needs roughly 33 GB of RAM** -- the
 2026-05-24 row's 12 GB no longer describes what running this costs.
 
-After subtracting the 157,097 schema tuples, this run is still 363,980
-(5.8%) short of the previous row, and that gap is **not** explained by
-#914: reverting only its `eval.c` hunk and re-running DOOP on today's
-dataset gives 5,857,332 tuples, so #914 *adds* 212,442 here and correcting
-for it widens the gap rather than closing it. What remains is the dataset
-itself, the fidelity of the two reconstructed relations, or both -- neither
-is decidable without the artifact the old row was measured on, which is no
-longer available at its original host. Tracked in #952.
+**The difference from the 2026-05-24 row is accounted for.** Upstream
+replaced the archive at that URL on 2026-05-24, 51 minutes after the old
+row was measured, with a regenerated Soot fact dump rather than a
+re-encoding. The HuggingFace mirror is git-backed, so the original is still
+served at revision `e9d2e0e` (117,156,975 bytes, sha256 `dcd842b8...`) --
+which is what the "~112 MB" in `download.sh` had been describing all along.
+Building the benchmark at `70f4d84` and running it against that recovered
+archive reproduces the old row exactly: **6,276,657 tuples, 28 iterations,
+11.8 GB**.
+
+With both endpoints measured, on a basis that excludes the two relations
+that are now derived:
+
+| | comparable total |
+|---|---|
+| `70f4d84` engine, old archive (the old row) | 6,276,657 |
+| today's engine and rules, old archive | 6,395,438 |
+| today's engine and rules, current archive | 5,912,677 |
+
+So the archive change accounts for **-482,761** and everything else since
+`70f4d84` for **+118,781**. The dominant single input change is
+`AssignLocal`, 306,227 -> 144,124 rows: it is the main source of `Assign`,
+and `VarPointsTo` closure over `Assign` dominates the total. 32 of the 34
+shared relations changed; only `MainClass` and `ApplicationClass` did not.
+See #952.
 
 **Incremental evaluation** (CSPA, delta-seeded): W=1 baseline 1.31s
 -> incremental re-eval 15.3ms (**86.0x faster**); W=8 baseline 691.3ms

--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -2608,7 +2608,8 @@ static const char *doop_rules
     "!Method_Modifier(\"abstract\", m).\n"
     "MainMethodDeclaration(m) :- MainClass(t), "
     "Method_DeclaringType(m, t), Method_SimpleName(m, \"main\"), "
-    "Method_Descriptor(m, \"java.lang.String[]\"), Method_Modifier(\"public\", m), "
+    "Method_Descriptor(m, \"void(java.lang.String[])\"), "
+    "Method_Modifier(\"public\", m), "
     "Method_Modifier(\"static\", m).\n"
     "DirectSubclass(a, c) :- DirectSuperclass(a, c).\n"
     "Subclass(c, a) :- DirectSubclass(a, c).\n"
@@ -2637,7 +2638,8 @@ static const char *doop_rules
     "SupertypeOf(s, t) :- SubtypeOf(t, s).\n"
     "SubtypeOfDifferent(s, t) :- SubtypeOf(s, t), s != t.\n"
     /* Phase 3: Class initialization */
-    "ClassInitializer(t, m) :- MethodImplemented(\"<clinit>\", \"\", t, m).\n"
+    "ClassInitializer(t, m) :- "
+    "MethodImplemented(\"<clinit>\", \"void()\", t, m).\n"
     "InitializedClass(sc) :- InitializedClass(c), "
     "DirectSuperclass(c, sc).\n"
     "InitializedClass(si) :- InitializedClass(ci), "
@@ -2753,10 +2755,19 @@ static const char *doop_rules
     "_MethodHandleConstant(h, _, _, _, _).\n"
     "HeapAllocation_Type(cat(cat(\"<method type \", d), \">\"), "
     "\"java.lang.invoke.MethodType\") :- _MethodTypeConstant(d, _, _, _).\n"
-    /* Method.facts column 3 is the Java-style descriptor (main ->
-     * java.lang.String[]); column 6 is the JVM one. */
+    /* DOOP's Method_Descriptor is ?returnType "(" ?paramTypes ")" -- not
+     * Method.facts column 3, which is the parameter list alone.  Confirmed
+     * against the recovered 2026-05-24 archive's own Method_Descriptor.csv:
+     * returnType+"("+params+")" matches all 70,373 rows, params alone
+     * matches none (#956).  Column 6 is the JVM descriptor, a third form.
+     *
+     * Binding params alone loses 562 MethodLookup rows to the
+     * !MethodImplemented antijoin and, worse, coarsens the dispatch key so
+     * covariant overrides and bridge methods collapse together: 1,829
+     * ambiguous dispatch keys instead of 625. */
     ".decl Method_Descriptor(method: string, descriptor: string)\n"
-    "Method_Descriptor(m, d) :- _Method(m, _, d, _, _, _, _).\n";
+    "Method_Descriptor(m, cat(cat(cat(rt, \"(\"), p), \")\")) :- "
+    "_Method(m, _, p, _, rt, _, _).\n";
 
 static int
 run_doop_workload(const char *data_dir, uint32_t workers, int repeat)

--- a/bench/bench_flowlog.c
+++ b/bench/bench_flowlog.c
@@ -2255,7 +2255,8 @@ run_crdt_workload(const char *data_dir, uint32_t workers, int repeat)
 
 /* DOOP uses .input directives to load 35 DOOP .facts files (~3.9M tuples).
  * EDB definitions are generated programmatically; rules are a static string.
- * Dataset: zxing (smallest FlowLog DOOP artifact, 83MB).
+ * Dataset: zxing (smallest FlowLog DOOP artifact, ~740MB unpacked -- the
+ * "83MB" in older comments was the encoded .csv form that no longer ships).
  * Columns are string-typed and the facts are read as shipped, so the
  * benchmark no longer depends on any particular integer encoding
  * (Issue #950). */

--- a/scripts/ci/check-doop-catalogue.sh
+++ b/scripts/ci/check-doop-catalogue.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# check-doop-catalogue.sh - keep the four DOOP fact catalogues in agreement.
+#
+# Copyright (C) CleverPlant
+# Licensed under LGPL-3.0
+#
+# The set of DOOP .facts files is written down in four places:
+#
+#   bench/data/doop/download.sh        REQUIRED     (what is extracted)
+#   bench/bench_flowlog.c              doop_edbs[]  (what is loaded)
+#   tests/test_option2_doop.c          doop_fact_files[]
+#   scripts/run_doop_validation.sh     the expected file count
+#
+# Issue #950 happened because these drifted apart silently: the archive
+# switched from .csv to .facts, one catalogue was updated and the others
+# were not, and the test that should have caught it skipped itself instead.
+# Issue #952 added this check so the next drift fails a build rather than
+# waiting to be noticed.
+#
+# Source-only: parses the four files and needs no dataset, so it runs in CI
+# on hosts that will never download the 740 MB archive.
+#
+# Usage: scripts/ci/check-doop-catalogue.sh [project_root]
+
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+DOWNLOAD="$ROOT/bench/data/doop/download.sh"
+BENCH="$ROOT/bench/bench_flowlog.c"
+TEST="$ROOT/tests/test_option2_doop.c"
+VALIDATE="$ROOT/scripts/run_doop_validation.sh"
+
+for f in "$DOWNLOAD" "$BENCH" "$TEST" "$VALIDATE"; do
+    if [[ ! -f "$f" ]]; then
+        echo "ERROR: missing $f" >&2
+        exit 1
+    fi
+done
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# download.sh lists bare relation names between REQUIRED=" and the closing
+# quote; the .facts suffix is appended at the use site.
+sed -n '/^REQUIRED="/,/"$/p' "$DOWNLOAD" \
+    | sed 's/^REQUIRED="//; s/"$//' \
+    | tr ' \t' '\n\n' \
+    | sed '/^$/d; s/$/.facts/' \
+    | sort -u > "$tmp/download"
+
+# The two C catalogues are the only quoted "*.facts" literals in their files.
+grep -o '"[A-Za-z0-9_-]*\.facts"' "$BENCH" | tr -d '"' | sort -u > "$tmp/bench"
+grep -o '"[A-Za-z0-9_-]*\.facts"' "$TEST" | tr -d '"' | sort -u > "$tmp/test"
+
+# A parse that silently yields nothing would make every set trivially equal --
+# the exact shape of failure this check exists to catch.  Demand a plausible
+# floor rather than merely non-empty.
+for name in download bench test; do
+    n=$(wc -l < "$tmp/$name")
+    if [[ "$n" -lt 30 ]]; then
+        echo "ERROR: extracted only $n .facts names from the '$name' catalogue." >&2
+        echo "       The catalogue shrank drastically or this parser broke;" >&2
+        echo "       either way do not treat the comparison below as meaningful." >&2
+        exit 1
+    fi
+done
+
+rc=0
+
+if ! diff -u "$tmp/download" "$tmp/bench" > "$tmp/d1"; then
+    echo "ERROR: download.sh REQUIRED and bench_flowlog.c doop_edbs[] disagree:" >&2
+    sed 's/^/    /' "$tmp/d1" >&2
+    rc=1
+fi
+
+if ! diff -u "$tmp/download" "$tmp/test" > "$tmp/d2"; then
+    echo "ERROR: download.sh REQUIRED and test_option2_doop.c doop_fact_files[]" >&2
+    echo "       disagree:" >&2
+    sed 's/^/    /' "$tmp/d2" >&2
+    rc=1
+fi
+
+EXPECTED=$(wc -l < "$tmp/download")
+
+# DOOP_NRELS sizes doop_edbs[]; a mismatch is a compile error there, but it is
+# still worth naming here so the count appears in one report.
+NRELS=$(sed -n 's/^#define DOOP_NRELS \([0-9]*\).*/\1/p' "$BENCH" | head -1)
+if [[ "$NRELS" != "$EXPECTED" ]]; then
+    echo "ERROR: DOOP_NRELS is $NRELS but the catalogue has $EXPECTED files." >&2
+    rc=1
+fi
+
+# run_doop_validation.sh gates on the file count before it runs anything.
+COUNT=$(sed -n 's/^DOOP_FACT_COUNT_EXPECTED=\([0-9]*\).*/\1/p' "$VALIDATE" | head -1)
+if [[ -z "$COUNT" ]]; then
+    echo "ERROR: run_doop_validation.sh has no DOOP_FACT_COUNT_EXPECTED." >&2
+    echo "       It gates on the fact-file count, so that count must be" >&2
+    echo "       greppable from here or this check silently stops covering it." >&2
+    rc=1
+elif [[ "$COUNT" != "$EXPECTED" ]]; then
+    echo "ERROR: run_doop_validation.sh expects $COUNT fact files," >&2
+    echo "       but the catalogue has $EXPECTED." >&2
+    rc=1
+fi
+
+if [[ "$rc" -eq 0 ]]; then
+    echo "DOOP catalogue check: OK ($EXPECTED .facts files agreed across 4 sources)"
+fi
+
+exit "$rc"

--- a/scripts/ci/check-doop-catalogue.sh
+++ b/scripts/ci/check-doop-catalogue.sh
@@ -57,7 +57,9 @@ grep -o '"[A-Za-z0-9_-]*\.facts"' "$TEST" | tr -d '"' | sort -u > "$tmp/test"
 # the exact shape of failure this check exists to catch.  Demand a plausible
 # floor rather than merely non-empty.
 for name in download bench test; do
-    n=$(wc -l < "$tmp/$name")
+    # BSD wc pads its output with leading spaces; strip so the value is
+    # usable in string comparisons as well as arithmetic ones.
+    n=$(wc -l < "$tmp/$name" | tr -d '[:space:]')
     if [[ "$n" -lt 30 ]]; then
         echo "ERROR: extracted only $n .facts names from the '$name' catalogue." >&2
         echo "       The catalogue shrank drastically or this parser broke;" >&2
@@ -81,7 +83,7 @@ if ! diff -u "$tmp/download" "$tmp/test" > "$tmp/d2"; then
     rc=1
 fi
 
-EXPECTED=$(wc -l < "$tmp/download")
+EXPECTED=$(wc -l < "$tmp/download" | tr -d '[:space:]')
 
 # DOOP_NRELS sizes doop_edbs[]; a mismatch is a compile error there, but it is
 # still worth naming here so the count appears in one report.

--- a/scripts/run_doop_validation.sh
+++ b/scripts/run_doop_validation.sh
@@ -4,15 +4,16 @@
 # Copyright (C) CleverPlant
 # Licensed under LGPL-3.0
 #
-# Runs the DOOP Java points-to analysis (zxing dataset, 83MB, 34 CSV files)
-# using the bench_flowlog binary and captures wall time, peak RSS, and tuple
-# count.  Reports PASS/FAIL based on completion plus a tuple-count oracle when
-# one is provided.
+# Runs the DOOP Java points-to analysis (zxing dataset, ~740MB, 35 .facts
+# files) using the bench_flowlog binary and captures wall time, peak RSS,
+# tuple count, and iteration count.  Reports PASS/FAIL based on completion
+# plus tuple- and iteration-count oracles when they are provided.
 #
 # Usage:
 #   scripts/run_doop_validation.sh [--build-dir DIR] [--workers N]
 #                                  [--repeat N] [--baseline FILE]
-#                                  [--expected-tuples N] [--save-results]
+#                                  [--expected-tuples N]
+#                                  [--expected-iterations N] [--save-results]
 #
 # Options:
 #   --build-dir DIR   Meson build directory (default: build)
@@ -22,14 +23,32 @@
 #   --expected-tuples N
 #                     Expected DOOP output tuple count. Defaults to
 #                     DOOP_EXPECTED_TUPLES when set; otherwise defaults to
-#                     6276338 for the bundled bench/data/doop zxing dataset.
+#                     6069774 for the bundled bench/data/doop zxing dataset.
+#   --expected-iterations N
+#                     Expected fixpoint iteration count. Defaults to
+#                     DOOP_EXPECTED_ITERATIONS when set; otherwise defaults
+#                     to 28 for the bundled dataset.  See "Oracles" below.
 #   --save-results    Write a validation TSV under docs/performance
 #
 # Environment:
-#   DOOP_DATA_DIR     Override for DOOP CSV data directory
+#   DOOP_DATA_DIR     Override for the DOOP .facts data directory
 #                     (default: bench/data/doop relative to project root)
 #   DOOP_EXPECTED_TUPLES
 #                     Expected DOOP output tuple count
+#   DOOP_EXPECTED_ITERATIONS
+#                     Expected fixpoint iteration count
+#
+# Oracles:
+#   Both defaults describe the archive with sha256
+#   154593343fefd18306d4098ba9f6286947b134b56ebcf83d8e8eae368d5867e7,
+#   measured on 2026-08-04 (issue #952).  Supply --expected-tuples on any
+#   other dataset; the tuple count is dataset-specific.
+#
+#   The iteration count is checked because it is the more sensitive of the
+#   two.  Fixpoint depth responds to the *shape* of the derived relations,
+#   so a rule defect moves it even when the tuple total looks plausible: the
+#   heap-typing bug fixed in #951 ran 70 iterations while producing a tuple
+#   count within 3% of the correct one.
 #
 # Output:
 #   Benchmark output plus validation summary printed to stdout.
@@ -55,7 +74,13 @@ WORKERS="${WORKERS:-1}"
 REPEAT="${REPEAT:-1}"
 BASELINE_FILE=""
 EXPECTED_TUPLES="${DOOP_EXPECTED_TUPLES:-}"
+EXPECTED_ITERATIONS="${DOOP_EXPECTED_ITERATIONS:-}"
 SAVE_RESULTS=0
+
+# Number of .facts files the bundled dataset must contain.  Kept in step with
+# download.sh, doop_edbs[], and doop_fact_files[] by
+# scripts/ci/check-doop-catalogue.sh -- that check greps this exact name.
+DOOP_FACT_COUNT_EXPECTED=35
 
 # -------------------------------------------------------------------------
 # Argument parsing
@@ -83,12 +108,18 @@ while [[ $# -gt 0 ]]; do
             EXPECTED_TUPLES="$2"
             shift 2
             ;;
+        --expected-iterations)
+            EXPECTED_ITERATIONS="$2"
+            shift 2
+            ;;
         --save-results)
             SAVE_RESULTS=1
             shift
             ;;
         -h|--help)
-            head -40 "$0" | grep '^#' | sed 's/^# \?//'
+            # Print the whole leading comment block, however long it grows;
+            # a fixed head -N silently truncated the options list once.
+            awk 'NR > 1 { if (!/^#/) exit; sub(/^# ?/, ""); print }' "$0"
             exit 0
             ;;
         *)
@@ -130,20 +161,25 @@ fi
 # Check DOOP data directory
 if [[ ! -d "$DOOP_DATA" ]]; then
     echo "ERROR: DOOP data directory not found: $DOOP_DATA"
-    echo "Set DOOP_DATA_DIR to the zxing CSV directory."
+    echo "Set DOOP_DATA_DIR to the zxing .facts directory, or run"
+    echo "  bench/data/doop/download.sh"
     exit 1
 fi
 
-# Count CSV files
-CSV_COUNT=$(find "$DOOP_DATA" -maxdepth 1 -name "*.csv" | wc -l | tr -d ' ')
-echo "DOOP CSV files found: $CSV_COUNT (expected: 34)"
-if [[ "$CSV_COUNT" -ne 34 ]]; then
-    echo "ERROR: expected 34 CSV files, found $CSV_COUNT"
+# Count fact files
+FACT_COUNT=$(find "$DOOP_DATA" -maxdepth 1 -name "*.facts" | wc -l | tr -d ' ')
+echo "DOOP fact files found: $FACT_COUNT (expected: $DOOP_FACT_COUNT_EXPECTED)"
+if [[ "$FACT_COUNT" -ne "$DOOP_FACT_COUNT_EXPECTED" ]]; then
+    echo "ERROR: expected $DOOP_FACT_COUNT_EXPECTED .facts files, found $FACT_COUNT"
+    if [[ "$FACT_COUNT" -eq 0 ]]; then
+        echo "Fetch the dataset first:"
+        echo "  bench/data/doop/download.sh"
+    fi
     exit 1
 fi
 
 if [[ -z "$EXPECTED_TUPLES" && "$DOOP_DATA" == "$DEFAULT_DOOP_DATA" ]]; then
-    EXPECTED_TUPLES=6276338
+    EXPECTED_TUPLES=6069774
 fi
 if [[ -n "$EXPECTED_TUPLES" && ! "$EXPECTED_TUPLES" =~ ^[0-9]+$ ]]; then
     echo "ERROR: expected tuple count must be a non-negative integer"
@@ -151,15 +187,24 @@ if [[ -n "$EXPECTED_TUPLES" && ! "$EXPECTED_TUPLES" =~ ^[0-9]+$ ]]; then
 fi
 echo "Expected tuples: ${EXPECTED_TUPLES:-not supplied}"
 
+if [[ -z "$EXPECTED_ITERATIONS" && "$DOOP_DATA" == "$DEFAULT_DOOP_DATA" ]]; then
+    EXPECTED_ITERATIONS=28
+fi
+if [[ -n "$EXPECTED_ITERATIONS" && ! "$EXPECTED_ITERATIONS" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: expected iteration count must be a non-negative integer"
+    exit 1
+fi
+echo "Expected iterations: ${EXPECTED_ITERATIONS:-not supplied}"
+
 # Spot-check a key file
-ACTPARAM="$DOOP_DATA/ActualParam.csv"
+ACTPARAM="$DOOP_DATA/ActualParam.facts"
 if [[ ! -s "$ACTPARAM" ]]; then
-    echo "ERROR: ActualParam.csv is missing or empty"
+    echo "ERROR: ActualParam.facts is missing or empty"
     exit 1
 fi
 
 TOTAL_BYTES=$(du -sb "$DOOP_DATA" 2>/dev/null | awk '{print $1}' || \
-              find "$DOOP_DATA" -maxdepth 1 -name "*.csv" -exec stat -f%z {} \; 2>/dev/null | \
+              find "$DOOP_DATA" -maxdepth 1 -name "*.facts" -exec stat -f%z {} \; 2>/dev/null | \
               awk '{s+=$1} END{print s}')
 TOTAL_MB=$(( TOTAL_BYTES / 1048576 ))
 echo "Dataset size : ~${TOTAL_MB} MB"
@@ -253,6 +298,16 @@ if [[ -n "$EXPECTED_TUPLES" ]]; then
     echo "Tuple count: MATCH ($TUPLES)"
 else
     echo "Tuple count: not checked (no oracle supplied)"
+fi
+
+if [[ -n "$EXPECTED_ITERATIONS" ]]; then
+    if [[ "$ITERATIONS" != "$EXPECTED_ITERATIONS" ]]; then
+        echo "RESULT: FAIL - iteration count mismatch (got $ITERATIONS, expected $EXPECTED_ITERATIONS)"
+        exit 1
+    fi
+    echo "Iterations: MATCH ($ITERATIONS)"
+else
+    echo "Iterations: not checked (no oracle supplied)"
 fi
 
 echo "RESULT: PASS - DOOP completed successfully"

--- a/scripts/run_doop_validation.sh
+++ b/scripts/run_doop_validation.sh
@@ -44,11 +44,14 @@
 #   measured on 2026-08-04 (issue #952).  Supply --expected-tuples on any
 #   other dataset; the tuple count is dataset-specific.
 #
-#   The iteration count is checked because it is the more sensitive of the
-#   two.  Fixpoint depth responds to the *shape* of the derived relations,
-#   so a rule defect moves it even when the tuple total looks plausible: the
-#   heap-typing bug fixed in #951 ran 70 iterations while producing a tuple
-#   count within 3% of the correct one.
+#   The iteration count is checked as a cheap second signal, not as a
+#   sensitive one.  It does catch some rule defects the tuple total hides:
+#   the heap-typing bug fixed in #951 ran 70 iterations while its tuple
+#   count stayed within 3% of correct.  But it is insensitive in the other
+#   direction -- 28 is pinned by the depth of the points-to fixpoint and
+#   survives configurations in which the entire type hierarchy derives
+#   zero rows.  Do not read a matching iteration count as evidence that
+#   the analysis is right.
 #
 # Output:
 #   Benchmark output plus validation summary printed to stdout.

--- a/scripts/run_doop_validation.sh
+++ b/scripts/run_doop_validation.sh
@@ -23,13 +23,13 @@
 #   --expected-tuples N
 #                     Expected DOOP output tuple count. Defaults to
 #                     DOOP_EXPECTED_TUPLES when set; otherwise defaults to
-#                     6070090 for the bundled bench/data/doop zxing dataset
-#                     at --workers 1.  See "Oracles" below: W>1 is not
-#                     currently reproducible (#958).
+#                     14096448 for the bundled bench/data/doop zxing
+#                     dataset at --workers 1.  W>1 does not complete at all
+#                     (#959); see "Oracles" below.
 #   --expected-iterations N
 #                     Expected fixpoint iteration count. Defaults to
 #                     DOOP_EXPECTED_ITERATIONS when set; otherwise defaults
-#                     to 28 for the bundled dataset.  See "Oracles" below.
+#                     to 153 for the bundled dataset.  See "Oracles" below.
 #   --save-results    Write a validation TSV under docs/performance
 #
 # Environment:
@@ -43,7 +43,8 @@
 # Oracles:
 #   Both defaults describe the archive with sha256
 #   154593343fefd18306d4098ba9f6286947b134b56ebcf83d8e8eae368d5867e7,
-#   measured at --workers 1 on 2026-08-04 (issues #952, #956).  Supply
+#   measured at --workers 1 on 2026-08-05 (issues #952, #955, #956).
+#   The run takes about 23 minutes and peaks near 40 GB.  Supply
 #   --expected-tuples on any other dataset; the tuple count is
 #   dataset-specific.  An explicitly supplied --expected-tuples, and a
 #   --baseline TSV, are both applied at any width: comparing against a
@@ -51,16 +52,16 @@
 #   run warns rather than refusing.
 #
 #   The oracle is a FINGERPRINT of current code, not a statement about
-#   what DOOP should compute.  Three open defects pass through it:
-#   #955 (the fixpoint is not closed under its own rules), #957 (the
-#   total counts duplicate rows, so it is a row count and not a tuple
-#   count), and #958 (W>1 varies run to run, which is why this default
-#   is W=1-specific -- do not reuse it with --workers > 1).
+#   what DOOP should compute.  #957 still passes through it: the total
+#   counts duplicate rows, so it is a row count and not a tuple count.
+#   It is W=1-only because W>1 does not complete -- the per-worker
+#   join-output cap is the session cap divided by the worker count
+#   (#959) -- and because W>1 totals varied run to run when they did
+#   complete (#958).
 #
-#   The iteration oracle is NOT gated on W=1.  Unlike the tuple total, 28
-#   was observed at W=8 and W=16 in every run taken while the tuple count
-#   was varying (#958), so it is stable at the widths that matter here.  If
-#   a future run shows it moving, gate it the same way as the tuple oracle.
+#   #955 is fixed as of 2026-08-05.  Before it, this workload derived
+#   VarPointsTo = 5,266 against a true value near 4.1 million; any oracle
+#   recorded before that date describes a broken analysis.
 #
 #   The iteration count is checked as a cheap second signal, not as a
 #   sensitive one.  It does catch some rule defects the tuple total hides:
@@ -205,7 +206,7 @@ fi
 # call to make, not ours.
 if [[ -z "$EXPECTED_TUPLES" && "$DOOP_DATA" == "$DEFAULT_DOOP_DATA" ]]; then
     if [[ "$WORKERS" -eq 1 ]]; then
-        EXPECTED_TUPLES=6070090
+        EXPECTED_TUPLES=14096448
     else
         echo "note: no default tuple oracle at --workers $WORKERS;" \
              "W>1 is not reproducible (#958)"
@@ -218,7 +219,7 @@ fi
 echo "Expected tuples: ${EXPECTED_TUPLES:-not supplied}"
 
 if [[ -z "$EXPECTED_ITERATIONS" && "$DOOP_DATA" == "$DEFAULT_DOOP_DATA" ]]; then
-    EXPECTED_ITERATIONS=28
+    EXPECTED_ITERATIONS=153
 fi
 if [[ -n "$EXPECTED_ITERATIONS" && ! "$EXPECTED_ITERATIONS" =~ ^[0-9]+$ ]]; then
     echo "ERROR: expected iteration count must be a non-negative integer"

--- a/scripts/run_doop_validation.sh
+++ b/scripts/run_doop_validation.sh
@@ -23,7 +23,9 @@
 #   --expected-tuples N
 #                     Expected DOOP output tuple count. Defaults to
 #                     DOOP_EXPECTED_TUPLES when set; otherwise defaults to
-#                     6069774 for the bundled bench/data/doop zxing dataset.
+#                     6070090 for the bundled bench/data/doop zxing dataset
+#                     at --workers 1.  See "Oracles" below: W>1 is not
+#                     currently reproducible (#958).
 #   --expected-iterations N
 #                     Expected fixpoint iteration count. Defaults to
 #                     DOOP_EXPECTED_ITERATIONS when set; otherwise defaults
@@ -41,8 +43,24 @@
 # Oracles:
 #   Both defaults describe the archive with sha256
 #   154593343fefd18306d4098ba9f6286947b134b56ebcf83d8e8eae368d5867e7,
-#   measured on 2026-08-04 (issue #952).  Supply --expected-tuples on any
-#   other dataset; the tuple count is dataset-specific.
+#   measured at --workers 1 on 2026-08-04 (issues #952, #956).  Supply
+#   --expected-tuples on any other dataset; the tuple count is
+#   dataset-specific.  An explicitly supplied --expected-tuples, and a
+#   --baseline TSV, are both applied at any width: comparing against a
+#   baseline captured at a different width is the caller's call, and the
+#   run warns rather than refusing.
+#
+#   The oracle is a FINGERPRINT of current code, not a statement about
+#   what DOOP should compute.  Three open defects pass through it:
+#   #955 (the fixpoint is not closed under its own rules), #957 (the
+#   total counts duplicate rows, so it is a row count and not a tuple
+#   count), and #958 (W>1 varies run to run, which is why this default
+#   is W=1-specific -- do not reuse it with --workers > 1).
+#
+#   The iteration oracle is NOT gated on W=1.  Unlike the tuple total, 28
+#   was observed at W=8 and W=16 in every run taken while the tuple count
+#   was varying (#958), so it is stable at the widths that matter here.  If
+#   a future run shows it moving, gate it the same way as the tuple oracle.
 #
 #   The iteration count is checked as a cheap second signal, not as a
 #   sensitive one.  It does catch some rule defects the tuple total hides:
@@ -181,8 +199,17 @@ if [[ "$FACT_COUNT" -ne "$DOOP_FACT_COUNT_EXPECTED" ]]; then
     exit 1
 fi
 
+# The default tuple oracle is W=1-specific: W>1 varies run to run (#958),
+# so applying it there would report a spurious FAIL.  An explicitly supplied
+# --expected-tuples is still honoured at any width -- that is the caller's
+# call to make, not ours.
 if [[ -z "$EXPECTED_TUPLES" && "$DOOP_DATA" == "$DEFAULT_DOOP_DATA" ]]; then
-    EXPECTED_TUPLES=6069774
+    if [[ "$WORKERS" -eq 1 ]]; then
+        EXPECTED_TUPLES=6070090
+    else
+        echo "note: no default tuple oracle at --workers $WORKERS;" \
+             "W>1 is not reproducible (#958)"
+    fi
 fi
 if [[ -n "$EXPECTED_TUPLES" && ! "$EXPECTED_TUPLES" =~ ^[0-9]+$ ]]; then
     echo "ERROR: expected tuple count must be a non-negative integer"
@@ -347,6 +374,11 @@ if [[ -n "$BASELINE_FILE" && -f "$BASELINE_FILE" ]]; then
     echo "Baseline median  : ${BASE_MEDIAN:-?}ms"
     echo "Baseline tuples  : ${BASE_TUPLES:-?}"
     echo "Baseline iterations: ${BASE_ITERATIONS:-not recorded}"
+    if [[ "$WORKERS" -ne 1 ]]; then
+        echo "warning: comparing tuple counts against a baseline at" \
+             "--workers $WORKERS; W>1 is not reproducible (#958), so a" \
+             "mismatch here may be nondeterminism rather than a regression"
+    fi
     echo ""
 
     # Tuple correctness: must match baseline exactly

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -659,6 +659,19 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #952 (follow-up to #950): the DOOP .facts catalogue is written down
+# in four places -- download.sh, doop_edbs[], doop_fact_files[], and the
+# fact-file count in run_doop_validation.sh.  They drifted apart silently
+# once already, and the test that should have caught it skipped itself
+# instead.  Static text scan; needs no dataset, so it runs on hosts that
+# will never fetch the 740 MB archive.
+if sh.found()
+  test('doop_catalogue', sh,
+       args: [meson.project_source_root() / 'scripts/ci/check-doop-catalogue.sh',
+              meson.project_source_root()],
+       suite: 'abi')
+endif
+
 # Issue #733 K2 (cross-link #690 B3): pin the dynamic-symbol table of
 # libwirelog.so against `abi/libwirelog-1.0.symbols`.  Any new public
 # symbol must update the allowlist in the same PR; any accidental loss
@@ -1031,7 +1044,7 @@ test('option2_cse', test_option2_cse_exe)
 # ============================================================================
 #
 # Infrastructure tests (file checks, parse, synthetic 8-way join) run without
-# the 83MB DOOP dataset.  Data-dependent tests auto-skip when bench/data/doop
+# the ~740MB DOOP dataset.  Data-dependent tests auto-skip when bench/data/doop
 # is absent.  Full DOOP execution uses scripts/run_doop_validation.sh.
 
 test_option2_doop_exe = executable(

--- a/tests/test_doop_strings.c
+++ b/tests/test_doop_strings.c
@@ -43,18 +43,18 @@
  *
  *   test_main_method_declaration
  *       The conjunction of MainClass, simple name "main", descriptor
- *       "java.lang.String[]", and modifiers "public" and "static".  Five
- *       negatives: wrong class, wrong name, wrong descriptor, missing
- *       static, missing public.  Both modifier negatives are needed --
+ *       "void(java.lang.String[])", and modifiers "public" and "static".
+ *       Five negatives: wrong class, wrong name, wrong descriptor,
+ *       missing static, missing public.  Both modifier negatives are needed --
  *       with only one, the other conjunct could be dropped or duplicated
  *       and nothing would notice.  The two conjuncts are symmetric, so
  *       this pins the SET {public, static} and not which literal was
  *       which; nothing can distinguish that, and nothing needs to.
  *
  *   test_class_initializer
- *       MethodImplemented("<clinit>", "", t, m) -- the class initializer is
- *       matched by simple name AND empty descriptor.  Negative: a same-named
- *       method with a non-empty descriptor must not match.
+ *       MethodImplemented("<clinit>", "void()", t, m) -- the class
+ *       initializer is matched by simple name AND descriptor.  Negative: a
+ *       same-named method with a different descriptor must not match.
  *
  *   test_subtype_of_object_and_array_interfaces
  *       Every interface and every array type is a subtype of
@@ -219,8 +219,8 @@ test_method_implemented_excludes_abstract(void)
         ".decl Method_Modifier(mod: string, m: string)\n"
         "Method_SimpleName(\"<A: void f()>\", \"f\").\n"
         "Method_SimpleName(\"<A: void g()>\", \"g\").\n"
-        "Method_Descriptor(\"<A: void f()>\", \"\").\n"
-        "Method_Descriptor(\"<A: void g()>\", \"\").\n"
+        "Method_Descriptor(\"<A: void f()>\", \"void()\").\n"
+        "Method_Descriptor(\"<A: void g()>\", \"void()\").\n"
         "Method_DeclaringType(\"<A: void f()>\", \"A\").\n"
         "Method_DeclaringType(\"<A: void g()>\", \"A\").\n"
         "Method_Modifier(\"abstract\", \"<A: void g()>\").\n"
@@ -233,7 +233,7 @@ test_method_implemented_excludes_abstract(void)
     ASSERT(eval_relation(src, "MethodImplemented", &c) == 0,
         "evaluation failed");
     ASSERT(c.count == 1, "expected exactly the non-abstract method");
-    ASSERT(saw(&c, "f||A|<A: void f()>"),
+    ASSERT(saw(&c, "f|void()|A|<A: void f()>"),
         "expected f(), the method with a body");
     PASS();
 }
@@ -250,7 +250,7 @@ test_method_implemented_excludes_abstract(void)
         ".decl MainMethodDeclaration(m: string)\n"                           \
         "MainMethodDeclaration(m) :- MainClass(t), "                         \
         "Method_DeclaringType(m, t), Method_SimpleName(m, \"main\"), "       \
-        "Method_Descriptor(m, \"java.lang.String[]\"), "                     \
+        "Method_Descriptor(m, \"void(java.lang.String[])\"), "              \
         "Method_Modifier(\"public\", m), Method_Modifier(\"static\", m).\n"
 
 static void
@@ -267,27 +267,27 @@ test_main_method_declaration(void)
         "Method_DeclaringType(\"<App: void main(String[])>\", \"App\").\n"
         "Method_SimpleName(\"<App: void main(String[])>\", \"main\").\n"
         "Method_Descriptor(\"<App: void main(String[])>\", "
-        "\"java.lang.String[]\").\n"
+        "\"void(java.lang.String[])\").\n"
         "Method_Modifier(\"public\", \"<App: void main(String[])>\").\n"
         "Method_Modifier(\"static\", \"<App: void main(String[])>\").\n"
         /* not the main class */
         "Method_DeclaringType(\"<Other: void main(String[])>\", \"Other\").\n"
         "Method_SimpleName(\"<Other: void main(String[])>\", \"main\").\n"
         "Method_Descriptor(\"<Other: void main(String[])>\", "
-        "\"java.lang.String[]\").\n"
+        "\"void(java.lang.String[])\").\n"
         "Method_Modifier(\"public\", \"<Other: void main(String[])>\").\n"
         "Method_Modifier(\"static\", \"<Other: void main(String[])>\").\n"
         /* right class, wrong simple name */
         "Method_DeclaringType(\"<App: void run(String[])>\", \"App\").\n"
         "Method_SimpleName(\"<App: void run(String[])>\", \"run\").\n"
         "Method_Descriptor(\"<App: void run(String[])>\", "
-        "\"java.lang.String[]\").\n"
+        "\"void(java.lang.String[])\").\n"
         "Method_Modifier(\"public\", \"<App: void run(String[])>\").\n"
         "Method_Modifier(\"static\", \"<App: void run(String[])>\").\n"
         /* right name, wrong descriptor */
         "Method_DeclaringType(\"<App: void main(int)>\", \"App\").\n"
         "Method_SimpleName(\"<App: void main(int)>\", \"main\").\n"
-        "Method_Descriptor(\"<App: void main(int)>\", \"int\").\n"
+        "Method_Descriptor(\"<App: void main(int)>\", \"void(int)\").\n"
         "Method_Modifier(\"public\", \"<App: void main(int)>\").\n"
         "Method_Modifier(\"static\", \"<App: void main(int)>\").\n"
         /* right name and descriptor and static, but not public: this is
@@ -297,13 +297,13 @@ test_main_method_declaration(void)
         "Method_DeclaringType(\"<App: void main3(String[])>\", \"App\").\n"
         "Method_SimpleName(\"<App: void main3(String[])>\", \"main\").\n"
         "Method_Descriptor(\"<App: void main3(String[])>\", "
-        "\"java.lang.String[]\").\n"
+        "\"void(java.lang.String[])\").\n"
         "Method_Modifier(\"static\", \"<App: void main3(String[])>\").\n"
         /* right name and descriptor, but not static */
         "Method_DeclaringType(\"<App: void main2(String[])>\", \"App\").\n"
         "Method_SimpleName(\"<App: void main2(String[])>\", \"main\").\n"
         "Method_Descriptor(\"<App: void main2(String[])>\", "
-        "\"java.lang.String[]\").\n"
+        "\"void(java.lang.String[])\").\n"
         "Method_Modifier(\"public\", \"<App: void main2(String[])>\").\n"
         MAIN_RULE;
 
@@ -320,24 +320,26 @@ test_main_method_declaration(void)
 }
 
 /*
- * The class initializer is matched by simple name AND empty descriptor.  A
+ * The class initializer is matched by simple name AND descriptor.  A
  * same-named method taking arguments must not match, which is what makes the
  * descriptor constant load-bearing rather than decorative.
  */
 static void
 test_class_initializer(void)
 {
-    TEST("ClassInitializer matches <clinit> with the empty descriptor");
+    TEST("ClassInitializer matches <clinit> with the void() descriptor");
 
     const char *src =
         ".decl MethodImplemented(sn: string, d: string, t: string, m: string)\n"
-        "MethodImplemented(\"<clinit>\", \"\", \"A\", \"<A: void clinit()>\").\n"
-        "MethodImplemented(\"<clinit>\", \"int\", \"A\", "
+        "MethodImplemented(\"<clinit>\", \"void()\", \"A\", "
+        "\"<A: void clinit()>\").\n"
+        "MethodImplemented(\"<clinit>\", \"void(int)\", \"A\", "
         "\"<A: void clinit(int)>\").\n"
-        "MethodImplemented(\"<init>\", \"\", \"A\", \"<A: void init()>\").\n"
+        "MethodImplemented(\"<init>\", \"void()\", \"A\", "
+        "\"<A: void init()>\").\n"
         ".decl ClassInitializer(t: string, m: string)\n"
         "ClassInitializer(t, m) :- "
-        "MethodImplemented(\"<clinit>\", \"\", t, m).\n";
+        "MethodImplemented(\"<clinit>\", \"void()\", t, m).\n";
 
     collect_t c;
     ASSERT(eval_relation(src, "ClassInitializer", &c) == 0,
@@ -397,11 +399,133 @@ test_subtype_of_object_and_array_interfaces(void)
     PASS();
 }
 
+/*
+ * Issue #956.  Every other test here supplies Method_Descriptor as EDB
+ * facts, so none of them reaches the rule that DERIVES it from _Method --
+ * which is exactly how the wrong column survived review.  This one derives
+ * it.  The rule text is DUPLICATED from bench/bench_flowlog.c by hand and
+ * kept in step by hand -- reverting the benchmark's rule alone breaks
+ * nothing here.  Only scripts/run_doop_validation.sh would catch that,
+ * and it is not in CI.
+ *
+ * Two things must be pinned, and a count alone pins neither:
+ *
+ *   1. The FORMAT.  Asserting only cardinality passes under cat(rt, p)
+ *      with no parens, and under the arguments transposed, because every
+ *      descriptor stays distinct either way.  So the exact strings are
+ *      asserted, including one with NON-EMPTY params -- with only
+ *      empty-parameter methods, "void()" and "()void" are the same string
+ *      reversed and transposition survives.
+ *
+ *   2. The CONSEQUENCE.  The reason the column matters is that params
+ *      alone collapses covariant overrides: LongPipeline declares two
+ *      iterator() methods differing only in return type, so under the
+ *      params reading the subclass entry shadows the inherited one and
+ *      the !MethodImplemented antijoin deletes it.  Under the correct
+ *      reading the descriptors differ and both survive.  The grounding
+ *      pair is real -- 456 such superclass-spanning pairs exist in
+ *      Method.facts.
+ */
+static void
+test_method_descriptor_is_return_type_and_params(void)
+{
+    TEST("Method_Descriptor derives returnType(params), not params alone");
+
+    /* _Method columns, per doop_edbs[] in bench/bench_flowlog.c:
+     * (method, simplename, params, declaringType, returnType,
+     *  jvmDescriptor, arity) */
+    const char *src =
+        ".decl _Method(m: string, sn: string, p: string, t: string, "
+        "rt: string, jvm: string, ar: string)\n"
+        "_Method(\"<App: void main(java.lang.String[])>\", \"main\", "
+        "\"java.lang.String[]\", \"App\", \"void\", "
+        "\"([Ljava/lang/String;)V\", \"1\").\n"
+        "_Method(\"<App: void <clinit>()>\", \"<clinit>\", \"\", \"App\", "
+        "\"void\", \"()V\", \"0\").\n"
+        ".decl Method_Descriptor(method: string, descriptor: string)\n"
+        "Method_Descriptor(m, cat(cat(cat(rt, \"(\"), p), \")\")) :- "
+        "_Method(m, _, p, _, rt, _, _).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "Method_Descriptor", &c) == 0,
+        "evaluation failed");
+    ASSERT(c.count == 2, "expected one descriptor per method");
+    /* Non-empty params: kills transposition and the missing-paren forms. */
+    ASSERT(saw(&c, "<App: void main(java.lang.String[])>|"
+        "void(java.lang.String[])"),
+        "expected returnType(params), not params alone");
+    /* Empty params: pins that the parens are emitted even when empty, so
+     * <clinit> still matches the "void()" constant the rules use. */
+    ASSERT(saw(&c, "<App: void <clinit>()>|void()"),
+        "expected void() for a no-argument method, not the empty string");
+    PASS();
+}
+
+/*
+ * The consequence of getting that column wrong, in miniature: a covariant
+ * override across a DirectSuperclass edge.  Under the params reading both
+ * iterator() methods carry the same descriptor, the subclass entry shadows
+ * the superclass one, and the antijoin drops the inherited tuple.
+ */
+static void
+test_covariant_override_survives_lookup(void)
+{
+    TEST("MethodLookup keeps covariant overrides distinct");
+
+    const char *src =
+        ".decl Method_SimpleName(m: string, sn: string)\n"
+        ".decl Method_DeclaringType(m: string, t: string)\n"
+        ".decl Method_Modifier(mod: string, m: string)\n"
+        ".decl DirectSuperclass(t: string, st: string)\n"
+        ".decl _Method(m: string, sn: string, p: string, t: string, "
+        "rt: string, jvm: string, ar: string)\n"
+        /* Superclass declares the covariant pair; the subclass declares
+         * only the erased one.  Return types differ, params do not. */
+        "_Method(\"<Sup: I it()>\", \"it\", \"\", \"Sup\", \"I\", "
+        "\"()LI;\", \"0\").\n"
+        "_Method(\"<Sup: OfLong it()>\", \"it\", \"\", \"Sup\", "
+        "\"OfLong\", \"()LOfLong;\", \"0\").\n"
+        "_Method(\"<Sub: I it()>\", \"it\", \"\", \"Sub\", \"I\", "
+        "\"()LI;\", \"0\").\n"
+        "Method_SimpleName(\"<Sup: I it()>\", \"it\").\n"
+        "Method_SimpleName(\"<Sup: OfLong it()>\", \"it\").\n"
+        "Method_SimpleName(\"<Sub: I it()>\", \"it\").\n"
+        "Method_DeclaringType(\"<Sup: I it()>\", \"Sup\").\n"
+        "Method_DeclaringType(\"<Sup: OfLong it()>\", \"Sup\").\n"
+        "Method_DeclaringType(\"<Sub: I it()>\", \"Sub\").\n"
+        "DirectSuperclass(\"Sub\", \"Sup\").\n"
+        ".decl Method_Descriptor(method: string, descriptor: string)\n"
+        "Method_Descriptor(m, cat(cat(cat(rt, \"(\"), p), \")\")) :- "
+        "_Method(m, _, p, _, rt, _, _).\n"
+        ".decl MethodImplemented(sn: string, d: string, t: string, "
+        "m: string)\n"
+        "MethodImplemented(sn, d, t, m) :- Method_SimpleName(m, sn), "
+        "Method_Descriptor(m, d), Method_DeclaringType(m, t), "
+        "!Method_Modifier(\"abstract\", m).\n"
+        ".decl MethodLookup(sn: string, d: string, t: string, m: string)\n"
+        "MethodLookup(sn, d, t, m) :- MethodImplemented(sn, d, t, m).\n"
+        "MethodLookup(sn, d, t, m) :- DirectSuperclass(t, st), "
+        "MethodLookup(sn, d, st, m), !MethodImplemented(sn, d, t, _).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "MethodLookup", &c) == 0,
+        "evaluation failed");
+    /* 3 declared + the OfLong variant inherited by Sub.  Under the params
+     * reading the inherited tuple is shadowed and this is 3. */
+    ASSERT(c.count == 4, "expected the inherited covariant variant to "
+        "survive; params-only descriptors shadow it");
+    ASSERT(saw(&c, "it|OfLong()|Sub|<Sup: OfLong it()>"),
+        "Sub must inherit the covariant OfLong variant from Sup");
+    PASS();
+}
+
 int
 main(void)
 {
     printf("=== DOOP string-constant rule semantics (Issue #950) ===\n");
 
+    test_method_descriptor_is_return_type_and_params();
+    test_covariant_override_survives_lookup();
     test_method_implemented_excludes_abstract();
     test_main_method_declaration();
     test_class_initializer();

--- a/tests/test_plan_gen.c
+++ b/tests/test_plan_gen.c
@@ -364,6 +364,248 @@ test_k_fusion_sequences_fuse_join_project(void)
 }
 
 /* ----------------------------------------------------------------
+ * Test: SIP-inserted SEMIJOINs must not shift column indices (#955)
+ *
+ * A SEMIJOIN filters its left input and emits the left columns only.
+ * When the plan generator resolved join keys and projections against a
+ * column layout that also counted the SEMIJOIN's right side, every index
+ * past the first SEMIJOIN was shifted; out-of-range "colN" names then fell
+ * back to column 0 in the evaluator, silently dropping derivations.
+ *
+ * The chain below is the smallest shape that exposes it: five atoms, all
+ * variables live in the head (so no projection re-bases the layout), each
+ * atom introducing a fresh variable.
+ * ---------------------------------------------------------------- */
+
+static const char *k_semijoin_chain_src
+    = ".decl a(p1: int64, p2: int64)\n"
+    "a(1, 2).\n"
+    ".decl b(q1: int64, q2: int64)\n"
+    "b(2, 3).\n"
+    ".decl c(r1: int64, r2: int64)\n"
+    "c(3, 4).\n"
+    ".decl d(s1: int64, s2: int64)\n"
+    "d(4, 5).\n"
+    ".decl e(t1: int64, t2: int64)\n"
+    "e(5, 6).\n"
+    ".decl chain(c1: int64, c2: int64, c3: int64, c4: int64, c5: int64,"
+    " c6: int64)\n"
+    "chain(v1, v2, v3, v4, v5, v6) :- a(v1, v2), b(v2, v3), c(v3, v4),"
+    " d(v4, v5), e(v5, v6).\n";
+
+/* Declared arity of the relations in k_semijoin_chain_src. */
+static uint32_t
+chain_rel_width(const char *name)
+{
+    if (!name)
+        return 0;
+    if (strcmp(name, "chain") == 0)
+        return 6;
+    return 2; /* a, b, c, d, e are all binary */
+}
+
+static void
+test_semijoin_does_not_shift_column_indices(void)
+{
+    TEST("SEMIJOIN does not shift join key/projection indices");
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(k_semijoin_chain_src, &err);
+    ASSERT(prog != NULL, "parse failed");
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    ASSERT(rc == 0, "plan generation failed");
+
+    const wl_plan_relation_t *rp = NULL;
+    for (uint32_t s = 0; s < plan->stratum_count && !rp; s++) {
+        for (uint32_t r = 0; r < plan->strata[s].relation_count; r++) {
+            const wl_plan_relation_t *cand = &plan->strata[s].relations[r];
+            if (cand->name && strcmp(cand->name, "chain") == 0) {
+                rp = cand;
+                break;
+            }
+        }
+    }
+    ASSERT(rp != NULL, "relation chain not found");
+
+    /* Replay the operator sequence, tracking the width of the relation on
+     * top of the evaluator stack, and check every resolved index against
+     * the operand widths it will actually see at run time. */
+    uint32_t width = 0;
+    int saw_semijoin = 0;
+    for (uint32_t i = 0; i < rp->op_count; i++) {
+        const wl_plan_op_t *op = &rp->ops[i];
+        uint32_t rw = op->right_relation ? chain_rel_width(op->right_relation)
+                                         : 0;
+        if (op->op == WL_PLAN_OP_SEMIJOIN)
+            saw_semijoin = 1;
+        if (op->op == WL_PLAN_OP_JOIN || op->op == WL_PLAN_OP_SEMIJOIN
+            || op->op == WL_PLAN_OP_ANTIJOIN) {
+            for (uint32_t k = 0; k < op->key_count; k++) {
+                const char *lk = op->left_keys ? op->left_keys[k] : NULL;
+                ASSERT(lk != NULL, "missing left key");
+                ASSERT(strncmp(lk, "col", 3) == 0, "left key is not colN");
+                ASSERT((uint32_t)atoi(lk + 3) < width,
+                    "left join key column index out of range");
+            }
+            uint32_t concat = (op->op == WL_PLAN_OP_JOIN) ? width + rw : width;
+            for (uint32_t p = 0; p < op->project_count; p++) {
+                if (!op->project_indices)
+                    break;
+                ASSERT(op->project_indices[p] < concat,
+                    "projection index out of range");
+            }
+        }
+        switch (op->op) {
+        case WL_PLAN_OP_VARIABLE:
+            width = chain_rel_width(op->relation_name);
+            break;
+        case WL_PLAN_OP_JOIN:
+            width = op->project_count ? op->project_count : width + rw;
+            break;
+        case WL_PLAN_OP_MAP:
+        case WL_PLAN_OP_SEMIJOIN:
+        case WL_PLAN_OP_ANTIJOIN:
+            if (op->project_count)
+                width = op->project_count;
+            break;
+        default:
+            break;
+        }
+    }
+    ASSERT(saw_semijoin, "SIP inserted no SEMIJOIN -- test no longer covers "
+        "the regression");
+
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+struct chain_ctx {
+    int64_t count;
+    int64_t row[8];
+    uint32_t ncols;
+};
+
+static void
+chain_cb(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    struct chain_ctx *ctx = (struct chain_ctx *)user_data;
+    if (!relation || strcmp(relation, "chain") != 0)
+        return;
+    ctx->count++;
+    if (ctx->count == 1) {
+        ctx->ncols = ncols < 8 ? ncols : 8;
+        for (uint32_t i = 0; i < ctx->ncols; i++)
+            ctx->row[i] = row[i];
+    }
+}
+
+static void
+test_semijoin_chain_end_to_end(void)
+{
+    TEST("five-atom chain with SEMIJOINs derives its one tuple");
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(k_semijoin_chain_src, &err);
+    ASSERT(prog != NULL, "parse failed");
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    ASSERT(rc == 0, "plan generation failed");
+
+    wl_session_t *sess = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, 1, &sess);
+    ASSERT(rc == 0, "session create failed");
+
+    rc = wl_session_load_facts(sess, prog);
+    ASSERT(rc == 0, "load facts failed");
+
+    struct chain_ctx ctx = { 0, { 0 }, 0 };
+    rc = wl_session_snapshot(sess, chain_cb, &ctx);
+    ASSERT(rc == 0, "snapshot failed");
+
+    ASSERT(ctx.count == 1, "expected exactly one chain tuple");
+    ASSERT(ctx.ncols == 6, "expected six columns");
+    for (uint32_t i = 0; i < 6; i++)
+        ASSERT(ctx.row[i] == (int64_t)(i + 1), "unexpected chain tuple value");
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* Same chain shape, but with a negated atom so the head projection stays a
+ * separate MAP instead of being fused into the last JOIN.  The shifted
+ * layout corrupted that projection too: the tuple was still derived, with
+ * an out-of-range index silently yielding 0 in the last column. */
+static const char *k_semijoin_negation_src
+    = ".decl a(p1: int64, p2: int64)\n"
+    "a(1, 2).\n"
+    ".decl b(q1: int64, q2: int64)\n"
+    "b(2, 3).\n"
+    ".decl n(z1: int64)\n"
+    "n(99).\n"
+    ".decl c(r1: int64, r2: int64)\n"
+    "c(3, 4).\n"
+    ".decl d(s1: int64, s2: int64)\n"
+    "d(4, 5).\n"
+    ".decl chain(c1: int64, c2: int64, c3: int64, c4: int64, c5: int64)\n"
+    "chain(v1, v2, v3, v4, v5) :- a(v1, v2), b(v2, v3), !n(v3),"
+    " c(v3, v4), d(v4, v5).\n";
+
+static void
+test_semijoin_head_projection_values(void)
+{
+    TEST("SEMIJOIN chain keeps head projection values intact");
+
+    wirelog_error_t err;
+    wirelog_program_t *prog
+        = wirelog_parse_string(k_semijoin_negation_src, &err);
+    ASSERT(prog != NULL, "parse failed");
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    ASSERT(rc == 0, "plan generation failed");
+
+    wl_session_t *sess = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, 1, &sess);
+    ASSERT(rc == 0, "session create failed");
+
+    rc = wl_session_load_facts(sess, prog);
+    ASSERT(rc == 0, "load facts failed");
+
+    struct chain_ctx ctx = { 0, { 0 }, 0 };
+    rc = wl_session_snapshot(sess, chain_cb, &ctx);
+    ASSERT(rc == 0, "snapshot failed");
+
+    ASSERT(ctx.count == 1, "expected exactly one chain tuple");
+    ASSERT(ctx.ncols == 5, "expected five columns");
+    for (uint32_t i = 0; i < 5; i++)
+        ASSERT(ctx.row[i] == (int64_t)(i + 1), "unexpected chain tuple value");
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ----------------------------------------------------------------
  * Test: wl_plan_free NULL-safe
  * ---------------------------------------------------------------- */
 
@@ -403,6 +645,9 @@ main(void)
     test_join_project_fusion_plan_shape();
     test_join_project_fusion_keeps_computed_map();
     test_k_fusion_sequences_fuse_join_project();
+    test_semijoin_does_not_shift_column_indices();
+    test_semijoin_chain_end_to_end();
+    test_semijoin_head_projection_values();
     test_plan_free_null();
     test_load_facts_null_safe();
 

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -1160,6 +1160,29 @@ eval_stack_drain(eval_stack_t *s)
 
 /* Cross-module function declarations are in columnar/internal.h */
 
+/*
+ * col_op_resolve_key:
+ *   Resolve a plan-supplied "colN" join key against @rel.  A key that does
+ *   not resolve means the plan carries a column layout that disagrees with
+ *   the relation the operator actually sees; the operator then degrades to
+ *   column 0 and joins on the wrong column, which under-derives silently.
+ *   Log it under JOIN so the condition is observable (issue #955).
+ */
+static uint32_t
+col_op_resolve_key(const col_rel_t *rel, const char *name, const char *side,
+    const char *op_name, const char *right_relation)
+{
+    int idx = col_rel_col_idx(rel, name);
+    if (idx >= 0)
+        return (uint32_t)idx;
+    WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_ERROR,
+        "%s: unresolved %s key '%s' (right=%s, ncols=%u) -- falling back to "
+        "column 0",
+        op_name, side, name ? name : "(null)",
+        right_relation ? right_relation : "-", rel->ncols);
+    return 0;
+}
+
 /* --- VARIABLE ------------------------------------------------------------ */
 
 int
@@ -3178,11 +3201,12 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         return ENOMEM;
     }
     for (uint32_t k = 0; k < kc; k++) {
-        int li = col_rel_col_idx(left, op->left_keys ? op->left_keys[k] : NULL);
-        int ri
-            = col_rel_col_idx(right, op->right_keys ? op->right_keys[k] : NULL);
-        lk[k] = (li >= 0) ? (uint32_t)li : 0;
-        rk[k] = (ri >= 0) ? (uint32_t)ri : 0;
+        lk[k] = col_op_resolve_key(left,
+                op->left_keys ? op->left_keys[k] : NULL, "left", "JOIN",
+                op->right_relation);
+        rk[k] = col_op_resolve_key(right,
+                op->right_keys ? op->right_keys[k] : NULL, "right", "JOIN",
+                op->right_relation);
     }
 
     uint32_t ocols = col_join_output_width(left, right, op);
@@ -3618,11 +3642,12 @@ col_op_antijoin(const wl_plan_op_t *op, eval_stack_t *stack,
         return ENOMEM;
     }
     for (uint32_t k = 0; k < kc; k++) {
-        int li = col_rel_col_idx(left, op->left_keys ? op->left_keys[k] : NULL);
-        int ri
-            = col_rel_col_idx(right, op->right_keys ? op->right_keys[k] : NULL);
-        lk[k] = (li >= 0) ? (uint32_t)li : 0;
-        rk[k] = (ri >= 0) ? (uint32_t)ri : 0;
+        lk[k] = col_op_resolve_key(left,
+                op->left_keys ? op->left_keys[k] : NULL, "left", "ANTIJOIN",
+                op->right_relation);
+        rk[k] = col_op_resolve_key(right,
+                op->right_keys ? op->right_keys[k] : NULL, "right", "ANTIJOIN",
+                op->right_relation);
     }
 
     col_rel_t *out = col_rel_pool_new_like(sess->delta_pool, "$antijoin", left);
@@ -6141,11 +6166,12 @@ col_op_semijoin(const wl_plan_op_t *op, eval_stack_t *stack,
         return ENOMEM;
     }
     for (uint32_t k = 0; k < kc; k++) {
-        int li = col_rel_col_idx(left, op->left_keys ? op->left_keys[k] : NULL);
-        int ri
-            = col_rel_col_idx(right, op->right_keys ? op->right_keys[k] : NULL);
-        lk[k] = (li >= 0) ? (uint32_t)li : 0;
-        rk[k] = (ri >= 0) ? (uint32_t)ri : 0;
+        lk[k] = col_op_resolve_key(left,
+                op->left_keys ? op->left_keys[k] : NULL, "left", "SEMIJOIN",
+                op->right_relation);
+        rk[k] = col_op_resolve_key(right,
+                op->right_keys ? op->right_keys[k] : NULL, "right", "SEMIJOIN",
+                op->right_relation);
     }
 
     /* Output: project_indices selects output columns from left */
@@ -6903,11 +6929,13 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
         return ENOMEM;
     }
     for (uint32_t k = 0; k < kc; k++) {
-        int li = col_rel_col_idx(left, op->left_keys ? op->left_keys[k] : NULL);
-        int ri
-            = col_rel_col_idx(right, op->right_keys ? op->right_keys[k] : NULL);
-        lk[k] = (li >= 0) ? (uint32_t)li : 0;
-        rk[k] = (ri >= 0) ? (uint32_t)ri : 0;
+        lk[k] = col_op_resolve_key(left,
+                op->left_keys ? op->left_keys[k] : NULL, "left", "JOIN(diff)",
+                op->right_relation);
+        rk[k] = col_op_resolve_key(right,
+                op->right_keys ? op->right_keys[k] : NULL, "right",
+                "JOIN(diff)",
+                op->right_relation);
     }
 
     uint32_t ocols = col_join_output_width(left, right, op);

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -521,6 +521,8 @@ dup_indices(const uint32_t *src, uint32_t count)
  * Collect the output column names produced by an IR node.
  * For SCAN: returns the declared column_names.
  * For JOIN: concatenates left + right child column names.
+ * For SEMIJOIN/ANTIJOIN: the left child's columns only -- these operators
+ * filter rows and never widen their input.
  * For PROJECT/FILTER/FLATMAP/UNION: delegates to child[0].
  *
  * out_names and out_count are set on success (caller must free out_names
@@ -553,9 +555,54 @@ collect_output_columns(const wirelog_ir_node_t *node, char ***out_names,
         return 0;
     }
 
-    case WIRELOG_IR_JOIN:
     case WIRELOG_IR_ANTIJOIN:
     case WIRELOG_IR_SEMIJOIN: {
+        /* SEMIJOIN/ANTIJOIN filter their left input: col_op_semijoin and
+         * col_op_antijoin emit the left columns only (optionally narrowed
+         * by the node's own projection).  Concatenating the right child's
+         * columns here would shift every column index resolved above this
+         * node -- join keys and fused projections alike.  Out-of-range
+         * "colN" names then silently resolve to column 0 in the evaluator,
+         * so the rule joins on the wrong column and under-derives (#955). */
+        char **left_names = NULL;
+        uint32_t left_count = 0;
+        if (node->child_count == 0
+            || collect_output_columns(node->children[0], &left_names,
+            &left_count)
+            != 0) {
+            *out_names = NULL;
+            *out_count = 0;
+            return -1;
+        }
+        /* Only SEMIJOIN carries its projection into the plan operator
+         * (see translate_ir_node); ANTIJOIN always emits all left columns. */
+        if (node->type == WIRELOG_IR_SEMIJOIN && node->project_count > 0
+            && node->project_indices) {
+            uint32_t pc = node->project_count;
+            char **names = (char **)calloc(pc, sizeof(char *));
+            if (!names) {
+                for (uint32_t i = 0; i < left_count; i++)
+                    free(left_names[i]);
+                free((void *)left_names);
+                return -1;
+            }
+            for (uint32_t i = 0; i < pc; i++) {
+                uint32_t idx = node->project_indices[i];
+                names[i] = (idx < left_count) ? dup_str(left_names[idx]) : NULL;
+            }
+            for (uint32_t i = 0; i < left_count; i++)
+                free(left_names[i]);
+            free((void *)left_names);
+            *out_names = names;
+            *out_count = pc;
+            return 0;
+        }
+        *out_names = left_names;
+        *out_count = left_count;
+        return 0;
+    }
+
+    case WIRELOG_IR_JOIN: {
         /* Concatenate left child columns + right child columns */
         char **left_names = NULL, **right_names = NULL;
         uint32_t left_count = 0, right_count = 0;


### PR DESCRIPTION
Started as bookkeeping for #952 and ended in an engine soundness fix. Closes **#952**, **#956**, **#955**.

## #955 — the evaluator was dropping most of its own derivations

`collect_output_columns` grouped `WIRELOG_IR_SEMIJOIN` and `WIRELOG_IR_ANTIJOIN` with `WIRELOG_IR_JOIN` and concatenated the right child's columns. Both operators only *filter* — they emit the left side. So every SIP-inserted semijoin inflated the reported layout by the right relation's arity, shifting every join key and fused projection resolved above it. `col_rel_col_idx` returned -1 for the out-of-range `colN` and the resolution sites **silently fell back to column 0**.

A plan bug became a wrong answer instead of an error. In DOOP a `VarPointsTo` rule generated `col7=col0` over a six-column left input, so it compared `inv` against `sn`.

**SIP is on by default**, so this reached user programs with a rule of this shape, not only benchmarks. Among the 15 shipped workloads only DOOP's plan changes; out-of-range resolutions go 47 → 0 there and are 0 everywhere else both before and after.

### The first external check this benchmark has had

The recovered 2026-05-24 archive ships full-DOOP reference outputs:

| | before | after | reference |
|---|---|---|---|
| `Reachable` | 498 | 6,127 | 6,167 |
| `ArrayIndexPointsTo` | **0** | 32,859 | 33,018 |
| `InstanceFieldPointsTo` | — | 3,792,166 | 3,837,529 |
| `VarPointsTo` | **5,266** | 4,121,488 | 4,455,314 |

The benchmark had been computing about a thousandth of `VarPointsTo`. The reference is a different dataset so exact agreement is not expected; three of four land within 1.2%.

### Not over-derivation

Review type-checked every changed index against the rule text rather than merely checking it in range: all three resolve to the *unique correct* columns. E.g. over `[insn,im,insn,base,insn,sig,insn,to]` the new `proj=[3,5,7,1]` is `(base,sig,to,im)` — exactly the head — while the old `[3,5,9,1]` indexed 9 into an 8-wide row. Combined with all four relations landing slightly *below* the reference, there is no evidence of over-derivation. 153 iterations is what a fixpoint does when it stops terminating early.

### Five hypotheses were refuted before this one

The base-case EDB skip, cross-stratum delta visibility, the materialization cache, `has_empty_forced_delta`'s SEMIJOIN branch (dead code), and — mine — `projected_join ? false` re-arming the AUTO right-delta heuristic. That last was killed by instrumentation: across 28,677 traced operator events the AUTO branch substituted a right delta **zero times**.

## #956 — `Method_Descriptor` projected the parameter list

DOOP's convention is `?returnType "(" ?paramTypes ")"`. Confirmed row by row against the recovered archive's own `Method_Descriptor.csv`: the descriptor form matches 70,373/70,373, params alone matches none.

562 `MethodLookup` rows were lost to the `!MethodImplemented` antijoin, and — less visibly — the coarser key merged covariant overrides and bridge methods: 1,829 ambiguous dispatch keys against 625. Wrong dispatch targets, not just missing rows.

Three constant sites move together and cannot be split; missing the `ClassInitializer` one would silently empty it, since all 1,900 `<clinit>` rows carry the empty parameter list.

Every existing test supplied `Method_Descriptor` as EDB facts, so **none reached the derivation** — that is why constant-pinning could not catch it. Two tests now derive it, with a non-empty-params assertion, because with only no-argument methods the transposed and missing-paren forms produce the same partition as the correct rule. Mutation-tested with eight cases plus an identity control.

## #952 — the validation script and the README baselines

`run_doop_validation.sh` counted 34 `*.csv` and failed for every user with `expected 34 CSV files, found 0`. Its oracle `6276338` matched neither the measurement nor the README's `6,276,657` — two in-tree "expected" values for one workload, disagreeing by 319.

**The README table was asserting wrong tuple counts, not just stale timings.** CRDT (1,301,914 → 2,156,530), DDISASM (531 → 900) and Polonius (1,807 → 1,999) moved under `61e2530` (#914) — confirmed by building both sides of that commit, which reproduce the old and new values exactly.

Each workload is now measured in its own process: peak RSS is a process-wide high-water mark, so a single `--workload all` run attributed CSPA's 325 MB to five later rows.

A **drift gate** (`scripts/ci/check-doop-catalogue.sh`) now compares the four places the `.facts` catalogue is written down — that drift is what #950 was. Source-only, so it needs no dataset, and it refuses to compare catalogues it could not parse. Mutation-tested with eight cases.

## Cost, stated plainly

DOOP at W=1 is now **14,096,448 tuples / 153 iterations / 23 minutes / 39 GB**, from 6,070,090 / 28 / 91 s / 31 GB. The old speed was under-derivation, not performance.

**W=8 and W=16 no longer complete** — the per-worker join-output cap is the session cap divided by the worker count, so parallelism lowers the run's capacity. Filed as #959, along with the observation that the cap's current value was tuned in #791 against this same broken workload.

## Withdrawn

An earlier commit on this branch decomposed the difference from the 2026-05-24 row as archive −482,759 / everything-else +119,095. That is withdrawn: it decomposed a difference against a row produced by an evaluator dropping most of its derivations. Replaced by the same two-archive comparison on today's engine, plus the statement that the engine change dominates.

## Filed from this work

#953 (csv_reader silent corruption), #955, #956, #957 (totals count duplicate rows), #958 (head-position `cat()` is nondeterministic under parallel workers), #959.

## Validation

`meson test -C build` 257 Ok / 0 Fail / 11 Skipped throughout. CI 26/26. Independent review of each change by an agent that did not write it; both review passes blocked at least once and the blocks were fixed.
