### PR TITLE
fix(plan): compare symbol operands lexicographically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,56 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **Ordering comparisons on symbols compare strings, not intern ids** (#962):
+  `<`, `>`, `<=` and `>=` mapped to the integer opcodes regardless of operand
+  type, so on `string`/`symbol` columns they compared the interned integer
+  ids. Ids are assigned in first-appearance order, so `S("zz", "aa").` with
+  `R(a, b) :- S(a, b), a < b.` derived a row -- `"zz"` was seen first and
+  therefore held the smaller id -- and inserting an unrelated *earlier* fact
+  silently changed the answer. `exec_plan_gen.c` now types both operands and
+  emits `WL_PLAN_EXPR_CMP_STR_LT`/`GT`/`LTE`/`GTE`, which reverse the ids and
+  `strcmp` the strings. Those opcodes were already implemented in
+  `columnar/ops.c` and simply had no emitter.
+
+  Only the four ordering operators are converted, and only when *both*
+  operands are string-typed. `=` and `!=` are unchanged: interning is
+  canonical, so id equality already is string equality. A one-sided type
+  match keeps the integer opcode, because the string opcodes return false
+  whenever `wl_intern_reverse()` yields NULL -- applied to an integer operand
+  they would drop every row rather than misorder them. String-function
+  results (`cat`, `substr`, `to_upper`, `to_lower`, `str_replace`, `trim`,
+  `to_string`) are runtime-interned ids and count as string-typed, so
+  `to_upper(a) < to_upper(b)` is lexicographic too.
+
+  Columns with no declared type keep the old id-order behaviour: undeclared
+  relations are legitimate (head and intermediate relations need no `.decl`)
+  and rejecting them would break programs that work today. Each such
+  comparison, and each string-vs-numeric mix, is now reported at
+  `WL_LOG=EVAL:2`.
+
+  `min()` and `max()` over symbol columns still reduce by id and remain
+  non-lexicographic; that is #965. `examples/06-timestamp-lww` and
+  `examples/07-multi-source-analysis` recommended `min(Val)`/`min(Name)` as a
+  *deterministic* tiebreak, which was never true; both READMEs now say so.
+
+  Cost: a converted comparison falls off the compiled and column-native SIMD
+  filter paths onto the bytecode interpreter, because `col_expr_compile()`
+  and `filter_is_simple_cmp()` both reject unrecognised opcodes. Measured at
+  1M comparisons, 34 ms -> 111 ms (+77 ns per comparison); about 86% of that
+  is the demotion and 14% the two `wl_intern_reverse()` calls plus `strcmp`.
+  Integer filters are untouched and keep both fast paths -- a separate
+  integer-comparison program over the same 1M rows measures 40 ms before
+  and after, and does not become comparable to the 34 ms string baseline
+  above because the two programs differ in more than the operator.
+  Recovering a fast path for string comparisons is #966.
+
+  **Out-of-tree backends:** plans now contain expression opcodes `0x52`..`0x55`
+  where only `0x24`..`0x27` appeared before. A `wirelog/backend.h` consumer
+  that decodes expression buffers and treats unknown opcodes permissively --
+  as the in-tree `tests/fpga_backend.c` did -- will silently *admit every row*
+  through such a filter rather than fail. Decode the four new opcodes, or
+  reject unknown ones. This is not an installed-ABI break: `exec_plan.h` is
+  not in `wirelog_public_headers`.
 - **Shared intern table is now safe under parallel evaluation** (#958): every
   worker borrows the coordinator's `wl_intern_t` -- it is propagated by the
   bitwise session copy and is absent from both borrowed-field null-out lists --
@@ -61,11 +111,11 @@ All notable changes to wirelog are documented in this file.
 
   Ids are assigned in worker-interleaving order, so an id is unique and
   stable within a run but not reproducible across runs. That is visible in
-  results, not just internally: `<`, `>`, `<=`, `>=`, `min` and `max` on
-  symbols are evaluated as comparisons of the intern id rather than of the
-  string (`exec_plan_gen.c` maps them to the integer opcodes unconditionally,
-  and the implemented `CMP_STR_*` opcodes have no emitter), and `hash()`,
-  `crc32`, `md5`, `sha*`, `hmac` and `uuid5` digest the id rather than the
+  results, not just internally. At the time of this change `<`, `>`, `<=`,
+  `>=`, `min` and `max` on symbols all compared the intern id rather than
+  the string; the four ordering operators are fixed by #962, recorded above
+  in this same section, and `min`/`max` are #965. `hash()`, `crc32`,
+  `md5`, `sha*`, `hmac` and `uuid5` still digest the id rather than the
   string bytes. Queries using any of those over symbols produced during
   evaluation can therefore give different answers on different runs. Those
   are pre-existing defects, filed separately; before this change the same

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -72,6 +72,18 @@ Two patterns are supported:
   ordering.
 - The *identity* of intern ids assigned to symbols in inline facts is
   not stable across runs of the same program.
+
+  Because ids are unstable, nothing observable may be derived from their
+  order. The ordering operators (`<`, `>`, `<=`, `>=`) therefore compare
+  `string`/`symbol` columns **lexicographically**, not by id — see
+  `docs/SYNTAX.md`, "Comparison Operators". Id order still leaks through
+  in three places. A column with no declared type: the engine has nothing
+  to compare but the ids, so the result is as unstable as they are --
+  declare the relation. A comparison with one string and one numeric
+  operand: it stays an integer comparison, described in `docs/SYNTAX.md`.
+  And `min()`/`max()` over symbol columns, which still reduce by id.
+  Separately, `hash()` and the digest family take the id rather than the
+  string bytes.
 - Multiplicities other than the basic z-set arithmetic above (e.g.
   weighted aggregates) are subject to the engine's
   multiplicity-tracking rules, not promised by this document.

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -229,3 +229,32 @@ crypto hash functions.
 ### Comparison Operators
 
 `=`, `!=`, `<`, `>`, `<=`, `>=`
+
+The ordering operators (`<`, `>`, `<=`, `>=`) compare **numerically** on
+numeric columns and **lexicographically** (byte-wise, as `strcmp`) on
+`string`/`symbol` columns. Which one applies is decided from the declared
+column types, so a rule like
+
+```
+Before(a, b) :- Event(a), Event(b), a < b.
+```
+
+sorts event names alphabetically when `Event` is declared
+`.decl Event(name: string)`.
+
+`=` and `!=` are type-independent: symbols are interned canonically — one
+id per distinct string — so id equality already is string equality.
+
+**Undeclared columns compare by intern id.** Symbols are stored as
+interned integer ids, and ids are assigned in the order strings are first
+encountered. When a column has no declared type — the relation has no
+`.decl`, or the ordering operates on a value the declaration does not
+describe, such as an argument of an inline compound — the ordering
+operators fall back to comparing those ids, which orders symbols by when
+they were first seen rather than alphabetically. That result is *not*
+stable: adding an unrelated earlier fact changes it. Declare the relation
+to get lexicographic ordering. `WL_LOG=EVAL:2` reports each ordering
+comparison that falls back this way.
+
+Mixing a string operand with a numeric one in an ordering comparison also
+falls back to id order, and is likewise reported at `EVAL:2`.

--- a/examples/06-timestamp-lww/README.md
+++ b/examples/06-timestamp-lww/README.md
@@ -163,5 +163,14 @@ most common choice for simplicity.
 
 - Extend with a `tiebreak(Id, Val)` rule using `min(Val)` to resolve ties
   deterministically
+
+  > **Warning:** this is not deterministic today if `Val` is a `string` or
+  > `symbol` column. `min()`/`max()` reduce over the interned integer id of
+  > a symbol, and ids are assigned in the order strings are first
+  > encountered, so `min(Val)` picks whichever value happened to be interned
+  > first — which changes when unrelated facts are added. Lexicographic
+  > `min`/`max` over symbols is not yet implemented; ordering comparisons
+  > (`<`, `>`, `<=`, `>=`) already are (Issue #962). Until then, tiebreak on
+  > a numeric column, or compare with `<` in a rule instead of reducing.
 - Add a `stale(Id, Val, Ts)` output to capture discarded versions for auditing
 - Combine with `02-graph-reachability` to propagate LWW state across a network

--- a/examples/07-multi-source-analysis/README.md
+++ b/examples/07-multi-source-analysis/README.md
@@ -182,6 +182,16 @@ efficient for streaming MDM pipelines where new records arrive continuously.
 
 - Add a `tiebreak` rule using `min(Name)` to resolve conflicts deterministically
   without human intervention
+
+  > **Warning:** this is not deterministic today. `Name` is a `string`
+  > column, and `min()`/`max()` reduce over its interned integer id, not
+  > the string. Ids are assigned in the order strings are first encountered,
+  > so `min(Name)` picks whichever name happened to be interned first — which
+  > changes when unrelated facts are added. Lexicographic `min`/`max` over
+  > symbols is not yet implemented; ordering comparisons (`<`, `>`, `<=`,
+  > `>=`) already are (Issue #962). Until then, tiebreak on a numeric column
+  > such as an update timestamp, or compare with `<` in a rule instead of
+  > reducing.
 - Extend with a third source `src_c` and a priority chain (A > B > C)
 - Combine with `06-timestamp-lww` to use update timestamps as tiebreakers
 - Add a `merged(id, name_a, name_b, country_a, country_b)` relation to expose

--- a/tests/fpga_backend.c
+++ b/tests/fpga_backend.c
@@ -31,6 +31,7 @@
  */
 
 #include "fpga_backend.h"
+#include "../wirelog/intern.h"
 #include "../wirelog/session.h"
 
 #include <stdio.h>
@@ -273,9 +274,20 @@ fpga_parse_col_name_z(const char *name)
 
 #define EXPR_STACK_MAX 64
 
+/*
+ * Issue #962: the plan generator emits WL_PLAN_EXPR_CMP_STR_* (0x52..0x55)
+ * for ordering comparisons whose operands are both string-typed.  This
+ * evaluator's default arm is permissive -- an unknown opcode returns "row
+ * passes" -- so without the four cases below every such filter would be
+ * silently disabled here rather than merely unsupported.  @intern is the
+ * plan's borrowed table (wl_plan_t::intern); when it is NULL the ids cannot
+ * be reversed and the comparison degrades to id order.  Note this differs
+ * from col_eval_expr(), which returns false when a reverse lookup fails
+ * (ops.c) rather than falling back to id order.
+ */
 static int64_t
 fpga_eval_expr(const wl_plan_expr_buffer_t *expr, const int64_t *row,
-    uint32_t ncols)
+    uint32_t ncols, const wl_intern_t *intern)
 {
     if (!expr || !expr->data || expr->size == 0)
         return 1; /* no filter = pass */
@@ -435,6 +447,28 @@ fpga_eval_expr(const wl_plan_expr_buffer_t *expr, const int64_t *row,
                 sp--; stack[sp - 1] = stack[sp - 1] >= stack[sp] ? 1 : 0;
             }
             break;
+        /* String comparisons: intern ids reversed, then strcmp (0x52..0x55) */
+        case WL_PLAN_EXPR_CMP_STR_LT:  /* 0x52 */
+        case WL_PLAN_EXPR_CMP_STR_GT:  /* 0x53 */
+        case WL_PLAN_EXPR_CMP_STR_LTE: /* 0x54 */
+        case WL_PLAN_EXPR_CMP_STR_GTE: /* 0x55 */
+            if (sp >= 2) {
+                sp--;
+                int64_t a = stack[sp - 1], b = stack[sp];
+                const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+                const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+                int c = (sa && sb) ? strcmp(sa, sb)
+                                   : (a < b ? -1 : (a > b ? 1 : 0));
+                int64_t r;
+                switch (tag) {
+                case WL_PLAN_EXPR_CMP_STR_LT:  r = c < 0; break;
+                case WL_PLAN_EXPR_CMP_STR_GT:  r = c > 0; break;
+                case WL_PLAN_EXPR_CMP_STR_LTE: r = c <= 0; break;
+                default:                       r = c >= 0; break;
+                }
+                stack[sp - 1] = r;
+            }
+            break;
         /* Aggregates (used in REDUCE, not in filter context) */
         case WL_PLAN_EXPR_AGG_COUNT: /* 0x30 */
         case WL_PLAN_EXPR_AGG_SUM:   /* 0x31 */
@@ -533,7 +567,8 @@ fpga_eval_ops(wl_fpga_session_t *s, const wl_plan_op_t *ops, uint32_t op_count)
             fpga_rowset_init(&result, top->ncols);
             for (uint32_t r = 0; r < top->nrows; r++) {
                 const int64_t *row = fpga_rowset_row(top, r);
-                if (fpga_eval_expr(&op->filter_expr, row, top->ncols))
+                if (fpga_eval_expr(&op->filter_expr, row, top->ncols,
+                    s->plan ? s->plan->intern : NULL))
                     fpga_rowset_append(&result, row, top->ncols);
             }
             fpga_rowset_free(top);
@@ -585,7 +620,8 @@ fpga_eval_ops(wl_fpga_session_t *s, const wl_plan_op_t *ops, uint32_t op_count)
                         if (op->right_filter_expr.data
                             && op->right_filter_expr.size > 0) {
                             if (!fpga_eval_expr(&op->right_filter_expr,
-                                rrow, rrel->rows.ncols))
+                                rrow, rrel->rows.ncols,
+                                s->plan ? s->plan->intern : NULL))
                                 continue;
                         }
                         int64_t combined[128];

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1093,6 +1093,28 @@ test_doop_strings_exe = executable(
 
 test('doop_strings', test_doop_strings_exe)
 
+# Issue #962: `<`, `>`, `<=`, `>=` on symbol columns used to compare intern
+# ids, so the answer depended on the order strings happened to be interned.
+# Asserts exact tuples in both directions, across all four operators and both
+# the `a op b` and `a op "literal"` forms, and pins that integer comparisons
+# are untouched.
+test_symbol_ordering_exe = executable(
+  'test_symbol_ordering',
+  files('test_symbol_ordering.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('symbol_ordering', test_symbol_ordering_exe)
+
 test('option2_doop', test_option2_doop_exe,
   env: ['DOOP_DATA_DIR=' + meson.project_source_root() / 'bench/data/doop'],
 )

--- a/tests/test_symbol_ordering.c
+++ b/tests/test_symbol_ordering.c
@@ -1,0 +1,626 @@
+/*
+ * tests/test_symbol_ordering.c - ordering comparisons on symbol columns
+ *                                (Issue #962)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * `<`, `>`, `<=` and `>=` used to compare the *intern ids* of symbol
+ * columns rather than the strings those ids stand for.  Ids are assigned in
+ * first-appearance order, so
+ *
+ *     S("zz", "aa").
+ *     R(a, b) :- S(a, b), a < b.
+ *
+ * derived a row -- "zz" was interned first and therefore held the smaller
+ * id -- and inserting an unrelated earlier fact that shifted the assignment
+ * silently changed the answer.  The plan generator now emits the
+ * WL_PLAN_EXPR_CMP_STR_* opcodes for ordering comparisons whose operands are
+ * both string-typed, so the comparison is lexicographic.
+ *
+ * Cardinality alone cannot test this.  A wrong plan hits the right count by
+ * luck at these sizes, and "zero rows" is also what a string opcode fed a
+ * mistyped operand produces -- ops.c returns false whenever wl_intern_reverse
+ * yields NULL, which drops every row.  Every case below therefore asserts the
+ * exact tuples, and each has a positive counterpart that separates "correct"
+ * from "the opcode rejects everything":
+ *
+ *   test_lt_rejects_reversed_pair / test_lt_accepts_ordered_pair
+ *       The two directions of the defect report.
+ *
+ *   test_intern_order_independence
+ *       The property under test.  Same rule, same facts, plus an unrelated
+ *       earlier fact that flips which of "aa"/"zz" is interned first.  A
+ *       count cannot see this; the output must be identical.
+ *
+ *   test_all_operators_var_var / test_all_operators_var_literal
+ *       All four operators, in both the `a op b` and `a op "literal"` forms.
+ *       The literal form resolves through a different serialization path and
+ *       was independently broken.  Facts are chosen so the id ordering and
+ *       the lexicographic ordering select *different* tuples, never merely
+ *       different counts.
+ *
+ *   test_integer_comparisons_unchanged
+ *       Integer columns must keep the integer opcode.  This guards the
+ *       failure mode where the emitter converts unconditionally: a blanket
+ *       string opcode makes wl_intern_reverse return NULL on integer values
+ *       and drops every row.
+ *
+ *   test_string_function_results_order_lexicographically
+ *       to_upper()/to_lower() results are runtime-interned ids, so they are
+ *       string-typed too.
+ *
+ *   test_types_survive_the_column_layout_operators
+ *       A column's type travels with its position through the same recursion
+ *       that resolves its name -- which is where #955's column-provenance
+ *       defect lived.  Joins, antijoins, right atoms that contribute no head
+ *       columns, and jpp-inserted projections each get their own case.
+ *
+ *   test_inline_compound_relation
+ *       An inline compound column occupies several *physical* columns while
+ *       the declaration lists one *logical* column, so a type array indexed
+ *       by physical position assigns every column after the compound the
+ *       wrong type and runs off the end of the last one.  Here `name`
+ *       follows a pair/2 inline column; if its type is lost the rule silently
+ *       returns to comparing ids.
+ */
+
+#include "../wirelog/backend.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/intern.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int test_count;
+static int pass_count;
+static int fail_count;
+
+#define TEST(name)                                      \
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
+
+#define PASS()            \
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                    \
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
+
+#define ASSERT(cond, msg) \
+        do {                  \
+            if (!(cond))      \
+            FAIL(msg);    \
+        } while (0)
+
+#define MAX_SEEN 32
+
+typedef struct {
+    const char *rel;
+    uint32_t count;
+    const wirelog_intern_t *intern;
+    /* Interned values of each row, joined with '|'.  Integer columns have no
+     * reverse mapping, so they are rendered as decimal instead. */
+    char seen[MAX_SEEN][256];
+} collect_t;
+
+/* Rows the caller wants inserted directly (physical layout), used by the
+ * compound case where the fact cannot be written in source syntax. */
+typedef struct {
+    const char *relation;
+    const int64_t *rows;
+    uint32_t num_rows;
+    uint32_t ncols;
+} insert_spec_t;
+
+static void
+collect_cb(const char *relation, const int64_t *row, uint32_t ncols, void *user)
+{
+    collect_t *c = (collect_t *)user;
+    if (!c->rel || !relation || strcmp(relation, c->rel) != 0)
+        return;
+    if (c->count < MAX_SEEN) {
+        char *dst = c->seen[c->count];
+        size_t pos = 0;
+        dst[0] = '\0';
+        for (uint32_t i = 0; i < ncols && pos + 1 < sizeof(c->seen[0]); i++) {
+            const char *v = c->intern
+                ? wl_intern_reverse(c->intern, row[i]) : NULL;
+            int n;
+            if (v)
+                n = snprintf(dst + pos, sizeof(c->seen[0]) - pos, "%s%s",
+                        i ? "|" : "", v);
+            else
+                n = snprintf(dst + pos, sizeof(c->seen[0]) - pos,
+                        "%s%" PRId64, i ? "|" : "", row[i]);
+            if (n < 0)
+                break;
+            pos += (size_t)n;
+        }
+    }
+    c->count++;
+}
+
+/* True if any collected row equals @want. */
+static bool
+saw(const collect_t *c, const char *want)
+{
+    uint32_t n = c->count < MAX_SEEN ? c->count : MAX_SEEN;
+    for (uint32_t i = 0; i < n; i++) {
+        if (strcmp(c->seen[i], want) == 0)
+            return true;
+    }
+    return false;
+}
+
+/*
+ * Evaluate @src, filling @out with @relation's tuples.
+ *
+ * @prepare may be NULL.  When present it runs after parsing -- so the intern
+ * table already holds the source facts' symbols -- and describes rows to
+ * insert directly, which is how the compound case supplies facts that have
+ * no source syntax.  Returns 0 on success.
+ */
+static int
+eval_relation_ex(const char *src, const char *relation, collect_t *out,
+    int (*prepare)(const wirelog_program_t *prog, insert_spec_t *ins))
+{
+    memset(out, 0, sizeof(*out));
+    out->rel = relation;
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        fprintf(stderr, "  parse error: %d\n", (int)err);
+        return -1;
+    }
+
+    insert_spec_t ins;
+    memset(&ins, 0, sizeof(ins));
+    if (prepare && prepare(prog, &ins) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_session_t *sess = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    out->intern = wirelog_program_get_intern(prog);
+
+    int result = -1;
+    if (wl_session_load_facts(sess, prog) == 0
+        && (ins.relation == NULL
+        || wl_session_insert(sess, ins.relation, ins.rows, ins.num_rows,
+        ins.ncols) == 0)
+        && wl_session_snapshot(sess, collect_cb, out) == 0)
+        result = 0;
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return result;
+}
+
+static int
+eval_relation(const char *src, const char *relation, collect_t *out)
+{
+    return eval_relation_ex(src, relation, out, NULL);
+}
+
+/* Two symbols whose lexicographic order is the reverse of their intern
+ * order: "zz" appears first in the source and therefore holds the smaller
+ * id, while "aa" sorts first as a string. */
+#define S_DECL ".decl S(a: string, b: string)\n"
+#define R_DECL ".decl R(a: string, b: string)\n"
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_lt_rejects_reversed_pair(void)
+{
+    TEST("a < b rejects S(\"zz\", \"aa\") despite the id order");
+
+    const char *src =
+        S_DECL
+        "S(\"zz\", \"aa\").\n"
+        R_DECL
+        "R(a, b) :- S(a, b), a < b.\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "R", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 0,
+        "\"zz\" < \"aa\" is false; the row must not be derived");
+    PASS();
+}
+
+static void
+test_lt_accepts_ordered_pair(void)
+{
+    TEST("a < b accepts S(\"aa\", \"zz\")");
+
+    const char *src =
+        S_DECL
+        "S(\"aa\", \"zz\").\n"
+        R_DECL
+        "R(a, b) :- S(a, b), a < b.\n";
+
+    /* The positive direction: without it, an opcode that rejects every row
+     * (which is what a mistyped operand produces) would pass the test
+     * above and look like a fix. */
+    collect_t c;
+    ASSERT(eval_relation(src, "R", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 1, "expected exactly the ordered pair");
+    ASSERT(saw(&c, "aa|zz"), "expected (\"aa\", \"zz\")");
+    PASS();
+}
+
+static void
+test_intern_order_independence(void)
+{
+    TEST("the derived set does not depend on intern order");
+
+    /* Identical rule and identical S facts.  The only difference is an
+     * unrelated relation whose facts are parsed first and therefore claim
+     * the lower ids, flipping the id order of "aa" against "zz". */
+    const char *without =
+        S_DECL
+        "S(\"zz\", \"aa\").\n"
+        "S(\"aa\", \"zz\").\n"
+        R_DECL
+        "R(a, b) :- S(a, b), a < b.\n";
+
+    const char *with_shift =
+        ".decl Z(s: string)\n"
+        "Z(\"aa\").\n"
+        "Z(\"mm\").\n"
+        S_DECL
+        "S(\"zz\", \"aa\").\n"
+        "S(\"aa\", \"zz\").\n"
+        R_DECL
+        "R(a, b) :- S(a, b), a < b.\n";
+
+    collect_t a, b;
+    ASSERT(eval_relation(without, "R", &a) == 0, "evaluation failed (a)");
+    ASSERT(eval_relation(with_shift, "R", &b) == 0, "evaluation failed (b)");
+
+    ASSERT(a.count == 1 && b.count == 1,
+        "exactly one of the two pairs is lexicographically ordered");
+    ASSERT(saw(&a, "aa|zz") && saw(&b, "aa|zz"),
+        "both programs must derive (\"aa\", \"zz\") and nothing else");
+    ASSERT(!saw(&a, "zz|aa") && !saw(&b, "zz|aa"),
+        "(\"zz\", \"aa\") is not ordered under either intern assignment");
+    PASS();
+}
+
+/* Facts shared by the operator sweeps.  Interned in source order, so
+ * id("zz") < id("aa") < id("mm") while the strings sort aa < mm < zz. */
+#define SWEEP_FACTS       \
+        S_DECL                \
+        "S(\"zz\", \"aa\").\n"    \
+        "S(\"aa\", \"zz\").\n"    \
+        "S(\"mm\", \"mm\").\n"
+
+static void
+test_all_operators_var_var(void)
+{
+    TEST("all four operators compare two symbol variables lexicographically");
+
+    struct {
+        const char *op;
+        const char *want[2];
+        uint32_t want_count;
+        const char *reject; /* what the id ordering would have selected */
+    } cases[] = {
+        { "<",  { "aa|zz", NULL },    1, "zz|aa" },
+        { ">",  { "zz|aa", NULL },    1, "aa|zz" },
+        { "<=", { "aa|zz", "mm|mm" }, 2, "zz|aa" },
+        { ">=", { "zz|aa", "mm|mm" }, 2, "aa|zz" },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        char src[512];
+        snprintf(src, sizeof(src),
+            "%s" R_DECL "R(a, b) :- S(a, b), a %s b.\n",
+            SWEEP_FACTS, cases[i].op);
+
+        collect_t c;
+        ASSERT(eval_relation(src, "R", &c) == 0, "evaluation failed");
+        ASSERT(c.count == cases[i].want_count, "wrong number of rows");
+        for (uint32_t w = 0; w < cases[i].want_count; w++)
+            ASSERT(saw(&c, cases[i].want[w]), "expected tuple missing");
+        ASSERT(!saw(&c, cases[i].reject),
+            "derived the tuple the intern-id ordering would have selected");
+    }
+    PASS();
+}
+
+static void
+test_all_operators_var_literal(void)
+{
+    TEST("all four operators compare a symbol variable against a literal");
+
+    /* T holds one column; the literal "mm" is interned last, so under the id
+     * ordering it is the largest of the three and every operator selects a
+     * different set than the lexicographic answer. */
+    struct {
+        const char *op;
+        const char *want[2];
+        uint32_t want_count;
+        const char *reject;
+    } cases[] = {
+        { "<",  { "aa", NULL },  1, "zz" },
+        { ">",  { "zz", NULL },  1, "aa" },
+        { "<=", { "aa", "mm" },  2, "zz" },
+        { ">=", { "zz", "mm" },  2, "aa" },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        char src[512];
+        snprintf(src, sizeof(src),
+            ".decl T(a: string)\n"
+            "T(\"zz\").\n"
+            "T(\"aa\").\n"
+            "T(\"mm\").\n"
+            ".decl R(a: string)\n"
+            "R(a) :- T(a), a %s \"mm\".\n",
+            cases[i].op);
+
+        collect_t c;
+        ASSERT(eval_relation(src, "R", &c) == 0, "evaluation failed");
+        ASSERT(c.count == cases[i].want_count, "wrong number of rows");
+        for (uint32_t w = 0; w < cases[i].want_count; w++)
+            ASSERT(saw(&c, cases[i].want[w]), "expected tuple missing");
+        ASSERT(!saw(&c, cases[i].reject),
+            "derived the tuple the intern-id ordering would have selected");
+    }
+    PASS();
+}
+
+static void
+test_integer_comparisons_unchanged(void)
+{
+    TEST("integer columns keep the integer comparison");
+
+    /* Integer values are not intern ids: wl_intern_reverse returns NULL for
+     * almost all of them, and the string opcodes drop every row when it
+     * does.  A converted-unconditionally emitter therefore shows up here as
+     * an empty result, not as a subtly wrong one. */
+    struct {
+        const char *op;
+        const char *want[2];
+        uint32_t want_count;
+    } cases[] = {
+        { "<",  { "1|2", NULL },  1 },
+        { ">",  { "2|1", NULL },  1 },
+        { "<=", { "1|2", "3|3" }, 2 },
+        { ">=", { "2|1", "3|3" }, 2 },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        char src[512];
+        snprintf(src, sizeof(src),
+            ".decl N(x: int64, y: int64)\n"
+            "N(1, 2).\n"
+            "N(2, 1).\n"
+            "N(3, 3).\n"
+            ".decl M(x: int64, y: int64)\n"
+            "M(x, y) :- N(x, y), x %s y.\n",
+            cases[i].op);
+
+        collect_t c;
+        ASSERT(eval_relation(src, "M", &c) == 0, "evaluation failed");
+        ASSERT(c.count == cases[i].want_count, "wrong number of rows");
+        for (uint32_t w = 0; w < cases[i].want_count; w++)
+            ASSERT(saw(&c, cases[i].want[w]), "expected tuple missing");
+    }
+    PASS();
+}
+
+static void
+test_string_function_results_order_lexicographically(void)
+{
+    TEST("to_upper() results order lexicographically, not by id");
+
+    /* to_upper() interns its result at evaluation time, so "AA" and "ZZ" get
+     * ids in whatever order the rows happen to be visited -- there is no
+     * source ordering to appeal to.  Only a lexicographic comparison gives a
+     * stable answer. */
+    const char *src =
+        S_DECL
+        "S(\"zz\", \"aa\").\n"
+        "S(\"aa\", \"zz\").\n"
+        R_DECL
+        "R(a, b) :- S(a, b), to_upper(a) < to_upper(b).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "R", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 1, "expected exactly the ordered pair");
+    ASSERT(saw(&c, "aa|zz"), "expected (\"aa\", \"zz\")");
+    PASS();
+}
+
+static void
+test_types_survive_the_column_layout_operators(void)
+{
+    TEST("types survive joins, antijoins, semijoins and projections");
+
+    /*
+     * The type of a column travels with its position through the same
+     * recursion that resolves its name, and that recursion is exactly where
+     * #955's column-provenance defect lived -- SEMIJOIN and ANTIJOIN widen
+     * their layout if the right child is concatenated in.  A type array
+     * riding along inherits the same failure, so each shape gets its own
+     * case rather than being assumed to follow from the single-scan ones.
+     *
+     * Every case uses facts whose intern order is the reverse of their
+     * lexicographic order, so dropping the types anywhere along the way
+     * selects the *other* row instead of merely changing a count.
+     */
+    struct {
+        const char *what;
+        const char *src;
+    } cases[] = {
+        { "two joins and a jpp projection",
+          /* y and w die before the head, so jpp inserts PROJECT nodes; x and
+           * z are carried across two JOINs from opposite ends of the chain. */
+          ".decl A(x: string, y: int64)\n"
+          ".decl B(y: int64, w: int64)\n"
+          ".decl C(w: int64, z: string)\n"
+          "A(\"zz\", 1).\n"
+          "A(\"aa\", 2).\n"
+          "B(1, 10).\n"
+          "B(2, 20).\n"
+          "C(10, \"aa\").\n"
+          "C(20, \"zz\").\n"
+          R_DECL
+          "R(x, z) :- A(x, y), B(y, w), C(w, z), x < z.\n" },
+        { "antijoin",
+          S_DECL
+          "S(\"zz\", \"aa\").\n"
+          "S(\"aa\", \"zz\").\n"
+          ".decl Bad(a: string)\n"
+          "Bad(\"mm\").\n"
+          R_DECL
+          "R(a, b) :- S(a, b), !Bad(a), a < b.\n" },
+        { "right atom contributing no head columns",
+          S_DECL
+          "S(\"zz\", \"aa\").\n"
+          "S(\"aa\", \"zz\").\n"
+          ".decl T(a: string)\n"
+          "T(\"zz\").\n"
+          "T(\"aa\").\n"
+          R_DECL
+          "R(a, b) :- S(a, b), T(a), a < b.\n" },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        collect_t c;
+        ASSERT(eval_relation(cases[i].src, "R", &c) == 0, "evaluation failed");
+        ASSERT(c.count == 1, "expected exactly the lexicographically ordered "
+            "pair");
+        ASSERT(saw(&c, "aa|zz"), "expected (\"aa\", \"zz\")");
+        ASSERT(!saw(&c, "zz|aa"),
+            "derived the pair the intern-id ordering would have selected");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * ev(id: int64, lbl: pair/2 inline, lo: string, hi: string) occupies five
+ * physical columns -- [id][lbl_0][lbl_1][lo][hi] -- behind four logical
+ * ones.  Rows are inserted physically because compound facts have no source
+ * syntax.
+ */
+#define COMPOUND_SRC                                                   \
+        ".decl seed(s: string)\n"                                          \
+        "seed(\"zz\").\n"                                                  \
+        "seed(\"aa\").\n"                                                  \
+        ".decl ev(id: int64, lbl: pair/2 inline, lo: string, hi: string)\n" \
+        ".decl bad(lo: string, hi: string)\n"                              \
+        "bad(lo, hi) :- ev(i, pair(p, q), lo, hi), hi < lo.\n"
+
+static int64_t compound_rows[10];
+
+static int
+compound_prepare(const wirelog_program_t *prog, insert_spec_t *ins)
+{
+    const wirelog_intern_t *in = wirelog_program_get_intern(prog);
+    if (!in)
+        return -1;
+    int64_t zz = wl_intern_get(in, "zz");
+    int64_t aa = wl_intern_get(in, "aa");
+    if (zz < 0 || aa < 0 || zz >= aa)
+        return -1; /* the seed facts must have made id("zz") < id("aa") */
+
+    /* row 0: lo = "aa", hi = "zz"  ->  hi < lo is false as strings,
+     *                                  true as ids
+     * row 1: lo = "zz", hi = "aa"  ->  hi < lo is true as strings,
+     *                                  false as ids */
+    int64_t r[10] = {
+        1, 7, 8, aa, zz,
+        2, 7, 8, zz, aa,
+    };
+    memcpy(compound_rows, r, sizeof(r));
+
+    ins->relation = "ev";
+    ins->rows = compound_rows;
+    ins->num_rows = 2;
+    ins->ncols = 5;
+    return 0;
+}
+
+static void
+test_inline_compound_relation(void)
+{
+    TEST("string columns after an inline compound keep their type");
+
+    collect_t c;
+    ASSERT(eval_relation_ex(COMPOUND_SRC, "bad", &c, compound_prepare)
+        == 0, "evaluation failed");
+    ASSERT(c.count == 1, "expected exactly one row");
+    /* Under the id ordering the other row is selected instead; a lost type
+     * for `lo`/`hi` -- which is what indexing the type array by physical
+     * position produces -- shows up here and nowhere else. */
+    ASSERT(saw(&c, "zz|aa"),
+        "expected the row where hi=\"aa\" sorts before lo=\"zz\"");
+    ASSERT(!saw(&c, "aa|zz"),
+        "selected the row the intern-id ordering would have selected");
+    PASS();
+}
+
+int
+main(void)
+{
+    printf("=== symbol ordering comparisons (Issue #962) ===\n");
+
+    test_lt_rejects_reversed_pair();
+    test_lt_accepts_ordered_pair();
+    test_intern_order_independence();
+    test_all_operators_var_var();
+    test_all_operators_var_literal();
+    test_integer_comparisons_unchanged();
+    test_string_function_results_order_lexicographically();
+    test_types_survive_the_column_layout_operators();
+    test_inline_compound_relation();
+
+    printf("\n--- Results: %d/%d passed", pass_count, test_count);
+    if (fail_count > 0)
+        printf(", %d FAILED", fail_count);
+    printf(" ---\n");
+    return (fail_count > 0) ? 1 : 0;
+}

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -15,6 +15,7 @@
 #include "intern.h"
 #include "ir/ir.h"
 #include "ir/program.h"
+#include "util/log.h"
 #include "wirelog-ir.h"
 #include "wirelog-types.h"
 
@@ -224,6 +225,96 @@ expr_buf_push_bytes(expr_buf_t *buf, const uint8_t *data, uint32_t len)
     return 0;
 }
 
+/* ======================================================================== */
+/* Column layout context                                                    */
+/* ======================================================================== */
+
+/**
+ * col_ctx_t:
+ *
+ * The column layout an expression is resolved against: one name and one
+ * value domain per column.  @types is allocated whenever @names is, so a
+ * type is never simply missing -- it is WL_IR_COLTYPE_UNKNOWN, which the
+ * comparison emitter can see and report.  @types is NULL only for an empty
+ * context; col_ctx_type_at() treats that as all-UNKNOWN.
+ */
+typedef struct {
+    char **names;           /* owned; @count entries, each possibly NULL */
+    wl_ir_coltype_t *types; /* owned; @count entries */
+    uint32_t count;
+} col_ctx_t;
+
+static void
+col_ctx_free(col_ctx_t *ctx)
+{
+    if (!ctx)
+        return;
+    if (ctx->names) {
+        for (uint32_t i = 0; i < ctx->count; i++)
+            free(ctx->names[i]);
+        free((void *)ctx->names);
+    }
+    free(ctx->types);
+    ctx->names = NULL;
+    ctx->types = NULL;
+    ctx->count = 0;
+}
+
+/* Allocate @count names and types.  Returns 0 on success. */
+static int
+col_ctx_alloc(col_ctx_t *ctx, uint32_t count)
+{
+    ctx->count = count;
+    ctx->names = (char **)calloc(count ? count : 1, sizeof(char *));
+    ctx->types
+        = (wl_ir_coltype_t *)calloc(count ? count : 1, sizeof(wl_ir_coltype_t));
+    if (!ctx->names || !ctx->types) {
+        col_ctx_free(ctx);
+        return -1;
+    }
+    return 0;
+}
+
+static wl_ir_coltype_t
+col_ctx_type_at(const col_ctx_t *ctx, uint32_t idx)
+{
+    if (!ctx || !ctx->types || idx >= ctx->count)
+        return WL_IR_COLTYPE_UNKNOWN;
+    return ctx->types[idx];
+}
+
+/**
+ * Resolve a variable name to its column's value domain.
+ *
+ * Names are matched the same way serialize_expr() matches them for emission,
+ * so typing and emission cannot disagree about which column a variable
+ * refers to: first by declared name, then -- for expressions whose variables
+ * were already rewritten to positional form by
+ * rewrite_expr_vars_to_columns() -- by parsing "colN".
+ */
+static wl_ir_coltype_t
+col_ctx_lookup_type(const col_ctx_t *ctx, const char *var_name)
+{
+    if (!ctx || !var_name)
+        return WL_IR_COLTYPE_UNKNOWN;
+
+    for (uint32_t c = 0; c < ctx->count; c++) {
+        if (ctx->names && ctx->names[c]
+            && strcmp(ctx->names[c], var_name) == 0)
+            return col_ctx_type_at(ctx, c);
+    }
+
+    if (strncmp(var_name, "col", 3) == 0
+        && isdigit((unsigned char)var_name[3])) {
+        char *end = NULL;
+        unsigned long idx = strtoul(var_name + 3, &end, 10);
+        if (end && *end == '\0' && idx < ctx->count)
+            return col_ctx_type_at(ctx, (uint32_t)idx);
+    }
+
+    return WL_IR_COLTYPE_UNKNOWN;
+}
+
 /* Map IR arith op -> plan expr tag */
 static uint8_t
 arith_to_tag(wirelog_arith_op_t op)
@@ -297,9 +388,51 @@ str_fn_to_tag(wirelog_str_fn_t fn)
     return WL_PLAN_EXPR_STR_FN_STRLEN; /* fallback */
 }
 
-/* Map IR cmp op -> plan expr tag */
+static const char *
+cmp_op_name(wirelog_cmp_op_t op)
+{
+    switch (op) {
+    case WIRELOG_CMP_EQ:  return "=";
+    case WIRELOG_CMP_NEQ: return "!=";
+    case WIRELOG_CMP_LT:  return "<";
+    case WIRELOG_CMP_GT:  return ">";
+    case WIRELOG_CMP_LTE: return "<=";
+    case WIRELOG_CMP_GTE: return ">=";
+    }
+    return "?";
+}
+
+/**
+ * Map an IR comparison to a plan expr tag, given the value domains of its
+ * two operands (Issue #962).
+ *
+ * Symbols are stored as intern ids, and ids are assigned in first-appearance
+ * order, so the integer opcodes order symbols by when they were first seen.
+ * WL_PLAN_EXPR_CMP_STR_* reverse the ids through wl_intern_reverse() and
+ * strcmp() the strings instead, which is the ordering the language means.
+ *
+ * Only LT/GT/LTE/GTE are converted:
+ *
+ *   - EQ and NEQ are already correct.  Interning is canonical -- one id per
+ *     distinct string -- so id equality IS string equality.  Converting them
+ *     would buy nothing and cost the demotion described below on every
+ *     equality filter in every program.
+ *
+ *   - The conversion is only sound when BOTH operands are strings.
+ *     col_eval_expr() returns false as soon as wl_intern_reverse() yields
+ *     NULL for either side, so a string opcode applied to an integer operand
+ *     does not misorder rows, it drops all of them.  A one-sided type match
+ *     therefore keeps the integer opcode.
+ *
+ * Emitting a CMP_STR_* opcode also demotes the filter from the compiled and
+ * column-native SIMD paths to the bytecode interpreter: col_expr_compile()
+ * and filter_is_simple_cmp() both reject unrecognised opcodes.  That is the
+ * bulk of the measured cost (~66 ns of ~77 ns per comparison) and is why the
+ * conversion is kept as narrow as it is.  Integer filters keep the fast
+ * paths untouched.
+ */
 static uint8_t
-cmp_to_tag(wirelog_cmp_op_t op)
+cmp_to_tag(wirelog_cmp_op_t op, wl_ir_coltype_t lhs, wl_ir_coltype_t rhs)
 {
     switch (op) {
     case WIRELOG_CMP_EQ:
@@ -307,15 +440,52 @@ cmp_to_tag(wirelog_cmp_op_t op)
     case WIRELOG_CMP_NEQ:
         return WL_PLAN_EXPR_CMP_NEQ;
     case WIRELOG_CMP_LT:
-        return WL_PLAN_EXPR_CMP_LT;
     case WIRELOG_CMP_GT:
-        return WL_PLAN_EXPR_CMP_GT;
     case WIRELOG_CMP_LTE:
-        return WL_PLAN_EXPR_CMP_LTE;
     case WIRELOG_CMP_GTE:
-        return WL_PLAN_EXPR_CMP_GTE;
+        break;
+    default:
+        return WL_PLAN_EXPR_CMP_EQ; /* fallback */
     }
-    return WL_PLAN_EXPR_CMP_EQ; /* fallback */
+
+    if (lhs == WL_IR_COLTYPE_STRING && rhs == WL_IR_COLTYPE_STRING) {
+        switch (op) {
+        case WIRELOG_CMP_LT:  return WL_PLAN_EXPR_CMP_STR_LT;
+        case WIRELOG_CMP_GT:  return WL_PLAN_EXPR_CMP_STR_GT;
+        case WIRELOG_CMP_LTE: return WL_PLAN_EXPR_CMP_STR_LTE;
+        default:              return WL_PLAN_EXPR_CMP_STR_GTE;
+        }
+    }
+
+    /*
+     * Anything else keeps the integer opcode, but says so.  Rejecting these
+     * at lowering time would break programs that work today: head and
+     * intermediate relations need no .decl, undeclared relations have no
+     * column types at all, and a rule over an undeclared integer relation
+     * evaluates perfectly well.  A warning is the most that can be done
+     * without breaking them, and the UNKNOWN sentinel is what makes the two
+     * cases distinguishable -- a conflict between two known types is a
+     * different report from a type that was never established.
+     */
+    if (lhs == WL_IR_COLTYPE_UNKNOWN || rhs == WL_IR_COLTYPE_UNKNOWN) {
+        WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_WARN,
+            "ordering comparison '%s' on a column with no declared type: "
+            "comparing interned ids, not strings. Declare the relation "
+            "(.decl R(c: string)) if the column holds symbols",
+            cmp_op_name(op));
+    } else if (lhs != rhs) {
+        WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_WARN,
+            "ordering comparison '%s' mixes a string operand with a numeric "
+            "one: comparing interned ids, not strings",
+            cmp_op_name(op));
+    }
+
+    switch (op) {
+    case WIRELOG_CMP_LT:  return WL_PLAN_EXPR_CMP_LT;
+    case WIRELOG_CMP_GT:  return WL_PLAN_EXPR_CMP_GT;
+    case WIRELOG_CMP_LTE: return WL_PLAN_EXPR_CMP_LTE;
+    default:              return WL_PLAN_EXPR_CMP_GTE;
+    }
 }
 
 /* Map IR agg fn -> plan expr tag */
@@ -338,12 +508,67 @@ agg_to_tag(wirelog_agg_fn_t fn)
 }
 
 /**
+ * The value domain an expression evaluates to (Issue #962).
+ *
+ * Everything the postfix evaluator pushes is an int64_t; what differs is
+ * whether that int64_t is a value or an interned symbol id.  String
+ * functions return runtime-interned ids, which is why to_upper(a) < to_upper(b)
+ * is a string comparison even though neither operand is a bare column.
+ * Comparisons and aggregates push counts and booleans, which are values.
+ */
+static wl_ir_coltype_t
+expr_result_type(const wl_ir_expr_t *expr, const col_ctx_t *ctx)
+{
+    if (!expr)
+        return WL_IR_COLTYPE_UNKNOWN;
+
+    switch (expr->type) {
+    case WL_IR_EXPR_VAR:
+        return col_ctx_lookup_type(ctx, expr->var_name);
+
+    case WL_IR_EXPR_CONST_STR:
+        return WL_IR_COLTYPE_STRING;
+
+    case WL_IR_EXPR_CONST_INT:
+    case WL_IR_EXPR_BOOL:
+    case WL_IR_EXPR_ARITH:
+    case WL_IR_EXPR_CMP:
+    case WL_IR_EXPR_AGG:
+        return WL_IR_COLTYPE_SCALAR;
+
+    case WL_IR_EXPR_STR_FN:
+        switch (expr->str_fn) {
+        /* Produce a new interned string. */
+        case WIRELOG_STR_FN_CAT:
+        case WIRELOG_STR_FN_SUBSTR:
+        case WIRELOG_STR_FN_TO_UPPER:
+        case WIRELOG_STR_FN_TO_LOWER:
+        case WIRELOG_STR_FN_STR_REPLACE:
+        case WIRELOG_STR_FN_TRIM:
+        case WIRELOG_STR_FN_TO_STRING:
+            return WL_IR_COLTYPE_STRING;
+        /* Produce a length, a code point, a boolean or a number. */
+        case WIRELOG_STR_FN_STRLEN:
+        case WIRELOG_STR_FN_CONTAINS:
+        case WIRELOG_STR_FN_STR_PREFIX:
+        case WIRELOG_STR_FN_STR_SUFFIX:
+        case WIRELOG_STR_FN_STR_ORD:
+        case WIRELOG_STR_FN_TO_NUMBER:
+            return WL_IR_COLTYPE_SCALAR;
+        }
+        return WL_IR_COLTYPE_UNKNOWN;
+    }
+
+    return WL_IR_COLTYPE_UNKNOWN;
+}
+
+/**
  * Serialize an IR expression tree into postfix (RPN) byte encoding.
  * Walks the tree recursively: children first (postfix), then operator.
  */
 static int
-serialize_expr(expr_buf_t *buf, const wl_ir_expr_t *expr, char **col_names,
-    uint32_t col_count)
+serialize_expr(expr_buf_t *buf, const wl_ir_expr_t *expr,
+    const col_ctx_t *ctx)
 {
     if (!expr)
         return -1;
@@ -355,9 +580,10 @@ serialize_expr(expr_buf_t *buf, const wl_ir_expr_t *expr, char **col_names,
         /* Resolve variable name to "colN" using column name context */
         char resolved[32];
         const char *emit_name = expr->var_name;
-        if (col_names && col_count > 0) {
-            for (uint32_t c = 0; c < col_count; c++) {
-                if (col_names[c] && strcmp(col_names[c], expr->var_name) == 0) {
+        if (ctx && ctx->names && ctx->count > 0) {
+            for (uint32_t c = 0; c < ctx->count; c++) {
+                if (ctx->names[c]
+                    && strcmp(ctx->names[c], expr->var_name) == 0) {
                     snprintf(resolved, sizeof(resolved), "col%u", c);
                     emit_name = resolved;
                     break;
@@ -399,24 +625,28 @@ serialize_expr(expr_buf_t *buf, const wl_ir_expr_t *expr, char **col_names,
     case WL_IR_EXPR_ARITH:
         /* Serialize children first (postfix) */
         for (uint32_t i = 0; i < expr->child_count; i++) {
-            if (serialize_expr(buf, expr->children[i], col_names, col_count)
-                != 0)
+            if (serialize_expr(buf, expr->children[i], ctx) != 0)
                 return -1;
         }
         return expr_buf_push_u8(buf, arith_to_tag(expr->arith_op));
 
-    case WL_IR_EXPR_CMP:
+    case WL_IR_EXPR_CMP: {
         for (uint32_t i = 0; i < expr->child_count; i++) {
-            if (serialize_expr(buf, expr->children[i], col_names, col_count)
-                != 0)
+            if (serialize_expr(buf, expr->children[i], ctx) != 0)
                 return -1;
         }
-        return expr_buf_push_u8(buf, cmp_to_tag(expr->cmp_op));
+        wl_ir_coltype_t lhs = (expr->child_count > 0)
+            ? expr_result_type(expr->children[0], ctx)
+            : WL_IR_COLTYPE_UNKNOWN;
+        wl_ir_coltype_t rhs = (expr->child_count > 1)
+            ? expr_result_type(expr->children[1], ctx)
+            : WL_IR_COLTYPE_UNKNOWN;
+        return expr_buf_push_u8(buf, cmp_to_tag(expr->cmp_op, lhs, rhs));
+    }
 
     case WL_IR_EXPR_AGG:
         for (uint32_t i = 0; i < expr->child_count; i++) {
-            if (serialize_expr(buf, expr->children[i], col_names, col_count)
-                != 0)
+            if (serialize_expr(buf, expr->children[i], ctx) != 0)
                 return -1;
         }
         return expr_buf_push_u8(buf, agg_to_tag(expr->agg_fn));
@@ -424,8 +654,7 @@ serialize_expr(expr_buf_t *buf, const wl_ir_expr_t *expr, char **col_names,
     case WL_IR_EXPR_STR_FN:
         /* Serialize arguments first (postfix), then emit the function opcode */
         for (uint32_t i = 0; i < expr->child_count; i++) {
-            if (serialize_expr(buf, expr->children[i], col_names, col_count)
-                != 0)
+            if (serialize_expr(buf, expr->children[i], ctx) != 0)
                 return -1;
         }
         return expr_buf_push_u8(buf, str_fn_to_tag(expr->str_fn));
@@ -436,12 +665,13 @@ serialize_expr(expr_buf_t *buf, const wl_ir_expr_t *expr, char **col_names,
 
 /**
  * Serialize an IR expression into a wl_plan_expr_buffer_t.
- * col_names/col_count provide variable name -> column index resolution.
+ * @ctx provides variable name -> column index resolution and the column
+ * types the comparison emitter needs.
  * Returns 0 on success. On NULL expr, produces empty buffer (valid no-op).
  */
 static int
-serialize_expr_to_buffer_ctx(const wl_ir_expr_t *expr, char **col_names,
-    uint32_t col_count, wl_plan_expr_buffer_t *out_buf)
+serialize_expr_to_buffer_ctx(const wl_ir_expr_t *expr, const col_ctx_t *ctx,
+    wl_plan_expr_buffer_t *out_buf)
 {
     out_buf->data = NULL;
     out_buf->size = 0;
@@ -453,7 +683,7 @@ serialize_expr_to_buffer_ctx(const wl_ir_expr_t *expr, char **col_names,
     if (expr_buf_init(&buf) != 0)
         return -1;
 
-    if (serialize_expr(&buf, expr, col_names, col_count) != 0) {
+    if (serialize_expr(&buf, expr, ctx) != 0) {
         free(buf.data);
         return -1;
     }
@@ -518,40 +748,41 @@ dup_indices(const uint32_t *src, uint32_t count)
 /* ======================================================================== */
 
 /**
- * Collect the output column names produced by an IR node.
- * For SCAN: returns the declared column_names.
- * For JOIN: concatenates left + right child column names.
+ * Collect the output column layout produced by an IR node.
+ * For SCAN: returns the declared column_names and column_types.
+ * For JOIN: concatenates left + right child columns.
  * For SEMIJOIN/ANTIJOIN: the left child's columns only -- these operators
  * filter rows and never widen their input.
  * For PROJECT/FILTER/FLATMAP/UNION: delegates to child[0].
  *
- * out_names and out_count are set on success (caller must free out_names
- * array AND each string in it).  Returns 0 on success, -1 on failure.
+ * Types ride the same recursion as names, position for position, so a layout
+ * that resolves a variable to column N also reports column N's type.  Any
+ * column whose type could not be established is WL_IR_COLTYPE_UNKNOWN
+ * (Issue #962).
+ *
+ * @out is filled on success and left empty on failure; the caller frees it
+ * with col_ctx_free() either way.  Returns 0 on success, -1 on failure.
  */
 static int
-collect_output_columns(const wirelog_ir_node_t *node, char ***out_names,
-    uint32_t *out_count)
+collect_output_columns(const wirelog_ir_node_t *node, col_ctx_t *out)
 {
-    if (!node) {
-        *out_names = NULL;
-        *out_count = 0;
+    memset(out, 0, sizeof(*out));
+
+    if (!node)
         return -1;
-    }
 
     switch (node->type) {
     case WIRELOG_IR_SCAN:
     case WIRELOG_IR_COMPOUND_INLINE:
     case WIRELOG_IR_COMPOUND_SIDE: {
-        uint32_t nc = node->column_count;
-        char **names = (char **)calloc(nc ? nc : 1, sizeof(char *));
-        if (!names)
+        if (col_ctx_alloc(out, node->column_count) != 0)
             return -1;
-        for (uint32_t i = 0; i < nc; i++) {
-            names[i]
+        for (uint32_t i = 0; i < out->count; i++) {
+            out->names[i]
                 = dup_str(node->column_names ? node->column_names[i] : NULL);
+            out->types[i] = node->column_types ? node->column_types[i]
+                                               : WL_IR_COLTYPE_UNKNOWN;
         }
-        *out_names = names;
-        *out_count = nc;
         return 0;
     }
 
@@ -564,73 +795,64 @@ collect_output_columns(const wirelog_ir_node_t *node, char ***out_names,
          * node -- join keys and fused projections alike.  Out-of-range
          * "colN" names then silently resolve to column 0 in the evaluator,
          * so the rule joins on the wrong column and under-derives (#955). */
-        char **left_names = NULL;
-        uint32_t left_count = 0;
+        col_ctx_t left;
+        memset(&left, 0, sizeof(left));
         if (node->child_count == 0
-            || collect_output_columns(node->children[0], &left_names,
-            &left_count)
-            != 0) {
-            *out_names = NULL;
-            *out_count = 0;
+            || collect_output_columns(node->children[0], &left) != 0) {
+            col_ctx_free(&left);
             return -1;
         }
         /* Only SEMIJOIN carries its projection into the plan operator
          * (see translate_ir_node); ANTIJOIN always emits all left columns. */
         if (node->type == WIRELOG_IR_SEMIJOIN && node->project_count > 0
             && node->project_indices) {
-            uint32_t pc = node->project_count;
-            char **names = (char **)calloc(pc, sizeof(char *));
-            if (!names) {
-                for (uint32_t i = 0; i < left_count; i++)
-                    free(left_names[i]);
-                free((void *)left_names);
+            col_ctx_t proj;
+            if (col_ctx_alloc(&proj, node->project_count) != 0) {
+                col_ctx_free(&left);
                 return -1;
             }
-            for (uint32_t i = 0; i < pc; i++) {
+            for (uint32_t i = 0; i < proj.count; i++) {
                 uint32_t idx = node->project_indices[i];
-                names[i] = (idx < left_count) ? dup_str(left_names[idx]) : NULL;
+                if (idx < left.count) {
+                    proj.names[i] = dup_str(left.names[idx]);
+                    proj.types[i] = col_ctx_type_at(&left, idx);
+                }
             }
-            for (uint32_t i = 0; i < left_count; i++)
-                free(left_names[i]);
-            free((void *)left_names);
-            *out_names = names;
-            *out_count = pc;
+            col_ctx_free(&left);
+            *out = proj;
             return 0;
         }
-        *out_names = left_names;
-        *out_count = left_count;
+        *out = left;
         return 0;
     }
 
     case WIRELOG_IR_JOIN: {
         /* Concatenate left child columns + right child columns */
-        char **left_names = NULL, **right_names = NULL;
-        uint32_t left_count = 0, right_count = 0;
+        col_ctx_t left, right;
+        memset(&left, 0, sizeof(left));
+        memset(&right, 0, sizeof(right));
         if (node->child_count > 0)
-            collect_output_columns(node->children[0], &left_names, &left_count);
+            collect_output_columns(node->children[0], &left);
         if (node->child_count > 1)
-            collect_output_columns(node->children[1], &right_names,
-                &right_count);
+            collect_output_columns(node->children[1], &right);
 
-        uint32_t total = left_count + right_count;
-        char **names = (char **)calloc(total ? total : 1, sizeof(char *));
-        if (!names) {
-            for (uint32_t i = 0; i < left_count; i++)
-                free(left_names[i]);
-            free((void *)left_names);
-            for (uint32_t i = 0; i < right_count; i++)
-                free(right_names[i]);
-            free((void *)right_names);
+        if (col_ctx_alloc(out, left.count + right.count) != 0) {
+            col_ctx_free(&left);
+            col_ctx_free(&right);
             return -1;
         }
-        for (uint32_t i = 0; i < left_count; i++)
-            names[i] = left_names[i]; /* transfer ownership */
-        for (uint32_t i = 0; i < right_count; i++)
-            names[left_count + i] = right_names[i]; /* transfer ownership */
-        free((void *)left_names);
-        free((void *)right_names);
-        *out_names = names;
-        *out_count = total;
+        for (uint32_t i = 0; i < left.count; i++) {
+            out->names[i] = left.names[i]; /* transfer ownership */
+            left.names[i] = NULL;
+            out->types[i] = col_ctx_type_at(&left, i);
+        }
+        for (uint32_t i = 0; i < right.count; i++) {
+            out->names[left.count + i] = right.names[i]; /* transfer */
+            right.names[i] = NULL;
+            out->types[left.count + i] = col_ctx_type_at(&right, i);
+        }
+        col_ctx_free(&left);
+        col_ctx_free(&right);
         return 0;
     }
 
@@ -641,24 +863,37 @@ collect_output_columns(const wirelog_ir_node_t *node, char ***out_names,
          * sees the correct (narrowed) column set. */
         if (!node->project_exprs && node->column_names
             && node->column_count > 0) {
-            uint32_t nc = node->column_count;
-            char **names = (char **)calloc(nc ? nc : 1, sizeof(char *));
-            if (!names)
+            /* The node records the projected names but not their types, so
+             * the types are recovered from the child through
+             * project_indices -- the same mapping the MAP operator applies
+             * at run time.  Without this the whole layout above any jpp
+             * projection would read as untyped. */
+            col_ctx_t child;
+            memset(&child, 0, sizeof(child));
+            if (node->child_count > 0)
+                collect_output_columns(node->children[0], &child);
+
+            if (col_ctx_alloc(out, node->column_count) != 0) {
+                col_ctx_free(&child);
                 return -1;
-            for (uint32_t i = 0; i < nc; i++)
-                names[i] = dup_str(node->column_names[i]);
-            *out_names = names;
-            *out_count = nc;
+            }
+            for (uint32_t i = 0; i < out->count; i++) {
+                out->names[i] = dup_str(node->column_names[i]);
+                if (node->project_indices && i < node->project_count)
+                    out->types[i]
+                        = col_ctx_type_at(&child, node->project_indices[i]);
+                else
+                    out->types[i]
+                        = col_ctx_lookup_type(&child, node->column_names[i]);
+            }
+            col_ctx_free(&child);
             return 0;
         }
         /* Head PROJECT nodes have project_exprs; delegate to child so
          * resolve_project_indices can map expression variables to child
          * column positions. */
         if (node->child_count > 0)
-            return collect_output_columns(node->children[0], out_names,
-                       out_count);
-        *out_names = NULL;
-        *out_count = 0;
+            return collect_output_columns(node->children[0], out);
         return -1;
 
     case WIRELOG_IR_FILTER:
@@ -667,15 +902,10 @@ collect_output_columns(const wirelog_ir_node_t *node, char ***out_names,
     case WIRELOG_IR_UNION:
         /* Delegate to first child */
         if (node->child_count > 0)
-            return collect_output_columns(node->children[0], out_names,
-                       out_count);
-        *out_names = NULL;
-        *out_count = 0;
+            return collect_output_columns(node->children[0], out);
         return -1;
     }
 
-    *out_names = NULL;
-    *out_count = 0;
     return -1;
 }
 
@@ -696,17 +926,16 @@ resolve_project_indices(const wirelog_ir_node_t *project_node)
     if (project_node->child_count > 0)
         child = project_node->children[0];
 
-    char **col_names = NULL;
-    uint32_t col_count = 0;
-    if (collect_output_columns(child, &col_names, &col_count) != 0)
+    col_ctx_t ctx;
+    if (collect_output_columns(child, &ctx) != 0) {
+        col_ctx_free(&ctx);
         return NULL;
+    }
 
     uint32_t pc = project_node->project_count;
     uint32_t *indices = (uint32_t *)malloc(pc * sizeof(uint32_t));
     if (!indices) {
-        for (uint32_t i = 0; i < col_count; i++)
-            free(col_names[i]);
-        free((void *)col_names);
+        col_ctx_free(&ctx);
         return NULL;
     }
 
@@ -714,8 +943,9 @@ resolve_project_indices(const wirelog_ir_node_t *project_node)
         indices[i] = i; /* fallback: identity */
         const wl_ir_expr_t *expr = project_node->project_exprs[i];
         if (expr && expr->type == WL_IR_EXPR_VAR && expr->var_name) {
-            for (uint32_t c = 0; c < col_count; c++) {
-                if (col_names[c] && strcmp(col_names[c], expr->var_name) == 0) {
+            for (uint32_t c = 0; c < ctx.count; c++) {
+                if (ctx.names[c]
+                    && strcmp(ctx.names[c], expr->var_name) == 0) {
                     indices[i] = c;
                     break;
                 }
@@ -723,9 +953,7 @@ resolve_project_indices(const wirelog_ir_node_t *project_node)
         }
     }
 
-    for (uint32_t i = 0; i < col_count; i++)
-        free(col_names[i]);
-    free((void *)col_names);
+    col_ctx_free(&ctx);
     return indices;
 }
 
@@ -741,19 +969,16 @@ resolve_key_to_colN(const char *key_name, const wirelog_ir_node_t *child)
     uint32_t idx = 0; /* fallback */
 
     if (key_name && child) {
-        char **col_names = NULL;
-        uint32_t col_count = 0;
-        if (collect_output_columns(child, &col_names, &col_count) == 0) {
-            for (uint32_t c = 0; c < col_count; c++) {
-                if (col_names[c] && strcmp(col_names[c], key_name) == 0) {
+        col_ctx_t ctx;
+        if (collect_output_columns(child, &ctx) == 0) {
+            for (uint32_t c = 0; c < ctx.count; c++) {
+                if (ctx.names[c] && strcmp(ctx.names[c], key_name) == 0) {
                     idx = c;
                     break;
                 }
             }
-            for (uint32_t c = 0; c < col_count; c++)
-                free(col_names[c]);
-            free((void *)col_names);
         }
+        col_ctx_free(&ctx);
     }
 
     snprintf(buf, sizeof(buf), "col%u", idx);
@@ -823,9 +1048,8 @@ unwrap_filters_collect(const wirelog_ir_node_t *node,
         return node;
 
     /* Resolve column names from the base SCAN for variable resolution */
-    char **col_names = NULL;
-    uint32_t col_count = 0;
-    collect_output_columns(node, &col_names, &col_count);
+    col_ctx_t ctx;
+    collect_output_columns(node, &ctx);
 
     expr_buf_t combined;
     if (expr_buf_init(&combined) != 0)
@@ -838,7 +1062,7 @@ unwrap_filters_collect(const wirelog_ir_node_t *node,
             ok = false;
             break;
         }
-        if (serialize_expr(&tmp, filt_exprs[i], col_names, col_count) != 0) {
+        if (serialize_expr(&tmp, filt_exprs[i], &ctx) != 0) {
             free(tmp.data);
             ok = false;
             break;
@@ -870,9 +1094,7 @@ unwrap_filters_collect(const wirelog_ir_node_t *node,
     }
 
 cleanup:
-    for (uint32_t c = 0; c < col_count; c++)
-        free(col_names[c]);
-    free((void *)col_names);
+    col_ctx_free(&ctx);
     return node;
 }
 
@@ -940,28 +1162,23 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             if (!op->map_exprs)
                 return -1;
             op->map_expr_count = node->project_count;
-            /* Collect child column names for variable name resolution */
-            char **child_col_names = NULL;
-            uint32_t child_col_count = 0;
+            /* Collect the child column layout for name and type resolution */
+            col_ctx_t child_ctx;
             const wirelog_ir_node_t *child0
                 = (node->child_count > 0) ? node->children[0] : NULL;
-            collect_output_columns(child0, &child_col_names, &child_col_count);
+            collect_output_columns(child0, &child_ctx);
             for (uint32_t i = 0; i < node->project_count; i++) {
                 if (node->project_exprs[i]) {
                     if (serialize_expr_to_buffer_ctx(
-                            node->project_exprs[i], child_col_names,
-                            child_col_count, &op->map_exprs[i])
+                            node->project_exprs[i], &child_ctx,
+                            &op->map_exprs[i])
                         != 0) {
-                        for (uint32_t c = 0; c < child_col_count; c++)
-                            free(child_col_names[c]);
-                        free((void *)child_col_names);
+                        col_ctx_free(&child_ctx);
                         return -1;
                     }
                 }
             }
-            for (uint32_t c = 0; c < child_col_count; c++)
-                free(child_col_names[c]);
-            free((void *)child_col_names);
+            col_ctx_free(&child_ctx);
         }
         return 0;
     }
@@ -977,17 +1194,13 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             return -1;
         op->op = WL_PLAN_OP_FILTER;
         {
-            char **filt_col_names = NULL;
-            uint32_t filt_col_count = 0;
+            col_ctx_t filt_ctx;
             const wirelog_ir_node_t *fchild
                 = (node->child_count > 0) ? node->children[0] : NULL;
-            collect_output_columns(fchild, &filt_col_names, &filt_col_count);
+            collect_output_columns(fchild, &filt_ctx);
             int rc = serialize_expr_to_buffer_ctx(
-                node->filter_expr, filt_col_names, filt_col_count,
-                &op->filter_expr);
-            for (uint32_t c = 0; c < filt_col_count; c++)
-                free(filt_col_names[c]);
-            free((void *)filt_col_names);
+                node->filter_expr, &filt_ctx, &op->filter_expr);
+            col_ctx_free(&filt_ctx);
             if (rc != 0)
                 return -1;
         }
@@ -1091,27 +1304,43 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             = dup_indices(node->group_by_indices, node->group_by_count);
         op->group_by_count = node->group_by_count;
         if (node->agg_expr) {
-            char **child_col_names = NULL;
-            uint32_t child_col_count = 0;
+            const wirelog_ir_node_t *child0
+                = (node->child_count > 0) ? node->children[0] : NULL;
+            col_ctx_t agg_ctx;
             if (node->column_names && node->column_count > 0) {
-                child_col_count = node->column_count;
-                child_col_names = (char **)calloc(child_col_count,
-                        sizeof(char *));
-                if (!child_col_names)
+                /*
+                 * The AGGREGATE node records the body's variable names but
+                 * no types, and it is the one serialize_expr() entry point
+                 * that does not take its layout from collect_output_columns()
+                 * -- so without this the aggregated expression would be the
+                 * only untyped expression in the plan.  The names here are
+                 * the body variables, which is exactly what the child's
+                 * layout is keyed by, so the types come across by name.
+                 */
+                col_ctx_t child_ctx;
+                collect_output_columns(child0, &child_ctx);
+                if (col_ctx_alloc(&agg_ctx, node->column_count) != 0) {
+                    col_ctx_free(&child_ctx);
                     return -1;
-                for (uint32_t i = 0; i < child_col_count; i++)
-                    child_col_names[i] = dup_str(node->column_names[i]);
+                }
+                for (uint32_t i = 0; i < agg_ctx.count; i++) {
+                    agg_ctx.names[i] = dup_str(node->column_names[i]);
+                    /* Positional first: the AGGREGATE's column list is the
+                     * body layout verbatim, and agg_expr's variables were
+                     * rewritten to "colN" against that same list.  Fall back
+                     * to the name only where the child is narrower. */
+                    agg_ctx.types[i] = (i < child_ctx.count)
+                        ? col_ctx_type_at(&child_ctx, i)
+                        : col_ctx_lookup_type(&child_ctx,
+                            node->column_names[i]);
+                }
+                col_ctx_free(&child_ctx);
             } else {
-                const wirelog_ir_node_t *child0
-                    = (node->child_count > 0) ? node->children[0] : NULL;
-                collect_output_columns(child0, &child_col_names,
-                    &child_col_count);
+                collect_output_columns(child0, &agg_ctx);
             }
             int agg_rc = serialize_expr_to_buffer_ctx(node->agg_expr,
-                    child_col_names, child_col_count, &op->agg_expr);
-            for (uint32_t c = 0; c < child_col_count; c++)
-                free(child_col_names[c]);
-            free((void *)child_col_names);
+                    &agg_ctx, &op->agg_expr);
+            col_ctx_free(&agg_ctx);
             if (agg_rc != 0)
                 return -1;
         }
@@ -1156,17 +1385,13 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             if (!filt)
                 return -1;
             filt->op = WL_PLAN_OP_FILTER;
-            char **filt2_names = NULL;
-            uint32_t filt2_count = 0;
+            col_ctx_t filt2_ctx;
             const wirelog_ir_node_t *fchild2
                 = (node->child_count > 0) ? node->children[0] : NULL;
-            collect_output_columns(fchild2, &filt2_names, &filt2_count);
-            int frc
-                = serialize_expr_to_buffer_ctx(node->filter_expr, filt2_names,
-                    filt2_count, &filt->filter_expr);
-            for (uint32_t c = 0; c < filt2_count; c++)
-                free(filt2_names[c]);
-            free((void *)filt2_names);
+            collect_output_columns(fchild2, &filt2_ctx);
+            int frc = serialize_expr_to_buffer_ctx(node->filter_expr,
+                    &filt2_ctx, &filt->filter_expr);
+            col_ctx_free(&filt2_ctx);
             if (frc != 0)
                 return -1;
         }
@@ -1200,29 +1425,23 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
                 if (!map->map_exprs)
                     return -1;
                 map->map_expr_count = node->project_count;
-                /* Collect child column names for variable name resolution */
-                char **child_col_names2 = NULL;
-                uint32_t child_col_count2 = 0;
+                /* Collect the child column layout for name/type resolution */
+                col_ctx_t child_ctx2;
                 const wirelog_ir_node_t *child2
                     = (node->child_count > 0) ? node->children[0] : NULL;
-                collect_output_columns(child2, &child_col_names2,
-                    &child_col_count2);
+                collect_output_columns(child2, &child_ctx2);
                 for (uint32_t i = 0; i < node->project_count; i++) {
                     if (node->project_exprs[i]) {
                         if (serialize_expr_to_buffer_ctx(
-                                node->project_exprs[i], child_col_names2,
-                                child_col_count2, &map->map_exprs[i])
+                                node->project_exprs[i], &child_ctx2,
+                                &map->map_exprs[i])
                             != 0) {
-                            for (uint32_t c = 0; c < child_col_count2; c++)
-                                free(child_col_names2[c]);
-                            free((void *)child_col_names2);
+                            col_ctx_free(&child_ctx2);
                             return -1;
                         }
                     }
                 }
-                for (uint32_t c = 0; c < child_col_count2; c++)
-                    free(child_col_names2[c]);
-                free((void *)child_col_names2);
+                col_ctx_free(&child_ctx2);
             }
         }
         return 0;
@@ -2639,6 +2858,21 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
         return -1;
 
     *out = NULL;
+
+    /* Issue #287/#962: plan generation is the first stage that emits WL_LOG
+     * diagnostics -- cmp_to_tag() reports ordering comparisons that fall back
+     * to intern-id order -- and it runs before any session exists, so the
+     * logger would still be at its all-silent default.  wl_log_init() is
+     * idempotent and cheap on re-entry; col_session_create() calls it for the
+     * same reason.
+     *
+     * Two caveats, both inherited rather than introduced.  It rewrites the
+     * sink and thresholds without a lock, so calling it while another
+     * thread logs is unsafe -- the same hazard col_session_create() already
+     * carries.  And at the release ceiling -Dwirelog_log_max_level=error the
+     * WARN sites below compile out entirely, so this call does nothing
+     * there. */
+    wl_log_init();
 
     if (wl_exec_plan_gen_preintern_static_strings(prog) != 0)
         return -1;

--- a/wirelog/ir/ir.c
+++ b/wirelog/ir/ir.c
@@ -34,6 +34,27 @@ strdup_safe(const char *s)
     return dup;
 }
 
+wl_ir_coltype_t
+wl_ir_coltype_from_column_type(wirelog_column_type_t type)
+{
+    /* Only WIRELOG_TYPE_STRING carries interned symbol ids; everything else
+     * is a value that compares as a number.  Written as an exhaustive switch
+     * so a newly added column type has to be classified here rather than
+     * defaulting into SCALAR by accident. */
+    switch (type) {
+    case WIRELOG_TYPE_STRING:
+        return WL_IR_COLTYPE_STRING;
+    case WIRELOG_TYPE_INT32:
+    case WIRELOG_TYPE_INT64:
+    case WIRELOG_TYPE_UINT32:
+    case WIRELOG_TYPE_UINT64:
+    case WIRELOG_TYPE_FLOAT:
+    case WIRELOG_TYPE_BOOL:
+        return WL_IR_COLTYPE_SCALAR;
+    }
+    return WL_IR_COLTYPE_UNKNOWN;
+}
+
 /* ======================================================================== */
 /* Expression API                                                           */
 /* ======================================================================== */
@@ -195,6 +216,7 @@ wl_ir_node_free(wirelog_ir_node_t *node)
         }
         free(node->column_names);
     }
+    free(node->column_types);
 
     /* Free PROJECT data */
     free(node->project_indices);

--- a/wirelog/ir/ir.h
+++ b/wirelog/ir/ir.h
@@ -57,6 +57,46 @@ struct wl_ir_expr {
 };
 
 /* ======================================================================== */
+/* Column Value Domain (Issue #962)                                         */
+/* ======================================================================== */
+
+/**
+ * wl_ir_coltype_t:
+ *
+ * The value domain of a physical column, as far as expression typing cares.
+ *
+ * This deliberately is NOT wirelog_column_type_t.  WIRELOG_TYPE_INT32 == 0,
+ * so an array of wirelog_column_type_t that was calloc()'d -- or that some
+ * path forgot to fill in -- is bit-identical to "every column is INT32".
+ * That is precisely the value that makes the comparison emitter keep the
+ * integer opcode, so a plumbing gap would degrade silently to the very bug
+ * being fixed and no test could tell the difference.
+ *
+ * Here UNKNOWN is 0 instead: a zero-filled or unpropagated array reads as
+ * "type not established", which the emitter detects and reports.
+ *
+ * Only the string/non-string distinction is represented, because that is
+ * the only distinction the comparison emitter can act on: every non-string
+ * column is compared by value exactly as it is today.  Collapsing
+ * int32/int64/float/bool into one SCALAR value also keeps the "both sides
+ * known and in conflict" warning from firing on int32-vs-int64 pairs, which
+ * are not a conflict at all.
+ */
+typedef enum {
+    WL_IR_COLTYPE_UNKNOWN = 0, /* not established -- calloc() default */
+    WL_IR_COLTYPE_SCALAR = 1,  /* int/uint/float/bool: compared by value */
+    WL_IR_COLTYPE_STRING = 2,  /* interned symbol id: compared by content */
+} wl_ir_coltype_t;
+
+/**
+ * wl_ir_coltype_from_column_type:
+ *
+ * Project a declared column type onto the comparison lattice.
+ */
+wl_ir_coltype_t
+wl_ir_coltype_from_column_type(wirelog_column_type_t type);
+
+/* ======================================================================== */
 /* IR Node Internal Definition                                              */
 /* ======================================================================== */
 
@@ -67,6 +107,11 @@ struct wirelog_ir_node {
     /* Operator-specific data */
     char **column_names;   /* SCAN: declared column names (NULL for wildcard) */
     uint32_t column_count; /* SCAN: column count */
+    /* SCAN: value domain of each column, parallel to column_names and the
+     * same column_count entries.  NULL means "nothing established", which
+     * every consumer must read as all-UNKNOWN rather than as a default
+     * type (Issue #962). */
+    wl_ir_coltype_t *column_types;
 
     uint32_t *project_indices; /* PROJECT: column index mapping */
     uint32_t project_count;    /* PROJECT: number of projected columns */

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -1040,6 +1040,26 @@ compound_arg_functor_matches(const wl_parser_ast_node_t *arg,
     return functor_id >= 0 && (uint32_t)functor_id == col->compound_functor_id;
 }
 
+/*
+ * The comparison lattice value of logical column @logical_idx, or UNKNOWN
+ * when the relation was never declared, was declared with fewer columns than
+ * the atom uses, or the column is a compound.  Compound columns carry no
+ * meaningful `type`: type_name_to_column_type() does not recognise
+ * "pair/2 inline" and falls through to its INT32 default, so reporting that
+ * would be reporting a parser artifact as a declaration (Issue #962).
+ */
+static wl_ir_coltype_t
+declared_coltype(const wl_ir_relation_info_t *rel_info, uint32_t logical_idx)
+{
+    if (!rel_info || !rel_info->columns
+        || logical_idx >= rel_info->column_count)
+        return WL_IR_COLTYPE_UNKNOWN;
+    const wirelog_column_t *col = &rel_info->columns[logical_idx];
+    if (col->compound_kind != WIRELOG_COMPOUND_KIND_NONE)
+        return WL_IR_COLTYPE_UNKNOWN;
+    return wl_ir_coltype_from_column_type(col->type);
+}
+
 static uint32_t
 atom_physical_column_count(const wl_parser_ast_node_t *atom,
     const wl_ir_relation_info_t *rel_info, const struct wirelog_program *prog)
@@ -1255,12 +1275,19 @@ build_side_compound_scan(const wl_parser_ast_node_t *compound_arg,
     uint32_t count = compound_arg->child_count + 1u;
     scan->column_names = (char **)calloc(count, sizeof(char *));
     char **var_names = (char **)calloc(count, sizeof(char *));
-    if (!scan->column_names || !var_names) {
+    /* __compound_<f>_<n> is (handle: int64, arg0..arg{n-1}: int64) -- see
+     * docs/COMPOUND_TERMS.md, "Side-relation tier".  The argument columns
+     * hold values whose original type the side relation does not record, so
+     * they stay UNKNOWN; only the handle is known to be an integer. */
+    scan->column_types = (wl_ir_coltype_t *)calloc(count,
+            sizeof(wl_ir_coltype_t));
+    if (!scan->column_names || !var_names || !scan->column_types) {
         free_var_names(var_names, count);
         wl_ir_node_free(scan);
         return NULL;
     }
     scan->column_count = count;
+    scan->column_types[0] = WL_IR_COLTYPE_SCALAR;
 
     scan->column_names[0] = strdup_safe(handle_var);
     var_names[0] = strdup_safe(handle_var);
@@ -1368,6 +1395,11 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
     scan->column_names
         = (char **)calloc(physical_count > 0 ? physical_count : 1,
             sizeof(char *));
+    /* calloc leaves every entry WL_IR_COLTYPE_UNKNOWN, which is what an
+     * undeclared or partially declared relation must read as (Issue #962). */
+    scan->column_types
+        = (wl_ir_coltype_t *)calloc(physical_count > 0 ? physical_count : 1,
+            sizeof(wl_ir_coltype_t));
     scan->column_count = physical_count;
 
     char **var_names
@@ -1380,8 +1412,8 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
     side_compound_binding_t *side_bindings
         = (side_compound_binding_t *)calloc(
             arg_count > 0 ? arg_count : 1, sizeof(side_compound_binding_t));
-    if (!scan->column_names || !var_names || !physical_args
-        || !side_bindings) {
+    if (!scan->column_names || !scan->column_types || !var_names
+        || !physical_args || !side_bindings) {
         free(side_bindings);
         free(physical_args);
         free(var_names);
@@ -1389,7 +1421,20 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
         return NULL;
     }
 
-    /* Collect column names from atom arguments */
+    /*
+     * Collect column names from atom arguments.
+     *
+     * This loop IS the logical -> physical column mapping: an inline
+     * compound argument that matches its declaration expands into
+     * arg->child_count physical slots, everything else takes one.  Column
+     * types are assigned here, in lockstep with phys_idx, for exactly that
+     * reason.  Deriving them anywhere else -- in particular by indexing
+     * rel_info->columns[] with a physical position -- shifts every type
+     * after the first inline compound and reads past column_count on the
+     * last one, and the resulting mistype is silent: a physical integer
+     * column that inherits `string` makes wl_intern_reverse return NULL, and
+     * WL_PLAN_EXPR_CMP_STR_LT then drops every row (Issue #962).
+     */
     uint32_t phys_idx = 0;
     uint32_t side_binding_count = 0;
     for (uint32_t i = 0; i < arg_count; i++) {
@@ -1397,6 +1442,7 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
         if (arg->type == WL_PARSER_AST_NODE_VARIABLE) {
             physical_args[phys_idx] = arg;
             scan->column_names[phys_idx] = strdup_safe(arg->name);
+            scan->column_types[phys_idx] = declared_coltype(rel_info, i);
             var_names[phys_idx] = strdup_safe(arg->name);
             phys_idx++;
         } else if (rel_info && i < rel_info->column_count
@@ -1413,6 +1459,10 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
                     scan->column_names[phys_idx] = NULL;
                     var_names[phys_idx] = NULL;
                 }
+                /* A declaration names the functor and arity of an inline
+                 * compound but not the types of its arguments, so these
+                 * slots genuinely have no declared type. */
+                scan->column_types[phys_idx] = WL_IR_COLTYPE_UNKNOWN;
                 phys_idx++;
             }
         } else if (rel_info && i < rel_info->column_count
@@ -1428,11 +1478,14 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
                 side_bindings[side_binding_count].handle_var = handle_var;
                 side_binding_count++;
             }
+            /* The physical slot holds a side-relation handle, an int64. */
+            scan->column_types[phys_idx] = WL_IR_COLTYPE_SCALAR;
             phys_idx++;
         } else {
             /* Wildcard, integer, string -> NULL (anonymous position) */
             physical_args[phys_idx] = arg;
             scan->column_names[phys_idx] = NULL;
+            scan->column_types[phys_idx] = declared_coltype(rel_info, i);
             var_names[phys_idx] = NULL;
             phys_idx++;
         }

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -256,6 +256,40 @@ collect_body_atoms(const wirelog_ir_node_t *ir_root, ms_atom_t *atoms)
     return count;
 }
 
+/*
+ * The value domain of variable @var as bound somewhere under @node.
+ *
+ * Used to type the magic guard SCAN, whose columns hold the same values as
+ * the body variables they are named after.  The guard SCAN is joined in as
+ * the LEFT child, so its columns come first in the rule's column layout and
+ * a comparison on a bound variable resolves against them.  Leaving them
+ * untyped would silently return string comparisons in magic-set-rewritten
+ * rules to comparing intern ids (Issue #962).
+ *
+ * First match wins, which is the same rule collect_output_columns() and
+ * serialize_expr() use to resolve a name to a column.
+ */
+static wl_ir_coltype_t
+ms_lookup_var_type(const wirelog_ir_node_t *node, const char *var)
+{
+    if (!node || !var)
+        return WL_IR_COLTYPE_UNKNOWN;
+
+    if (node->column_names && node->column_types) {
+        for (uint32_t i = 0; i < node->column_count; i++) {
+            if (node->column_names[i]
+                && strcmp(node->column_names[i], var) == 0)
+                return node->column_types[i];
+        }
+    }
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        wl_ir_coltype_t t = ms_lookup_var_type(node->children[i], var);
+        if (t != WL_IR_COLTYPE_UNKNOWN)
+            return t;
+    }
+    return WL_IR_COLTYPE_UNKNOWN;
+}
+
 /* ======================================================================== */
 /* Head Variable Extraction                                                 */
 /* ======================================================================== */
@@ -330,8 +364,15 @@ build_demand_rule_ir(const char *body_magic_name, const char *guard_magic_name,
     const ms_atom_t *prefix_atoms, uint32_t prefix_count,
     const ms_atom_t *target_atom, uint64_t target_bound_mask)
 {
-    /* === Step 1: Start with the guard magic SCAN === */
-
+    /*
+     * === Step 1: Start with the guard magic SCAN ===
+     *
+     * The SCANs built here carry names but no column_types.  A demand rule
+     * is only SCAN/JOIN/PROJECT -- it holds no filter or projection
+     * expression -- so nothing in it consults a column type.  (The guard
+     * inserted into the ORIGINAL rule does, and is typed; see
+     * insert_magic_guard.)
+     */
     wirelog_ir_node_t *current = wl_ir_node_create(WIRELOG_IR_SCAN);
     if (!current)
         return NULL;
@@ -502,14 +543,24 @@ insert_magic_guard(wirelog_ir_node_t *ir_root, const char *magic_name,
     wl_ir_node_set_relation(magic_scan, magic_name);
 
     magic_scan->column_names = (char **)calloc(bound_count, sizeof(char *));
-    if (!magic_scan->column_names) {
+    magic_scan->column_types
+        = (wl_ir_coltype_t *)calloc(bound_count, sizeof(wl_ir_coltype_t));
+    if (!magic_scan->column_names || !magic_scan->column_types) {
         wl_ir_node_free(magic_scan);
         return -1;
     }
     magic_scan->column_count = bound_count;
     for (uint32_t i = 0; i < bound_count; i++) {
-        if (bound_vars[i])
+        if (bound_vars[i]) {
             magic_scan->column_names[i] = strdup_safe(bound_vars[i]);
+            /* The magic relation carries the same values as the body
+             * variables it is keyed on, so it inherits their types.
+             * Not observable today -- no expression is serialized against
+             * this guard's layout -- but wrong types here would be a
+             * silent mistype if one ever were (Issue #962). */
+            magic_scan->column_types[i]
+                = ms_lookup_var_type(body, bound_vars[i]);
+        }
     }
 
     /* JOIN(magic_scan, body) keyed on bound variables */

--- a/wirelog/passes/sip.c
+++ b/wirelog/passes/sip.c
@@ -65,6 +65,21 @@ clone_scan_metadata(const wirelog_ir_node_t *scan)
             if (scan->column_names[i])
                 clone->column_names[i] = strdup_safe(scan->column_names[i]);
         }
+        /* Column types travel with the names so the clone stays a faithful
+         * copy.  Nothing observes them today: this clone becomes the
+         * SEMIJOIN's child[1], and collect_output_columns reads only
+         * child[0] for SEMIJOIN/ANTIJOIN.  Kept so the invariant holds if
+         * that ever changes (Issue #962). */
+        if (scan->column_types) {
+            clone->column_types = (wl_ir_coltype_t *)calloc(
+                scan->column_count, sizeof(wl_ir_coltype_t));
+            if (!clone->column_types) {
+                wl_ir_node_free(clone);
+                return NULL;
+            }
+            memcpy(clone->column_types, scan->column_types,
+                scan->column_count * sizeof(wl_ir_coltype_t));
+        }
     }
 
     return clone;


### PR DESCRIPTION
Closes #962.

## The defect

`<`, `>`, `<=`, `>=` on symbols compared intern **ids**, not strings:

```
S("zz", "aa").
r(a, b) :- S(a, b), a < b.     -- emitted a row
```

`"zz" < "aa"` is false lexicographically. Worse, **adding an unrelated earlier fact changed the answer**, because it shifts id assignment. Two programs with identical rules and facts could disagree.

The correct opcodes already existed: `WL_PLAN_EXPR_CMP_STR_LT`..`GTE` declared in `exec_plan.h`, implemented via `strcmp` in `ops.c` — with **no emitter anywhere in the tree**. Dead correct code beside live wrong code.

The work is plumbing, not evaluation: `cmp_to_tag()` took only the operator, and `WIRELOG_TYPE_STRING` appeared nowhere outside `ir/program.c`.

## What this does

`wirelog_ir_node_t` gains `column_types` beside `column_names`, carried through `collect_output_columns` for SCAN / JOIN concat / SEMIJOIN+ANTIJOIN / PROJECT / delegating nodes, reaching all six `serialize_expr` entry points. `cmp_to_tag(op, lhs, rhs)` then emits the string opcode when both operands are strings.

### Three details that are load-bearing

**Types are assigned inside the logical→physical expansion loop, not by physical index.** Inline compounds expand — `ev(id:int64, lbl:pair/2 inline, lo:string)` is physically `[id][lbl_0][lbl_1][lo]` — so indexing `rel_info->columns[]` by physical position shifts every type past the first compound and reads past `column_count` on the last. An earlier draft did exactly that. The mistype is silent in the worst way: an integer column typed `string` makes the reverse lookup fail and `CMP_STR_LT` returns hard 0, dropping **every row**.

**`UNKNOWN = 0` is a deliberate sentinel.** Reusing `wirelog_column_type_t` would make an unpropagated array indistinguishable from a genuine declaration, since `WIRELOG_TYPE_INT32` is also 0 — and that is precisely the value that keeps the broken opcode. With UNKNOWN as zero, a plumbing gap is structurally visible rather than silently correct-looking.

**`EQ`/`NEQ` are not converted, and a one-sided type match keeps the integer opcode.** Interning is canonical so id equality already *is* string equality. And `CMP_STR_*` returns false when `wl_intern_reverse` yields NULL — verified by building a blanket-STR variant, which returned nothing at all for an integer program.

## A backend that would have silently stopped filtering

`tests/fpga_backend.c`'s decoder has `default: return 1` — an unrecognised comparison **admits every row**. Adding the emitter without it would have disabled filtering there. Fixed in this commit, not a later one. Out-of-tree `wirelog/backend.h` consumers have the same hazard and are called out in the CHANGELOG. (`exec_plan.h` is not in `wirelog_public_headers`, so this is not an installed-ABI break.)

## Tests

`tests/test_symbol_ordering.c`, 9 cases. Notably:

- **Exact contents in both directions** — "no rows" is also what a broken opcode produces, so the positive case is what separates correct from rejects-everything.
- **Intern-order independence** — the property actually under test, and one a cardinality assertion cannot see.
- Facts chosen so id order and lexicographic order select *different* tuples.
- A **compound-bearing** program, guarding the expansion-loop mapping.

Mutation-tested with nine mutations, each failing only the case that covers it — including dropping types on the SEMIJOIN/ANTIJOIN path, which is where #955's defect lived in this same function.

**This defect was invisible to all 258 existing tests.** A sweep of `tests/`, `examples/`, `docs/` and `bench/` found no program anywhere comparing symbol operands or reducing `min`/`max` over a symbol column. No golden changes.

## Cost

A converted comparison falls off the compiled and SIMD filter paths onto the bytecode interpreter, since both reject unrecognised opcodes. 1M comparisons: **34 ms → 111 ms**.

An attribution probe splits that: **86% is the demotion**, 14% the two reverse lookups plus `strcmp` — so the irreducible cost of comparing strings properly is about **1.4x**, not 3.2x. Recovering the fast path is #966.

Two concerns measured and dismissed: long shared prefixes cost ~5 ns at 232 shared bytes, and the ratio is flat in worker count because `wl_intern_reverse` is lock-free after #958. **Integer filters are untouched** — 40 ms before and after.

## Docs that were wrong

`examples/06-timestamp-lww` and `examples/07-multi-source-analysis` recommended `min(Val)`/`min(Name)` on string columns as a **deterministic** tiebreak. That was never true. `min`/`max` still reduce by id (#965), so both READMEs now say so plainly rather than waiting for the fix.

## Validation

`meson test -C build` **259 Ok / 0 Fail / 11 Skipped** (baseline 258 + the new test). ASan full suite clean; TSan clean on the multiworker/kfusion/intern set. `abi` gates pass.

Review independently verified the compound mapping against two-compound and trailing-compound shapes the implementer had not tried, confirmed `compound_arity_map` is genuinely unreachable from the IR layer rather than accepting the claim, and re-ran the mutation table with five additions of its own.
