### PR TITLE
fix(plan): digest built-ins hash string bytes, not intern ids

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -241,8 +241,12 @@ jobs:
       - name: Verify enabled compile flag
         run: grep -R -- '-DWL_MBEDTLS_ENABLED=1' builddir-mbedtls/compile_commands.json
 
+      # symbol_digests covers the half of #963 that needs no mbedTLS and so
+      # already runs in every other job; it is listed here as well because
+      # this is the only job that exercises the emitter with the crypto
+      # evaluator arms compiled in.
       - name: Test mbedTLS crypto built-ins
-        run: meson test -C builddir-mbedtls cryptographic_hashes --print-errorlogs
+        run: meson test -C builddir-mbedtls cryptographic_hashes symbol_digests --print-errorlogs
 
       - name: Publish results
         if: always()

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -331,8 +331,12 @@ jobs:
       - name: Verify enabled compile flag
         run: grep -R -- '-DWL_MBEDTLS_ENABLED=1' builddir-mbedtls/compile_commands.json
 
+      # symbol_digests covers the half of #963 that needs no mbedTLS and so
+      # already runs in every other job; it is listed here as well because
+      # this is the only job that exercises the emitter with the crypto
+      # evaluator arms compiled in.
       - name: Test mbedTLS crypto built-ins
-        run: meson test -C builddir-mbedtls cryptographic_hashes --print-errorlogs
+        run: meson test -C builddir-mbedtls cryptographic_hashes symbol_digests --print-errorlogs
 
   # ==========================================================================
   # Phase: Sanitizer Matrix (starts after lint, parallel with build-primary)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,95 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **`hash()` and the digest family digest string bytes, not intern ids**
+  (#963): `hash`, `crc32_ethernet`, `crc32_castagnoli`, `md5`, `sha1`,
+  `sha256`, `sha512`, `hmac_sha256` and `uuid5` digested the `int64_t` on the
+  evaluation stack. For a `symbol` column that `int64_t` is an interned id, so
+  the result described the intern table rather than the string:
+  `hash("abc")` matched no external tool, and the same string digested
+  differently depending on what had been interned first.
+  `examples/04-hash-functions` showed both failures at once. Prepending one
+  row to `records.csv` gave alice bob's fingerprint, and
+  `hash("carol@example.com")` collided with the Part 3 checksum `hash(5)`
+  over a genuine integer -- both were really digests of small ids. `examples/05-crc32-checksum` was outright broken: its
+  committed checksums are `crc32(payload)`, so every one of its six frames was
+  reported corrupt and the `diff` its README documents failed.
+
+  `exec_plan_gen.c` now types the operands of a digest the same way #962 types
+  the operands of a comparison, and emits one of thirteen new payload-free
+  opcodes, `0x60`..`0x6C`, when an operand is string-typed. Those digest the
+  string's own bytes -- `strlen()` many, **no NUL terminator** -- which is what
+  `xxhsum -H3`, `zlib.crc32` and `sha256sum` see for the same input.
+  `examples/05` now reproduces its committed output exactly, byte for byte,
+  with no edit to any golden; `examples/04`'s fingerprints move to the values
+  `xxhsum -H3` prints, and its checksum and deduplication outputs do not move
+  at all.
+
+  `hmac_sha256(msg, key)` and `uuid5(ns, name)` type their two operands
+  independently and so get three opcodes each (`_SS`, `_SI`, `_IS`); the
+  all-integer case keeps the existing opcode. This deliberately diverges from
+  #962's rule that a one-sided type match keeps the integer opcode: an
+  ordering comparison needs *both* ids reversed to mean anything, while each
+  digest operand contributes its own bytes, so following that rule would leave
+  every mixed call digesting an id -- the defect itself.
+
+  **Column types are not enforced, and the fix inherits that.** A column
+  declared `symbol` that holds values which were never interned digests their
+  `int64` representation, i.e. exactly what the numeric opcode would have
+  produced, and the query still runs. Failing the row instead was considered
+  and rejected: in head position an expression failure is not a dropped row
+  but an `ERANGE` that aborts the entire `PROJECT` operator, so a query that
+  runs today would become `error: execution failed` with no output. A column
+  with no declared type at all still digests the id and is reported at
+  `WL_LOG=EVAL:2`; a failed reverse lookup is reported at `WL_LOG=EVAL:4`.
+  `docs/SEMANTICS.md` and `docs/SYNTAX.md` state the limit.
+
+  One thing the docs now say plainly that is not new behaviour:
+  `md5`/`sha*`/`hmac_sha256` return `XXH3_64bits(digest)`, not the digest --
+  reproducible as `printf 'abc' | sha256sum | cut -d' ' -f1 | xxd -r -p |
+  xxhsum -H3`. `sha256("abc")` is not SHA-256 of "abc" and never was.
+
+  One thing that *is* new, because this change would otherwise have created
+  it: `uuid5()` concatenated its two operands, which is unambiguous only
+  while both are fixed-width. Giving it variable-length operands would have
+  made `uuid5("ab", "c")` and `uuid5("a", "bc")` hash identical bytes and
+  return one value, and two distinct `(namespace, name)` pairs colliding is
+  the one thing a namespaced identifier must not do. RFC 4122 avoids this by
+  requiring the namespace to be exactly 16 bytes; wirelog adopted the
+  two-operand signature without that property, so the three symbol-bearing
+  opcodes length-prefix each operand -- its length as a little-endian
+  `uint64` -- before hashing. `uuid5(int64, int64)` keeps the unframed
+  construction and its exact previous values: its operands are 8 bytes each,
+  so nothing was ambiguous there, and an out-of-tree decoder that already
+  implements `0x2A` keeps computing the same answer. Rejected alternatives:
+  reducing the namespace to a fixed 16 bytes by digesting it, which is
+  lossy, costs a second SHA-1 per row, treats the two operands asymmetrically
+  and makes the result *look* RFC-conformant when it is not; and applying
+  the framing to `0x2A` as well, which would have changed values that were
+  never wrong. `uuid5()` remains non-conformant either way -- the namespace
+  need not be a UUID and only 8 of the 16 bytes are returned -- and
+  `docs/SYNTAX.md` keeps "unambiguous" and "RFC 4122" as separate claims.
+  `hmac_sha256()` has no such exposure: it passes message and key to the
+  HMAC primitive as distinct inputs rather than concatenating them, verified
+  by evaluating both splits.
+
+  Cost: none of these functions was ever on a fast path -- `col_expr_compile()`
+  returns NULL for them and `filter_is_simple_cmp()` rejects them on shape --
+  so unlike #962 there is no demotion. End-to-end over 1M rows of ~20-byte
+  symbols, a program computing `hash(sym)` in a head position measures within
+  a few percent of the same program over an `int64` column.
+
+  **Out-of-tree backends:** plans now contain expression opcodes `0x60`..`0x6C`.
+  They are payload-free, exactly like the opcodes they shadow, so a decoder
+  that skips one byte per unknown opcode stays in sync with the rest of the
+  stream -- this is why a flag byte on the existing opcodes was rejected. A
+  decoder that treats unknown opcodes *permissively*, however, will admit rows
+  through a filter it did not evaluate. `tests/fpga_backend.c` did exactly
+  that; its default arm now rejects instead, matching `columnar/ops.c`, and it
+  decodes the new opcodes. Its `WL_PLAN_EXPR_ARITH_HASH` arm was also a
+  no-op that silently degraded `hash(x) = k` to `x = k`, and is now a real
+  digest. `exec_plan.h` is not in `wirelog_public_headers`, so this is not an
+  installed-ABI break.
 - **Ordering comparisons on symbols compare strings, not intern ids** (#962):
   `<`, `>`, `<=` and `>=` mapped to the integer opcodes regardless of operand
   type, so on `string`/`symbol` columns they compared the interned integer

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -68,11 +68,19 @@ wirelog exposes the following mbedTLS-backed Datalog built-ins:
 
 wirelog does not currently expose broader digest-family or generic
 HMAC-family built-ins as callable Datalog functions.
-Digest and HMAC built-ins operate on `int64` Datalog values. They
-compute mbedTLS digest/HMAC bytes and fold those bytes with
+Digest and HMAC built-ins take their input bytes from the operand's
+declared type (#963): the string's own bytes for a `symbol`/`string`
+column, `strlen()` many with no NUL terminator, and the 8-byte `int64`
+representation for a numeric one. `.decl` types are not enforced, so a
+`symbol` column holding values that were never interned falls back to
+the `int64` form — the guarantee is only as strong as the declaration.
+They compute mbedTLS digest/HMAC bytes and fold those bytes with
 `XXH3_64bits()` into the single `int64` value stored by wirelog;
-they do not return hex strings or byte arrays. `uuid4()` and
-`uuid5(namespace, name)` return the first 8 UUID bytes as an `int64`.
+they do not return hex strings or byte arrays. **The fold means these
+are 64-bit fingerprints, not full-width digests**, and must not be
+relied on for collision resistance at scale. `uuid4()` and
+`uuid5(namespace, name)` return the first 8 UUID bytes as an `int64`;
+`uuid5()` is not RFC 4122 (see `docs/SYNTAX.md`).
 
 These functions become callable as Datalog built-ins; the host has no
 control over whether a `.dl` program calls them once mbedTLS is

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -82,8 +82,19 @@ Two patterns are supported:
   declare the relation. A comparison with one string and one numeric
   operand: it stays an integer comparison, described in `docs/SYNTAX.md`.
   And `min()`/`max()` over symbol columns, which still reduce by id.
-  Separately, `hash()` and the digest family take the id rather than the
-  string bytes.
+
+  `hash()` and the digest family — `crc32_*`, `md5`, `sha*`,
+  `hmac_sha256`, `uuid5` — take the **string's bytes** for a column
+  declared `symbol`/`string`, `strlen()` many with no NUL terminator, and
+  the 8-byte `int64` representation for a numeric one. So a fingerprint
+  is a property of the data and reproduces outside wirelog. Two caveats,
+  both consequences of `.decl` types not being enforced. A column with no
+  declared type digests the id, and is therefore as unstable as the id
+  assignment. A column declared `symbol` whose values were never interned
+  digests their `int64` representation — the numeric answer for numeric
+  data — rather than failing the query; in head position a failure would
+  abort the whole projection, not drop a row. Both are reported under
+  `WL_LOG=EVAL`. The guarantee is only as good as the declaration.
 - Multiplicities other than the basic z-set arithmetic above (e.g.
   weighted aggregates) are subject to the engine's
   multiplicity-tracking rules, not promised by this document.

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -204,18 +204,58 @@ predicates without crypto support, columnar expression evaluation fails
 closed. Filters reject the row, while MAP/head and REDUCE expression
 contexts return an evaluation error.
 
+**`sha256(x)` is not SHA-256 of `x`.** These built-ins return
+`XXH3_64bits(digest)`, so the result is 64 bits wide and is not the
+digest itself. It is still reproducible outside wirelog, in two steps:
+
+```
+printf 'abc' | sha256sum | cut -d' ' -f1 | xxd -r -p | xxhsum -H3
+```
+
+The same recipe works for `md5`, `sha1`, `sha512` and `hmac_sha256`
+(via `openssl dgst -mac hmac`). Use the digest for fingerprinting and
+change detection, not where a full-width cryptographic digest is
+required — 64 bits is not collision-resistant at scale.
+
+### What the digest functions cover
+
+`hash`, `crc32_ethernet`, `crc32_castagnoli`, `md5`, `sha1`, `sha256`,
+`sha512`, `hmac_sha256` and `uuid5` all take their bytes from the
+**declared type** of the operand:
+
+- A `symbol`/`string` operand digests the string's own bytes,
+  `strlen()` many, **with no NUL terminator**. `hash("abc")` is
+  therefore the value `printf 'abc' | xxhsum -H3` prints, and
+  `crc32_ethernet(payload)` is the value `zlib.crc32(payload)` prints.
+- A numeric operand digests the 8-byte little-endian `int64`
+  representation of its value.
+
+`hmac_sha256(msg, key)` and `uuid5(namespace, name)` decide the two
+operands independently, so `hmac_sha256(sym, 42)` keys the HMAC with the
+8 bytes of `42` and messages it with the symbol's bytes.
+
+**The guarantee is only as good as the `.decl`.** Column types are not
+enforced: a column declared `symbol` that actually holds integers which
+were never interned digests their `int64` representation instead — the
+same answer the numeric form would have given, and the query still runs
+rather than failing. A column with no declared type at all digests the
+interned id, which is *not* stable across runs; `WL_LOG=EVAL:2` reports
+each digest that falls back this way, and `WL_LOG=EVAL:4` reports each
+value whose reverse lookup failed. Declare the relation.
+
 ### Checksum Functions
 
 `crc32_ethernet(x)`, `crc32_castagnoli(x)`
 
-Both compute a CRC-32 over the 8-byte `int64` representation of their
-argument and return the result as a non-negative `int64` in the range
-`[0, 2^32)`. `crc32_ethernet` uses the Ethernet/ISO-HDLC polynomial
-(0x04C11DB7, ISO 3309 / IEEE 802.3); `crc32_castagnoli` uses the
-Castagnoli polynomial (CRC-32C, iSCSI/SCTP). Unlike the crypto hash
-built-ins above, the CRC-32 functions are always available and do not
-depend on the `mbedTLS` build option. See `examples/05-crc32-checksum/`
-for a frame-integrity validation example.
+Both return a non-negative `int64` in the range `[0, 2^32)`, computed
+over the operand's bytes as described above: the string's bytes for a
+`symbol` column, the 8-byte `int64` representation for a numeric one.
+`crc32_ethernet` uses the Ethernet/ISO-HDLC polynomial (0x04C11DB7,
+ISO 3309 / IEEE 802.3); `crc32_castagnoli` uses the Castagnoli
+polynomial (CRC-32C, iSCSI/SCTP). Unlike the crypto hash built-ins
+above, the CRC-32 functions are always available and do not depend on
+the `mbedTLS` build option. See `examples/05-crc32-checksum/` for a
+frame-integrity validation example.
 
 ### UUID Functions
 
@@ -225,6 +265,39 @@ The UUID built-ins require mbedTLS for non-zero runtime output and
 return the first 8 UUID bytes as an `int64`, not formatted text.
 Disabled UUID calls follow the same fail-closed behavior described for
 crypto hash functions.
+
+**Operand boundaries are unambiguous.** With a `symbol` operand,
+`uuid5()` length-prefixes each operand before hashing — the length as a
+little-endian `uint64` — so distinct `(namespace, name)` pairs always
+hash distinct bytes:
+
+```
+uuid5("ab", "c")  !=  uuid5("a", "bc")
+```
+
+A bare concatenation could not promise that: `"ab" + "c"` and
+`"a" + "bc"` are the same three bytes. RFC 4122 sidesteps the question
+by fixing the namespace at 16 bytes, making the split point unambiguous
+by construction; wirelog adopted the two-operand signature without that
+property, so it makes the framing explicit instead. In Python:
+
+```python
+buf = pack('<Q', len(ns)) + ns + pack('<Q', len(name)) + name
+d = bytearray(sha1(buf).digest())
+d[6] = (d[6] & 0x0F) | 0x50
+d[8] = (d[8] & 0x3F) | 0x80
+value = unpack('<q', bytes(d[:8]))[0]
+```
+
+`uuid5(int64, int64)` keeps the older unframed `SHA-1(ns || name)` — its
+operands are 8 bytes each, so its split point is already fixed and its
+values are unchanged.
+
+**`uuid5()` is still not RFC 4122**, and being unambiguous does not make
+it so. RFC 4122 requires the namespace to *be* a 16-byte UUID and defines
+a 128-bit result; wirelog accepts whatever bytes the operand carries and
+returns only the first 8 of the 16 digest bytes. Treat the result as a
+namespaced fingerprint, not as a UUID.
 
 ### Comparison Operators
 
@@ -258,3 +331,13 @@ comparison that falls back this way.
 
 Mixing a string operand with a numeric one in an ordering comparison also
 falls back to id order, and is likewise reported at `EVAL:2`.
+
+**The digest built-ins deliberately do not follow that last rule.** An
+ordering comparison needs *both* operands reversed to the strings they
+name before it means anything, so a one-sided type match keeps the
+integer comparison. A digest has no such coupling: each operand
+contributes its own bytes, so `hmac_sha256(sym, 42)` and
+`uuid5(42, sym)` take the symbol's bytes for the symbol operand and the
+`int64` bytes for the numeric one. Applying the comparison rule here
+would leave every mixed call digesting an interned id, which is the
+defect the digest functions were fixed for.

--- a/examples/04-hash-functions/README.md
+++ b/examples/04-hash-functions/README.md
@@ -44,11 +44,30 @@ the same fingerprint, making duplicate detection a simple integer comparison.
 
 Example output (fingerprints_output.csv):
 ```
-1,alice,alice@example.com,3439722301264460078
-4,alice_dup,alice@example.com,3439722301264460078   <- same fp as id=1
-2,bob,bob@example.com,5589565451239960189
-6,bob_dup,bob@example.com,5589565451239960189       <- same fp as id=2
+1,alice,alice@example.com,8569093714482247167
+4,alice_dup,alice@example.com,8569093714482247167   <- same fp as id=1
+2,bob,bob@example.com,8153412963705046890
+6,bob_dup,bob@example.com,8153412963705046890       <- same fp as id=2
 ```
+
+The fingerprint is a property of the address, nothing else. It is xxHash3 over the
+address's own bytes, so it reproduces outside wirelog:
+
+```
+$ printf 'alice@example.com' | xxhsum -H3
+XXH3_76eb895512bf35ff  stdin        # = 8569093714482247167 as int64
+```
+
+That also means the values do not move when the input file changes around them.
+Until #963, `hash()` digested the *interned id* of the string rather than the string,
+so inserting one row at the top of `records.csv` renumbered the ids and gave every
+record below it a different fingerprint. It also put the fingerprints in the same
+value domain as the Part 3 checksums, which hash genuine integers — `hash("carol@example.com")`
+and `hash(5)` were the same number.
+
+This depends on `email` being declared `symbol` in `.decl record(...)`. Column types
+are not enforced, so an undeclared column still digests its id — see
+`docs/SYNTAX.md`, "What the digest functions cover".
 
 ### Part 2: Deduplication
 
@@ -129,7 +148,13 @@ No output means the files match.
 ### hash() Function
 
 - Accepts `int64` or `symbol` arguments and returns `int64`.
-- Deterministic within a single evaluation: the same input always produces the same output.
+- The bytes it digests come from the operand's **declared type**: a `symbol` column
+  digests the string's own bytes (`strlen()` many, no NUL terminator), a numeric column
+  digests the 8-byte `int64`. This example uses both — `hash(email)` in Part 1 and
+  `hash(id)` in Part 3 — and they no longer share a value domain, which they did before
+  #963.
+- Deterministic across runs and across machines: the same input always produces the same
+  output, and it is the output `xxhsum -H3` produces for the same bytes.
 - Built on xxHash3, a fast non-cryptographic hash suitable for fingerprinting and
   deduplication. Do not use it for security-sensitive purposes (passwords, signatures).
 

--- a/examples/04-hash-functions/fingerprints_output.csv
+++ b/examples/04-hash-functions/fingerprints_output.csv
@@ -1,6 +1,6 @@
-1,alice,alice@example.com,3439722301264460078
-2,bob,bob@example.com,5589565451239960189
-3,carol,carol@example.com,-8213464378072455284
-4,alice_dup,alice@example.com,3439722301264460078
-5,dave,dave@example.com,-6774754053936718594
-6,bob_dup,bob@example.com,5589565451239960189
+1,alice,alice@example.com,8569093714482247167
+2,bob,bob@example.com,8153412963705046890
+3,carol,carol@example.com,1513278612195422706
+4,alice_dup,alice@example.com,8569093714482247167
+5,dave,dave@example.com,-6155219185708674874
+6,bob_dup,bob@example.com,8153412963705046890

--- a/examples/04-hash-functions/meson.build
+++ b/examples/04-hash-functions/meson.build
@@ -1,0 +1,33 @@
+# examples/04-hash-functions/meson.build
+# Golden-output regression test for the hash() example (#963)
+#
+# The example addresses its CSVs with repository-root-relative paths, so the
+# runner copies it into a temporary tree, runs the CLI there, and diffs the
+# produced files against the committed ones.  Nothing under the source tree
+# is written, so a regression cannot update its own golden.
+#
+# fingerprints_output.csv is the file #963 moved: before the fix it held
+# XXH3 of the intern ids 1/3/5/8 rather than of the e-mail addresses.  The
+# other three outputs are the integer path and must not move.
+
+py3 = find_program('python3', 'python', required: true)
+
+test(
+  'example_04_hash_functions_golden',
+  py3,
+  args: [
+    meson.project_source_root() / 'examples' / 'golden_example_diff.py',
+    '--cli', wirelog_cli.full_path(),
+    '--root', meson.project_source_root(),
+    '--dir', 'examples/04-hash-functions',
+    '--program', 'hash_dedup.dl',
+    '--golden', 'fingerprints_output.csv',
+    '--golden', 'unique_records_output.csv',
+    '--golden', 'valid_records_output.csv',
+    '--golden', 'corrupted_records_output.csv',
+    # The deduplication check the example's README tells the reader to run.
+    '--same', 'unique_records_output.csv:expected_deduplicated.csv',
+  ],
+  depends: wirelog_cli,
+  suite: 'examples',
+)

--- a/examples/05-crc32-checksum/meson.build
+++ b/examples/05-crc32-checksum/meson.build
@@ -1,0 +1,30 @@
+# examples/05-crc32-checksum/meson.build
+# Golden-output regression test for the CRC-32 example (#963)
+#
+# This example is the regression test for #963: its committed checksums are
+# crc32 over the payload bytes, so while crc32_ethernet() digested the
+# payload's intern id instead, valid_frames_output.csv came out empty against
+# a four-row golden, all six frames were reported corrupt, and the `diff`
+# step the README documents failed.  Both rules are covered -- the filter
+# `crc32_ethernet(Payload) = Stored` and the head projection
+# `corrupt_frame(Id, Stored, crc32_ethernet(Payload))`.
+
+py3 = find_program('python3', 'python', required: true)
+
+test(
+  'example_05_crc32_checksum_golden',
+  py3,
+  args: [
+    meson.project_source_root() / 'examples' / 'golden_example_diff.py',
+    '--cli', wirelog_cli.full_path(),
+    '--root', meson.project_source_root(),
+    '--dir', 'examples/05-crc32-checksum',
+    '--program', 'crc32_validate.dl',
+    '--golden', 'valid_frames_output.csv',
+    '--golden', 'corrupt_frames_output.csv',
+    # The check the example's README tells the reader to run.
+    '--same', 'valid_frames_output.csv:expected_valid_frames.csv',
+  ],
+  depends: wirelog_cli,
+  suite: 'examples',
+)

--- a/examples/golden_example_diff.py
+++ b/examples/golden_example_diff.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Run an example's Datalog program and diff its outputs against the goldens.
+
+The examples address their inputs and outputs with paths relative to the
+repository root -- `.input record(filename="examples/04-hash-functions/...")`
+-- which is why they were never wired into the `examples` test suite: running
+one in place rewrites the very `*_output.csv` files that are supposed to be
+the expected values, so a regression would silently update its own golden and
+pass.
+
+This runner copies the example directory into a temporary tree that mirrors
+the repository layout, deletes the outputs from the copy, runs the CLI with
+that tree as its working directory, and diffs what the run produced against
+the committed files.  The source tree is only ever read.
+
+Usage:
+  golden_example_diff.py --cli PATH --root PATH --dir examples/NN-name
+                         --program NAME.dl --golden OUT.csv [--golden ...]
+                         [--same A.csv:B.csv]
+
+  --golden  Output file that must match the committed copy of itself.
+  --same    Two files in the produced tree that must match each other; used
+            for the `diff unique_records_output.csv expected_deduplicated.csv`
+            check the example's README documents.
+"""
+
+import argparse
+import filecmp
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def fail(msg):
+    print("FAIL: %s" % msg, file=sys.stderr)
+    return 1
+
+
+def diff(expected, actual):
+    """Print a unified diff of two text files, best effort."""
+    import difflib
+    try:
+        with open(expected, "r", encoding="utf-8", errors="replace") as f:
+            a = f.readlines()
+        with open(actual, "r", encoding="utf-8", errors="replace") as f:
+            b = f.readlines()
+    except OSError as exc:
+        print("  (could not read for diff: %s)" % exc, file=sys.stderr)
+        return
+    for line in difflib.unified_diff(a, b, fromfile=expected,
+                                     tofile=actual, lineterm="\n"):
+        sys.stderr.write(line)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cli", required=True)
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--dir", required=True,
+                    help="example directory, relative to --root")
+    ap.add_argument("--program", required=True,
+                    help="Datalog program, relative to --dir")
+    ap.add_argument("--golden", action="append", default=[],
+                    help="output file, relative to --dir")
+    ap.add_argument("--same", action="append", default=[],
+                    help="A:B, both relative to --dir")
+    args = ap.parse_args()
+
+    src_dir = os.path.join(args.root, args.dir)
+    if not os.path.isdir(src_dir):
+        return fail("no such example directory: %s" % src_dir)
+    for name in args.golden:
+        if not os.path.isfile(os.path.join(src_dir, name)):
+            return fail("golden %s is missing from %s" % (name, args.dir))
+
+    with tempfile.TemporaryDirectory(prefix="wl-example-") as tmp:
+        work_dir = os.path.join(tmp, args.dir)
+        os.makedirs(os.path.dirname(work_dir), exist_ok=True)
+        shutil.copytree(src_dir, work_dir)
+
+        # Remove the goldens from the working copy so a program that writes
+        # nothing fails instead of inheriting the committed answer.
+        for name in args.golden:
+            os.remove(os.path.join(work_dir, name))
+
+        proc = subprocess.run(
+            [args.cli, os.path.join(args.dir, args.program)],
+            cwd=tmp, capture_output=True, text=True)
+        if proc.returncode != 0:
+            sys.stderr.write(proc.stdout)
+            sys.stderr.write(proc.stderr)
+            return fail("%s exited %d" % (args.program, proc.returncode))
+
+        failures = 0
+        for name in args.golden:
+            produced = os.path.join(work_dir, name)
+            expected = os.path.join(src_dir, name)
+            if not os.path.isfile(produced):
+                failures += fail("%s was not written" % name)
+                continue
+            if not filecmp.cmp(expected, produced, shallow=False):
+                failures += fail("%s does not match the committed golden"
+                                 % name)
+                diff(expected, produced)
+
+        for pair in args.same:
+            a_name, _, b_name = pair.partition(":")
+            a = os.path.join(work_dir, a_name)
+            b = os.path.join(work_dir, b_name)
+            if not (os.path.isfile(a) and os.path.isfile(b)):
+                failures += fail("%s: one side is missing" % pair)
+                continue
+            if not filecmp.cmp(a, b, shallow=False):
+                failures += fail("%s and %s differ" % (a_name, b_name))
+                diff(b, a)
+
+        if failures:
+            return 1
+
+    print("OK: %s reproduced %d golden file(s)"
+          % (args.dir, len(args.golden)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/meson.build
+++ b/meson.build
@@ -497,6 +497,10 @@ endif
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
 if not mobile_cross
+  # 04 and 05 are golden-diff tests over wirelog_cli rather than their own
+  # executables; they run the committed .dl programs in a temporary tree.
+  subdir('examples/04-hash-functions')
+  subdir('examples/05-crc32-checksum')
   subdir('examples/08-delta-queries')
   subdir('examples/09-retraction-basics')
   subdir('examples/10-recursive-under-update')

--- a/tests/fpga_backend.c
+++ b/tests/fpga_backend.c
@@ -19,9 +19,15 @@
  * 2. wirelog-easy.h hardcodes the columnar backend via wl_backend_columnar().
  *    Alternative backends require manual wl_session_create() calls.
  *
- * 3. Expression opcode coverage: only arithmetic and comparison opcodes
- *    are validated by this backend.  String, hash, and cryptographic
- *    opcodes are treated as pass-through (permissive).
+ * 3. Expression opcode coverage: arithmetic, comparison, string-comparison
+ *    (#962) and non-cryptographic digest opcodes (hash, both CRC-32
+ *    variants, in their int64 and symbol forms -- #963) are evaluated.
+ *    The mbedTLS-backed digest and UUID opcodes are not implemented here,
+ *    and the default arm rejects the row rather than admitting it, which
+ *    matches the production interpreter (ops.c's `goto bad`).  A permissive
+ *    default silently disables filtering whenever plan generation learns a
+ *    new opcode, which is how a filter can appear to work while comparing
+ *    nothing at all.
  *
  * 4. Positive findings: intern sharing via plan->intern works cleanly.
  *    Session embedding (wl_session_t as first field) and the wrapper
@@ -31,9 +37,13 @@
  */
 
 #include "fpga_backend.h"
+#include "../wirelog/crc32.h"
 #include "../wirelog/intern.h"
 #include "../wirelog/session.h"
 
+#include <xxhash.h>
+
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -413,8 +423,49 @@ fpga_eval_expr(const wl_plan_expr_buffer_t *expr, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_BNOT: /* 0x1A */
             if (sp >= 1) stack[sp - 1] = ~stack[sp - 1];
             break;
-        case WL_PLAN_EXPR_ARITH_HASH: /* 0x1B */
-            /* Hash: pass through value (no xxhash dependency) */
+        /*
+         * Digests.  The _S opcodes (#963) reverse the intern id and digest
+         * the string's bytes -- strlen many, no NUL -- while the int64
+         * forms digest the 8-byte representation.  An id that names no
+         * string falls back to the int64 form, matching ops.c.
+         *
+         * The previous "pass through value" arm for 0x1B was worse than
+         * unimplemented: it silently degraded `hash(x) = k` to `x = k`,
+         * which admits rows no digest would.
+         */
+        case WL_PLAN_EXPR_ARITH_HASH:        /* 0x1B */
+        case WL_PLAN_EXPR_ARITH_CRC32_ETH:   /* 0x1C */
+        case WL_PLAN_EXPR_ARITH_CRC32_CAST:  /* 0x1D */
+        case WL_PLAN_EXPR_ARITH_HASH_S:      /* 0x60 */
+        case WL_PLAN_EXPR_ARITH_CRC32_ETH_S: /* 0x61 */
+        case WL_PLAN_EXPR_ARITH_CRC32_CAST_S: /* 0x62 */
+            if (sp >= 1) {
+                int64_t v = stack[sp - 1];
+                bool as_sym = (tag == WL_PLAN_EXPR_ARITH_HASH_S
+                    || tag == WL_PLAN_EXPR_ARITH_CRC32_ETH_S
+                    || tag == WL_PLAN_EXPR_ARITH_CRC32_CAST_S);
+                const char *str = (as_sym && intern)
+                    ? wl_intern_reverse(intern, v) : NULL;
+                uint8_t inl[sizeof(int64_t)];
+                const uint8_t *bytes;
+                size_t len;
+                if (str) {
+                    bytes = (const uint8_t *)str;
+                    len = strlen(str);
+                } else {
+                    memcpy(inl, &v, sizeof(v));
+                    bytes = inl;
+                    len = sizeof(v);
+                }
+                if (tag == WL_PLAN_EXPR_ARITH_CRC32_ETH
+                    || tag == WL_PLAN_EXPR_ARITH_CRC32_ETH_S)
+                    stack[sp - 1] = (int64_t)ethernet_crc32(bytes, len);
+                else if (tag == WL_PLAN_EXPR_ARITH_CRC32_CAST
+                    || tag == WL_PLAN_EXPR_ARITH_CRC32_CAST_S)
+                    stack[sp - 1] = (int64_t)castagnoli_crc32(bytes, len);
+                else
+                    stack[sp - 1] = (int64_t)XXH3_64bits(bytes, len);
+            }
             break;
         /* Comparisons */
         case WL_PLAN_EXPR_CMP_EQ: /* 0x22 */
@@ -477,8 +528,15 @@ fpga_eval_expr(const wl_plan_expr_buffer_t *expr, const int64_t *row,
             /* In filter context, pass through */
             break;
         default:
-            /* Unknown/unsupported opcode: permissive, return true */
-            return 1;
+            /*
+             * Unknown or unimplemented opcode: reject the row.  ops.c's
+             * evaluator does the same (`goto bad`), and it is the only
+             * safe answer -- a permissive default answers "yes" to a
+             * predicate it did not evaluate, so a filter this backend does
+             * not understand stops filtering without saying so.  The
+             * mbedTLS digest and UUID opcodes land here.
+             */
+            return 0;
         }
     }
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1115,6 +1115,29 @@ test_symbol_ordering_exe = executable(
 
 test('symbol_ordering', test_symbol_ordering_exe)
 
+# Issue #963: hash() and the CRC-32 built-ins digested the intern id of a
+# symbol column rather than the string's bytes, so hash("abc") matched no
+# external tool and the answer depended on what was interned first.  Every
+# expected value here was derived outside wirelog (xxhsum -H3, zlib.crc32).
+# The mbedTLS-backed half lives in test_cryptographic_hashes.c so that this
+# binary runs in every build configuration.
+test_symbol_digests_exe = executable(
+  'test_symbol_digests',
+  files('test_symbol_digests.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('symbol_digests', test_symbol_digests_exe)
+
 test('option2_doop', test_option2_doop_exe,
   env: ['DOOP_DATA_DIR=' + meson.project_source_root() / 'bench/data/doop'],
 )

--- a/tests/test_cryptographic_hashes.c
+++ b/tests/test_cryptographic_hashes.c
@@ -1053,6 +1053,197 @@ test_integration_hmac_sha256_datalog_rule(void)
     PASS();
 }
 
+/* ======================================================================== */
+/* Symbol operands (Issue #963)                                             */
+/*                                                                          */
+/* The digests above take the 8-byte int64 representation of their operand. */
+/* When the operand is a symbol that int64 is an *intern id*, so the digest */
+/* answered a question about the intern table, not about the string: the    */
+/* same string digested differently depending on what had been interned     */
+/* first.  Symbol operands now digest the string's own bytes -- strlen      */
+/* many, no NUL -- which is what an external tool sees.                     */
+/*                                                                          */
+/* Every expected value below was derived outside wirelog, e.g.             */
+/*                                                                          */
+/*     printf 'aa' | sha256sum | cut -d' ' -f1 | xxd -r -p | xxhsum -H3     */
+/*                                                                          */
+/* which is also the two-step recipe docs/SYNTAX.md documents.  Note what   */
+/* it says about these built-ins: sha256("aa") is not SHA-256 of "aa", it   */
+/* is XXH3_64bits of the SHA-256 digest of "aa".                            */
+/* ======================================================================== */
+
+#define XXH3_OF_MD5_AA     8108801538665929855LL
+#define XXH3_OF_SHA1_AA    4228114194375067801LL
+#define XXH3_OF_SHA256_AA  (-8977746440570084450LL)
+#define XXH3_OF_SHA512_AA  (-3394976671127927984LL)
+/* HMAC-SHA-256, msg first and key second, in the four operand typings. */
+#define XXH3_OF_HMAC_SS    1125073340110602348LL  /* msg "aa", key "zz"   */
+#define XXH3_OF_HMAC_SI    (-1543635408773734377LL) /* msg "aa", key 1    */
+#define XXH3_OF_HMAC_IS    (-5755376871629748970LL) /* msg 1,    key "zz" */
+#define XXH3_OF_HMAC_II    5350477797202862412LL  /* msg 1,    key 1      */
+#define XXH3_OF_HMAC_EMPTY_KEY 5217900878614730541LL /* msg "msg", key "" */
+/*
+ * uuid5 over symbols returns the first 8 bytes of the tagged SHA-1 of
+ * u64le(len(ns)) || ns || u64le(len(name)) || name, as int64.  In Python:
+ *
+ *   buf = pack('<Q', len(ns)) + ns + pack('<Q', len(name)) + name
+ *   d = bytearray(sha1(buf).digest())
+ *   d[6] = (d[6] & 0x0F) | 0x50; d[8] = (d[8] & 0x3F) | 0x80
+ *   unpack('<q', bytes(d[:8]))[0]
+ */
+#define UUID5_SS_AA_ZZ     (-985806390465751602LL)
+#define UUID5_SI_AA_1      6942838433878392903LL
+#define UUID5_IS_1_ZZ      7085806886377378579LL
+#define UUID5_AB_C         (-5235876162600150845LL)
+#define UUID5_A_BC         2187083094203415983LL
+
+/* Run @src and require exactly one row whose first column is @want. */
+static void
+expect_single_value(const char *name, const char *src, int64_t want)
+{
+    TEST(name);
+
+    struct result_ctx ctx;
+    if (run_program_full(src, &ctx) != 0 || ctx.snapshot_rc != 0) {
+        FAIL("evaluation failed");
+    }
+    if (ctx.count != 1) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "expected 1 row, got %u", ctx.count);
+        FAIL(buf);
+    }
+    if (ctx.col0[0] != want) {
+        char buf[128];
+        snprintf(buf, sizeof(buf),
+            "expected %" PRId64 ", got %" PRId64, want, ctx.col0[0]);
+        FAIL(buf);
+    }
+    PASS();
+}
+
+#define SYM_FACT ".decl s(v: symbol)\ns(\"aa\").\n"
+
+static void
+test_digests_of_symbol_operands(void)
+{
+    expect_single_value("md5(sym) digests the string's bytes",
+        SYM_FACT ".decl r(z: int64)\nr(md5(v)) :- s(v).\n",
+        XXH3_OF_MD5_AA);
+    expect_single_value("sha1(sym) digests the string's bytes",
+        SYM_FACT ".decl r(z: int64)\nr(sha1(v)) :- s(v).\n",
+        XXH3_OF_SHA1_AA);
+    expect_single_value("sha256(sym) digests the string's bytes",
+        SYM_FACT ".decl r(z: int64)\nr(sha256(v)) :- s(v).\n",
+        XXH3_OF_SHA256_AA);
+    expect_single_value("sha512(sym) digests the string's bytes",
+        SYM_FACT ".decl r(z: int64)\nr(sha512(v)) :- s(v).\n",
+        XXH3_OF_SHA512_AA);
+}
+
+/*
+ * hmac_sha256() and uuid5() take two operands that type independently, so
+ * each has three symbol-bearing opcodes rather than one.  #962's rule for
+ * comparisons -- a one-sided type match keeps the integer opcode -- is
+ * deliberately not followed here: a comparison needs both ids reversed to
+ * mean anything, while each digest operand contributes its own bytes, so
+ * applying that rule would leave the mixed cases digesting an id.
+ */
+static void
+test_two_operand_digests_type_each_operand(void)
+{
+    expect_single_value("hmac_sha256(sym, sym) keys and messages with bytes",
+        SYM_FACT ".decl k(v: symbol)\nk(\"zz\").\n"
+        ".decl r(z: int64)\n"
+        "r(hmac_sha256(m, key)) :- s(m), k(key).\n",
+        XXH3_OF_HMAC_SS);
+    expect_single_value("hmac_sha256(sym, int) uses the int64 key bytes",
+        SYM_FACT ".decl r(z: int64)\n"
+        "r(hmac_sha256(v, 1)) :- s(v).\n",
+        XXH3_OF_HMAC_SI);
+    expect_single_value("hmac_sha256(int, sym) uses the int64 message bytes",
+        ".decl k(v: symbol)\nk(\"zz\").\n"
+        ".decl r(z: int64)\n"
+        "r(hmac_sha256(1, key)) :- k(key).\n",
+        XXH3_OF_HMAC_IS);
+    expect_single_value("hmac_sha256(int, int) is unchanged",
+        ".decl n(x: int64)\nn(1).\n"
+        ".decl r(z: int64)\n"
+        "r(hmac_sha256(x, 1)) :- n(x).\n",
+        XXH3_OF_HMAC_II);
+    /*
+     * An empty symbol key is zero bytes, which PSA will not import; before
+     * #963 both operands were 8 bytes so it could not arise.  RFC 2104
+     * zero-pads the key, so this must equal Python's hmac.new(b"", ...) and
+     * not fail the query.
+     */
+    expect_single_value("hmac_sha256(sym, \"\") uses the RFC 2104 empty key",
+        ".decl p(m: symbol, k: symbol)\n"
+        "p(\"msg\", \"\").\n"
+        ".decl r(z: int64)\n"
+        "r(hmac_sha256(m, k)) :- p(m, k).\n",
+        XXH3_OF_HMAC_EMPTY_KEY);
+
+    expect_single_value("uuid5(sym, sym) hashes both strings' bytes",
+        SYM_FACT ".decl k(v: symbol)\nk(\"zz\").\n"
+        ".decl r(z: int64)\n"
+        "r(uuid5(ns, nm)) :- s(ns), k(nm).\n",
+        UUID5_SS_AA_ZZ);
+    expect_single_value("uuid5(sym, int) hashes bytes then int64",
+        SYM_FACT ".decl r(z: int64)\n"
+        "r(uuid5(v, 1)) :- s(v).\n",
+        UUID5_SI_AA_1);
+    expect_single_value("uuid5(int, sym) hashes int64 then bytes",
+        ".decl k(v: symbol)\nk(\"zz\").\n"
+        ".decl r(z: int64)\n"
+        "r(uuid5(1, nm)) :- k(nm).\n",
+        UUID5_IS_1_ZZ);
+}
+
+/*
+ * Distinct (namespace, name) pairs produce distinct values.
+ *
+ * Giving uuid5() variable-length operands is what makes this possible to
+ * get wrong.  A bare concatenation of "ab" + "c" and of "a" + "bc" is the
+ * same three bytes, so both calls would hash identical input and return one
+ * value -- a collision that could not arise while both operands were
+ * fixed-width int64s, and which this change would therefore have created
+ * rather than exposed.  RFC 4122 does not have the problem because it fixes
+ * the namespace at 16 bytes, making the split point unambiguous by
+ * construction; wirelog inherited the two-operand signature without that
+ * property, so the symbol opcodes length-prefix each operand instead.
+ *
+ * Both the inequality and the two values are asserted.  The inequality
+ * alone would be satisfied by any construction that merely differs, and
+ * pinned values alone would not say what property they encode.
+ *
+ * Unambiguous is still not RFC 4122: the namespace need not be a UUID and
+ * only 8 of the 16 bytes are returned.  Those are separate claims.
+ */
+static void
+test_uuid5_distinguishes_operand_boundaries(void)
+{
+    expect_single_value("uuid5(\"ab\",\"c\") length-frames its operands",
+        ".decl p(a: symbol, b: symbol)\n"
+        "p(\"ab\", \"c\").\n"
+        ".decl r(z: int64)\n"
+        "r(uuid5(a, b)) :- p(a, b).\n",
+        UUID5_AB_C);
+    expect_single_value("uuid5(\"a\",\"bc\") differs from uuid5(\"ab\",\"c\")",
+        ".decl q(a: symbol, b: symbol)\n"
+        "q(\"a\", \"bc\").\n"
+        ".decl r(z: int64)\n"
+        "r(uuid5(a, b)) :- q(a, b).\n",
+        UUID5_A_BC);
+
+    /* Stated as a property too, so a future change to the pinned values
+     * cannot quietly reintroduce the collision. */
+    TEST("uuid5 operand boundaries are unambiguous");
+    if (UUID5_AB_C == UUID5_A_BC) {
+        FAIL("the two pinned values are equal: the framing is not working");
+    }
+    PASS();
+}
+
 #else /* !WL_MBEDTLS_ENABLED */
 
 /* ======================================================================== */
@@ -1171,6 +1362,34 @@ test_uuid5_fails_closed_no_mbedtls(void)
         src);
 }
 
+/*
+ * The symbol-operand opcodes (#963) are emitted unconditionally -- only the
+ * evaluator arms behind them are #ifdef'd -- so the new opcodes must fail
+ * closed here too, not fall through to some permissive default.
+ */
+static void
+test_symbol_operand_digests_fail_closed_no_mbedtls(void)
+{
+    test_unavailable_builtin_fails_closed(
+        "sha256(sym): without mbedTLS fails closed",
+        ".decl s(v: symbol)\n"
+        "s(\"aa\").\n"
+        ".decl r(z: int64)\n"
+        "r(sha256(v)) :- s(v).\n");
+    test_unavailable_builtin_fails_closed(
+        "hmac_sha256(sym, sym): without mbedTLS fails closed",
+        ".decl p(m: symbol, k: symbol)\n"
+        "p(\"aa\", \"zz\").\n"
+        ".decl r(z: int64)\n"
+        "r(hmac_sha256(m, k)) :- p(m, k).\n");
+    test_unavailable_builtin_fails_closed(
+        "uuid5(sym, sym): without mbedTLS fails closed",
+        ".decl p(a: symbol, b: symbol)\n"
+        "p(\"aa\", \"zz\").\n"
+        ".decl r(z: int64)\n"
+        "r(uuid5(a, b)) :- p(a, b).\n");
+}
+
 #endif /* WL_MBEDTLS_ENABLED */
 
 /* ======================================================================== */
@@ -1233,6 +1452,11 @@ main(void)
     test_integration_sha1_datalog_filter();
     test_integration_hmac_sha256_datalog_rule();
 
+    printf("\n--- Symbol Operand Tests (Issue #963) ---\n");
+    test_digests_of_symbol_operands();
+    test_two_operand_digests_type_each_operand();
+    test_uuid5_distinguishes_operand_boundaries();
+
 #else
     printf("=== wirelog Cryptographic Hash Tests (Issue #73) [mbedTLS "
         "DISABLED] ===\n\n");
@@ -1245,6 +1469,7 @@ main(void)
     test_hmac_sha256_fails_closed_no_mbedtls();
     test_uuid4_fails_closed_no_mbedtls();
     test_uuid5_fails_closed_no_mbedtls();
+    test_symbol_operand_digests_fail_closed_no_mbedtls();
 #endif
 
     printf("\n--- sha256()/sha512() Determinism Tests (always run) ---\n");

--- a/tests/test_fpga_backend.c
+++ b/tests/test_fpga_backend.c
@@ -511,6 +511,98 @@ test_filter(void)
     PASS();
 }
 
+/*
+ * Run @src against the fpga backend with a(1,3,7,10,5) and report which of
+ * those five values reached relation "r".  Returns -1 on setup failure.
+ */
+static int
+fpga_filter_survivors(const char *src, bool *out_seen)
+{
+    static const int64_t data[] = { 1, 3, 7, 10, 5 };
+
+    wl_plan_t *plan = build_plan(src);
+    if (!plan)
+        return -1;
+    wl_session_t *session = NULL;
+    if (wl_session_create(wl_backend_fpga(), plan, 1, &session) != 0
+        || !session) {
+        wl_plan_free(plan);
+        return -1;
+    }
+    int rc = wl_session_insert(session, "a", data, 5, 1);
+    tuple_collector_t tc;
+    memset(&tc, 0, sizeof(tc));
+    if (rc == 0)
+        rc = wl_session_snapshot(session, collect_tuple, &tc);
+    if (rc == 0) {
+        for (int i = 0; i < 5; i++)
+            out_seen[i] = has_tuple(&tc, "r", &data[i], 1);
+    }
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    return rc == 0 ? tc.count : -1;
+}
+
+/*
+ * hash() used to be decoded as "pass through value", which silently turns
+ * `hash(x) = k` into `x = k`.  With the constant set to XXH3_64bits of the
+ * int64 1, the pass-through arm derives nothing (no row holds that value)
+ * while a real hash derives r(1).
+ */
+static void
+test_hash_filter_is_evaluated(void)
+{
+    TEST("fpga: hash(x) = XXH3(1) selects a(1), not a(XXH3(1))");
+
+    bool seen[5];
+    int count = fpga_filter_survivors(
+        ".decl a(x: int64)\n"
+        ".decl r(x: int64)\n"
+        "r(x) :- a(x), hash(x) = 3439722301264460078.\n", seen);
+    if (count < 0) {
+        FAIL("setup failed");
+        return;
+    }
+    if (count != 1 || !seen[0]) {
+        char msg[128];
+        snprintf(msg, sizeof(msg),
+            "expected exactly r(1), got %d tuples", count);
+        FAIL(msg);
+        return;
+    }
+    PASS();
+}
+
+/*
+ * The decoder's default arm used to return 1, admitting every row for any
+ * opcode it did not recognise -- which means a filter it cannot evaluate
+ * stops filtering rather than failing.  sha256() is decoded by nothing in
+ * this backend, so it exercises that arm directly.
+ */
+static void
+test_unknown_opcode_rejects_rows(void)
+{
+    TEST("fpga: an unimplemented opcode rejects rows, it does not admit them");
+
+    bool seen[5];
+    int count = fpga_filter_survivors(
+        ".decl a(x: int64)\n"
+        ".decl r(x: int64)\n"
+        "r(x) :- a(x), sha256(x) = 0.\n", seen);
+    if (count < 0) {
+        FAIL("setup failed");
+        return;
+    }
+    if (count != 0) {
+        char msg[128];
+        snprintf(msg, sizeof(msg),
+            "an unevaluated predicate admitted %d rows", count);
+        FAIL(msg);
+        return;
+    }
+    PASS();
+}
+
 static void
 test_transitive_closure(void)
 {
@@ -720,6 +812,8 @@ main(void)
     test_passthrough();
     test_join();
     test_filter();
+    test_hash_filter_is_evaluated();
+    test_unknown_opcode_rejects_rows();
     test_transitive_closure();
     test_delta_callback();
     test_backend_specific_ops();

--- a/tests/test_symbol_digests.c
+++ b/tests/test_symbol_digests.c
@@ -1,0 +1,656 @@
+/*
+ * tests/test_symbol_digests.c - digests over symbol columns (Issue #963)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * hash() and the CRC-32 built-ins used to digest the *intern id* of a
+ * symbol column rather than the string that id stands for.  Two
+ * consequences, both observable in-tree before the fix:
+ *
+ *   - hash("abc") matched no external tool, because it was really
+ *     XXH3_64bits of an int64 counter.
+ *   - The same string digested differently depending on what had been
+ *     interned first, so prepending an unrelated row to an input file
+ *     changed every fingerprint below it.
+ *
+ * The plan generator now emits the WL_PLAN_EXPR_ARITH_*_S opcodes when the
+ * operand's declared type is `symbol`/`string`, and those digest the
+ * string's own bytes -- strlen many, no NUL terminator.
+ *
+ * Every expected value here was produced outside wirelog before the code
+ * was written, so the tests pin the external convention rather than
+ * whatever the implementation happens to do:
+ *
+ *     printf 'alice@example.com' | xxhsum -H3     -> 76eb895512bf35ff
+ *     python3 -c 'import zlib; print(zlib.crc32(b"aa"))'
+ *
+ * The mbedTLS-backed digests (md5, sha1/256/512, hmac, uuid5) get the same
+ * treatment and are covered in tests/test_cryptographic_hashes.c, the test
+ * the mbedtls-enabled CI job runs.  This file deliberately contains only
+ * the half that is available in every build configuration.
+ */
+
+#include "../wirelog/backend.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/intern.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int test_count;
+static int pass_count;
+static int fail_count;
+
+#define TEST(name)                                      \
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
+
+#define PASS()            \
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                    \
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
+
+#define ASSERT(cond, msg) \
+        do {                  \
+            if (!(cond))      \
+            FAIL(msg);    \
+        } while (0)
+
+/*
+ * Externally derived expected values.  Digest results are compared as raw
+ * int64 -- never rendered through the intern table -- because a digest is a
+ * value, and a collector that reversed ids would hide exactly the confusion
+ * between the two domains that this file is about.
+ */
+#define XXH3_ALICE  8569093714482247167LL  /* "alice@example.com"        */
+#define XXH3_BOB    8153412963705046890LL  /* "bob@example.com"          */
+#define XXH3_CAROL  1513278612195422706LL  /* "carol@example.com"        */
+#define XXH3_DAVE   (-6155219185708674874LL) /* "dave@example.com"       */
+#define XXH3_AA     3932278706564862771LL  /* "aa"                       */
+#define XXH3_ZZ     (-6040919500630484495LL) /* "zz"                     */
+#define XXH3_UPPER_AA (-8874864312778924372LL) /* "AA"                   */
+#define XXH3_I64_0  (-4072596861322023719LL) /* int64 0                  */
+#define XXH3_I64_1  3439722301264460078LL  /* int64 1, little-endian     */
+#define XXH3_I64_2  2343778756980564547LL  /* int64 2                    */
+#define XXH3_I64_3  5589565451239960189LL  /* int64 3                    */
+#define XXH3_I64_1000000 3181700808144611680LL
+#define XXH3_I64_1000001 (-1343336171446265251LL)
+/* XXH3 of the int64 XXH3_I64_1: the outer digest of hash(hash(x)). */
+#define XXH3_OF_XXH3_I64_1 (-3387566715524744054LL)
+#define CRC32E_AA   126491095LL            /* zlib.crc32(b"aa")          */
+#define CRC32E_ZZ   618208161LL
+#define CRC32C_AA   4059224770LL           /* CRC-32C of "aa"            */
+
+#define MAX_SEEN 32
+#define MAX_COLS 8
+
+typedef struct {
+    const char *rel;
+    uint32_t count;
+    uint32_t ncols[MAX_SEEN];
+    int64_t rows[MAX_SEEN][MAX_COLS];
+} collect_t;
+
+/* Rows the caller wants inserted directly (physical layout), used by the
+ * compound case where the fact cannot be written in source syntax. */
+typedef struct {
+    const char *relation;
+    const int64_t *rows;
+    uint32_t num_rows;
+    uint32_t ncols;
+} insert_spec_t;
+
+static void
+collect_cb(const char *relation, const int64_t *row, uint32_t ncols, void *user)
+{
+    collect_t *c = (collect_t *)user;
+    if (!c->rel || !relation || strcmp(relation, c->rel) != 0)
+        return;
+    if (c->count < MAX_SEEN) {
+        uint32_t n = ncols < MAX_COLS ? ncols : MAX_COLS;
+        c->ncols[c->count] = n;
+        for (uint32_t i = 0; i < n; i++)
+            c->rows[c->count][i] = row[i];
+    }
+    c->count++;
+}
+
+/* True if any collected row equals the @n values at @want. */
+static bool
+saw(const collect_t *c, const int64_t *want, uint32_t n)
+{
+    uint32_t rows = c->count < MAX_SEEN ? c->count : MAX_SEEN;
+    for (uint32_t i = 0; i < rows; i++) {
+        if (c->ncols[i] != n)
+            continue;
+        bool match = true;
+        for (uint32_t j = 0; j < n; j++) {
+            if (c->rows[i][j] != want[j]) {
+                match = false;
+                break;
+            }
+        }
+        if (match)
+            return true;
+    }
+    return false;
+}
+
+/* True if any collected row has @v in column @col. */
+static bool
+saw_value(const collect_t *c, uint32_t col, int64_t v)
+{
+    uint32_t rows = c->count < MAX_SEEN ? c->count : MAX_SEEN;
+    for (uint32_t i = 0; i < rows; i++) {
+        if (col < c->ncols[i] && c->rows[i][col] == v)
+            return true;
+    }
+    return false;
+}
+
+/*
+ * Evaluate @src, filling @out with @relation's tuples.
+ *
+ * @prepare may be NULL.  When present it runs after parsing -- so the intern
+ * table already holds the source facts' symbols -- and describes rows to
+ * insert directly, which is how the mistyped-column and compound cases
+ * supply facts that have no source syntax.  Returns 0 on success.
+ */
+static int
+eval_relation_ex(const char *src, const char *relation, collect_t *out,
+    int (*prepare)(const wirelog_program_t *prog, insert_spec_t *ins))
+{
+    memset(out, 0, sizeof(*out));
+    out->rel = relation;
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        fprintf(stderr, "  parse error: %d\n", (int)err);
+        return -1;
+    }
+
+    insert_spec_t ins;
+    memset(&ins, 0, sizeof(ins));
+    if (prepare && prepare(prog, &ins) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_session_t *sess = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    int result = -1;
+    if (wl_session_load_facts(sess, prog) == 0
+        && (ins.relation == NULL
+        || wl_session_insert(sess, ins.relation, ins.rows, ins.num_rows,
+        ins.ncols) == 0)
+        && wl_session_snapshot(sess, collect_cb, out) == 0)
+        result = 0;
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return result;
+}
+
+static int
+eval_relation(const char *src, const char *relation, collect_t *out)
+{
+    return eval_relation_ex(src, relation, out, NULL);
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * The defect report, in its original setting: examples/04-hash-functions
+ * fingerprints four e-mail addresses.  Before the fix column 4 held
+ * XXH3_64bits of the int64 ids 1, 3, 5 and 8, so the same file produced
+ * different fingerprints if a row was inserted above it.
+ */
+static void
+test_hash_of_symbol_in_head_position(void)
+{
+    TEST("hash(sym) in a head projection digests the string's bytes");
+
+    const char *src =
+        ".decl record(id: int64, email: symbol)\n"
+        "record(1, \"alice@example.com\").\n"
+        "record(2, \"bob@example.com\").\n"
+        "record(3, \"carol@example.com\").\n"
+        "record(4, \"dave@example.com\").\n"
+        ".decl fp(id: int64, h: int64)\n"
+        "fp(id, hash(email)) :- record(id, email).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "fp", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 4, "expected one fingerprint per record");
+
+    const int64_t want[4][2] = {
+        { 1, XXH3_ALICE }, { 2, XXH3_BOB },
+        { 3, XXH3_CAROL }, { 4, XXH3_DAVE },
+    };
+    for (int i = 0; i < 4; i++)
+        ASSERT(saw(&c, want[i], 2), "fingerprint does not match xxhsum -H3");
+
+    /* The pre-fix values were digests of the ids 1..4.  If any survives,
+     * the string opcode was not emitted for this position. */
+    ASSERT(!saw_value(&c, 1, XXH3_I64_1) && !saw_value(&c, 1, XXH3_I64_2),
+        "a fingerprint is still the digest of an intern id");
+    PASS();
+}
+
+static void
+test_hash_of_symbol_in_filter_position(void)
+{
+    TEST("hash(sym) in a body filter digests the string's bytes");
+
+    /* The literal is the value xxhsum prints for "alice@example.com"; only
+     * a byte-wise digest can match it. */
+    const char *src =
+        ".decl record(id: int64, email: symbol)\n"
+        "record(1, \"alice@example.com\").\n"
+        "record(2, \"bob@example.com\").\n"
+        ".decl found(id: int64)\n"
+        "found(id) :- record(id, email), "
+        "hash(email) = 8569093714482247167.\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "found", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 1, "expected exactly the alice row");
+    const int64_t want[1] = { 1 };
+    ASSERT(saw(&c, want, 1), "expected found(1)");
+    PASS();
+}
+
+static void
+test_hash_is_independent_of_intern_order(void)
+{
+    TEST("the fingerprint of a symbol does not depend on intern order");
+
+    /*
+     * Identical rule and identical S facts.  The only difference is an
+     * unrelated relation whose facts are parsed first and therefore claim
+     * the lower ids.  Before the fix this changed every fingerprint.
+     */
+    const char *without =
+        ".decl S(s: symbol)\n"
+        "S(\"aa\").\n"
+        "S(\"zz\").\n"
+        ".decl H(h: int64)\n"
+        "H(hash(s)) :- S(s).\n";
+
+    const char *with_shift =
+        ".decl Z(s: symbol)\n"
+        "Z(\"pad0\").\n"
+        "Z(\"pad1\").\n"
+        "Z(\"pad2\").\n"
+        ".decl S(s: symbol)\n"
+        "S(\"aa\").\n"
+        "S(\"zz\").\n"
+        ".decl H(h: int64)\n"
+        "H(hash(s)) :- S(s).\n";
+
+    collect_t a, b;
+    ASSERT(eval_relation(without, "H", &a) == 0, "evaluation failed (a)");
+    ASSERT(eval_relation(with_shift, "H", &b) == 0, "evaluation failed (b)");
+
+    const int64_t aa[1] = { XXH3_AA }, zz[1] = { XXH3_ZZ };
+    ASSERT(a.count == 2 && b.count == 2, "expected two fingerprints each");
+    ASSERT(saw(&a, aa, 1) && saw(&a, zz, 1), "wrong fingerprints (a)");
+    ASSERT(saw(&b, aa, 1) && saw(&b, zz, 1), "wrong fingerprints (b)");
+    PASS();
+}
+
+/*
+ * The integer path is the half that must not move.  These four values are
+ * the ones tests/test_hash_eval.c has always pinned; a blanket conversion
+ * to the string opcodes would reverse a genuine integer and digest whatever
+ * string happened to hold that id.
+ */
+static void
+test_hash_of_integer_is_unchanged(void)
+{
+    TEST("hash(int64) still digests the 8-byte int64 representation");
+
+    const char *src =
+        ".decl N(x: int64)\n"
+        "N(1).\n"
+        "N(2).\n"
+        ".decl H(x: int64, h: int64)\n"
+        "H(x, hash(x)) :- N(x).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "H", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 2, "expected two rows");
+    const int64_t one[2] = { 1, XXH3_I64_1 };
+    const int64_t two[2] = { 2, XXH3_I64_2 };
+    ASSERT(saw(&c, one, 2), "hash(1) moved");
+    ASSERT(saw(&c, two, 2), "hash(2) moved");
+    PASS();
+}
+
+/*
+ * The sharp edge of the integer path.  Because a symbol-typed operand whose
+ * reverse lookup fails falls back to the int64 digest, an emitter that
+ * converted *everything* would still look correct on integers -- right up
+ * to the point where an integer value happens to equal a live intern id,
+ * and the digest silently becomes a digest of some unrelated string.  This
+ * program interns four symbols first so that ids 0..3 all resolve, then
+ * digests the integers 0..3.
+ */
+static int
+require_low_ids_are_interned(const wirelog_program_t *prog, insert_spec_t *ins)
+{
+    const wirelog_intern_t *in = wirelog_program_get_intern(prog);
+    (void)ins;
+    if (!in)
+        return -1;
+    /* Without this the test is vacuous: the fallback would make a blanket
+     * string opcode indistinguishable from the integer one. */
+    for (int64_t id = 0; id < 4; id++) {
+        if (wl_intern_reverse(in, id) == NULL)
+            return -1;
+    }
+    return 0;
+}
+
+static void
+test_integer_values_that_collide_with_intern_ids(void)
+{
+    TEST("hash(int64) is not diverted by an id that names a string");
+
+    const char *src =
+        ".decl S(s: symbol)\n"
+        "S(\"aa\").\n"
+        "S(\"zz\").\n"
+        "S(\"mm\").\n"
+        "S(\"qq\").\n"
+        ".decl N(x: int64)\n"
+        "N(0).\n"
+        "N(1).\n"
+        "N(2).\n"
+        "N(3).\n"
+        ".decl H(x: int64, h: int64)\n"
+        "H(x, hash(x)) :- N(x).\n";
+
+    collect_t c;
+    ASSERT(eval_relation_ex(src, "H", &c, require_low_ids_are_interned) == 0,
+        "evaluation failed, or ids 0..3 name no strings (test is vacuous)");
+    ASSERT(c.count == 4, "expected four rows");
+
+    const int64_t want[4][2] = {
+        { 0, XXH3_I64_0 }, { 1, XXH3_I64_1 },
+        { 2, XXH3_I64_2 }, { 3, XXH3_I64_3 },
+    };
+    for (int i = 0; i < 4; i++)
+        ASSERT(saw(&c, want[i], 2), "an integer was digested as a symbol");
+    /* The values a blanket string opcode would have produced. */
+    ASSERT(!saw_value(&c, 1, XXH3_AA) && !saw_value(&c, 1, XXH3_ZZ),
+        "digested the string an intern id happened to name");
+    PASS();
+}
+
+static void
+test_crc32_of_symbol_covers_the_string_bytes(void)
+{
+    TEST("crc32_ethernet/castagnoli(sym) cover strlen bytes, no NUL");
+
+    /* examples/05-crc32-checksum's committed checksums are crc32 over the
+     * payload with no NUL; before the fix every frame in that example was
+     * reported corrupt.  "aa" is the same convention in miniature -- the
+     * with-NUL answers differ from these. */
+    const char *src =
+        ".decl S(s: symbol)\n"
+        "S(\"aa\").\n"
+        "S(\"zz\").\n"
+        ".decl C(e: int64, k: int64)\n"
+        "C(crc32_ethernet(s), crc32_castagnoli(s)) :- S(s).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "C", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 2, "expected one row per symbol");
+    const int64_t aa[2] = { CRC32E_AA, CRC32C_AA };
+    ASSERT(saw(&c, aa, 2), "crc32 of \"aa\" does not match zlib/CRC-32C");
+    ASSERT(saw_value(&c, 0, CRC32E_ZZ), "crc32_ethernet of \"zz\" is wrong");
+    PASS();
+}
+
+static void
+test_crc32_of_integer_is_unchanged(void)
+{
+    TEST("crc32_ethernet(int64) still covers the 8-byte representation");
+
+    const char *src =
+        ".decl N(x: int64)\n"
+        "N(1).\n"
+        ".decl C(k: int64)\n"
+        "C(crc32_ethernet(x)) :- N(x).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "C", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 1, "expected one row");
+    const int64_t want[1] = { 2844319735LL }; /* zlib.crc32(pack('<q', 1)) */
+    ASSERT(saw(&c, want, 1), "crc32_ethernet(1) moved");
+    PASS();
+}
+
+static void
+test_string_function_results_are_digested_as_strings(void)
+{
+    TEST("hash(to_upper(sym)) digests \"AA\", not the runtime intern id");
+
+    /* to_upper() interns its result at evaluation time, so its id depends
+     * on row visit order -- there is no source ordering to appeal to and
+     * the pre-fix answer was not even stable run to run. */
+    const char *src =
+        ".decl S(s: symbol)\n"
+        "S(\"aa\").\n"
+        ".decl H(h: int64)\n"
+        "H(hash(to_upper(s))) :- S(s).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "H", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 1, "expected one row");
+    const int64_t want[1] = { XXH3_UPPER_AA };
+    ASSERT(saw(&c, want, 1), "expected xxhsum -H3 of \"AA\"");
+    PASS();
+}
+
+static void
+test_nested_digest_takes_the_integer_path(void)
+{
+    TEST("hash(hash(sym)) digests the inner result as the integer it is");
+
+    /* expr_result_type() reports SCALAR for an arith expression, which is
+     * right: no arith op produces a string, so the outer hash must not try
+     * to reverse the inner one's output through the intern table. */
+    const char *src =
+        ".decl N(x: int64)\n"
+        "N(1).\n"
+        ".decl H(h: int64)\n"
+        "H(hash(hash(x))) :- N(x).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "H", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 1, "expected one row");
+    const int64_t want[1] = { XXH3_OF_XXH3_I64_1 };
+    ASSERT(saw(&c, want, 1), "nested hash is not the integer digest");
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * A `symbol` column holding values that were never interned.  `.decl` types
+ * are not enforced, so this is reachable, and the emitter has no way to see
+ * it -- the declaration is all it has.
+ *
+ * The engine digests the int64 representation of such a value, i.e. exactly
+ * what the integer opcode would have produced, and the query still runs.
+ * The alternative considered was to fail the row; in MAP position that is
+ * not a dropped row but an ERANGE that aborts the whole PROJECT operator,
+ * so a query that runs today would become `error: execution failed` with no
+ * output at all.  This test pins the softer choice: both the values and,
+ * just as importantly, that there *are* values.
+ */
+static int64_t mistyped_rows[2];
+
+static int
+mistyped_prepare(const wirelog_program_t *prog, insert_spec_t *ins)
+{
+    const wirelog_intern_t *in = wirelog_program_get_intern(prog);
+    if (!in)
+        return -1;
+    /* Far above any id this program assigns, so the reverse lookup fails
+     * rather than finding some unrelated string. */
+    mistyped_rows[0] = 1000000;
+    mistyped_rows[1] = 1000001;
+    ins->relation = "S";
+    ins->rows = mistyped_rows;
+    ins->num_rows = 2;
+    ins->ncols = 1;
+    return 0;
+}
+
+static void
+test_mistyped_declaration_digests_the_integer(void)
+{
+    TEST("a symbol column holding non-interned values still evaluates");
+
+    const char *src =
+        ".decl S(s: symbol)\n"
+        ".decl H(h: int64)\n"
+        "H(hash(s)) :- S(s).\n";
+
+    collect_t c;
+    ASSERT(eval_relation_ex(src, "H", &c, mistyped_prepare) == 0,
+        "evaluation failed: the mistyped column aborted the query");
+    ASSERT(c.count == 2, "expected one row per inserted value");
+    const int64_t a[1] = { XXH3_I64_1000000 };
+    const int64_t b[1] = { XXH3_I64_1000001 };
+    ASSERT(saw(&c, a, 1) && saw(&c, b, 1),
+        "expected the int64 digest of each un-interned value");
+    ASSERT(!saw_value(&c, 0, XXH3_I64_0),
+        "digested something other than the value itself");
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * ev(id: int64, lbl: pair/2 inline, s: symbol) occupies four *physical*
+ * columns -- [id][lbl_0][lbl_1][s] -- behind three logical ones.  A type
+ * array indexed by physical position gives `s` the compound's type and runs
+ * off the end, which #962 records as the plumbing bug it nearly shipped.
+ * #963 reads the same array from a new position (arith operands rather than
+ * comparison operands), so it gets its own case: if `s` loses its type here
+ * the digest silently returns to hashing the id.
+ */
+#define COMPOUND_SRC                                                    \
+        ".decl seed(s: symbol)\n"                                           \
+        "seed(\"aa\").\n"                                                   \
+        ".decl ev(id: int64, lbl: pair/2 inline, s: symbol)\n"              \
+        ".decl H(h: int64)\n"                                               \
+        "H(hash(s)) :- ev(i, pair(p, q), s).\n"
+
+static int64_t compound_rows[4];
+static int64_t compound_aa_id;
+
+static int
+compound_prepare(const wirelog_program_t *prog, insert_spec_t *ins)
+{
+    const wirelog_intern_t *in = wirelog_program_get_intern(prog);
+    if (!in)
+        return -1;
+    int64_t aa = wl_intern_get(in, "aa");
+    if (aa < 0)
+        return -1;
+    compound_aa_id = aa;
+
+    compound_rows[0] = 1;  /* id     */
+    compound_rows[1] = 7;  /* lbl_0  */
+    compound_rows[2] = 8;  /* lbl_1  */
+    compound_rows[3] = aa; /* s      */
+
+    ins->relation = "ev";
+    ins->rows = compound_rows;
+    ins->num_rows = 1;
+    ins->ncols = 4;
+    return 0;
+}
+
+static void
+test_inline_compound_relation(void)
+{
+    TEST("a symbol column after an inline compound keeps its type");
+
+    collect_t c;
+    ASSERT(eval_relation_ex(COMPOUND_SRC, "H", &c, compound_prepare) == 0,
+        "evaluation failed");
+    ASSERT(c.count == 1, "expected one row");
+    const int64_t want[1] = { XXH3_AA };
+    ASSERT(saw(&c, want, 1),
+        "expected xxhsum -H3 of \"aa\"; the column's type was lost");
+    PASS();
+}
+
+int
+main(void)
+{
+    printf("=== digests over symbol columns (Issue #963) ===\n");
+
+    test_hash_of_symbol_in_head_position();
+    test_hash_of_symbol_in_filter_position();
+    test_hash_is_independent_of_intern_order();
+    test_hash_of_integer_is_unchanged();
+    test_integer_values_that_collide_with_intern_ids();
+    test_crc32_of_symbol_covers_the_string_bytes();
+    test_crc32_of_integer_is_unchanged();
+    test_string_function_results_are_digested_as_strings();
+    test_nested_digest_takes_the_integer_path();
+    test_mistyped_declaration_digests_the_integer();
+    test_inline_compound_relation();
+
+    printf("\n--- Results: %d/%d passed", pass_count, test_count);
+    if (fail_count > 0)
+        printf(", %d FAILED", fail_count);
+    printf(" ---\n");
+    return (fail_count > 0) ? 1 : 0;
+}

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -48,6 +48,7 @@
 #endif
 
 #include <errno.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -82,21 +83,42 @@ wl_columnar_ops_psa_init(void)
 }
 
 static int
-wl_columnar_ops_psa_hash_int64(psa_algorithm_t alg, int64_t value,
-    unsigned char *digest, size_t digest_len)
+wl_columnar_ops_psa_hash_bytes(psa_algorithm_t alg, const void *data,
+    size_t len, unsigned char *digest, size_t digest_len)
 {
     size_t actual_len = 0;
     if (wl_columnar_ops_psa_init() != 0)
         return -1;
-    if (psa_hash_compute(alg, (const unsigned char *)&value, sizeof(value),
+    if (psa_hash_compute(alg, (const unsigned char *)data, len,
         digest, digest_len, &actual_len) != PSA_SUCCESS)
         return -1;
     return actual_len == digest_len ? 0 : -1;
 }
 
+/**
+ * Digest @first followed by @second.  uuid5()'s only caller.
+ *
+ * When @framed, each operand is preceded by its length as a little-endian
+ * uint64, so the pair maps to exactly one byte string and no two distinct
+ * (namespace, name) pairs can produce the same digest input.  A bare
+ * concatenation cannot promise that once the operands are variable-length:
+ * uuid5("ab", "c") and uuid5("a", "bc") would hash identical bytes.
+ *
+ * @framed is false only for WL_PLAN_EXPR_ARITH_UUID5, the int64-only opcode,
+ * whose two operands are 8 bytes each.  The split point there is fixed, so
+ * the concatenation is already unambiguous and there is nothing to fix --
+ * and leaving its bytes alone is what lets an out-of-tree decoder that
+ * already implements 0x2A keep computing the same answer.
+ *
+ * Reproducible outside wirelog:
+ *
+ *     buf = pack('<Q', len(ns)) + ns + pack('<Q', len(name)) + name
+ *     d   = bytearray(sha1(buf).digest())
+ */
 static int
-wl_columnar_ops_psa_hash_pair(psa_algorithm_t alg, int64_t first,
-    int64_t second, unsigned char *digest, size_t digest_len)
+wl_columnar_ops_psa_hash_pair(psa_algorithm_t alg, bool framed,
+    const void *first, size_t first_len, const void *second, size_t second_len,
+    unsigned char *digest, size_t digest_len)
 {
     psa_hash_operation_t op = PSA_HASH_OPERATION_INIT;
     size_t actual_len = 0;
@@ -106,10 +128,26 @@ wl_columnar_ops_psa_hash_pair(psa_algorithm_t alg, int64_t first,
         return -1;
     if (psa_hash_setup(&op, alg) != PSA_SUCCESS)
         goto out;
-    if (psa_hash_update(&op, (const unsigned char *)&first, sizeof(first))
+    if (framed) {
+        uint8_t len_le[8];
+        uint64_t n = (uint64_t)first_len;
+        for (unsigned i = 0; i < 8; i++)
+            len_le[i] = (uint8_t)(n >> (8 * i));
+        if (psa_hash_update(&op, len_le, sizeof(len_le)) != PSA_SUCCESS)
+            goto out;
+    }
+    if (psa_hash_update(&op, (const unsigned char *)first, first_len)
         != PSA_SUCCESS)
         goto out;
-    if (psa_hash_update(&op, (const unsigned char *)&second, sizeof(second))
+    if (framed) {
+        uint8_t len_le[8];
+        uint64_t n = (uint64_t)second_len;
+        for (unsigned i = 0; i < 8; i++)
+            len_le[i] = (uint8_t)(n >> (8 * i));
+        if (psa_hash_update(&op, len_le, sizeof(len_le)) != PSA_SUCCESS)
+            goto out;
+    }
+    if (psa_hash_update(&op, (const unsigned char *)second, second_len)
         != PSA_SUCCESS)
         goto out;
     if (psa_hash_finish(&op, digest, digest_len, &actual_len) != PSA_SUCCESS)
@@ -122,8 +160,8 @@ out:
 }
 
 static int
-wl_columnar_ops_psa_hmac_sha256_int64(int64_t msg, int64_t key,
-    unsigned char *digest, size_t digest_len)
+wl_columnar_ops_psa_hmac_sha256(const void *msg, size_t msg_len,
+    const void *key, size_t key_len, unsigned char *digest, size_t digest_len)
 {
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_id_t key_id = 0;
@@ -138,14 +176,29 @@ wl_columnar_ops_psa_hmac_sha256_int64(int64_t msg, int64_t key,
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_MESSAGE);
     psa_set_key_algorithm(&attributes, PSA_ALG_HMAC(PSA_ALG_SHA_256));
 
-    status = psa_import_key(&attributes, (const unsigned char *)&key,
-            sizeof(key), &key_id);
+    /*
+     * A symbol key can be the empty string, which PSA refuses to import.
+     * RFC 2104 zero-pads the key to the block size, so an empty key and a
+     * one-byte zero key produce the same MAC -- verified against
+     * hmac.new(b"", ...) == hmac.new(b"\0", ...).  Substituting it keeps
+     * hmac_sha256(x, "") externally reproducible instead of failing the
+     * query.  (Before #963 both operands were 8 bytes, so this could not
+     * arise.)
+     */
+    static const unsigned char empty_key[1] = { 0 };
+    if (key_len == 0) {
+        key = empty_key;
+        key_len = sizeof(empty_key);
+    }
+
+    status = psa_import_key(&attributes, (const unsigned char *)key,
+            key_len, &key_id);
     psa_reset_key_attributes(&attributes);
     if (status != PSA_SUCCESS)
         return -1;
 
     status = psa_mac_compute(key_id, PSA_ALG_HMAC(PSA_ALG_SHA_256),
-            (const unsigned char *)&msg, sizeof(msg), digest, digest_len,
+            (const unsigned char *)msg, msg_len, digest, digest_len,
             &actual_len);
     if (status == PSA_SUCCESS && actual_len == digest_len)
         ret = 0;
@@ -155,6 +208,65 @@ wl_columnar_ops_psa_hmac_sha256_int64(int64_t msg, int64_t key,
     return ret;
 }
 #endif
+
+/* ======================================================================== */
+/* Digest operand bytes (Issue #963)                                        */
+/* ======================================================================== */
+
+/**
+ * filt_bytes_t: the byte range a digest opcode consumes for one operand.
+ *
+ * @ptr either aliases the interned string or points into @inl, so the value
+ * must outlive its use and must not be copied after being filled.
+ */
+typedef struct {
+    const uint8_t *ptr;
+    size_t len;
+    uint8_t inl[sizeof(int64_t)];
+} filt_bytes_t;
+
+/**
+ * Fill @out with the bytes @v contributes to a digest.
+ *
+ * @as_symbol is set by the caller for the WL_PLAN_EXPR_ARITH_*_S opcode
+ * family, which the plan generator emits when the operand's declared type
+ * is `symbol`/`string`.  Then @v is an intern id and the digest covers the
+ * string's own bytes -- strlen(@v) of them, with no NUL terminator, which
+ * is what `xxhsum`, `crc32` and `sha256sum` see for the same input.
+ * Otherwise @v is a value and the digest covers its 8-byte int64
+ * representation, unchanged from before #963.
+ *
+ * The reverse lookup can fail even under an _S opcode, because `.decl`
+ * types are not enforced: a column declared `symbol` may hold raw integers
+ * that were never interned.  This falls back to the int64 representation
+ * rather than failing the row.  The alternative -- failing -- is not a
+ * dropped row in MAP position but an ERANGE that aborts the whole PROJECT
+ * operator (col_op_project()), turning a query that runs today into
+ * `error: execution failed` with no output.  The fallback instead gives
+ * exactly what the integer opcode would have given for that value, which
+ * for data that is genuinely integral is the right answer; nothing that is
+ * genuinely a symbol reaches it.  The guarantee #963 establishes is
+ * therefore only as strong as the `.decl`, and docs/SEMANTICS.md says so.
+ */
+static void
+filt_digest_bytes(filt_bytes_t *out, int64_t v, bool as_symbol,
+    wl_intern_t *intern)
+{
+    if (as_symbol) {
+        const char *str = intern ? wl_intern_reverse(intern, v) : NULL;
+        if (str) {
+            out->ptr = (const uint8_t *)str;
+            out->len = strlen(str);
+            return;
+        }
+        WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_DEBUG,
+            "digest operand %" PRId64 " is declared symbol but names no "
+            "interned string: digesting its int64 representation", v);
+    }
+    memcpy(out->inl, &v, sizeof(v));
+    out->ptr = out->inl;
+    out->len = sizeof(v);
+}
 
 static inline void
 filt_push(filt_stack_t *s, int64_t v)
@@ -444,34 +556,50 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
             filt_push(&s, v);
             break;
         }
-        case WL_PLAN_EXPR_ARITH_HASH: {
+        /*
+         * Digest opcodes.  Each integer opcode is paired with the _S
+         * variant the plan generator emits when the operand is
+         * symbol-typed (Issue #963); filt_digest_bytes() is the only
+         * place the two differ.
+         */
+        case WL_PLAN_EXPR_ARITH_HASH:
+        case WL_PLAN_EXPR_ARITH_HASH_S: {
             int64_t a = filt_pop(&s);
-            filt_push(&s, (int64_t)XXH3_64bits(&a, sizeof(a)));
+            filt_bytes_t m;
+            filt_digest_bytes(&m, a, tag == WL_PLAN_EXPR_ARITH_HASH_S, intern);
+            filt_push(&s, (int64_t)XXH3_64bits(m.ptr, m.len));
             break;
         }
 
-        case WL_PLAN_EXPR_ARITH_CRC32_ETH: {
+        case WL_PLAN_EXPR_ARITH_CRC32_ETH:
+        case WL_PLAN_EXPR_ARITH_CRC32_ETH_S: {
             int64_t a = filt_pop(&s);
-            uint8_t bytes[sizeof(a)];
-            memcpy(bytes, &a, sizeof(bytes));
-            filt_push(&s, (int64_t)ethernet_crc32(bytes, sizeof(bytes)));
+            filt_bytes_t m;
+            filt_digest_bytes(&m, a,
+                tag == WL_PLAN_EXPR_ARITH_CRC32_ETH_S, intern);
+            filt_push(&s, (int64_t)ethernet_crc32(m.ptr, m.len));
             break;
         }
 
-        case WL_PLAN_EXPR_ARITH_CRC32_CAST: {
+        case WL_PLAN_EXPR_ARITH_CRC32_CAST:
+        case WL_PLAN_EXPR_ARITH_CRC32_CAST_S: {
             int64_t a = filt_pop(&s);
-            uint8_t bytes[sizeof(a)];
-            memcpy(bytes, &a, sizeof(bytes));
-            filt_push(&s, (int64_t)castagnoli_crc32(bytes, sizeof(bytes)));
+            filt_bytes_t m;
+            filt_digest_bytes(&m, a,
+                tag == WL_PLAN_EXPR_ARITH_CRC32_CAST_S, intern);
+            filt_push(&s, (int64_t)castagnoli_crc32(m.ptr, m.len));
             break;
         }
 
-        case WL_PLAN_EXPR_ARITH_MD5: {
+        case WL_PLAN_EXPR_ARITH_MD5:
+        case WL_PLAN_EXPR_ARITH_MD5_S: {
 #ifdef WL_MBEDTLS_ENABLED
             int64_t a = filt_pop(&s);
             unsigned char digest[16];
-            if (wl_columnar_ops_psa_hash_int64(PSA_ALG_MD5, a, digest,
-                sizeof(digest)) != 0)
+            filt_bytes_t m;
+            filt_digest_bytes(&m, a, tag == WL_PLAN_EXPR_ARITH_MD5_S, intern);
+            if (wl_columnar_ops_psa_hash_bytes(PSA_ALG_MD5, m.ptr, m.len,
+                digest, sizeof(digest)) != 0)
                 goto bad;
             filt_push(&s, (int64_t)XXH3_64bits(digest, sizeof(digest)));
 #else
@@ -481,12 +609,15 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
             break;
         }
 
-        case WL_PLAN_EXPR_ARITH_SHA1: {
+        case WL_PLAN_EXPR_ARITH_SHA1:
+        case WL_PLAN_EXPR_ARITH_SHA1_S: {
 #ifdef WL_MBEDTLS_ENABLED
             int64_t a = filt_pop(&s);
             unsigned char digest[20];
-            if (wl_columnar_ops_psa_hash_int64(PSA_ALG_SHA_1, a, digest,
-                sizeof(digest)) != 0)
+            filt_bytes_t m;
+            filt_digest_bytes(&m, a, tag == WL_PLAN_EXPR_ARITH_SHA1_S, intern);
+            if (wl_columnar_ops_psa_hash_bytes(PSA_ALG_SHA_1, m.ptr, m.len,
+                digest, sizeof(digest)) != 0)
                 goto bad;
             filt_push(&s, (int64_t)XXH3_64bits(digest, sizeof(digest)));
 #else
@@ -496,11 +627,15 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
             break;
         }
 
-        case WL_PLAN_EXPR_ARITH_SHA256: {
+        case WL_PLAN_EXPR_ARITH_SHA256:
+        case WL_PLAN_EXPR_ARITH_SHA256_S: {
 #ifdef WL_MBEDTLS_ENABLED
             int64_t a = filt_pop(&s);
             unsigned char digest[32];
-            if (wl_columnar_ops_psa_hash_int64(PSA_ALG_SHA_256, a,
+            filt_bytes_t m;
+            filt_digest_bytes(&m, a, tag == WL_PLAN_EXPR_ARITH_SHA256_S,
+                intern);
+            if (wl_columnar_ops_psa_hash_bytes(PSA_ALG_SHA_256, m.ptr, m.len,
                 digest, sizeof(digest)) != 0)
                 goto bad;
             filt_push(&s, (int64_t)XXH3_64bits(digest, sizeof(digest)));
@@ -511,11 +646,15 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
             break;
         }
 
-        case WL_PLAN_EXPR_ARITH_SHA512: {
+        case WL_PLAN_EXPR_ARITH_SHA512:
+        case WL_PLAN_EXPR_ARITH_SHA512_S: {
 #ifdef WL_MBEDTLS_ENABLED
             int64_t a = filt_pop(&s);
             unsigned char digest[64];
-            if (wl_columnar_ops_psa_hash_int64(PSA_ALG_SHA_512, a,
+            filt_bytes_t m;
+            filt_digest_bytes(&m, a, tag == WL_PLAN_EXPR_ARITH_SHA512_S,
+                intern);
+            if (wl_columnar_ops_psa_hash_bytes(PSA_ALG_SHA_512, m.ptr, m.len,
                 digest, sizeof(digest)) != 0)
                 goto bad;
             filt_push(&s, (int64_t)XXH3_64bits(digest, sizeof(digest)));
@@ -526,12 +665,22 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
             break;
         }
 
-        case WL_PLAN_EXPR_ARITH_HMAC_SHA256: {
+        case WL_PLAN_EXPR_ARITH_HMAC_SHA256:
+        case WL_PLAN_EXPR_ARITH_HMAC_SHA256_SS:
+        case WL_PLAN_EXPR_ARITH_HMAC_SHA256_SI:
+        case WL_PLAN_EXPR_ARITH_HMAC_SHA256_IS: {
 #ifdef WL_MBEDTLS_ENABLED
             int64_t key_val = filt_pop(&s);
             int64_t msg_val = filt_pop(&s);
             unsigned char digest[32];
-            if (wl_columnar_ops_psa_hmac_sha256_int64(msg_val, key_val,
+            bool msg_sym = (tag == WL_PLAN_EXPR_ARITH_HMAC_SHA256_SS
+                || tag == WL_PLAN_EXPR_ARITH_HMAC_SHA256_SI);
+            bool key_sym = (tag == WL_PLAN_EXPR_ARITH_HMAC_SHA256_SS
+                || tag == WL_PLAN_EXPR_ARITH_HMAC_SHA256_IS);
+            filt_bytes_t m, k;
+            filt_digest_bytes(&m, msg_val, msg_sym, intern);
+            filt_digest_bytes(&k, key_val, key_sym, intern);
+            if (wl_columnar_ops_psa_hmac_sha256(m.ptr, m.len, k.ptr, k.len,
                 digest, sizeof(digest)) != 0)
                 goto bad;
             filt_push(&s, (int64_t)XXH3_64bits(digest, sizeof(digest)));
@@ -563,13 +712,32 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
             break;
         }
 
-        case WL_PLAN_EXPR_ARITH_UUID5: {
+        /*
+         * uuid5(ns, name) over symbols length-prefixes each operand before
+         * hashing, so distinct (namespace, name) pairs always hash distinct
+         * bytes.  A bare concatenation -- what the int64-only opcode does,
+         * and what it can safely keep doing with two fixed-width operands --
+         * would make uuid5("ab", "c") and uuid5("a", "bc") the same value
+         * the moment the operands became variable-length.
+         */
+        case WL_PLAN_EXPR_ARITH_UUID5:
+        case WL_PLAN_EXPR_ARITH_UUID5_SS:
+        case WL_PLAN_EXPR_ARITH_UUID5_SI:
+        case WL_PLAN_EXPR_ARITH_UUID5_IS: {
 #ifdef WL_MBEDTLS_ENABLED
             int64_t name = filt_pop(&s);
             int64_t ns = filt_pop(&s);
             unsigned char digest[20]; /* SHA-1 output */
-            if (wl_columnar_ops_psa_hash_pair(PSA_ALG_SHA_1, ns, name, digest,
-                sizeof(digest)) != 0)
+            bool ns_sym = (tag == WL_PLAN_EXPR_ARITH_UUID5_SS
+                || tag == WL_PLAN_EXPR_ARITH_UUID5_SI);
+            bool name_sym = (tag == WL_PLAN_EXPR_ARITH_UUID5_SS
+                || tag == WL_PLAN_EXPR_ARITH_UUID5_IS);
+            filt_bytes_t nsb, nmb;
+            filt_digest_bytes(&nsb, ns, ns_sym, intern);
+            filt_digest_bytes(&nmb, name, name_sym, intern);
+            if (wl_columnar_ops_psa_hash_pair(PSA_ALG_SHA_1,
+                tag != WL_PLAN_EXPR_ARITH_UUID5, nsb.ptr, nsb.len,
+                nmb.ptr, nmb.len, digest, sizeof(digest)) != 0)
                 goto bad;
             /* RFC 4122 v5: set version=5, variant=0b10 */
             digest[6] = (digest[6] & 0x0F) | 0x50;

--- a/wirelog/crc32.c
+++ b/wirelog/crc32.c
@@ -36,6 +36,15 @@
 #include <arm_acle.h> /* __crc32cb */
 #endif
 
+/* MSVC spells it differently and rejects the GNU attribute outright. */
+#if defined(_MSC_VER)
+#define WL_CRC32_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__) || defined(__clang__)
+#define WL_CRC32_NOINLINE __attribute__((noinline))
+#else
+#define WL_CRC32_NOINLINE
+#endif
+
 /* Runtime detection: returns 1 if hardware CRC32 is available */
 static int
 crc32_hw_available(void)
@@ -183,7 +192,19 @@ castagnoli_crc32_init(void)
     castagnoli_table_ready = 1;
 }
 
-uint32_t
+/*
+ * noinline is load-bearing, not a style choice.  Under clang 18 with LTO
+ * and AddressSanitizer, inlining this function across the TU boundary into
+ * col_eval_expr_run() produces a copy whose references to this file's
+ * statics -- castagnoli_table, castagnoli_table_ready, and the cached
+ * g_hw_crc32_available behind hw_crc32_check() -- resolve to unmapped
+ * addresses, and the very first read of one segfaults.  ethernet_crc32(),
+ * which is not inlined at that call site, reads its own statics correctly
+ * on the identical arguments.  Bisected on CI: forcing the software path
+ * did not help, a global-free rewrite did, and restoring the table with
+ * only this attribute added also does.  See #970.
+ */
+WL_CRC32_NOINLINE uint32_t
 castagnoli_crc32(const uint8_t *data, size_t len)
 {
     uint32_t crc = 0xFFFFFFFFu;

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -165,6 +165,49 @@ typedef enum {
     WL_PLAN_EXPR_CMP_STR_GT  = 0x53,
     WL_PLAN_EXPR_CMP_STR_LTE = 0x54,
     WL_PLAN_EXPR_CMP_STR_GTE = 0x55,
+
+    /*
+     * Digest opcodes whose operands are symbols (Issue #963).
+     *
+     * The 0x1B..0x2A family digests the int64_t on the stack.  When that
+     * int64_t is an interned symbol id, digesting it answers a question
+     * about the intern table rather than about the string: hash("abc")
+     * matches no external tool, and the same string digests differently
+     * depending on what was interned first.  These opcodes reverse the id
+     * and digest the string's own bytes instead.
+     *
+     * Byte convention: strlen(s) bytes, no NUL terminator.  That is what
+     * `printf '%s' abc | xxhsum -H3` and `crc32(payload)` see, so the
+     * values are reproducible outside wirelog.
+     *
+     * All are payload-free, exactly like the integer opcodes they shadow,
+     * so a decoder that does not know them still advances by one byte and
+     * stays in sync with the rest of the stream.
+     *
+     * hmac_sha256() and uuid5() take two operands that type independently,
+     * so each gets three opcodes; the II case keeps the existing opcode.
+     * _SS = both symbols, _SI = first symbol, _IS = second symbol.
+     *
+     * The UUID5_* opcodes additionally length-prefix each operand (its
+     * length as a little-endian uint64) before hashing, which the 0x2A
+     * opcode does not.  Without it two variable-length operands could be
+     * split at more than one point -- uuid5("ab", "c") and uuid5("a", "bc")
+     * would hash the same bytes.  0x2A's operands are 8 bytes each, so its
+     * split point is fixed and its bytes are unchanged.
+     */
+    WL_PLAN_EXPR_ARITH_HASH_S        = 0x60, /* unary:  pop 1 push 1 */
+    WL_PLAN_EXPR_ARITH_CRC32_ETH_S   = 0x61,
+    WL_PLAN_EXPR_ARITH_CRC32_CAST_S  = 0x62,
+    WL_PLAN_EXPR_ARITH_MD5_S         = 0x63,
+    WL_PLAN_EXPR_ARITH_SHA1_S        = 0x64,
+    WL_PLAN_EXPR_ARITH_SHA256_S      = 0x65,
+    WL_PLAN_EXPR_ARITH_SHA512_S      = 0x66,
+    WL_PLAN_EXPR_ARITH_HMAC_SHA256_SS = 0x67, /* binary: pop 2 push 1 */
+    WL_PLAN_EXPR_ARITH_HMAC_SHA256_SI = 0x68,
+    WL_PLAN_EXPR_ARITH_HMAC_SHA256_IS = 0x69,
+    WL_PLAN_EXPR_ARITH_UUID5_SS      = 0x6A, /* binary: pop 2 push 1 */
+    WL_PLAN_EXPR_ARITH_UUID5_SI      = 0x6B,
+    WL_PLAN_EXPR_ARITH_UUID5_IS      = 0x6C,
 } wl_plan_expr_tag_t;
 
 /**

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -315,10 +315,149 @@ col_ctx_lookup_type(const col_ctx_t *ctx, const char *var_name)
     return WL_IR_COLTYPE_UNKNOWN;
 }
 
-/* Map IR arith op -> plan expr tag */
-static uint8_t
-arith_to_tag(wirelog_arith_op_t op)
+static const char *
+arith_op_name(wirelog_arith_op_t op)
 {
+    switch (op) {
+    case WIRELOG_ARITH_HASH:        return "hash";
+    case WIRELOG_ARITH_CRC32_ETH:   return "crc32_ethernet";
+    case WIRELOG_ARITH_CRC32_CAST:  return "crc32_castagnoli";
+    case WIRELOG_ARITH_MD5:         return "md5";
+    case WIRELOG_ARITH_SHA1:        return "sha1";
+    case WIRELOG_ARITH_SHA256:      return "sha256";
+    case WIRELOG_ARITH_SHA512:      return "sha512";
+    case WIRELOG_ARITH_HMAC_SHA256: return "hmac_sha256";
+    case WIRELOG_ARITH_UUID5:       return "uuid5";
+    default:                        return "?";
+    }
+}
+
+/**
+ * Map an IR arith op to a plan expr tag, given the value domains of its
+ * operands (Issue #963).
+ *
+ * @t0 and @t1 are the domains of the first and second child; @t1 is
+ * WL_IR_COLTYPE_UNKNOWN for unary operators.
+ *
+ * Symbols are stored as intern ids.  The 0x1B..0x2A digest opcodes digest
+ * that id, which makes hash("abc") a fact about the intern table rather
+ * than about "abc": it matches no external tool, and the same string
+ * digests differently depending on what was interned first.  When an
+ * operand is string-typed the emitter picks the shadow opcode that reverses
+ * the id and digests the string's own bytes instead.
+ *
+ * Two points where this diverges from cmp_to_tag()'s rules, deliberately:
+ *
+ *   - #962 keeps the integer opcode when only one operand of a comparison
+ *     is a string, because CMP_STR_* needs *both* sides reversed and a
+ *     one-sided match would drop every row.  hmac_sha256() and uuid5()
+ *     have no such coupling -- each operand contributes its own bytes --
+ *     so applying that rule here would leave the mixed case digesting an
+ *     id, i.e. would preserve the defect.  Each therefore gets three
+ *     opcodes (_SS/_SI/_IS) and only the all-integer case keeps 0x28/0x2A.
+ *
+ *   - EQ/NEQ are exempt in #962 because interning is canonical.  Nothing
+ *     analogous applies to a digest: the digest of an id is not the digest
+ *     of the string under any convention.
+ *
+ * WL_IR_EXPR_ARITH itself reports SCALAR from expr_result_type(), which is
+ * correct -- no arith op produces a string -- so hash(hash(x)) digests the
+ * inner result as the integer it is.
+ */
+static uint8_t
+arith_digest_tag(wirelog_arith_op_t op, wl_ir_coltype_t t0, wl_ir_coltype_t t1)
+{
+    bool s0 = (t0 == WL_IR_COLTYPE_STRING);
+    bool s1 = (t1 == WL_IR_COLTYPE_STRING);
+
+    switch (op) {
+    case WIRELOG_ARITH_HASH:
+        return s0 ? WL_PLAN_EXPR_ARITH_HASH_S : WL_PLAN_EXPR_ARITH_HASH;
+    case WIRELOG_ARITH_CRC32_ETH:
+        return s0 ? WL_PLAN_EXPR_ARITH_CRC32_ETH_S
+                  : WL_PLAN_EXPR_ARITH_CRC32_ETH;
+    case WIRELOG_ARITH_CRC32_CAST:
+        return s0 ? WL_PLAN_EXPR_ARITH_CRC32_CAST_S
+                  : WL_PLAN_EXPR_ARITH_CRC32_CAST;
+    case WIRELOG_ARITH_MD5:
+        return s0 ? WL_PLAN_EXPR_ARITH_MD5_S : WL_PLAN_EXPR_ARITH_MD5;
+    case WIRELOG_ARITH_SHA1:
+        return s0 ? WL_PLAN_EXPR_ARITH_SHA1_S : WL_PLAN_EXPR_ARITH_SHA1;
+    case WIRELOG_ARITH_SHA256:
+        return s0 ? WL_PLAN_EXPR_ARITH_SHA256_S : WL_PLAN_EXPR_ARITH_SHA256;
+    case WIRELOG_ARITH_SHA512:
+        return s0 ? WL_PLAN_EXPR_ARITH_SHA512_S : WL_PLAN_EXPR_ARITH_SHA512;
+    case WIRELOG_ARITH_HMAC_SHA256:
+        if (s0 && s1)
+            return WL_PLAN_EXPR_ARITH_HMAC_SHA256_SS;
+        if (s0)
+            return WL_PLAN_EXPR_ARITH_HMAC_SHA256_SI;
+        if (s1)
+            return WL_PLAN_EXPR_ARITH_HMAC_SHA256_IS;
+        return WL_PLAN_EXPR_ARITH_HMAC_SHA256;
+    case WIRELOG_ARITH_UUID5:
+        if (s0 && s1)
+            return WL_PLAN_EXPR_ARITH_UUID5_SS;
+        if (s0)
+            return WL_PLAN_EXPR_ARITH_UUID5_SI;
+        if (s1)
+            return WL_PLAN_EXPR_ARITH_UUID5_IS;
+        return WL_PLAN_EXPR_ARITH_UUID5;
+    default:
+        break;
+    }
+    return WL_PLAN_EXPR_ARITH_ADD; /* unreachable: caller filters */
+}
+
+/* True for the ops whose operand domain selects between opcode families. */
+static bool
+arith_op_is_digest(wirelog_arith_op_t op)
+{
+    switch (op) {
+    case WIRELOG_ARITH_HASH:
+    case WIRELOG_ARITH_CRC32_ETH:
+    case WIRELOG_ARITH_CRC32_CAST:
+    case WIRELOG_ARITH_MD5:
+    case WIRELOG_ARITH_SHA1:
+    case WIRELOG_ARITH_SHA256:
+    case WIRELOG_ARITH_SHA512:
+    case WIRELOG_ARITH_HMAC_SHA256:
+    case WIRELOG_ARITH_UUID5:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/* Map IR arith op -> plan expr tag.
+ *
+ * @t0/@t1 are the operand value domains (Issue #963); pass UNKNOWN for
+ * operands that do not exist.  Only the digest family reads them. */
+static uint8_t
+arith_to_tag(wirelog_arith_op_t op, wl_ir_coltype_t t0, wl_ir_coltype_t t1)
+{
+    if (arith_op_is_digest(op)) {
+        /*
+         * An operand with no declared type keeps the integer opcode, so it
+         * digests an id.  Rejecting it would break programs that work
+         * today -- head and intermediate relations need no .decl -- but the
+         * result is as unstable as the id assignment, so say so.  The
+         * UNKNOWN sentinel is what makes "never declared" distinguishable
+         * from "declared numeric", which is a legitimate integer digest.
+         */
+        bool binary = (op == WIRELOG_ARITH_HMAC_SHA256
+            || op == WIRELOG_ARITH_UUID5);
+        if (t0 == WL_IR_COLTYPE_UNKNOWN
+            || (binary && t1 == WL_IR_COLTYPE_UNKNOWN)) {
+            WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_WARN,
+                "'%s' applied to a column with no declared type: digesting "
+                "the interned id, not the string bytes. Declare the relation "
+                "(.decl R(c: symbol)) if the column holds symbols",
+                arith_op_name(op));
+        }
+        return arith_digest_tag(op, t0, t1);
+    }
+
     switch (op) {
     case WIRELOG_ARITH_ADD:
         return WL_PLAN_EXPR_ARITH_ADD;
@@ -622,13 +761,22 @@ serialize_expr(expr_buf_t *buf, const wl_ir_expr_t *expr,
             return -1;
         return expr_buf_push_u8(buf, expr->bool_value ? 1 : 0);
 
-    case WL_IR_EXPR_ARITH:
+    case WL_IR_EXPR_ARITH: {
         /* Serialize children first (postfix) */
         for (uint32_t i = 0; i < expr->child_count; i++) {
             if (serialize_expr(buf, expr->children[i], ctx) != 0)
                 return -1;
         }
-        return expr_buf_push_u8(buf, arith_to_tag(expr->arith_op));
+        /* Operand domains select between the integer and the string digest
+         * opcode families (Issue #963). */
+        wl_ir_coltype_t t0 = (expr->child_count > 0)
+            ? expr_result_type(expr->children[0], ctx)
+            : WL_IR_COLTYPE_UNKNOWN;
+        wl_ir_coltype_t t1 = (expr->child_count > 1)
+            ? expr_result_type(expr->children[1], ctx)
+            : WL_IR_COLTYPE_UNKNOWN;
+        return expr_buf_push_u8(buf, arith_to_tag(expr->arith_op, t0, t1));
+    }
 
     case WL_IR_EXPR_CMP: {
         for (uint32_t i = 0; i < expr->child_count; i++) {


### PR DESCRIPTION
Closes #963.

## The defect

`hash`, `crc32_ethernet`, `crc32_castagnoli`, `md5`, `sha1`, `sha256`, `sha512`, `hmac_sha256` and `uuid5` digested whatever `int64_t` sat on the evaluation stack. For a `symbol` column that is an interned id, so the result described the **intern table**, not the string. `hash("abc")` matched no external tool, and the same string digested differently depending on what had been interned before it.

## Both in-tree examples were already wrong

**`examples/04-hash-functions` showed the defect twice over.** Prepending one row to `records.csv` gave alice bob's fingerprint. And `hash("carol@example.com")` equalled the Part 3 checksum `hash(5)` over a *genuine integer* — the example's two halves collided across domains, because both were really digests of small ids.

**`examples/05-crc32-checksum` was outright broken and nobody noticed.** Its committed checksums are `crc32(payload_bytes)`, so every one of its six frames reported corrupt, `valid_frames_output.csv` came out empty against a four-row golden, and the `diff` its README documents failed.

That file was computed by an external tool and committed as the expected answer, which makes it an **author-independent oracle** for both the byte convention and this fix. After this change `diff -r` against the committed directory is identical, with no edits to it.

## Design

Thirteen payload-free opcodes at `0x60`–`0x6C`: seven unary string variants plus three each for `hmac_sha256` and `uuid5`, whose operands type independently. `arith_to_tag(op, t0, t1)` mirrors what #962 did to `cmp_to_tag` and reuses its `expr_result_type()`/`col_ctx_lookup_type()` unchanged. **Nothing is added to the plan encoding.**

A flag byte on the existing opcodes was rejected because it changes their **length** — an out-of-tree decoder that correctly reads a 1-byte `ARITH_HASH` today would mis-parse the entire remaining buffer. An unknown opcode is a local failure a consumer can detect; a changed length is global stream corruption it cannot.

Having the existing opcode try `wl_intern_reverse` and hash the string when the lookup succeeds was rejected because `hash(3)` on a genuine integer column would then hash whatever string holds id 3 — the same intern-order dependence this issue exists to remove.

**Byte convention: `strlen` bytes, no NUL** — and it is not ours. `examples/05`'s committed checksums match `crc32(payload)` and not `crc32(payload + NUL)`, and its README's CRC-32C table agrees: ten values, all no-NUL. It also matches every external tool, which is the point of naming a function `sha256`.

## The `.decl` is not enforced, and failing closed would be worse

A column declared `symbol` that holds un-interned integers reaches an `_S` opcode. It digests the `int64` and logs at `EVAL:4` rather than failing.

Failing is worse than it sounds: digests are used in **head position** — both examples do — where an evaluation error aborts the whole `PROJECT` operator with `ERANGE`, turning a query that runs today into `error: execution failed` with no output and no way to ask for the integer instead.

That fallback makes a *blanket* string-opcode emitter nearly indistinguishable from the correct one, since integers naming no id fall back to the same answer. `test_integer_values_that_collide_with_intern_ids` closes it: it interns four symbols so ids 0–3 resolve, then digests the integers 0–3, and refuses to run vacuously.

## `uuid5` operand boundaries

Making operands variable-width would have made `uuid5("ab","c") == uuid5("a","bc")` reachable — a collision that could not be constructed while both operands were fixed-width `int64`s. Rather than document a defect this change would create, the three symbol-bearing opcodes **length-prefix each operand** (little-endian `uint64`), with a Python reproduction in `docs/SYNTAX.md`. The all-integer opcode is untouched and its values are unchanged, preserving the rule that an existing opcode keeps its exact meaning.

`uuid5` is still not RFC 4122 and framing does not make it so — the namespace need not be a UUID and only 8 of the 16 bytes are returned. The docs state unambiguity and conformance as **separate claims**; residual scope is #968.

## The fpga backend was silently disabling filters

Its decoder returned `1` from the `default:` arm — **admitting every row** — and its one `ARITH_HASH` case was a pass-through no-op that degraded `hash(x) = k` to `x = k`. Fixed in this commit rather than a later one, following #962. A standalone fail-closed flip was measured to break **zero** tests, which means it would have been a behaviour change with no coverage at all.

## Second commit: the examples become tests

Neither example had ever been executed by CI. They were never wired in because their `.dl` programs resolve paths relative to the repo root and their documented workflow **overwrites the goldens in place** — running them is a regeneration, not a check. The runner copies each example into a temp tree, deletes the goldens from the copy, runs with that tree as cwd, and diffs. The source tree is only read.

## Validation

`meson test -C build` **261 Ok / 1 Fail / 11 Skipped** in *both* mbedTLS configurations (the failure is the known-environmental `sbom_snapshot`; baseline 258/1/11, +3 new tests). `--suite abi` passes under `-Dwirelog_log_max_level=error`, so the new `WL_LOG` sites erase.

Every expected value was derived **outside wirelog before the code existed** — `xxhsum -H3`, `zlib.crc32`, a standalone CRC-32C table, `hashlib`, `hmac`. Four mutations, each caught only by its own cases.

Integer digests verified unchanged against every pinned value in the tree: `test_hash_eval`'s four goldens, `test_hash_integration`'s bucket list, and `examples/04`'s five other CSVs, all byte-identical after a real CLI run.

Cost: none of these was ever on a fast path, so unlike #962 there is no demotion. 1M rows of ~20-byte symbols: `hash(sym)` 642 ms vs `hash(int64)` 630 ms.

One edge case appeared and is fixed here: `hmac_sha256(sym, "")` is a zero-length key, which PSA will not import and which could not arise while both operands were 8 bytes. A one-byte zero key is substituted, exactly equivalent under RFC 2104's zero-padding, and pinned against Python's `hmac.new(b"", ...)`.

The CI `mbedtls-enabled` job ran only `cryptographic_hashes`, so a new test would have been built and never executed there; the always-available half is a separate binary that runs everywhere and the crypto half is added to that job's list.
