### PR TITLE
fix(intern): make the shared symbol table safe under parallel evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,43 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **Shared intern table is now safe under parallel evaluation** (#958): every
+  worker borrows the coordinator's `wl_intern_t` -- it is propagated by the
+  bitwise session copy and is absent from both borrowed-field null-out lists --
+  so all three worker families (non-recursive, TDD, K-fusion) called an
+  unsynchronized hash table concurrently. A rule that builds strings in a head
+  position could therefore hand two ids to one string, and the `realloc()` that
+  doubled the id -> string array could relocate it out from under a worker
+  mid-dereference: measured at 100% SIGSEGV for a 31k-row recursive rule and a
+  100k-row non-recursive rule at W >= 8. The id -> string storage is now
+  segmented and never moves, `count` is published with a release store after
+  the entry is complete and read with an acquire load, and writers serialize on
+  a mutex. `wl_intern_reverse()` and `wl_intern_count()` stay lock-free: reverse
+  runs once or twice per row inside `contains`/`strlen`/`substr`/`to_number`,
+  a lock there measured 10.9x slower at W=8 than the unlocked baseline.
+
+  Two consequences to know about, both of which only affect W > 1.
+
+  Ids are assigned in worker-interleaving order, so an id is unique and
+  stable within a run but not reproducible across runs. That is visible in
+  results, not just internally: `<`, `>`, `<=`, `>=`, `min` and `max` on
+  symbols are evaluated as comparisons of the intern id rather than of the
+  string (`exec_plan_gen.c` maps them to the integer opcodes unconditionally,
+  and the implemented `CMP_STR_*` opcodes have no emitter), and `hash()`,
+  `crc32`, `md5`, `sha*`, `hmac` and `uuid5` digest the id rather than the
+  string bytes. Queries using any of those over symbols produced during
+  evaluation can therefore give different answers on different runs. Those
+  are pre-existing defects, filed separately; before this change the same
+  programs crashed instead.
+
+  Serializing writers costs throughput on workloads that intern heavily
+  during evaluation -- a rule with `cat()` in head position, say. Measured
+  at a fixed 1.6M unique inserts split across workers: 561 ms at W=1
+  against 2,224 ms at W=8, with 8.8 s of system time and 938k voluntary
+  context switches. That is futex convoy rather than plain serialization,
+  and it is a follow-up. The comparison is against a baseline that
+  SIGSEGVs on the same input, so there is no correct prior timing to
+  regress from.
 - **`scripts/run_doop_validation.sh` no longer expects the vanished CSV
   layout** (#952): it counted 34 `*.csv` files and spot-checked
   `ActualParam.csv`, so after the archive switched to 35 string-valued

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -192,12 +192,32 @@ On non-MSVC builds the same macros expand to
 `atomic_load_explicit(p, memory_order_relaxed)` and friends
 (`lockfree_queue.c:47-57`).
 
-### 4.4 Type aliases
+### 4.4 MSVC shim in `intern.c`
+
+`wirelog/intern.c:63-88` provides the same shape of shim for the
+`uint32_t` published-entry counter of the shared symbol table
+(Issue #958):
+
+- `WL_INTERN_LOAD_ACQUIRE(p)` / `WL_INTERN_LOAD_RELAXED(p)` both expand
+  to `(*(p))` on MSVC, a plain read of a `volatile uint32_t`.
+- `WL_INTERN_STORE_RELEASE(p, v)` expands to a plain assignment.
+  Aligned 32-bit accesses are atomic on x86/x86-64 and ARM64, and
+  under MSVC's `/volatile:ms` model -- the default on x86/x64, but not
+  on ARM64, where MSVC defaults to `/volatile:iso` -- a volatile store
+  carries release
+  semantics -- the same assumption `mem_ledger.h` already makes.
+
+On non-MSVC builds (including the MinGW GCC Windows job) the macros
+expand to `atomic_load_explicit` / `atomic_store_explicit` with the
+orders named above.
+
+### 4.5 Type aliases
 
 - `wirelog/columnar/mem_ledger.h:33-42` defines `wl_atomic_u64`,
   `atomic_bool`, `atomic_uint_fast64_t` as MSVC-compatible aliases.
 - `wirelog/util/lockfree_queue.c:31,48` defines `wl_atomic_u32` per
   branch.
+- `wirelog/intern.c:74,80` defines `wl_intern_atomic_u32` per branch.
 
 These exist so struct fields can be declared portably; the audit in
 §5 below covers only call sites, not type-declaration sites.
@@ -208,7 +228,7 @@ These exist so struct fields can be declared portably; the audit in
 
 Every `atomic_*` call site in `wirelog/` production sources. Counted
 mechanically by `scripts/ci/check-threading-doc.sh`; row count must
-match the script's count (currently **40**).
+match the script's count (currently **43**).
 
 Format: `file:line` | field | operation | order | justification.
 
@@ -303,9 +323,25 @@ and the wasted work is bounded.
 |---|---|---|---|---|
 | `session.c:1484` | per-worker view of `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Worker session reads coordinator's budget snapshot; advisory, no edge required |
 
-### 5.7 Total
+### 5.7 `wirelog/intern.c` — shared symbol table (3 rows)
 
-22 + 4 + 2 + 10 + 1 + 1 = **40 atomic call sites**.
+The intern table is shared, unsynchronized, by every parallel worker
+(Issue #958). Writers (`wl_intern_put`, `wl_intern_get`) serialize on
+`intern->lock`; `wl_intern_reverse` and `wl_intern_count` are lock-free
+because reverse lookup runs once or twice per row in the string
+operations and a lock there costs more than the parallelism is worth.
+The three sites are the macro bodies; the call sites they serve are
+named in the justification.
+
+| `file:line` | Field | Op | Order | Justification |
+|---|---|---|---|---|
+| `intern.c:82` | `intern->count` | `atomic_load_explicit` | `acquire` | `WL_INTERN_LOAD_ACQUIRE`, used by `wl_intern_reverse`/`wl_intern_count`. Pairs with the release store below: an id below the observed count names a fully written entry, and the segment holding it is allocated and never moves |
+| `intern.c:84` | `intern->count` | `atomic_load_explicit` | `relaxed` | `WL_INTERN_LOAD_RELAXED`, used by `wl_intern_put`, `intern_resize` and `wl_intern_free`. The writer holds `intern->lock` (or, in `free`, has exclusive access), so no edge is needed |
+| `intern.c:86` | `intern->count` | `atomic_store_explicit` | `release` | `WL_INTERN_STORE_RELEASE`, used by `wl_intern_put` after the string and its segment pointer are written. Publishing the count first would let a lock-free reader dereference an unwritten slot |
+
+### 5.8 Total
+
+22 + 4 + 2 + 10 + 1 + 1 + 3 = **43 atomic call sites**.
 
 `scripts/ci/check-threading-doc.sh` extracts the same count from
 `grep -rE '\batomic_(load|store|fetch_add|fetch_sub|compare_exchange|exchange|init|thread_fence)(_explicit)?\s*\(' wirelog/ --include='*.c' --include='*.h'`

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -34,9 +34,13 @@ optimizer_src = files(
   '../wirelog/passes/magic_sets.c',
 )
 
-intern_src = files(
-  '../wirelog/intern.c',
-)
+# intern.c takes the writer mutex from wirelog/thread.h (Issue #958), so
+# every target that compiles it must also link the threading backend.
+# Meson deduplicates against targets that already list thread_src.
+intern_src = [
+  files('../wirelog/intern.c'),
+  wirelog_thread_src,
+]
 
 string_ops_src = files(
   '../wirelog/string_ops.c',
@@ -187,9 +191,11 @@ if get_option('enable_fuzz')
           '../wirelog/io/csv_reader.c',
           '../wirelog/intern.c',
         ),
+        wirelog_thread_src,
         c_args: ['-fsanitize=fuzzer'],
         link_args: ['-fsanitize=fuzzer'],
         include_directories: [wirelog_inc, wirelog_src_inc],
+        dependencies: [threads_dep],
         install: false,
       )
 
@@ -213,9 +219,11 @@ if get_option('enable_fuzz')
         'intern_fuzz',
         files('fuzz/intern_fuzz.c',
           '../wirelog/intern.c'),
+        wirelog_thread_src,
         include_directories: [wirelog_inc, wirelog_src_inc],
         c_args: ['-fsanitize=fuzzer'],
         link_args: ['-fsanitize=fuzzer'],
+        dependencies: [threads_dep],
         install: false,
       )
 
@@ -341,6 +349,7 @@ test_csv_exe = executable(
   csv_src,
   intern_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 test('csv', test_csv_exe)
@@ -793,6 +802,7 @@ test_intern_exe = executable(
   files('test_intern.c'),
   intern_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 test('intern', test_intern_exe)
@@ -4213,6 +4223,26 @@ test('queue_transport', test_queue_transport_exe)
 # DOOP Multi-Worker Stability Tests (Issue #416)
 # ============================================================================
 
+# Issue #958: the intern table is shared by every parallel worker.  The
+# K-fusion path (recursive rule, 4 IDB body atoms, cat() in the head) is
+# the cheapest way to reach it -- no row-count gate, 30 facts suffice.
+test_intern_parallel_determinism_exe = executable(
+  'test_intern_parallel_determinism',
+  files('test_intern_parallel_determinism.c'),
+  backend_src,
+  parser_src,
+  ir_src,
+  optimizer_src,
+  arena_src,
+  io_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('intern_parallel_determinism', test_intern_parallel_determinism_exe)
+
 test_doop_multiworker_exe = executable(
   'test_doop_multiworker',
   files('test_doop_multiworker.c'),
@@ -4242,6 +4272,7 @@ test_string_ops_exe = executable(
   intern_src,
   string_ops_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
 )
 
 test('string_ops', test_string_ops_exe)
@@ -4442,6 +4473,7 @@ test_io_ctx_exe = executable(
   intern_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
   c_args: ['-DWIRELOG_BUILDING'],
+  dependencies: [threads_dep],
   install: false,
 )
 test('io_ctx', test_io_ctx_exe)

--- a/tests/test_intern.c
+++ b/tests/test_intern.c
@@ -10,6 +10,8 @@
 
 #include "../wirelog/intern.h"
 
+#include "../wirelog/thread.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -23,22 +25,22 @@ static int tests_passed = 0;
 static int tests_failed = 0;
 
 #define TEST(name)                            \
-    do {                                      \
-        tests_run++;                          \
-        printf("  [%d] %s", tests_run, name); \
-    } while (0)
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
 
 #define PASS()                 \
-    do {                       \
-        tests_passed++;        \
-        printf(" ... PASS\n"); \
-    } while (0)
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
 
 #define FAIL(msg)                         \
-    do {                                  \
-        tests_failed++;                   \
-        printf(" ... FAIL: %s\n", (msg)); \
-    } while (0)
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
 
 /* ======================================================================== */
 /* Tests                                                                    */
@@ -326,6 +328,167 @@ test_many_strings(void)
     PASS();
 }
 
+/*
+ * Issue #958: one intern table is shared, unsynchronized, by every
+ * parallel evaluation worker.  Two threads interning the same strings
+ * must agree on every id, and reverse lookups issued while the other
+ * thread is still interning must return complete strings.
+ *
+ * Before the fix this reported a count overshoot (e.g. 2083 for 2000
+ * distinct strings, because count was a non-atomic read-modify-write),
+ * disagreeing ids, and -- driven by the realloc() of the id -> string
+ * array under a concurrent reader -- heap corruption and SIGSEGV.
+ */
+
+#define CONCURRENT_STRINGS 2000
+#define CONCURRENT_THREADS 4
+
+typedef struct {
+    wl_intern_t *intern;
+    int64_t ids[CONCURRENT_STRINGS];
+    int bad_reverse; /* reverse() disagreed with the string just interned */
+    int bad_put;     /* put() failed outright */
+} concurrent_ctx_t;
+
+static void *
+concurrent_put_worker(void *arg)
+{
+    concurrent_ctx_t *ctx = (concurrent_ctx_t *)arg;
+    char buf[32];
+
+    for (int i = 0; i < CONCURRENT_STRINGS; i++) {
+        snprintf(buf, sizeof(buf), "sym_%d", i);
+        int64_t id = wl_intern_put(ctx->intern, buf);
+        ctx->ids[i] = id;
+        if (id < 0) {
+            ctx->bad_put++;
+            continue;
+        }
+        /* Lock-free read racing the other thread's writes. */
+        const char *rev = wl_intern_reverse(ctx->intern, id);
+        if (!rev || strcmp(rev, buf) != 0)
+            ctx->bad_reverse++;
+    }
+
+    return NULL;
+}
+
+static void
+test_concurrent_put(void)
+{
+    TEST("concurrent put from two threads (Issue #958)");
+
+    wl_intern_t *intern = wl_intern_create();
+    if (!intern) {
+        FAIL("create failed");
+        return;
+    }
+
+    concurrent_ctx_t *ctx
+        = (concurrent_ctx_t *)calloc(CONCURRENT_THREADS, sizeof(*ctx));
+    if (!ctx) {
+        FAIL("calloc failed");
+        wl_intern_free(intern);
+        return;
+    }
+
+    thread_t threads[CONCURRENT_THREADS];
+    int started = 0;
+    for (int t = 0; t < CONCURRENT_THREADS; t++) {
+        ctx[t].intern = intern;
+        if (thread_create(&threads[t], concurrent_put_worker, &ctx[t]) != 0)
+            break;
+        started++;
+    }
+    for (int t = 0; t < started; t++)
+        thread_join(&threads[t]);
+
+    if (started != CONCURRENT_THREADS) {
+        FAIL("thread_create failed");
+        free(ctx);
+        wl_intern_free(intern);
+        return;
+    }
+
+    /* Every string is interned exactly once, however the threads raced. */
+    if (wl_intern_count(intern) != (uint32_t)CONCURRENT_STRINGS) {
+        FAIL("count != number of distinct strings");
+        free(ctx);
+        wl_intern_free(intern);
+        return;
+    }
+
+    for (int t = 0; t < CONCURRENT_THREADS; t++) {
+        if (ctx[t].bad_put) {
+            FAIL("put returned -1");
+            free(ctx);
+            wl_intern_free(intern);
+            return;
+        }
+        if (ctx[t].bad_reverse) {
+            FAIL("concurrent reverse returned the wrong string");
+            free(ctx);
+            wl_intern_free(intern);
+            return;
+        }
+    }
+
+    /* Both threads must have been handed the same id for each string,
+     * and that id must still reverse-map correctly afterwards. */
+    char buf[32];
+    char *seen = (char *)calloc(CONCURRENT_STRINGS, 1);
+    if (!seen) {
+        FAIL("calloc failed");
+        free(ctx);
+        wl_intern_free(intern);
+        return;
+    }
+
+    for (int i = 0; i < CONCURRENT_STRINGS; i++) {
+        int64_t id = ctx[0].ids[i];
+
+        snprintf(buf, sizeof(buf), "sym_%d", i);
+        for (int t = 1; t < CONCURRENT_THREADS; t++) {
+            if (ctx[t].ids[i] != id) {
+                FAIL("threads disagree on the id of a string");
+                free(seen);
+                free(ctx);
+                wl_intern_free(intern);
+                return;
+            }
+        }
+        if (id < 0 || id >= CONCURRENT_STRINGS || seen[id]) {
+            FAIL("ids are not a permutation of 0..N-1");
+            free(seen);
+            free(ctx);
+            wl_intern_free(intern);
+            return;
+        }
+        seen[id] = 1;
+
+        const char *rev = wl_intern_reverse(intern, id);
+        if (!rev || strcmp(rev, buf) != 0) {
+            FAIL("reverse returned the wrong string");
+            free(seen);
+            free(ctx);
+            wl_intern_free(intern);
+            return;
+        }
+        if (wl_intern_get(intern, buf) != id) {
+            FAIL("get returned an id other than the one put returned");
+            free(seen);
+            free(ctx);
+            wl_intern_free(intern);
+            return;
+        }
+    }
+
+    free(seen);
+    free(ctx);
+    wl_intern_free(intern);
+    PASS();
+}
+
 static void
 test_free_null(void)
 {
@@ -352,10 +515,11 @@ main(void)
     test_reverse_lookup();
     test_null_and_empty();
     test_many_strings();
+    test_concurrent_put();
     test_free_null();
 
     printf("\nResults: %d/%d passed, %d failed\n", tests_passed, tests_run,
-           tests_failed);
+        tests_failed);
 
     return tests_failed > 0 ? 1 : 0;
 }

--- a/tests/test_intern_parallel_determinism.c
+++ b/tests/test_intern_parallel_determinism.c
@@ -1,0 +1,317 @@
+/*
+ * test_intern_parallel_determinism.c - shared intern table under parallel
+ * evaluation (Issue #958)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Every parallel worker borrows the coordinator's wl_intern_t: the
+ * per-worker session copies carry the same pointer and it is not on
+ * either null-out list.  A rule that builds strings in a head position
+ * therefore has several threads calling wl_intern_put()/reverse() on
+ * one table at once.  Unsynchronized, that produced two ids for one
+ * string (wrong joins, extra tuples) and, once the id -> string array
+ * was reallocated under a concurrent reader, heap corruption.
+ *
+ * The reproducer is a recursive rule with four IDB body atoms and a
+ * cat() in the head, which is the K-fusion dispatch shape:
+ * wirelog/columnar/ops.c has no row-count gate on that path, only
+ * WL_KFUSION_MIN_PARALLEL_K = 4 live body atoms.  It is therefore the
+ * cheapest of the three parallel paths to reach -- 30 EDB facts are
+ * enough, where the non-recursive path needs 65,536 rows.
+ *
+ * The assertion is that W=8 reproduces the W=1 result exactly, over
+ * repetitions, comparing the full sorted string-valued output rather
+ * than a tuple count: a count alone misses a run where a symbol was
+ * interned twice but the row totals happened to match.
+ */
+
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/intern.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test Harness                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+/* *INDENT-OFF* */
+#define TEST(name) \
+        do { \
+            tests_run++; \
+            printf("  [%d] %s", tests_run, (name)); \
+        } while (0)
+
+#define PASS() \
+        do { \
+            tests_passed++; \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg) \
+        do { \
+            tests_failed++; \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
+/* *INDENT-ON* */
+
+/* ======================================================================== */
+/* Workload                                                                 */
+/* ======================================================================== */
+
+/* 3 chains x 10 edges = 30 EDB facts. */
+#define CHAINS 3
+#define CHAIN_LEN 10
+
+/* Repetitions per worker count.  The defect is probabilistic: measured
+ * on the unfixed table this shape mismatched in roughly a third of the
+ * W=8 runs, so a handful of repetitions is enough to catch it while
+ * keeping the test well under a second. */
+#define REPS 12
+
+#define MAX_ROWS 4096
+#define MAX_ROW_TEXT 128
+
+/*
+ * P is seeded from the EDB and then closed under a four-way self-join,
+ * with the label built by cat() in the head position -- the string that
+ * each worker has to intern.
+ */
+static char *
+build_program(void)
+{
+    size_t cap = 4096 + (size_t)CHAINS * CHAIN_LEN * 48;
+    char *src = (char *)malloc(cap);
+    if (!src)
+        return NULL;
+
+    size_t pos = 0;
+    int n = snprintf(src + pos, cap - pos,
+            ".decl E(x: symbol, y: symbol)\n"
+            ".decl P(x: symbol, y: symbol, l: symbol)\n");
+    if (n < 0)
+        goto fail;
+    pos += (size_t)n;
+
+    for (int c = 0; c < CHAINS; c++) {
+        for (int d = 0; d < CHAIN_LEN; d++) {
+            n = snprintf(src + pos, cap - pos, "E(\"n%d_%d\", \"n%d_%d\").\n",
+                    c, d, c, d + 1);
+            if (n < 0 || (size_t)n >= cap - pos)
+                goto fail;
+            pos += (size_t)n;
+        }
+    }
+
+    n = snprintf(src + pos, cap - pos,
+            "P(x, y, cat(cat(x, \"->\"), y)) :- E(x, y).\n"
+            "P(a, e, cat(cat(a, \"=>\"), e)) :-"
+            " P(a, b, l1), P(b, c, l2), P(c, d, l3), P(d, e, l4).\n");
+    if (n < 0 || (size_t)n >= cap - pos)
+        goto fail;
+
+    return src;
+
+fail:
+    free(src);
+    return NULL;
+}
+
+/* ======================================================================== */
+/* Result Collection                                                        */
+/* ======================================================================== */
+
+typedef struct {
+    const wl_intern_t *intern;
+    uint32_t count;
+    int overflow;
+    int unresolved; /* a column id that did not reverse-map */
+    char rows[MAX_ROWS][MAX_ROW_TEXT];
+} result_t;
+
+static void
+collect_cb(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    result_t *res = (result_t *)user_data;
+
+    if (res->count >= MAX_ROWS) {
+        res->overflow = 1;
+        return;
+    }
+
+    char *dst = res->rows[res->count];
+    size_t pos = 0;
+
+    int n = snprintf(dst, MAX_ROW_TEXT, "%s(", relation ? relation : "?");
+    if (n < 0)
+        return;
+    pos += (size_t)n;
+
+    for (uint32_t i = 0; i < ncols && pos + 1 < MAX_ROW_TEXT; i++) {
+        const char *val = wl_intern_reverse(res->intern, row[i]);
+        if (!val)
+            res->unresolved = 1;
+        n = snprintf(dst + pos, MAX_ROW_TEXT - pos, "%s%s", i ? "," : "",
+                val ? val : "?");
+        if (n < 0)
+            break;
+        pos += (size_t)n;
+    }
+    if (pos + 1 < MAX_ROW_TEXT)
+        snprintf(dst + pos, MAX_ROW_TEXT - pos, ")");
+
+    res->count++;
+}
+
+static int
+row_cmp(const void *a, const void *b)
+{
+    return strcmp((const char *)a, (const char *)b);
+}
+
+/*
+ * Evaluate @src with @workers workers and fill @res with the sorted
+ * string form of every derived tuple.  Returns 0 on success.
+ */
+static int
+evaluate(const char *src, uint32_t workers, result_t *res)
+{
+    memset(res, 0, sizeof(*res));
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return -1;
+
+    wl_fusion_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0 || !plan) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_session_t *session = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, workers, &session) != 0
+        || !session) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    res->intern = wirelog_program_get_intern(prog);
+
+    int rc = -1;
+    if (wl_session_load_facts(session, prog) == 0
+        && wl_session_snapshot(session, collect_cb, res) == 0)
+        rc = 0;
+
+    if (rc == 0 && (res->overflow || res->unresolved))
+        rc = -1;
+
+    if (rc == 0)
+        qsort(res->rows, res->count, MAX_ROW_TEXT, row_cmp);
+
+    /* The rows are copied out as text, so the intern table can go. */
+    res->intern = NULL;
+
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+static int
+results_equal(const result_t *a, const result_t *b)
+{
+    if (a->count != b->count)
+        return 0;
+    for (uint32_t i = 0; i < a->count; i++) {
+        if (strcmp(a->rows[i], b->rows[i]) != 0)
+            return 0;
+    }
+    return 1;
+}
+
+/* ======================================================================== */
+/* Tests                                                                    */
+/* ======================================================================== */
+
+static void
+test_kfusion_symbol_determinism(uint32_t workers)
+{
+    char name[96];
+
+    snprintf(name, sizeof(name),
+        "K-fusion head cat(): W=%u matches W=1 over %d runs", workers, REPS);
+    TEST(name);
+
+    char *src = build_program();
+    if (!src) {
+        FAIL("program generation failed");
+        return;
+    }
+
+    result_t *baseline = (result_t *)malloc(sizeof(*baseline));
+    result_t *actual = (result_t *)malloc(sizeof(*actual));
+    if (!baseline || !actual) {
+        FAIL("allocation failed");
+        goto out;
+    }
+
+    if (evaluate(src, 1, baseline) != 0) {
+        FAIL("single-worker evaluation failed");
+        goto out;
+    }
+    if (baseline->count == 0) {
+        FAIL("single-worker evaluation derived nothing");
+        goto out;
+    }
+
+    for (int rep = 0; rep < REPS; rep++) {
+        if (evaluate(src, workers, actual) != 0) {
+            FAIL("parallel evaluation failed");
+            goto out;
+        }
+        if (!results_equal(baseline, actual)) {
+            printf("\n      rep %d: %u rows vs %u at W=1\n", rep,
+                actual->count, baseline->count);
+            FAIL("parallel output differs from single-worker output");
+            goto out;
+        }
+    }
+
+    PASS();
+
+out:
+    free(baseline);
+    free(actual);
+    free(src);
+}
+
+int
+main(void)
+{
+    printf("=== Shared Intern Table Under Parallel Evaluation ===\n");
+
+    test_kfusion_symbol_determinism(8);
+    test_kfusion_symbol_determinism(16);
+
+    printf("\nResults: %d/%d passed, %d failed\n", tests_passed, tests_run,
+        tests_failed);
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/wirelog/intern.c
+++ b/wirelog/intern.c
@@ -8,13 +8,85 @@
  * Open-addressing hash table (FNV-1a + linear probing) for string
  * interning.  Maps strings to sequential integer IDs and supports
  * reverse lookup by ID.
+ *
+ * ========================================================================
+ * Thread safety (Issue #958)
+ * ========================================================================
+ *
+ * Parallel evaluation shares one table: the per-worker session copies
+ * borrow the coordinator's `intern` pointer, so every worker family
+ * (non-recursive, TDD, K-fusion) calls into this file concurrently.
+ * String operations (contains/strlen/substr/to_number, and cat() in a
+ * head position) reverse-map once or twice per row and intern their
+ * results, so both directions are hot and concurrent.
+ *
+ * The split is therefore:
+ *
+ *   - wl_intern_put() and wl_intern_get() serialize on a writer mutex.
+ *     They are the only functions that touch the slot table, so the
+ *     table can still be grown and freed in place.
+ *
+ *   - wl_intern_reverse() and wl_intern_count() are lock-free.  A
+ *     global lock here is not shippable: reverse is called per row, and
+ *     locking it makes an 8-worker run several times slower than a
+ *     1-worker run.
+ *
+ * Two properties make the lock-free readers safe:
+ *
+ *   1. The id -> string storage is segmented and never moves.  A
+ *      segment is allocated once and is neither reallocated nor freed
+ *      until the table is destroyed, so a pointer a reader has loaded
+ *      stays valid.  (The previous realloc()-doubled array was the
+ *      crash driver: a writer could relocate the array out from under
+ *      a reader mid-dereference.)
+ *
+ *   2. `count` is published with a release store *after* the entry is
+ *      fully written, and read with an acquire load.  A reader that
+ *      sees id < count therefore also sees the segment pointer and the
+ *      string bytes it names.
+ *
+ * wl_intern_create() and wl_intern_free() are not concurrent with
+ * anything: the table is created before workers start and destroyed
+ * after they join.
  */
 
 #include "intern.h"
 
+#include "thread.h"
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* C11 atomics for the lock-free reader path.  Mirrors the MSVC split
+ * already carried by columnar/mem_ledger.h. */
+/* *INDENT-OFF* */
+#ifdef _MSC_VER
+#include <intrin.h>
+
+/* MSVC does not support C11 _Atomic as a type qualifier or keyword.
+ * Use volatile uint32_t as the atomic field type: under MSVC's
+ * /volatile:ms model a volatile load/store carries acquire/release
+ * semantics on x86 and x64.  MSVC defaults to /volatile:iso on ARM64,
+ * where it does not; that path is unexercised here -- the Windows CI job
+ * is MinGW GCC and takes the <stdatomic.h> branch.  This
+ * is the same assumption columnar/mem_ledger.h makes.  MinGW GCC is not
+ * _MSC_VER and takes the <stdatomic.h> branch below. */
+typedef volatile uint32_t wl_intern_atomic_u32;
+#define WL_INTERN_LOAD_ACQUIRE(p) (*(p))
+#define WL_INTERN_LOAD_RELAXED(p) (*(p))
+#define WL_INTERN_STORE_RELEASE(p, v) (*(p) = (uint32_t)(v))
+#else
+#include <stdatomic.h>
+typedef _Atomic uint32_t wl_intern_atomic_u32;
+#define WL_INTERN_LOAD_ACQUIRE(p) \
+        atomic_load_explicit((p), memory_order_acquire)
+#define WL_INTERN_LOAD_RELAXED(p) \
+        atomic_load_explicit((p), memory_order_relaxed)
+#define WL_INTERN_STORE_RELEASE(p, v) \
+        atomic_store_explicit((p), (uint32_t)(v), memory_order_release)
+#endif
+/* *INDENT-ON* */
 
 /* ======================================================================== */
 /* Constants                                                                */
@@ -27,12 +99,30 @@
 /* Sentinel: empty hash table slot */
 #define SLOT_EMPTY UINT32_MAX
 
+/*
+ * Segmented id -> string storage.
+ *
+ * Segment s holds the ids [64 * (2^s - 1), 64 * (2^(s+1) - 1)), that is
+ * 64 << s entries, and is allocated on first use.  Growth adds a new
+ * segment instead of reallocating, so existing entries never move.  The
+ * segment directory itself is a fixed-size array inside the table, so
+ * it never moves either.
+ *
+ * 26 segments span the whole uint32 id space up to INTERN_MAX_STRINGS.
+ * The doubling schedule keeps the directory tiny and the per-lookup
+ * arithmetic to a shift, an add and a bit scan.
+ */
+#define INTERN_SEG0_SHIFT 6
+#define INTERN_SEG0 (1u << INTERN_SEG0_SHIFT) /* first segment: 64 entries */
+#define INTERN_MAX_SEGMENTS 26
+#define INTERN_MAX_STRINGS (UINT32_MAX - INTERN_SEG0 + 1u)
+
 /* ======================================================================== */
 /* Hash Table Entry                                                         */
 /* ======================================================================== */
 
 typedef struct {
-    uint32_t string_id; /* index into strings array, or SLOT_EMPTY */
+    uint32_t string_id; /* index into the segments, or SLOT_EMPTY */
 } wl_intern_slot_t;
 
 /* ======================================================================== */
@@ -40,14 +130,22 @@ typedef struct {
 /* ======================================================================== */
 
 struct wl_intern {
-    /* Reverse array: id -> string (owned copies) */
-    char **strings;
-    uint32_t count;
-    uint32_t string_capacity;
+    /* Reverse mapping: id -> string (owned copies), never relocated.
+     * Read without the lock; see the header comment. */
+    char **segments[INTERN_MAX_SEGMENTS];
 
-    /* Hash table: string -> id (open addressing) */
+    /* Number of published entries.  Release-stored by the writer once
+     * the entry is complete; acquire-loaded by lock-free readers. */
+    wl_intern_atomic_u32 count;
+
+    /* Hash table: string -> id (open addressing).  Only ever touched
+     * with @lock held, which is what makes growing it (and freeing the
+     * old allocation) safe. */
     wl_intern_slot_t *slots;
     uint32_t slot_capacity;
+
+    /* Writers only.  Readers (reverse/count) never take it. */
+    mutex_t lock;
 };
 
 /* ======================================================================== */
@@ -66,12 +164,98 @@ fnv1a(const char *str)
 }
 
 /* ======================================================================== */
+/* Segment Addressing                                                       */
+/* ======================================================================== */
+
+/* floor(log2(v)) for v >= 1. */
+static inline uint32_t
+intern_ilog2(uint32_t v)
+{
+    /* *INDENT-OFF* */
+#if defined(__GNUC__) || defined(__clang__)
+    return 31u - (uint32_t)__builtin_clz(v);
+#elif defined(_MSC_VER)
+    unsigned long idx;
+    _BitScanReverse(&idx, (unsigned long)v);
+    return (uint32_t)idx;
+#else
+    uint32_t r = 0;
+    while (v > 1u) {
+        v >>= 1;
+        r++;
+    }
+    return r;
+#endif
+    /* *INDENT-ON* */
+}
+
+/* Segment holding @id. */
+static inline uint32_t
+intern_seg_of(uint32_t id)
+{
+    return intern_ilog2((id >> INTERN_SEG0_SHIFT) + 1u);
+}
+
+/* First id stored in segment @seg. */
+static inline uint32_t
+intern_seg_base(uint32_t seg)
+{
+    return (INTERN_SEG0 << seg) - INTERN_SEG0;
+}
+
+/* Number of entries in segment @seg. */
+static inline uint32_t
+intern_seg_size(uint32_t seg)
+{
+    return INTERN_SEG0 << seg;
+}
+
+/* Entry for @id.  @id must be below the published count (readers) or
+ * below the writer's own count (writers). */
+static inline char *
+intern_string_at(const wl_intern_t *intern, uint32_t id)
+{
+    uint32_t seg = intern_seg_of(id);
+
+    return intern->segments[seg][id - intern_seg_base(seg)];
+}
+
+/* Make sure the segment holding @id exists.  Caller holds @lock. */
+static int
+intern_seg_ensure(wl_intern_t *intern, uint32_t id)
+{
+    uint32_t seg = intern_seg_of(id);
+
+    if (seg >= INTERN_MAX_SEGMENTS)
+        return -1;
+    if (intern->segments[seg])
+        return 0;
+
+    char **block = (char **)calloc((size_t)intern_seg_size(seg),
+            sizeof(char *));
+    if (!block)
+        return -1;
+
+    intern->segments[seg] = block;
+    return 0;
+}
+
+/* ======================================================================== */
 /* Internal Helpers                                                         */
 /* ======================================================================== */
 
+/*
+ * Double the slot table and re-insert every published entry.
+ *
+ * Caller holds @lock.  wl_intern_put() and wl_intern_get() are the only
+ * readers of intern->slots and both hold the lock, so the old table can
+ * be freed here.
+ */
 static int
 intern_resize(wl_intern_t *intern)
 {
+    uint32_t count = WL_INTERN_LOAD_RELAXED(&intern->count);
+
     if (intern->slot_capacity > UINT32_MAX / 2U)
         return -1;
     uint32_t new_cap = intern->slot_capacity * 2U;
@@ -84,8 +268,8 @@ intern_resize(wl_intern_t *intern)
     memset(new_slots, 0xff, (size_t)new_cap * sizeof(wl_intern_slot_t));
 
     /* Re-insert all existing entries */
-    for (uint32_t i = 0; i < intern->count; i++) {
-        uint32_t h = fnv1a(intern->strings[i]) & (new_cap - 1);
+    for (uint32_t i = 0; i < count; i++) {
+        uint32_t h = fnv1a(intern_string_at(intern, i)) & (new_cap - 1);
         while (new_slots[h].string_id != SLOT_EMPTY)
             h = (h + 1) & (new_cap - 1);
         new_slots[h].string_id = i;
@@ -95,6 +279,31 @@ intern_resize(wl_intern_t *intern)
     intern->slots = new_slots;
     intern->slot_capacity = new_cap;
     return 0;
+}
+
+/*
+ * Probe the slot table for @str.  Caller holds @lock.
+ *
+ * Returns the id if present.  Otherwise returns -1 and, when @out_slot
+ * is non-NULL, stores the index of the empty slot the probe stopped on.
+ */
+static int64_t
+intern_lookup_locked(const wl_intern_t *intern, const char *str,
+    uint32_t *out_slot)
+{
+    uint32_t mask = intern->slot_capacity - 1;
+    uint32_t h = fnv1a(str) & mask;
+
+    while (intern->slots[h].string_id != SLOT_EMPTY) {
+        uint32_t sid = intern->slots[h].string_id;
+        if (strcmp(intern_string_at(intern, sid), str) == 0)
+            return (int64_t)sid;
+        h = (h + 1) & mask;
+    }
+
+    if (out_slot)
+        *out_slot = h;
+    return -1;
 }
 
 /* ======================================================================== */
@@ -108,18 +317,18 @@ wl_intern_create(void)
     if (!intern)
         return NULL;
 
-    intern->string_capacity = INTERN_INITIAL_CAP;
-    intern->strings = (char **)malloc(intern->string_capacity * sizeof(char *));
-    if (!intern->strings) {
+    if (mutex_init(&intern->lock) != 0) {
         free(intern);
         return NULL;
     }
+
+    WL_INTERN_STORE_RELEASE(&intern->count, 0u);
 
     intern->slot_capacity = INTERN_INITIAL_CAP;
     intern->slots = (wl_intern_slot_t *)malloc(intern->slot_capacity
             * sizeof(wl_intern_slot_t));
     if (!intern->slots) {
-        free((void *)intern->strings);
+        mutex_destroy(&intern->lock);
         free(intern);
         return NULL;
     }
@@ -136,11 +345,15 @@ wl_intern_free(wl_intern_t *intern)
     if (!intern)
         return;
 
-    for (uint32_t i = 0; i < intern->count; i++)
-        free(intern->strings[i]);
+    uint32_t count = WL_INTERN_LOAD_RELAXED(&intern->count);
+    for (uint32_t i = 0; i < count; i++)
+        free(intern_string_at(intern, i));
 
-    free((void *)intern->strings);
+    for (uint32_t seg = 0; seg < INTERN_MAX_SEGMENTS; seg++)
+        free((void *)intern->segments[seg]);
+
     free(intern->slots);
+    mutex_destroy(&intern->lock);
     free(intern);
 }
 
@@ -150,54 +363,63 @@ wl_intern_put(wl_intern_t *intern, const char *str)
     if (!intern || !str)
         return -1;
 
-    /* Check if already interned */
-    uint32_t mask = intern->slot_capacity - 1;
-    uint32_t h = fnv1a(str) & mask;
+    mutex_lock(&intern->lock);
 
-    while (intern->slots[h].string_id != SLOT_EMPTY) {
-        uint32_t sid = intern->slots[h].string_id;
-        if (strcmp(intern->strings[sid], str) == 0)
-            return (int64_t)sid;
-        h = (h + 1) & mask;
+    /* Check if already interned */
+    uint32_t h = 0;
+    int64_t existing = intern_lookup_locked(intern, str, &h);
+    if (existing >= 0) {
+        mutex_unlock(&intern->lock);
+        return existing;
     }
 
-    /* New string: grow string array if needed */
-    if (intern->count >= intern->string_capacity) {
-        if (intern->string_capacity > UINT32_MAX / 2U)
-            return -1;
-        uint32_t new_cap = intern->string_capacity * 2U;
-        char **new_strs = (char **)realloc((void *)intern->strings,
-                (size_t)new_cap * sizeof(char *));
-        if (!new_strs)
-            return -1;
-        intern->strings = new_strs;
-        intern->string_capacity = new_cap;
+    /* New string: make room for it in the segmented storage. */
+    uint32_t new_id = WL_INTERN_LOAD_RELAXED(&intern->count);
+    if (new_id >= INTERN_MAX_STRINGS
+        || intern_seg_ensure(intern, new_id) != 0) {
+        mutex_unlock(&intern->lock);
+        return -1;
     }
 
     size_t slen = strlen(str);
     char *copy = (char *)malloc(slen + 1);
-    if (!copy)
+    if (!copy) {
+        mutex_unlock(&intern->lock);
         return -1;
+    }
     memcpy(copy, str, slen + 1);
 
     /* Resize hash table before insertion if the new entry would exceed the load factor. */
-    if ((uint64_t)(intern->count + 1U) * INTERN_LOAD_FACTOR_DEN
+    if ((uint64_t)(new_id + 1U) * INTERN_LOAD_FACTOR_DEN
         > (uint64_t)intern->slot_capacity * INTERN_LOAD_FACTOR_NUM) {
         if (intern_resize(intern) != 0) {
             free(copy);
+            mutex_unlock(&intern->lock);
             return -1;
         }
-        mask = intern->slot_capacity - 1U;
+        uint32_t mask = intern->slot_capacity - 1U;
         h = fnv1a(str) & mask;
         while (intern->slots[h].string_id != SLOT_EMPTY)
             h = (h + 1U) & mask;
     }
 
-    uint32_t new_id = intern->count;
-    intern->strings[new_id] = copy;
-    intern->count++;
+    uint32_t seg = intern_seg_of(new_id);
+    intern->segments[seg][new_id - intern_seg_base(seg)] = copy;
+
+    /* Release store: any reader that acquire-loads a count greater than
+     * new_id also sees the segment pointer and the string above.  The
+     * entry must be complete before the count is published, never the
+     * other way round. */
+    /* Release is sufficient only because EVERY store to count happens
+     * under intern->lock: another writer's segment and slot writes are
+     * ordered before its unlock, which is ordered before our lock and
+     * therefore before this store.  An unlocked count store would break
+     * the transitivity a lock-free reverse() depends on. */
+    WL_INTERN_STORE_RELEASE(&intern->count, new_id + 1U);
+
     intern->slots[h].string_id = new_id;
 
+    mutex_unlock(&intern->lock);
     return (int64_t)new_id;
 }
 
@@ -207,26 +429,31 @@ wl_intern_get(const wl_intern_t *intern, const char *str)
     if (!intern || !str)
         return -1;
 
-    uint32_t mask = intern->slot_capacity - 1;
-    uint32_t h = fnv1a(str) & mask;
+    /* Reading the slot table requires the lock, because a concurrent
+     * put() may be growing it.  The table is heap-allocated, so casting
+     * away const to take the lock is well defined. */
+    wl_intern_t *mutable_intern = (wl_intern_t *)intern;
 
-    while (intern->slots[h].string_id != SLOT_EMPTY) {
-        uint32_t sid = intern->slots[h].string_id;
-        if (strcmp(intern->strings[sid], str) == 0)
-            return (int64_t)sid;
-        h = (h + 1) & mask;
-    }
+    mutex_lock(&mutable_intern->lock);
+    int64_t id = intern_lookup_locked(intern, str, NULL);
+    mutex_unlock(&mutable_intern->lock);
 
-    return -1;
+    return id;
 }
 
 const char *
 wl_intern_reverse(const wl_intern_t *intern, int64_t id)
 {
-    if (!intern || id < 0 || (uint32_t)id >= intern->count)
+    if (!intern || id < 0)
         return NULL;
 
-    return intern->strings[(uint32_t)id];
+    /* Acquire load: pairs with the release store in wl_intern_put(), so
+     * an id below the observed count names a fully written entry. */
+    uint32_t count = WL_INTERN_LOAD_ACQUIRE(&intern->count);
+    if (id > (int64_t)UINT32_MAX || (uint32_t)id >= count)
+        return NULL;
+
+    return intern_string_at(intern, (uint32_t)id);
 }
 
 uint32_t
@@ -235,5 +462,5 @@ wl_intern_count(const wl_intern_t *intern)
     if (!intern)
         return 0;
 
-    return intern->count;
+    return WL_INTERN_LOAD_ACQUIRE(&intern->count);
 }

--- a/wirelog/intern.h
+++ b/wirelog/intern.h
@@ -9,6 +9,23 @@
  * Bidirectional mapping between strings and integer IDs for symbol
  * interning.  Strings are interned at parse/load time; integer IDs
  * are used throughout the DD execution pipeline.
+ *
+ * Thread safety (Issue #958): one table is shared by every parallel
+ * evaluation worker, so all four accessors below are safe to call
+ * concurrently on the same table.  wl_intern_put() and wl_intern_get()
+ * serialize with each other; wl_intern_reverse() and wl_intern_count()
+ * are lock-free and may run concurrently with a put().  Note that this
+ * makes the id a string receives dependent on worker interleaving:
+ * ids are unique and stable for the lifetime of the table, but not
+ * reproducible across runs when workers intern in parallel.
+ * That is user-visible, not merely internal: ordering comparisons and
+ * digests over symbols resolve through the id rather than the string
+ * bytes, so a query using them over symbols created during evaluation
+ * can give a different answer on a different run at W > 1.  Those are
+ * pre-existing defects tracked separately; they are reachable now
+ * because the same programs used to crash instead.
+ * wl_intern_create() and wl_intern_free() are not thread-safe and must
+ * not overlap any other call on the same table.
  */
 
 #ifndef WIRELOG_INTERN_H


### PR DESCRIPTION
Closes #958.

## The defect

Every worker borrows the coordinator's `wl_intern_t`. It is propagated by the bitwise session copy and absent from **both** borrowed-field null-out lists, so all three worker families — non-recursive, TDD, K-fusion — called an unsynchronized hash table concurrently. `intern.h` documented no thread-safety contract at all, which is the root of it.

**Memory corruption, not just a varying answer.** The `realloc()` that doubled the id→string array relocated it under a worker mid-dereference: 100% SIGSEGV over 30 runs each for a 31k-row recursive rule and a 100k-row non-recursive rule at W ≥ 8. A second defect hands one string two ids, which is why DOOP's totals drifted *upward* and varied per run rather than merely differing.

## Readers stay lock-free; writers serialize

- id→string storage is **segmented** into a fixed 26-entry directory and never moves, so a reader's pointer survives growth. The segments tile `[0, INTERN_MAX_STRINGS)` exactly and preserve the prior ~1.6e9 capacity.
- `count` is published with a **release store after** the entry and its segment pointer are written — the old code published it *before* — and read with an acquire load.
- `put()` and `get()` take a mutex. `get()` joins the writers because it is the other reader of the slot table, which `resize()` frees in place; it has one caller, in single-threaded plan generation.

**A global mutex was measured and rejected.** `wl_intern_reverse()` runs once or twice per row inside `contains`/`strlen`/`substr`/`to_number`:

| | W=1 eval | W=8 eval |
|---|---|---|
| baseline | 623 ms | 359 ms |
| global mutex | 782 ms | **3,926 ms (10.9x)** |
| this change | 642 ms | 414 ms |

With the mutex, W=8 is slower than mutex's own W=1 — parallelism becomes a pessimisation. `pthread_rwlock` is no better on reads and 2x worse on writes.

## Tests

Both added **with** the fix. Failing-first is not viable: under TSan the concurrent harness hangs while emitting DEADLYSIGNAL, and CI runs ASan/TSan with `halt_on_error=1`, so a red test kills the whole leg.

- 4-thread put/reverse race test — detects **17/20** on the unfixed tree, split between assertion failures and hard aborts (`realloc(): invalid old size`, `double free or corruption`).
- K-fusion determinism test — a recursive rule with four IDB body atoms and `cat()` in head position. That path has **no row gate**, so it reproduces at **30 facts in 50 ms**. Detects **20/20**. It reverse-maps rows to strings and sorts with `strcmp` before comparing W=8/16 to W=1, so it is immune to the id permutation it exists to test around.

A row-count-keyed reproducer would have missed this entirely: the 65,536-row threshold belongs only to the non-recursive path, while K-fusion has no gate and TDD's default is 4096. The earlier failure to shrink this to a miniature was not a scale problem — it was never reaching a parallel path.

## Disclosed, not buried

**Write-path convoy.** 1.6M unique inserts split across workers: 561 ms at W=1 against 2,224 ms at W=8, with 8.8 s system time and 938k voluntary context switches — futex convoy, not plain serialization. Follow-up #961, where hoisting the `malloc` out of the critical section measured 44% back at W=4. There is no correct "before": the same input SIGSEGVs on every run without this change.

**Id-dependent semantics.** Ordering comparisons and digests over symbols resolve through the intern id rather than the string, so `<`/`>`/`min`/`max` (#962) and `hash()`/`crc32`/`md5`/`sha*` (#963) over symbols created during evaluation can differ between runs at W > 1. Pre-existing; before this change those programs crashed instead. Both `intern.h` and the CHANGELOG state the consequence, not only the mechanism.

## Validation

`meson test -C build` **258 Ok / 0 Fail / 11 Skipped**. TSan 3/3 clean, ASan+UBSan 5/5 clean on both new tests. Correctness sweep across three shapes × W ∈ {8,16,32}: **225/225**, against a baseline that is 100% SIGSEGV on two of the three. `abi:threading_doc` gate passes (43 sites, 43 rows).

Review verified the segment tiling exhaustively at every boundary and at `INTERN_MAX_STRINGS`, confirmed `__builtin_clz(0)` is unreachable, checked the fallback agrees with the intrinsic, and established that the release store is sufficient **only because every `count` store happens under the lock** — a transitivity a future unlocked store would silently break. That invariant is now commented at the store site.
