### PR TITLE
fix(columnar): tag uuid5 operands by domain, not just by length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,50 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **`uuid5()` framing carries the operand's type, not only its length**
+  (#968): #963 length-prefixed each operand of the three symbol-bearing
+  `uuid5` opcodes, which fixed the split point but not the *domain*. Two
+  collisions survived it, both reproduced end to end. `uuid5("", "")`
+  framed to `LE64(0) || "" || LE64(0) || ""` -- sixteen zero bytes, exactly
+  what the unframed int64-only opcode emits for `uuid5(0, 0)` -- so both
+  returned `6655197997870229985`. And a length prefix says nothing about
+  what an operand *is*, so `uuid5("abcdefgh", x)` equalled
+  `uuid5(7523094288207667809, x)`, that integer being precisely the `int64`
+  whose little-endian bytes spell `abcdefgh`.
+
+  Each framed operand is now `tag || LE64(len) || bytes`, where the tag is
+  one byte: `'S'` for a symbol's bytes, `'I'` for an `int64`'s. The encoding
+  is thereby injective over *typed* operand pairs rather than only over byte
+  strings. The tag is taken from the bytes actually emitted, not from the
+  opcode's declared operand type, so the documented fallback -- a `symbol`
+  column holding a value that was never interned digests its `int64` form --
+  is tagged `'I'` and cannot collide with the symbol spelling those same
+  eight bytes.
+
+  **`0x2A`, the int64-only opcode, is untouched**: still unframed, still
+  untagged, still returning every value it ever has. It is the only `uuid5`
+  encoding that has shipped, and its two operands are 8 bytes each and both
+  `int64`, so neither ambiguity can arise there. Adding a framed `UUID5_II`
+  opcode was considered and rejected: the unframed 16-byte encoding is
+  currently the *only* domain separation `uuid5` has, so framing the integer
+  path would have pulled it into the second collision's family -- trading
+  one degenerate collision for an unbounded one. No opcode was added;
+  `0x6A`..`0x6C` and their framing are unreleased, so only their values
+  moved, and the five pinned constants in `tests/test_cryptographic_hashes.c`
+  move with them.
+
+  **Injective encoding is not collision-free output**, and the docs no
+  longer let that read as if it were. `uuid5()` returns `digest[0..7]` with
+  four bits overwritten by the version nibble, so it has at most 2^60
+  distinct results however unambiguous its input. Separately,
+  `docs/SECURITY_MODEL.md` now states domain non-separation as its own
+  caveat for the unary digests and `hmac_sha256()`, where it is *not* being
+  fixed: those are bound by #963's byte-transparency contract -- `printf
+  '%s' abcdefgh | xxhsum -H3` must reproduce `hash("abcdefgh")` -- which
+  leaves no room for a type tag. That caveat is distinct from the 64-bit
+  fold already documented: the fold is a birthday bound, while this is
+  constructible at zero cost.
+
 - **`hash()` and the digest family digest string bytes, not intern ids**
   (#963): `hash`, `crc32_ethernet`, `crc32_castagnoli`, `md5`, `sha1`,
   `sha256`, `sha512`, `hmac_sha256` and `uuid5` digested the `int64_t` on the
@@ -98,8 +142,9 @@ All notable changes to wirelog are documented in this file.
   the one thing a namespaced identifier must not do. RFC 4122 avoids this by
   requiring the namespace to be exactly 16 bytes; wirelog adopted the
   two-operand signature without that property, so the three symbol-bearing
-  opcodes length-prefix each operand -- its length as a little-endian
-  `uint64` -- before hashing. `uuid5(int64, int64)` keeps the unframed
+  opcodes frame each operand -- a one-byte domain tag and its length as a
+  little-endian `uint64` (the tag was added by #968, below, before either
+  shipped) -- before hashing. `uuid5(int64, int64)` keeps the unframed
   construction and its exact previous values: its operands are 8 bytes each,
   so nothing was ambiguous there, and an out-of-tree decoder that already
   implements `0x2A` keeps computing the same answer. Rejected alternatives:

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -82,6 +82,41 @@ relied on for collision resistance at scale. `uuid4()` and
 `uuid5(namespace, name)` return the first 8 UUID bytes as an `int64`;
 `uuid5()` is not RFC 4122 (see `docs/SYNTAX.md`).
 
+**The digest built-ins do not separate operand domains.** A `symbol`
+operand contributes its own bytes and an `int64` operand contributes its
+8-byte little-endian representation, with nothing recording which of the
+two it was. A symbol whose bytes coincide with an `int64`'s therefore
+digests identically to that integer:
+
+```
+hash("abcdefgh")  ==  hash(7523094288207667809)
+```
+
+This is the documented behaviour, not a defect, and it is not being
+fixed. It falls out of the byte-transparency contract from #963 — the
+whole point of digesting a symbol's own bytes is that
+`printf '%s' abcdefgh | xxhsum -H3` reproduces `hash("abcdefgh")`, which
+leaves no room for a type tag in the digest input. It applies to every
+single-operand digest — `hash()`, `crc32_ethernet()`,
+`crc32_castagnoli()`, `md5()`, `sha1()`, `sha256()`, `sha512()`
+(the first three are available in every build) — and to both operands of
+`hmac_sha256(msg, key)`. If a relation mixes typed operands and the
+distinction matters, digest a value that carries the type, or key the
+relation on the type as well.
+
+Note that this is a *separate* caveat from the 64-bit fold above. That
+one is a birthday bound: collisions exist but cost work to find. This
+one is constructible at zero cost by anyone who can choose an operand.
+
+`uuid5()` is the one exception. Its symbol-bearing opcodes prefix each
+operand with a one-byte domain tag and its length (#968), so
+`uuid5("abcdefgh", x)` and `uuid5(7523094288207667809, x)` differ. That
+buys an unambiguous *digest input* and nothing more: the return value is
+the first 8 digest bytes with 4 bits overwritten by the version nibble,
+so `uuid5()` has at most 2^60 distinct outputs and is subject to the
+same birthday bound as everything else here. Injective encoding is not
+collision-free output.
+
 These functions become callable as Datalog built-ins; the host has no
 control over whether a `.dl` program calls them once mbedTLS is
 linked in.

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -234,6 +234,15 @@ required — 64 bits is not collision-resistant at scale.
 operands independently, so `hmac_sha256(sym, 42)` keys the HMAC with the
 8 bytes of `42` and messages it with the symbol's bytes.
 
+**Nothing records which of the two forms was used**, so a symbol whose
+bytes coincide with an `int64`'s digests identically to that integer:
+`hash("abcdefgh") == hash(7523094288207667809)`. That is the price of
+the byte transparency above — a type tag in the digest input is exactly
+what would stop `printf '%s' abcdefgh | xxhsum -H3` from reproducing
+`hash("abcdefgh")` — and it is not being changed. `uuid5()` is the one
+exception; see below. `docs/SECURITY_MODEL.md` states the caveat in
+full.
+
 **The guarantee is only as good as the `.decl`.** Column types are not
 enforced: a column declared `symbol` that actually holds integers which
 were never interned digests their `int64` representation instead — the
@@ -266,23 +275,32 @@ return the first 8 UUID bytes as an `int64`, not formatted text.
 Disabled UUID calls follow the same fail-closed behavior described for
 crypto hash functions.
 
-**Operand boundaries are unambiguous.** With a `symbol` operand,
-`uuid5()` length-prefixes each operand before hashing — the length as a
-little-endian `uint64` — so distinct `(namespace, name)` pairs always
-hash distinct bytes:
+**Operands are framed, so the digest input is unambiguous.** With a
+`symbol` operand, `uuid5()` prefixes each operand with a one-byte domain
+tag — `'S'` for a symbol's bytes, `'I'` for an `int64`'s eight
+little-endian bytes — and then its length as a little-endian `uint64`.
+Distinct `(namespace, name)` pairs therefore always hash distinct bytes,
+whether they differ in where they split or in what they are:
 
 ```
-uuid5("ab", "c")  !=  uuid5("a", "bc")
+uuid5("ab", "c")       !=  uuid5("a", "bc")
+uuid5("abcdefgh", "x") !=  uuid5(7523094288207667809, "x")
 ```
 
-A bare concatenation could not promise that: `"ab" + "c"` and
-`"a" + "bc"` are the same three bytes. RFC 4122 sidesteps the question
-by fixing the namespace at 16 bytes, making the split point unambiguous
-by construction; wirelog adopted the two-operand signature without that
-property, so it makes the framing explicit instead. In Python:
+Neither holds for a bare concatenation: `"ab" + "c"` and `"a" + "bc"`
+are the same three bytes, and `7523094288207667809` is exactly the
+`int64` whose little-endian bytes are `abcdefgh`. The length settles the
+first, the tag the second. RFC 4122 sidesteps both by fixing the
+namespace at 16 bytes of one type; wirelog adopted the two-operand
+signature without that property, so it makes the framing explicit
+instead. In Python:
 
 ```python
-buf = pack('<Q', len(ns)) + ns + pack('<Q', len(name)) + name
+frame = lambda tag, b: tag + pack('<Q', len(b)) + b
+
+buf = frame(b'S', ns) + frame(b'S', name)      # uuid5(symbol, symbol)
+# frame(b'I', pack('<q', v)) for an int64 operand
+
 d = bytearray(sha1(buf).digest())
 d[6] = (d[6] & 0x0F) | 0x50
 d[8] = (d[8] & 0x3F) | 0x80
@@ -290,8 +308,15 @@ value = unpack('<q', bytes(d[:8]))[0]
 ```
 
 `uuid5(int64, int64)` keeps the older unframed `SHA-1(ns || name)` — its
-operands are 8 bytes each, so its split point is already fixed and its
-values are unchanged.
+operands are 8 bytes each and both `int64`, so neither ambiguity can
+arise and its values are unchanged.
+
+**Unambiguous input is not a collision-free output.** The framing makes
+the bytes fed to SHA-1 one-to-one with the typed operand pair. It says
+nothing about the return value, which is the first 8 of the 16 digest
+bytes with 4 bits overwritten by the version nibble: at most 2^60
+distinct results exist, so `uuid5()` collides at scale like any 60-bit
+fingerprint. See `docs/SECURITY_MODEL.md`.
 
 **`uuid5()` is still not RFC 4122**, and being unambiguous does not make
 it so. RFC 4122 requires the namespace to *be* a 16-byte UUID and defines

--- a/tests/test_cryptographic_hashes.c
+++ b/tests/test_cryptographic_hashes.c
@@ -1083,19 +1083,49 @@ test_integration_hmac_sha256_datalog_rule(void)
 #define XXH3_OF_HMAC_II    5350477797202862412LL  /* msg 1,    key 1      */
 #define XXH3_OF_HMAC_EMPTY_KEY 5217900878614730541LL /* msg "msg", key "" */
 /*
- * uuid5 over symbols returns the first 8 bytes of the tagged SHA-1 of
- * u64le(len(ns)) || ns || u64le(len(name)) || name, as int64.  In Python:
+ * uuid5 over symbols frames each operand as
  *
- *   buf = pack('<Q', len(ns)) + ns + pack('<Q', len(name)) + name
+ *     tag || u64le(len(operand)) || operand
+ *
+ * where tag is 'S' for a symbol's bytes and 'I' for an int64's eight
+ * little-endian bytes, and returns the first 8 bytes of the version-tagged
+ * SHA-1 of the two frames, as int64.  In Python:
+ *
+ *   frame = lambda t, b: t + pack('<Q', len(b)) + b
+ *   buf = frame(b'S', ns) + frame(b'I', pack('<q', name))   # the _SI case
  *   d = bytearray(sha1(buf).digest())
  *   d[6] = (d[6] & 0x0F) | 0x50; d[8] = (d[8] & 0x3F) | 0x80
  *   unpack('<q', bytes(d[:8]))[0]
+ *
+ * Only the three symbol-bearing opcodes frame.  The int64-only opcode
+ * (0x2A) still hashes a bare u64le(ns) || u64le(name), so uuid5(int, int)
+ * keeps every value it has ever returned.
  */
-#define UUID5_SS_AA_ZZ     (-985806390465751602LL)
-#define UUID5_SI_AA_1      6942838433878392903LL
-#define UUID5_IS_1_ZZ      7085806886377378579LL
-#define UUID5_AB_C         (-5235876162600150845LL)
-#define UUID5_A_BC         2187083094203415983LL
+#define UUID5_SS_AA_ZZ     (-551394562050983893LL)
+#define UUID5_SI_AA_1      (-7614036125174443443LL)
+#define UUID5_IS_1_ZZ      (-5165379894741549620LL)
+#define UUID5_AB_C         (-3651962211908811388LL)
+#define UUID5_A_BC         (-1560628122420165596LL)
+/*
+ * The two operand pairs that the domain tag exists to separate.
+ *
+ *   UUID5_SS_EMPTY  uuid5("", "")   -- two empty symbols
+ *   UUID5_II_ZERO   uuid5(0, 0)     -- the 0x2A opcode, value unchanged
+ *
+ * Without the tag both hash sixteen zero bytes: an empty framed pair was
+ * u64le(0) || "" || u64le(0) || "", which is exactly what two zero int64s
+ * concatenate to.
+ *
+ *   UUID5_SS_8BYTE  uuid5("abcdefgh", "x")
+ *   UUID5_IS_8BYTE  uuid5(7523094288207667809, "x")
+ *
+ * 7523094288207667809 is unpack('<q', b"abcdefgh"), so without the tag the
+ * two hash identical bytes however they are length-prefixed.
+ */
+#define UUID5_SS_EMPTY     (-5593758115287104118LL)
+#define UUID5_II_ZERO      6655197997870229985LL
+#define UUID5_SS_8BYTE     1250797450875576375LL
+#define UUID5_IS_8BYTE     4854796543189122013LL
 
 /* Run @src and require exactly one row whose first column is @want. */
 static void
@@ -1119,6 +1149,26 @@ expect_single_value(const char *name, const char *src, int64_t want)
         FAIL(buf);
     }
     PASS();
+}
+
+/*
+ * Run @src and hand back the single value it produced.  Returns 0 on
+ * success.  Unlike expect_single_value() this asserts nothing about the
+ * value, so callers can compare two evaluator results against each other
+ * rather than comparing two compile-time constants -- which is what makes
+ * an inequality test able to fail when the evaluator changes.
+ */
+static int
+eval_single_value(const char *src, int64_t *out)
+{
+    struct result_ctx ctx;
+
+    if (run_program_full(src, &ctx) != 0 || ctx.snapshot_rc != 0)
+        return -1;
+    if (ctx.count != 1)
+        return -1;
+    *out = ctx.col0[0];
+    return 0;
 }
 
 #define SYM_FACT ".decl s(v: symbol)\ns(\"aa\").\n"
@@ -1200,24 +1250,32 @@ test_two_operand_digests_type_each_operand(void)
 }
 
 /*
- * Distinct (namespace, name) pairs produce distinct values.
+ * Distinct typed (namespace, name) pairs produce distinct digest inputs.
  *
  * Giving uuid5() variable-length operands is what makes this possible to
- * get wrong.  A bare concatenation of "ab" + "c" and of "a" + "bc" is the
+ * get wrong, in two independent ways.
+ *
+ * The split.  A bare concatenation of "ab" + "c" and of "a" + "bc" is the
  * same three bytes, so both calls would hash identical input and return one
  * value -- a collision that could not arise while both operands were
- * fixed-width int64s, and which this change would therefore have created
- * rather than exposed.  RFC 4122 does not have the problem because it fixes
- * the namespace at 16 bytes, making the split point unambiguous by
- * construction; wirelog inherited the two-operand signature without that
- * property, so the symbol opcodes length-prefix each operand instead.
+ * fixed-width int64s.  A length prefix per operand fixes it.
  *
- * Both the inequality and the two values are asserted.  The inequality
+ * The type.  A length prefix says nothing about what an operand *is*, so
+ * the symbol "abcdefgh" and the int64 whose eight little-endian bytes spell
+ * it are still the same framed operand.  A one-byte domain tag per operand
+ * -- 'S' or 'I' -- fixes that, and as a side effect separates uuid5("", "")
+ * from uuid5(0, 0), whose framings were both sixteen zero bytes.
+ *
+ * Both the inequalities and the values are asserted.  The inequalities
  * alone would be satisfied by any construction that merely differs, and
  * pinned values alone would not say what property they encode.
  *
- * Unambiguous is still not RFC 4122: the namespace need not be a UUID and
- * only 8 of the 16 bytes are returned.  Those are separate claims.
+ * Unambiguous is still not injective, and not RFC 4122.  The digest input
+ * is one-to-one with the typed operand pair, but only 8 of the 16 digest
+ * bytes are returned and 4 bits of those are overwritten with the version
+ * nibble, so uuid5() has at most 2^60 outputs and collides at scale like
+ * any 60-bit fingerprint.  Separately, the namespace need not be a UUID.
+ * Those are separate claims from the ones tested here.
  */
 static void
 test_uuid5_distinguishes_operand_boundaries(void)
@@ -1235,11 +1293,128 @@ test_uuid5_distinguishes_operand_boundaries(void)
         "r(uuid5(a, b)) :- q(a, b).\n",
         UUID5_A_BC);
 
-    /* Stated as a property too, so a future change to the pinned values
-     * cannot quietly reintroduce the collision. */
+    /*
+     * Stated as a property too.  Comparing the two #defines would be a
+     * preprocessor comparison that no source change can ever falsify, so
+     * re-evaluate both programs instead.
+     */
     TEST("uuid5 operand boundaries are unambiguous");
-    if (UUID5_AB_C == UUID5_A_BC) {
-        FAIL("the two pinned values are equal: the framing is not working");
+    int64_t ab_c = 0, a_bc = 0;
+    if (eval_single_value(
+            ".decl p(a: symbol, b: symbol)\n"
+            "p(\"ab\", \"c\").\n"
+            ".decl r(z: int64)\n"
+            "r(uuid5(a, b)) :- p(a, b).\n", &ab_c) != 0
+        || eval_single_value(
+            ".decl p(a: symbol, b: symbol)\n"
+            "p(\"a\", \"bc\").\n"
+            ".decl r(z: int64)\n"
+            "r(uuid5(a, b)) :- p(a, b).\n", &a_bc) != 0) {
+        FAIL("evaluation failed");
+    } else if (ab_c == a_bc) {
+        FAIL("uuid5(\"ab\",\"c\") still equals uuid5(\"a\",\"bc\")");
+    } else {
+        PASS();
+    }
+}
+
+/*
+ * The operand's *type* is part of the digest input too (Issue #968).
+ *
+ * These are the two pairs that a length prefix alone cannot separate.  Each
+ * is asserted as a value and then as an inequality, so removing the domain
+ * tag fails the property and not only the pin.
+ *
+ * uuid5(0, 0) goes through the int64-only opcode 0x2A, which is deliberately
+ * left unframed and untagged: it is the one uuid5 encoding that has shipped,
+ * and UUID5_II_ZERO is the value it returned before #968.
+ */
+static void
+test_uuid5_distinguishes_operand_types(void)
+{
+    /* Two empty symbols; framed, they were sixteen zero bytes. */
+    static const char *const src_ss_empty =
+        ".decl p(a: symbol, b: symbol)\n"
+        "p(\"\", \"\").\n"
+        ".decl r(z: int64)\n"
+        "r(uuid5(a, b)) :- p(a, b).\n";
+    /* Two zero int64s, via the unframed 0x2A opcode. */
+    static const char *const src_ii_zero =
+        ".decl n(a: int64, b: int64)\n"
+        "n(0, 0).\n"
+        ".decl r(z: int64)\n"
+        "r(uuid5(a, b)) :- n(a, b).\n";
+    /* An 8-byte symbol namespace... */
+    static const char *const src_ss_8byte =
+        ".decl p(a: symbol, b: symbol)\n"
+        "p(\"abcdefgh\", \"x\").\n"
+        ".decl r(z: int64)\n"
+        "r(uuid5(a, b)) :- p(a, b).\n";
+    /* ...and the int64 whose little-endian bytes are that same "abcdefgh",
+     * i.e. unpack('<q', b"abcdefgh") == 7523094288207667809. */
+    static const char *const src_is_8byte =
+        ".decl k(b: symbol)\n"
+        "k(\"x\").\n"
+        ".decl r(z: int64)\n"
+        "r(uuid5(7523094288207667809, b)) :- k(b).\n";
+
+    /*
+     * The tag comes from what filt_digest_bytes() actually emitted, not
+     * from the operand's declared type -- and that distinction is the
+     * whole fix.  .decl types are not enforced, so a symbol-declared
+     * column can hold a value that names no interned string; the digest
+     * then falls back to the int64 bytes.  Tagging that 'S' because the
+     * column says symbol would put those bytes back in the symbol domain
+     * and restore the very collision this test pins apart.  Without this
+     * case that mutation passes the entire suite.
+     */
+    static const char *const src_mistyped =
+        ".decl S(s: symbol)\n"
+        "S(7523094288207667809).\n"
+        ".decl k(b: symbol)\n"
+        "k(\"x\").\n"
+        ".decl r(z: int64)\n"
+        "r(uuid5(s, b)) :- S(s), k(b).\n";
+
+    expect_single_value("uuid5(\"\",\"\") tags its empty symbol operands",
+        src_ss_empty, UUID5_SS_EMPTY);
+    expect_single_value("uuid5(0,0) keeps the unframed int64 encoding",
+        src_ii_zero, UUID5_II_ZERO);
+    expect_single_value("uuid5(sym, sym) tags an 8-byte symbol namespace",
+        src_ss_8byte, UUID5_SS_8BYTE);
+    expect_single_value("uuid5(int, sym) tags the int64 namespace",
+        src_is_8byte, UUID5_IS_8BYTE);
+    /* The mistyped column: declared symbol, holding a value that names no
+     * interned string.  It must land in the int64 domain, i.e. agree with
+     * the genuine int64 call above rather than the 8-byte symbol one. */
+    expect_single_value("a symbol column holding an un-interned value is "
+        "tagged int64", src_mistyped, UUID5_IS_8BYTE);
+
+    /*
+     * The same two facts as properties.  These re-evaluate rather than
+     * comparing the pinned macros above: a macro-vs-macro assertion is
+     * decided by the preprocessor and cannot fail however the encoding
+     * changes, so it would not catch the domain tag being dropped.
+     */
+    int64_t ss_empty = 0, ii_zero = 0, ss_8byte = 0, is_8byte = 0;
+
+    TEST("uuid5(\"\",\"\") differs from uuid5(0,0)");
+    if (eval_single_value(src_ss_empty, &ss_empty) != 0
+        || eval_single_value(src_ii_zero, &ii_zero) != 0) {
+        FAIL("evaluation failed");
+    }
+    if (ss_empty == ii_zero) {
+        FAIL("empty symbols and zero int64s hash alike: the tag is missing");
+    }
+    PASS();
+
+    TEST("uuid5(\"abcdefgh\",x) differs from uuid5(<same bytes as int64>,x)");
+    if (eval_single_value(src_ss_8byte, &ss_8byte) != 0
+        || eval_single_value(src_is_8byte, &is_8byte) != 0) {
+        FAIL("evaluation failed");
+    }
+    if (ss_8byte == is_8byte) {
+        FAIL("a symbol and the int64 spelling it hash alike: tag is missing");
     }
     PASS();
 }
@@ -1456,6 +1631,7 @@ main(void)
     test_digests_of_symbol_operands();
     test_two_operand_digests_type_each_operand();
     test_uuid5_distinguishes_operand_boundaries();
+    test_uuid5_distinguishes_operand_types();
 
 #else
     printf("=== wirelog Cryptographic Hash Tests (Issue #73) [mbedTLS "

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -95,29 +95,67 @@ wl_columnar_ops_psa_hash_bytes(psa_algorithm_t alg, const void *data,
     return actual_len == digest_len ? 0 : -1;
 }
 
+/*
+ * Domain tags for framed digest operands (Issue #968).  One byte, chosen to
+ * be legible in a hexdump of the digest input.
+ */
+#define WL_DIGEST_TAG_SYMBOL ((uint8_t)'S')
+#define WL_DIGEST_TAG_INT64  ((uint8_t)'I')
+
+/**
+ * Emit one framed operand's header: its domain tag, then its length as a
+ * little-endian uint64.
+ */
+static int
+wl_columnar_ops_psa_hash_frame(psa_hash_operation_t *op, uint8_t tag,
+    size_t len)
+{
+    uint8_t hdr[1 + 8];
+    uint64_t n = (uint64_t)len;
+
+    hdr[0] = tag;
+    for (unsigned i = 0; i < 8; i++)
+        hdr[1 + i] = (uint8_t)(n >> (8 * i));
+    return psa_hash_update(op, hdr, sizeof(hdr)) == PSA_SUCCESS ? 0 : -1;
+}
+
 /**
  * Digest @first followed by @second.  uuid5()'s only caller.
  *
- * When @framed, each operand is preceded by its length as a little-endian
- * uint64, so the pair maps to exactly one byte string and no two distinct
- * (namespace, name) pairs can produce the same digest input.  A bare
- * concatenation cannot promise that once the operands are variable-length:
- * uuid5("ab", "c") and uuid5("a", "bc") would hash identical bytes.
+ * When @framed, each operand is preceded by a one-byte domain tag and its
+ * length as a little-endian uint64, so the encoding is injective over
+ * (type, bytes) pairs: the tag separates a symbol from an int64 whose
+ * little-endian bytes happen to spell it, and the length fixes the split
+ * point.  A bare concatenation promises neither once the operands are
+ * variable-length: uuid5("ab", "c") and uuid5("a", "bc") would hash
+ * identical bytes, and so would uuid5("abcdefgh", x) and uuid5(<the int64
+ * with those bytes>, x).  @first_tag and @second_tag must describe the bytes
+ * actually passed, not the opcode's declared operand types -- see
+ * filt_bytes_t::is_symbol.
+ *
+ * Injective is not collision-free.  uuid5() returns digest[0..7] with a
+ * version nibble forced, so it has at most 2^60 distinct outputs however
+ * unambiguous its input encoding is; see docs/SECURITY_MODEL.md.
  *
  * @framed is false only for WL_PLAN_EXPR_ARITH_UUID5, the int64-only opcode,
- * whose two operands are 8 bytes each.  The split point there is fixed, so
- * the concatenation is already unambiguous and there is nothing to fix --
- * and leaving its bytes alone is what lets an out-of-tree decoder that
- * already implements 0x2A keep computing the same answer.
+ * whose two operands are 8 bytes each.  The split point there is fixed and
+ * both operands are int64s, so there is nothing to disambiguate -- and
+ * leaving its bytes alone is what lets an out-of-tree decoder that already
+ * implements 0x2A keep computing the same answer.  Its input is always
+ * exactly 16 bytes, so the framed encoding must never be 16 bytes: the two
+ * headers alone are 18, which is why uuid5("", "") no longer collides with
+ * uuid5(0, 0) the way a bare 8-byte length prefix left it doing.
  *
  * Reproducible outside wirelog:
  *
- *     buf = pack('<Q', len(ns)) + ns + pack('<Q', len(name)) + name
- *     d   = bytearray(sha1(buf).digest())
+ *     frame = lambda t, b: t + pack('<Q', len(b)) + b
+ *     buf   = frame(b'S', ns) + frame(b'S', name)
+ *     d     = bytearray(sha1(buf).digest())
  */
 static int
 wl_columnar_ops_psa_hash_pair(psa_algorithm_t alg, bool framed,
-    const void *first, size_t first_len, const void *second, size_t second_len,
+    uint8_t first_tag, const void *first, size_t first_len,
+    uint8_t second_tag, const void *second, size_t second_len,
     unsigned char *digest, size_t digest_len)
 {
     psa_hash_operation_t op = PSA_HASH_OPERATION_INIT;
@@ -128,25 +166,15 @@ wl_columnar_ops_psa_hash_pair(psa_algorithm_t alg, bool framed,
         return -1;
     if (psa_hash_setup(&op, alg) != PSA_SUCCESS)
         goto out;
-    if (framed) {
-        uint8_t len_le[8];
-        uint64_t n = (uint64_t)first_len;
-        for (unsigned i = 0; i < 8; i++)
-            len_le[i] = (uint8_t)(n >> (8 * i));
-        if (psa_hash_update(&op, len_le, sizeof(len_le)) != PSA_SUCCESS)
-            goto out;
-    }
+    if (framed
+        && wl_columnar_ops_psa_hash_frame(&op, first_tag, first_len) != 0)
+        goto out;
     if (psa_hash_update(&op, (const unsigned char *)first, first_len)
         != PSA_SUCCESS)
         goto out;
-    if (framed) {
-        uint8_t len_le[8];
-        uint64_t n = (uint64_t)second_len;
-        for (unsigned i = 0; i < 8; i++)
-            len_le[i] = (uint8_t)(n >> (8 * i));
-        if (psa_hash_update(&op, len_le, sizeof(len_le)) != PSA_SUCCESS)
-            goto out;
-    }
+    if (framed
+        && wl_columnar_ops_psa_hash_frame(&op, second_tag, second_len) != 0)
+        goto out;
     if (psa_hash_update(&op, (const unsigned char *)second, second_len)
         != PSA_SUCCESS)
         goto out;
@@ -218,10 +246,19 @@ wl_columnar_ops_psa_hmac_sha256(const void *msg, size_t msg_len,
  *
  * @ptr either aliases the interned string or points into @inl, so the value
  * must outlive its use and must not be copied after being filled.
+ *
+ * @is_symbol reports which of those two happened.  It is not the caller's
+ * @as_symbol: a symbol-typed operand whose reverse lookup fails falls back
+ * to int64 bytes, and @is_symbol is then false.  Framed digests tag the
+ * operand from this field, so that fallback is tagged for the bytes it
+ * really emitted; tagging it from the opcode's declared type instead would
+ * label an int64 a symbol and let it collide with the symbol spelling those
+ * same eight bytes -- the very collision the tag exists to prevent.
  */
 typedef struct {
     const uint8_t *ptr;
     size_t len;
+    bool is_symbol;
     uint8_t inl[sizeof(int64_t)];
 } filt_bytes_t;
 
@@ -257,6 +294,7 @@ filt_digest_bytes(filt_bytes_t *out, int64_t v, bool as_symbol,
         if (str) {
             out->ptr = (const uint8_t *)str;
             out->len = strlen(str);
+            out->is_symbol = true;
             return;
         }
         WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_DEBUG,
@@ -266,6 +304,7 @@ filt_digest_bytes(filt_bytes_t *out, int64_t v, bool as_symbol,
     memcpy(out->inl, &v, sizeof(v));
     out->ptr = out->inl;
     out->len = sizeof(v);
+    out->is_symbol = false;
 }
 
 static inline void
@@ -713,12 +752,19 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         }
 
         /*
-         * uuid5(ns, name) over symbols length-prefixes each operand before
-         * hashing, so distinct (namespace, name) pairs always hash distinct
-         * bytes.  A bare concatenation -- what the int64-only opcode does,
-         * and what it can safely keep doing with two fixed-width operands --
+         * uuid5(ns, name) over symbols prefixes each operand with a one-byte
+         * domain tag and its length before hashing, so distinct typed
+         * (namespace, name) pairs always hash distinct bytes.  A bare
+         * concatenation -- what the int64-only opcode does, and what it can
+         * safely keep doing with two fixed-width operands of one type --
          * would make uuid5("ab", "c") and uuid5("a", "bc") the same value
-         * the moment the operands became variable-length.
+         * the moment the operands became variable-length; a length prefix
+         * without the tag would still equate uuid5("abcdefgh", x) with
+         * uuid5(<the int64 spelling those bytes>, x).
+         *
+         * "Distinct bytes" is a claim about the digest input only.  The
+         * digest is then truncated to 8 bytes with a version nibble forced,
+         * so distinct inputs can still return the same int64.
          */
         case WL_PLAN_EXPR_ARITH_UUID5:
         case WL_PLAN_EXPR_ARITH_UUID5_SS:
@@ -736,7 +782,10 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
             filt_digest_bytes(&nsb, ns, ns_sym, intern);
             filt_digest_bytes(&nmb, name, name_sym, intern);
             if (wl_columnar_ops_psa_hash_pair(PSA_ALG_SHA_1,
-                tag != WL_PLAN_EXPR_ARITH_UUID5, nsb.ptr, nsb.len,
+                tag != WL_PLAN_EXPR_ARITH_UUID5,
+                nsb.is_symbol ? WL_DIGEST_TAG_SYMBOL : WL_DIGEST_TAG_INT64,
+                nsb.ptr, nsb.len,
+                nmb.is_symbol ? WL_DIGEST_TAG_SYMBOL : WL_DIGEST_TAG_INT64,
                 nmb.ptr, nmb.len, digest, sizeof(digest)) != 0)
                 goto bad;
             /* RFC 4122 v5: set version=5, variant=0b10 */

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -188,12 +188,21 @@ typedef enum {
      * so each gets three opcodes; the II case keeps the existing opcode.
      * _SS = both symbols, _SI = first symbol, _IS = second symbol.
      *
-     * The UUID5_* opcodes additionally length-prefix each operand (its
-     * length as a little-endian uint64) before hashing, which the 0x2A
-     * opcode does not.  Without it two variable-length operands could be
-     * split at more than one point -- uuid5("ab", "c") and uuid5("a", "bc")
-     * would hash the same bytes.  0x2A's operands are 8 bytes each, so its
-     * split point is fixed and its bytes are unchanged.
+     * The UUID5_* opcodes additionally frame each operand -- a one-byte
+     * domain tag ('S' for a symbol's bytes, 'I' for an int64's) followed by
+     * its length as a little-endian uint64 -- which the 0x2A opcode does
+     * not.  Without the length, two variable-length operands could be split
+     * at more than one point: uuid5("ab", "c") and uuid5("a", "bc") would
+     * hash the same bytes.  Without the tag, an operand's type would not be
+     * recoverable either: uuid5("abcdefgh", x) and uuid5(<the int64 whose
+     * little-endian bytes are "abcdefgh">, x) would hash the same bytes.
+     * 0x2A's two operands are 8 bytes each and both int64, so neither
+     * ambiguity exists there and its bytes are unchanged.
+     *
+     * The framing makes the digest *input* injective over typed operand
+     * pairs.  It does not make uuid5() injective: the return is the first 8
+     * bytes of the digest with a version nibble forced, so at most 2^60
+     * distinct values exist regardless.  See docs/SECURITY_MODEL.md.
      */
     WL_PLAN_EXPR_ARITH_HASH_S        = 0x60, /* unary:  pop 1 push 1 */
     WL_PLAN_EXPR_ARITH_CRC32_ETH_S   = 0x61,


### PR DESCRIPTION
Closes #968.

## Two collisions, both measured

#963 length-prefixed `uuid5()`'s operands so the split between namespace and name was unambiguous. Two collisions survived:

```
uuid5("", "")            ==  uuid5(0, 0)              ==  6655197997870229985
uuid5("abcdefgh", "x")   ==  uuid5(7523094288207667809, "x")
```

The first: framed, two empty symbols are `LE64(0)||""||LE64(0)||""` — sixteen zero bytes — and the unframed int64 opcode with `(0,0)` emits the same sixteen. Exactly one input pair (framed length is `16+|ns|+|name|`, and the mixed opcodes always frame an 8-byte integer), but reachable from ordinary Datalog. **#963 created it**: before that `uuid5()` had no symbol operands, so the two constructions could not meet.

The second: length prefixes disambiguate the *split*, not the *type*. A symbol whose bytes are an int64's little-endian representation is indistinguishable from that integer.

## The fix

Each framed operand becomes `tag || LE64(len) || bytes`, `'S'` for a symbol's bytes and `'I'` for an int64's. Both collisions go.

**The tag comes from what `filt_digest_bytes()` actually emitted, not from the declared type.** `.decl` types are not enforced, so a `symbol`-declared column can hold a value naming no interned string, and the digest falls back to int64 bytes. Tagging that `'S'` because the declaration says symbol would restore the second collision through the fallback path.

That is the riskiest line in the change and it is pinned by a test. Review demonstrated why: the mutation reading the declared type instead **passes the entire suite** — 50/50 `cryptographic_hashes`, 11/11 `symbol_digests` — while silently reintroducing the collision. With the new case it fails, and only it.

## What was rejected, and why

**Framing `0x2A` in place.** Its unframed sixteen bytes are currently `uuid5()`'s *only* domain separation. Framing would pull int/int into the second collision's family — trading one degenerate pair for every 8-byte symbol pair. Verified: `uuid5("abcdefgh","abcdefgh")` and the matching int64 pair are distinct today and would not have been.

**Adding a framed `UUID5_II` opcode.** Unnecessary, and this is the finding that changed the plan: **#963 is unreleased.** `CHANGELOG.md` has it under `[Unreleased]`; the last release is `0.53.0`. So `0x6A`–`0x6C` and their framing have never shipped and are free to change. Only `0x2A` carries a stability obligation — and it keeps it, byte-identical, verified across 26 int/int pairs including the boundary values.

The five pinned constants this moves were all introduced by #963 and are likewise unreleased.

## Two claims in the tree were false

Corrected rather than carried forward:

- that no two distinct `(namespace, name)` pairs can produce the same digest input — true over byte strings, false over typed pairs;
- that `uuid5(int64,int64)` "keeps the older unframed" construction as a deliberate second encoding.

`docs/SECURITY_MODEL.md` gains **domain non-separation as its own caveat** for the unary digests and both `hmac_sha256` operands, deliberately kept separate from the existing birthday-bound one: that is about collisions at scale, this is constructible at zero cost. `uuid5()` is excluded now that it is fixed. The 2^60 output bound is stated alongside so "unambiguous input" cannot be read as "collision-free output".

`hash()`/`sha256()` and friends keep the collision — they are bound by #963's byte-transparency contract (`printf '%s' abcdefgh | xxhsum -H3` must reproduce `hash(...)`), so for them it is documented behaviour, not a defect. `uuid5()` has no external-tool contract and is separable.

## Validation

Every pinned value was derived from an independent model **before** the code changed, with the model validated by reproducing all five pre-change pins exactly. Review re-derived all nine independently and confirmed them.

Mutation-tested: dropping the tag fails ten cases and reproduces the old values byte-for-byte; tagging from the declared type fails exactly the mistyped-column case.

Full suite in **both** mbedTLS configurations: 261 Ok / 1 Fail / 11 Skipped, matching baseline (the Fail is the known-environmental `sbom_snapshot`). Tests went into the existing `cryptographic_hashes` binary — CI's mbedTLS job runs a literal named list, so a new executable would compile there and never run. Review also built ASan+UBSan with mbedTLS **enabled**, which no existing sanitizer build dir does, and found it clean.

RFC 4122 conformance is #971 — blocked by namespace semantics, not by the `int64` width.
