### PR TITLE
fix(columnar): min/max over symbols reduce lexicographically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,37 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **`min()`/`max()` over a symbol column compare strings, not intern ids**
+  (#965): both reduced over the raw `int64`, which for a `symbol` column is
+  its interned id. Ids are handed out in first-appearance order, so
+  prepending one unrelated fact that claimed the lower ids flipped
+  `min(v)` from `"zz"` to `"aa"` with no change to the data being reduced.
+  #962 fixed this class for `<`/`>`/`<=`/`>=`; this is the aggregate half,
+  and it applies to both reducers -- `col_op_reduce()` and the
+  recursive-aggregate canonicalisation, which flipped independently at
+  every worker count.
+
+  The plan's REDUCE operator now carries the operand's value domain,
+  derived at lowering time from `expr_result_type()` -- a bare column
+  lookup would not do, since `min(to_upper(v))` reduces a runtime-interned
+  id belonging to no column. An internal opcode in the manner of #962's
+  `WL_PLAN_EXPR_CMP_STR_*` was the other candidate and would have been
+  equally non-public; it was rejected because `col_op_reduce()` already
+  dispatches on `op->agg_fn`, so an opcode would be a second source of
+  truth for the same decision rather than a refinement of it.
+
+  Following #963, a column declared `symbol` whose values were never
+  interned is reported rather than failed closed: it still reduces
+  numerically, which is the right answer for numeric data, and erroring
+  out would turn programs that work today into no output at all. Where a
+  group mixes interned and un-interned values the interned ones win, for
+  `min` and `max` alike.  That rule is a correctness choice, not a
+  termination one: the intern table grows *during* evaluation, so
+  "reversible" is a property of the value and the table, not of the value
+  alone.  Termination holds either way -- the table only grows, so between
+  two of its sizes the comparator is a fixed total order and each group's
+  stored value strictly improves.
+
 - **`uuid5()` framing carries the operand's type, not only its length**
   (#968): #963 length-prefixed each operand of the three symbol-bearing
   `uuid5` opcodes, which fixed the split point but not the *domain*. Two

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -74,14 +74,22 @@ Two patterns are supported:
   not stable across runs of the same program.
 
   Because ids are unstable, nothing observable may be derived from their
-  order. The ordering operators (`<`, `>`, `<=`, `>=`) therefore compare
-  `string`/`symbol` columns **lexicographically**, not by id — see
-  `docs/SYNTAX.md`, "Comparison Operators". Id order still leaks through
-  in three places. A column with no declared type: the engine has nothing
-  to compare but the ids, so the result is as unstable as they are --
-  declare the relation. A comparison with one string and one numeric
-  operand: it stays an integer comparison, described in `docs/SYNTAX.md`.
-  And `min()`/`max()` over symbol columns, which still reduce by id.
+  order. The ordering operators (`<`, `>`, `<=`, `>=`) and the ordering
+  aggregates `min()`/`max()` therefore compare `string`/`symbol` columns
+  **lexicographically**, not by id — see `docs/SYNTAX.md`, "Comparison
+  Operators". Id order still leaks through in two places. A column with no
+  declared type: the engine has nothing to compare but the ids, so the
+  result is as unstable as they are -- declare the relation. And a
+  comparison with one string and one numeric operand: it stays an integer
+  comparison, described in `docs/SYNTAX.md`.
+
+  A column declared `symbol` whose values were never interned is the
+  aggregate's version of the same caveat as the digests below: `min()` and
+  `max()` reduce it numerically -- the numeric answer for numeric data --
+  rather than failing the query, and report the mistype under `WL_LOG=EVAL`.
+  Where a group mixes interned and un-interned values, the interned ones
+  win, in both directions, so the comparison does not depend on how many
+  strings happen to have been interned when the row is visited.
 
   `hash()` and the digest family — `crc32_*`, `md5`, `sha*`,
   `hmac_sha256`, `uuid5` — take the **string's bytes** for a column

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -343,6 +343,19 @@ sorts event names alphabetically when `Event` is declared
 `=` and `!=` are type-independent: symbols are interned canonically — one
 id per distinct string — so id equality already is string equality.
 
+The ordering **aggregates** `min()` and `max()` follow the same rule from
+the same declared types, so `min(Name)` over a `symbol` column is the
+alphabetically smallest name and not whichever was interned first.
+
+Two of the paragraphs below read differently for aggregates. The
+mixed-operand rule does not apply at all -- an aggregate compares values
+drawn from one column, not two operands of different types. Where such a
+column holds both interned and un-interned values, the interned ones win,
+for `min` and `max` alike; that is the opposite of the ordering
+comparisons, which fall back to comparing ids. And the undeclared-column
+report is emitted once per aggregate at plan generation rather than per
+comparison, so `WL_LOG=EVAL:2` names the aggregate, not each row.
+
 **Undeclared columns compare by intern id.** Symbols are stored as
 interned integer ids, and ids are assigned in the order strings are first
 encountered. When a column has no declared type — the relation has no

--- a/examples/06-timestamp-lww/README.md
+++ b/examples/06-timestamp-lww/README.md
@@ -162,15 +162,8 @@ most common choice for simplicity.
 ## Next Steps
 
 - Extend with a `tiebreak(Id, Val)` rule using `min(Val)` to resolve ties
-  deterministically
-
-  > **Warning:** this is not deterministic today if `Val` is a `string` or
-  > `symbol` column. `min()`/`max()` reduce over the interned integer id of
-  > a symbol, and ids are assigned in the order strings are first
-  > encountered, so `min(Val)` picks whichever value happened to be interned
-  > first — which changes when unrelated facts are added. Lexicographic
-  > `min`/`max` over symbols is not yet implemented; ordering comparisons
-  > (`<`, `>`, `<=`, `>=`) already are (Issue #962). Until then, tiebreak on
-  > a numeric column, or compare with `<` in a rule instead of reducing.
+  deterministically. `min()`/`max()` over a `string` or `symbol` column
+  compare the strings, not their interned ids, so the winner does not
+  change when unrelated facts are added (Issue #965)
 - Add a `stale(Id, Val, Ts)` output to capture discarded versions for auditing
 - Combine with `02-graph-reachability` to propagate LWW state across a network

--- a/examples/06-timestamp-lww/meson.build
+++ b/examples/06-timestamp-lww/meson.build
@@ -1,0 +1,42 @@
+# examples/06-timestamp-lww/meson.build
+# Golden-output regression test for the last-write-wins example (#965)
+#
+# The example addresses its CSVs with repository-root-relative paths, so the
+# runner copies it into a temporary tree, runs the CLI there, and diffs the
+# produced files against the committed ones.  Nothing under the source tree
+# is written, so a regression cannot update its own golden.
+#
+# lww_resolution.dl declares update(id: symbol, ts: int64, value: string) and
+# reduces `max(Ts)` over it: the one in-tree fixture where an aggregate's
+# operand is an integer column sitting between two symbol ones, so an
+# off-by-one in operand-type inference lands on it.  latest_out.csv then
+# exercises the join back to the full record, where a wrong winner shows up
+# as the wrong `value`.
+#
+# What this catches is the aggregate answer end to end through the CLI, not
+# operand typing as such: these timestamps are far past the end of the
+# intern table, so a `max(Ts)` mistyped as a string still falls back to the
+# numeric comparison and still answers correctly.  The discriminating case
+# needs values small enough to name real intern ids and lives in
+# tests/test_symbol_aggregates.c (test_integer_aggregates_unchanged).
+
+py3 = find_program('python3', 'python', required: true)
+
+test(
+  'example_06_timestamp_lww_golden',
+  py3,
+  args: [
+    meson.project_source_root() / 'examples' / 'golden_example_diff.py',
+    '--cli', wirelog_cli.full_path(),
+    '--root', meson.project_source_root(),
+    '--dir', 'examples/06-timestamp-lww',
+    '--program', 'lww_resolution.dl',
+    '--golden', 'latest_ts_out.csv',
+    '--golden', 'latest_out.csv',
+    # The check the example's README documents: the winning timestamps are
+    # the committed expected_latest.csv.
+    '--same', 'latest_ts_out.csv:expected_latest.csv',
+  ],
+  depends: wirelog_cli,
+  suite: 'examples',
+)

--- a/examples/07-multi-source-analysis/README.md
+++ b/examples/07-multi-source-analysis/README.md
@@ -181,17 +181,10 @@ efficient for streaming MDM pipelines where new records arrive continuously.
 ## Next Steps
 
 - Add a `tiebreak` rule using `min(Name)` to resolve conflicts deterministically
-  without human intervention
-
-  > **Warning:** this is not deterministic today. `Name` is a `string`
-  > column, and `min()`/`max()` reduce over its interned integer id, not
-  > the string. Ids are assigned in the order strings are first encountered,
-  > so `min(Name)` picks whichever name happened to be interned first — which
-  > changes when unrelated facts are added. Lexicographic `min`/`max` over
-  > symbols is not yet implemented; ordering comparisons (`<`, `>`, `<=`,
-  > `>=`) already are (Issue #962). Until then, tiebreak on a numeric column
-  > such as an update timestamp, or compare with `<` in a rule instead of
-  > reducing.
+  without human intervention. `Name` is a `string` column, and `min()`/`max()`
+  compare the strings themselves rather than their interned ids, so the name
+  chosen is the lexicographically smallest one and does not change when
+  unrelated facts are added (Issue #965)
 - Extend with a third source `src_c` and a priority chain (A > B > C)
 - Combine with `06-timestamp-lww` to use update timestamps as tiebreakers
 - Add a `merged(id, name_a, name_b, country_a, country_b)` relation to expose

--- a/meson.build
+++ b/meson.build
@@ -497,10 +497,11 @@ endif
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
 if not mobile_cross
-  # 04 and 05 are golden-diff tests over wirelog_cli rather than their own
-  # executables; they run the committed .dl programs in a temporary tree.
+  # 04, 05 and 06 are golden-diff tests over wirelog_cli rather than their
+  # own executables; they run the committed .dl programs in a temporary tree.
   subdir('examples/04-hash-functions')
   subdir('examples/05-crc32-checksum')
+  subdir('examples/06-timestamp-lww')
   subdir('examples/08-delta-queries')
   subdir('examples/09-retraction-basics')
   subdir('examples/10-recursive-under-update')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1138,6 +1138,30 @@ test_symbol_digests_exe = executable(
 
 test('symbol_digests', test_symbol_digests_exe)
 
+# Issue #965: min()/max() over a symbol column reduced by intern id rather
+# than lexicographically, so prepending one unrelated fact flipped the
+# answer.  Every case is framed as intern-order independence.
+test_symbol_aggregates_exe = executable(
+  'test_symbol_aggregates',
+  files('test_symbol_aggregates.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+# The mistyped-column case is recursive on purpose: a comparator whose
+# verdicts depend on an intern table that grows during evaluation has no
+# termination argument, so that failure mode is a hang, not a wrong answer.
+# The whole binary runs in well under a second; the timeout bounds the hang.
+test('symbol_aggregates', test_symbol_aggregates_exe, timeout: 60)
+
 test('option2_doop', test_option2_doop_exe,
   env: ['DOOP_DATA_DIR=' + meson.project_source_root() / 'bench/data/doop'],
 )

--- a/tests/test_symbol_aggregates.c
+++ b/tests/test_symbol_aggregates.c
@@ -1,0 +1,815 @@
+/*
+ * tests/test_symbol_aggregates.c - min()/max() over symbol columns (#965)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * `min()` and `max()` reduced over the *interned id* of a `symbol` column
+ * rather than over the string the id stands for.  Ids are handed out in
+ * first-appearance order, so
+ *
+ *     .decl S(g: symbol, v: symbol)
+ *     S("g", "zz").  S("g", "aa").
+ *     T(g, min(v)) :- S(g, v).
+ *
+ * answered "zz" -- interned first, therefore the smaller id -- and adding
+ * one unrelated fact ahead of it that claimed the lower ids flipped the
+ * answer to "aa" without touching the data being reduced.  #962 fixed the
+ * same class for `<`/`>`/`<=`/`>=`; this is the aggregate half.
+ *
+ * Every case here is framed as *intern-order independence*: the same rule
+ * over the same facts, run once alone and once behind an unrelated relation
+ * whose facts are parsed first, must give the same answer -- and the exact
+ * tuples are asserted in both directions.  Cardinality cannot see this
+ * defect: both orderings return one row per group.
+ *
+ * Each case is also a *single* aggregate program.  A head carrying two
+ * aggregates keeps only the last one, so `T(g, min(v), max(v))` would
+ * validate the max half and quietly green-light the min half.
+ *
+ * Case map:
+ *
+ *   test_min_lexicographic / test_max_lexicographic
+ *       The defect report, non-recursive, both directions.  min must not
+ *       return "zz" and max must not return "aa".
+ *
+ *   test_recursive_min_workers / test_recursive_max_workers
+ *       The same property through the recursive fixpoint, at W = 1, 4, 8
+ *       and 16.  A second reducer -- the recursive-aggregate
+ *       canonicalisation in columnar/eval.c -- runs only on this path and
+ *       flipped independently of col_op_reduce().
+ *
+ *   test_join_chain_aggregate
+ *       A body of three atoms joined on one key -- the shortest that
+ *       detect_lftj_chain() accepts -- is rewritten into a single LFTJ
+ *       operator, and every surviving op -- the REDUCE among them -- is
+ *       rebuilt by clone_plan_op().  An operand type that is populated at
+ *       translation but not carried across by the clone is lost exactly
+ *       here, which is why each case has a single-atom control beside it.
+ *
+ *   test_min_of_to_upper
+ *       min(to_upper(v)).  The operand is a runtime-interned id belonging
+ *       to no column, which is why the type has to come from
+ *       expr_result_type() and not from a column lookup.
+ *
+ *   test_integer_aggregates_unchanged
+ *       Integer columns must keep the numeric comparison, negatives
+ *       included.  This is the failure mode where the string path is
+ *       applied unconditionally.
+ *
+ *   test_mistyped_symbol_column_recursive
+ *       A relation declared `symbol` whose values were never interned --
+ *       accepted by the parser, and today it evaluates fine.  Following
+ *       #963 this is not failed closed: reducing it still gives the numeric
+ *       answer for numeric data, and the mistype is reported at plan
+ *       generation.  It is recursive because that is where a comparator
+ *       parameterised by the (growing) intern table would lose its
+ *       termination argument.
+ *
+ *   test_mixed_interned_and_uninterned_group
+ *       A group holding both an interned symbol and a value past the end of
+ *       the intern table.  The interned one wins for min() and for max()
+ *       alike, which is the step that keeps the comparator monotone while
+ *       the intern table grows underneath it.
+ *
+ *   test_undeclared_relation
+ *       An undeclared relation has no column types at all, so min() has
+ *       nothing to compare but ids.  Documented in docs/SEMANTICS.md; the
+ *       requirement here is only that such a program keeps working.
+ *
+ *   test_inline_compound_relation
+ *       A `symbol` column positioned after an inline compound, which
+ *       occupies several physical columns behind one logical one.  If the
+ *       type is lost there the aggregate silently returns to ids.
+ *
+ *   test_count_sum_average_unchanged
+ *       count()/sum()/average() over a symbol column are not ordering
+ *       aggregates and must not acquire the string comparison.
+ */
+
+#include "../wirelog/backend.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/intern.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int test_count;
+static int pass_count;
+static int fail_count;
+
+#define TEST(name)                                      \
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
+
+#define PASS()            \
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                    \
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
+
+#define ASSERT(cond, msg) \
+        do {                  \
+            if (!(cond))      \
+            FAIL(msg);    \
+        } while (0)
+
+#define MAX_SEEN 32
+#define MAX_COLS 8
+
+typedef struct {
+    const char *rel;
+    uint32_t count;
+    uint32_t ncols;
+    const wirelog_intern_t *intern;
+    /* Rows rendered for assertion, columns joined with '|'.  A value that
+     * names an interned string renders as that string, anything else as
+     * decimal -- which is also how a mistyped column renders. */
+    char seen[MAX_SEEN][256];
+    int64_t raw[MAX_SEEN][MAX_COLS];
+} collect_t;
+
+/* Rows the caller wants inserted directly (physical layout), used by the
+ * compound case whose facts cannot be written in source syntax. */
+typedef struct {
+    const char *relation;
+    const int64_t *rows;
+    uint32_t num_rows;
+    uint32_t ncols;
+} insert_spec_t;
+
+static void
+collect_cb(const char *relation, const int64_t *row, uint32_t ncols, void *user)
+{
+    collect_t *c = (collect_t *)user;
+    if (!c->rel || !relation || strcmp(relation, c->rel) != 0)
+        return;
+    if (c->count < MAX_SEEN) {
+        char *dst = c->seen[c->count];
+        size_t pos = 0;
+        dst[0] = '\0';
+        c->ncols = ncols;
+        for (uint32_t i = 0; i < ncols && pos + 1 < sizeof(c->seen[0]); i++) {
+            if (i < MAX_COLS)
+                c->raw[c->count][i] = row[i];
+            const char *v = c->intern
+                ? wl_intern_reverse(c->intern, row[i]) : NULL;
+            int n;
+            if (v)
+                n = snprintf(dst + pos, sizeof(c->seen[0]) - pos, "%s%s",
+                        i ? "|" : "", v);
+            else
+                n = snprintf(dst + pos, sizeof(c->seen[0]) - pos,
+                        "%s%" PRId64, i ? "|" : "", row[i]);
+            if (n < 0)
+                break;
+            pos += (size_t)n;
+        }
+    }
+    c->count++;
+}
+
+/* True if any collected row renders as @want. */
+static bool
+saw(const collect_t *c, const char *want)
+{
+    uint32_t n = c->count < MAX_SEEN ? c->count : MAX_SEEN;
+    for (uint32_t i = 0; i < n; i++) {
+        if (strcmp(c->seen[i], want) == 0)
+            return true;
+    }
+    return false;
+}
+
+/* True if any collected row holds @want in column @col. */
+static bool
+saw_value_at(const collect_t *c, uint32_t col, int64_t want)
+{
+    uint32_t n = c->count < MAX_SEEN ? c->count : MAX_SEEN;
+    for (uint32_t i = 0; i < n; i++) {
+        if (col < c->ncols && col < MAX_COLS && c->raw[i][col] == want)
+            return true;
+    }
+    return false;
+}
+
+/*
+ * Evaluate @src with @workers workers, filling @out with @relation's tuples.
+ *
+ * @prepare may be NULL.  When present it runs after parsing -- so the intern
+ * table already holds the source facts' symbols -- and describes rows to
+ * insert directly, which is how the compound case supplies facts that have
+ * no source syntax.  Returns 0 on success.
+ */
+static int
+eval_relation_ex(const char *src, const char *relation, uint32_t workers,
+    collect_t *out,
+    int (*prepare)(const wirelog_program_t *prog, insert_spec_t *ins))
+{
+    memset(out, 0, sizeof(*out));
+    out->rel = relation;
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        fprintf(stderr, "  parse error: %d\n", (int)err);
+        return -1;
+    }
+
+    insert_spec_t ins;
+    memset(&ins, 0, sizeof(ins));
+    if (prepare && prepare(prog, &ins) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_session_t *sess = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, workers, &sess) != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    out->intern = wirelog_program_get_intern(prog);
+
+    int result = -1;
+    if (wl_session_load_facts(sess, prog) == 0
+        && (ins.relation == NULL
+        || wl_session_insert(sess, ins.relation, ins.rows, ins.num_rows,
+        ins.ncols) == 0)
+        && wl_session_snapshot(sess, collect_cb, out) == 0)
+        result = 0;
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return result;
+}
+
+static int
+eval_relation(const char *src, const char *relation, collect_t *out)
+{
+    return eval_relation_ex(src, relation, 1, out, NULL);
+}
+
+/*
+ * "zz" is written first and therefore holds the smaller id, while "aa"
+ * sorts first as a string: the two orderings disagree on every case below.
+ *
+ * SHIFT is an unrelated relation whose facts are parsed first and claim the
+ * low ids, reversing the id order of "aa" against "zz".  Prepending it must
+ * change nothing.
+ */
+#define SHIFT                          \
+        ".decl Unrelated(x: symbol)\n" \
+        "Unrelated(\"aa\"). Unrelated(\"mm\"). Unrelated(\"zz\").\n"
+
+#define S_FACTS                          \
+        ".decl S(g: symbol, v: symbol)\n" \
+        "S(\"g\", \"zz\"). S(\"g\", \"mm\"). S(\"g\", \"aa\").\n"
+
+#define T_DECL ".decl T(g: symbol, m: symbol)\n"
+
+/* The worker counts test_recursive_agg_conformance.c already pins. */
+static const uint32_t k_worker_counts[] = { 1, 4, 8, 16 };
+#define N_WORKER_COUNTS \
+        (sizeof(k_worker_counts) / sizeof(k_worker_counts[0]))
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_min_lexicographic(void)
+{
+    TEST("min() over a symbol column is lexicographic, not by intern id");
+
+    static const char *cases[] = {
+        S_FACTS T_DECL "T(g, min(v)) :- S(g, v).\n",
+        SHIFT S_FACTS T_DECL "T(g, min(v)) :- S(g, v).\n",
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        collect_t c;
+        ASSERT(eval_relation(cases[i], "T", &c) == 0, "evaluation failed");
+        ASSERT(c.count == 1, "expected exactly one group");
+        ASSERT(saw(&c, "g|aa"), "min must be \"aa\"");
+        ASSERT(!saw(&c, "g|zz"),
+            "returned the value the intern-id ordering selects");
+    }
+    PASS();
+}
+
+static void
+test_max_lexicographic(void)
+{
+    TEST("max() over a symbol column is lexicographic, not by intern id");
+
+    static const char *cases[] = {
+        S_FACTS T_DECL "T(g, max(v)) :- S(g, v).\n",
+        SHIFT S_FACTS T_DECL "T(g, max(v)) :- S(g, v).\n",
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        collect_t c;
+        ASSERT(eval_relation(cases[i], "T", &c) == 0, "evaluation failed");
+        ASSERT(c.count == 1, "expected exactly one group");
+        ASSERT(saw(&c, "g|zz"), "max must be \"zz\"");
+        ASSERT(!saw(&c, "g|aa"),
+            "returned the value the intern-id ordering selects");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * Connected-component labelling over symbols.  {"zz","aa","mm"} form one
+ * component and {"pp","bb"} another, so the answer is the lexicographic
+ * minimum (or maximum) of each component -- propagated through the
+ * recursive rule, which is what makes the eval.c canonicalisation run.
+ */
+#define CC_EDGES                                     \
+        ".decl E(x: symbol, y: symbol)\n"            \
+        ".decl L(x: symbol, l: symbol)\n"            \
+        "E(\"zz\",\"aa\"). E(\"aa\",\"zz\"). E(\"aa\",\"mm\").\n" \
+        "E(\"mm\",\"aa\"). E(\"pp\",\"bb\"). E(\"bb\",\"pp\").\n"
+
+#define CC_RULES(fn)                        \
+        "L(x, " fn "(x)) :- E(x, y).\n"     \
+        "L(y, " fn "(y)) :- E(x, y).\n"     \
+        "L(x, " fn "(l)) :- L(y, l), E(y, x).\n"
+
+static void
+test_recursive_min_workers(void)
+{
+    TEST("recursive min() over symbols, W = 1/4/8/16");
+
+    static const char *cases[] = {
+        CC_EDGES CC_RULES("min"),
+        SHIFT CC_EDGES CC_RULES("min"),
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+            collect_t c;
+            ASSERT(eval_relation_ex(cases[i], "L", k_worker_counts[w], &c,
+                NULL) == 0, "evaluation failed");
+            ASSERT(c.count == 5, "expected one label per node");
+            ASSERT(saw(&c, "zz|aa") && saw(&c, "aa|aa") && saw(&c, "mm|aa"),
+                "component {zz,aa,mm} must label as \"aa\"");
+            ASSERT(saw(&c, "pp|bb") && saw(&c, "bb|bb"),
+                "component {pp,bb} must label as \"bb\"");
+        }
+    }
+    PASS();
+}
+
+static void
+test_recursive_max_workers(void)
+{
+    TEST("recursive max() over symbols, W = 1/4/8/16");
+
+    static const char *cases[] = {
+        CC_EDGES CC_RULES("max"),
+        SHIFT CC_EDGES CC_RULES("max"),
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+            collect_t c;
+            ASSERT(eval_relation_ex(cases[i], "L", k_worker_counts[w], &c,
+                NULL) == 0, "evaluation failed");
+            ASSERT(c.count == 5, "expected one label per node");
+            ASSERT(saw(&c, "zz|zz") && saw(&c, "aa|zz") && saw(&c, "mm|zz"),
+                "component {zz,aa,mm} must label as \"zz\"");
+            ASSERT(saw(&c, "pp|pp") && saw(&c, "bb|pp"),
+                "component {pp,bb} must label as \"pp\"");
+        }
+    }
+    PASS();
+}
+
+/*
+ * A body of four atoms joined on one key is rewritten into a single LFTJ
+ * operator, and every op that is *not* folded into it -- the REDUCE
+ * included -- is rebuilt by clone_plan_op().  An operand type that is
+ * populated at translation but not carried across by the clone is lost
+ * here and nowhere else: the same aggregate over `A` alone, below, is the
+ * control that keeps working when the clone drops it.
+ */
+#define CHAIN_FACTS                              \
+        ".decl A(k: symbol, v: symbol)\n"        \
+        ".decl B(k: symbol)\n"                   \
+        ".decl C(k: symbol)\n"                   \
+        "A(\"g\", \"zz\"). A(\"g\", \"mm\"). A(\"g\", \"aa\").\n" \
+        "B(\"g\"). C(\"g\").\n"                  \
+        ".decl T(k: symbol, m: symbol)\n"
+
+static void
+test_join_chain_aggregate(void)
+{
+    TEST("min()/max() survive the join-chain rewrite (clone_plan_op)");
+
+    static const struct {
+        const char *src;
+        const char *want;
+        const char *reject;
+    } cases[] = {
+        { CHAIN_FACTS "T(k, min(v)) :- A(k, v), B(k), C(k).\n",
+          "g|aa", "g|zz" },
+        { SHIFT CHAIN_FACTS "T(k, min(v)) :- A(k, v), B(k), C(k).\n",
+          "g|aa", "g|zz" },
+        { CHAIN_FACTS "T(k, max(v)) :- A(k, v), B(k), C(k).\n",
+          "g|zz", "g|aa" },
+        { SHIFT CHAIN_FACTS "T(k, max(v)) :- A(k, v), B(k), C(k).\n",
+          "g|zz", "g|aa" },
+        /*
+         * Controls: the single-atom bodies are not rewritten, so these
+         * still answer correctly even when the clone loses the type.
+         */
+        { CHAIN_FACTS "T(k, min(v)) :- A(k, v).\n", "g|aa", "g|zz" },
+        { CHAIN_FACTS "T(k, max(v)) :- A(k, v).\n", "g|zz", "g|aa" },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        collect_t c;
+        ASSERT(eval_relation(cases[i].src, "T", &c) == 0,
+            "evaluation failed");
+        ASSERT(c.count == 1, "expected exactly one group");
+        ASSERT(saw(&c, cases[i].want), "wrong aggregate value");
+        ASSERT(!saw(&c, cases[i].reject),
+            "returned the value the intern-id ordering selects");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_min_of_to_upper(void)
+{
+    TEST("min(to_upper(v)) orders the produced strings, not their ids");
+
+    /* to_upper() interns its result *during* evaluation, so the operand is
+     * an id that belongs to no column and whose value depends on the order
+     * rows happen to be visited.  "AA" < "MM" < "ZZ" either way. */
+    static const char *cases[] = {
+        S_FACTS T_DECL "T(g, min(to_upper(v))) :- S(g, v).\n",
+        SHIFT S_FACTS T_DECL "T(g, min(to_upper(v))) :- S(g, v).\n",
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        collect_t c;
+        ASSERT(eval_relation(cases[i], "T", &c) == 0, "evaluation failed");
+        ASSERT(c.count == 1, "expected exactly one group");
+        ASSERT(saw(&c, "g|AA"), "min(to_upper(v)) must be \"AA\"");
+    }
+
+    /* And the other direction, so a comparator that rejects everything or
+     * always keeps the first row cannot pass. */
+    collect_t c;
+    ASSERT(eval_relation(S_FACTS T_DECL
+        "T(g, max(to_upper(v))) :- S(g, v).\n", "T", &c) == 0,
+        "evaluation failed");
+    ASSERT(c.count == 1 && saw(&c, "g|ZZ"),
+        "max(to_upper(v)) must be \"ZZ\"");
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+#define N_FACTS                          \
+        ".decl N(g: int32, v: int64)\n"  \
+        "N(1, 5). N(1, 30). N(1, 7).\n"  \
+        ".decl R(g: int32, m: int64)\n"
+
+/* Interns "zz"=0, "mm"=1, "aa"=2, so the id order and the lexicographic
+ * order of the same three values are opposites. */
+#define REV_SHIFT                      \
+        ".decl Rev(x: symbol)\n"      \
+        "Rev(\"zz\"). Rev(\"mm\"). Rev(\"aa\").\n"
+
+#define SMALL_N                          \
+        ".decl N(g: int32, v: int64)\n" \
+        "N(1, 0). N(1, 1). N(1, 2).\n"  \
+        ".decl R(g: int32, m: int64)\n"
+
+static void
+test_integer_aggregates_unchanged(void)
+{
+    TEST("min()/max() over integer columns keep the numeric comparison");
+
+    /* Negative literals have no fact syntax, so the negative operands are
+     * produced by the expression instead. */
+    static const struct {
+        const char *src;
+        int64_t expect;
+    } cases[] = {
+        { N_FACTS "R(g, min(v)) :- N(g, v).\n", 5 },
+        { N_FACTS "R(g, max(v)) :- N(g, v).\n", 30 },
+        { N_FACTS "R(g, min(0 - v)) :- N(g, v).\n", -30 },
+        { N_FACTS "R(g, max(0 - v)) :- N(g, v).\n", -5 },
+        { SHIFT N_FACTS "R(g, min(v)) :- N(g, v).\n", 5 },
+        /*
+         * The discriminating pair.  REV_SHIFT interns "zz"/"mm"/"aa" in
+         * that order, so id 0 is "zz" and id 2 is "aa": the numeric order
+         * of 0/1/2 and the lexicographic order of the strings those ids
+         * hold are exact opposites.  An integer column that reached the
+         * string comparison -- which is what mistyping SCALAR as STRING
+         * produces -- answers 2 for min and 0 for max here.  Every other
+         * integer case above is blind to that mutation, because values as
+         * large as 5/7/30 are past the end of the intern table and fall
+         * back to the numeric comparison anyway.
+         */
+        { REV_SHIFT SMALL_N "R(g, min(v)) :- N(g, v).\n", 0 },
+        { REV_SHIFT SMALL_N "R(g, max(v)) :- N(g, v).\n", 2 },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        collect_t c;
+        ASSERT(eval_relation(cases[i].src, "R", &c) == 0,
+            "evaluation failed");
+        ASSERT(c.count == 1, "expected exactly one group");
+        ASSERT(saw_value_at(&c, 1, cases[i].expect),
+            "integer aggregate returned the wrong value");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_mistyped_symbol_column_recursive(void)
+{
+    TEST("a symbol column whose values were never interned still evaluates");
+
+    /*
+     * The parser accepts integer facts for a column declared `symbol`, and
+     * the resulting values are not intern ids at all.  #963 settled that
+     * this mistype is reported rather than failed closed -- so the answer
+     * here is the numeric one, unchanged from before the fix.
+     *
+     * It matters that this is *recursive*: a comparator that treated
+     * "reversible right now" as a property of the value would be
+     * parameterised by an intern table growing underneath it, and the
+     * fixpoint would have no termination argument.  This case reaching its
+     * assertions at all is the observable half of that.
+     */
+    static const char *src =
+        ".decl E(x: symbol, y: symbol)\n"
+        ".decl L(x: symbol, l: symbol)\n"
+        "E(1,2). E(2,1). E(2,3). E(3,2). E(4,5). E(5,4).\n"
+        "L(x, min(x)) :- E(x, y).\n"
+        "L(y, min(y)) :- E(x, y).\n"
+        "L(x, min(l)) :- L(y, l), E(y, x).\n";
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_ex(src, "L", k_worker_counts[w], &c, NULL) == 0,
+            "evaluation failed -- the mistype must not fail the query");
+        ASSERT(c.count == 5, "expected one label per node");
+        ASSERT(saw(&c, "1|1") && saw(&c, "2|1") && saw(&c, "3|1"),
+            "component {1,2,3} must label as 1");
+        ASSERT(saw(&c, "4|4") && saw(&c, "5|4"),
+            "component {4,5} must label as 4");
+    }
+    PASS();
+}
+
+static void
+test_mixed_interned_and_uninterned_group(void)
+{
+    TEST("a group mixing interned and un-interned values prefers the strings");
+
+    /*
+     * The step the termination argument rests on.  9999 is past the end of
+     * the intern table and "zz" is not, and which of the two that is stays
+     * true only *going forward*: the table grows during evaluation --
+     * to_upper(), cat(), trim() and the rest all intern their results --
+     * so a value can move from un-interned to interned but never back.
+     *
+     * Preferring the interned side for min() *and* for max() is what makes
+     * that move always an improvement, in both directions, and therefore
+     * what makes the reduction strictly monotone in a finite order.  A
+     * comparator that preferred the larger raw id for max() would have the
+     * fixpoint chasing a verdict that changes underneath it.
+     *
+     * Both fact orders are covered, so a comparator that simply keeps
+     * whichever row it saw first cannot pass.
+     */
+    static const struct {
+        const char *src;
+        const char *want;
+    } cases[] = {
+        { ".decl S(g: symbol, v: symbol)\n"
+          "S(\"g\", \"zz\"). S(\"g\", 9999).\n"
+          T_DECL "T(g, min(v)) :- S(g, v).\n", "g|zz" },
+        { ".decl S(g: symbol, v: symbol)\n"
+          "S(\"g\", \"zz\"). S(\"g\", 9999).\n"
+          T_DECL "T(g, max(v)) :- S(g, v).\n", "g|zz" },
+        { ".decl S(g: symbol, v: symbol)\n"
+          "S(\"g\", 9999). S(\"g\", \"zz\").\n"
+          T_DECL "T(g, min(v)) :- S(g, v).\n", "g|zz" },
+        { ".decl S(g: symbol, v: symbol)\n"
+          "S(\"g\", 9999). S(\"g\", \"zz\").\n"
+          T_DECL "T(g, max(v)) :- S(g, v).\n", "g|zz" },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        collect_t c;
+        ASSERT(eval_relation(cases[i].src, "T", &c) == 0,
+            "evaluation failed");
+        ASSERT(c.count == 1, "expected exactly one group");
+        ASSERT(saw(&c, cases[i].want),
+            "the interned value must win, whichever aggregate is running");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_undeclared_relation(void)
+{
+    TEST("min() over an undeclared relation keeps working");
+
+    /*
+     * `M` has no .decl, so it has no column types and min() has nothing to
+     * compare but ids -- the fallback docs/SEMANTICS.md documents, reported
+     * once at plan generation under WL_LOG=EVAL.  What must hold is that
+     * the program still evaluates and still produces its group: the failure
+     * mode guarded against is a string comparison applied to an untyped
+     * column, which drops every row.
+     */
+    static const char *src =
+        S_FACTS
+        "M(g, v) :- S(g, v).\n"
+        T_DECL
+        "T(g, min(v)) :- M(g, v).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "T", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 1, "expected exactly one group");
+    ASSERT(saw(&c, "g|aa") || saw(&c, "g|mm") || saw(&c, "g|zz"),
+        "expected one of the three values, not an empty or bogus row");
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * ev(id: int64, lbl: pair/2 inline, v: symbol) occupies four physical
+ * columns -- [id][lbl_0][lbl_1][v] -- behind three logical ones.  A type
+ * array indexed by physical position gives `v` the compound's type and runs
+ * off the end of the declaration, and the aggregate silently returns to
+ * ids.  Compound facts have no source syntax, so the rows go in physically.
+ */
+#define COMPOUND_SRC                                           \
+        ".decl seed(s: symbol)\n"                              \
+        "seed(\"zz\"). seed(\"mm\"). seed(\"aa\").\n"          \
+        ".decl ev(id: int64, lbl: pair/2 inline, v: symbol)\n" \
+        ".decl agg(id: int64, m: symbol)\n"                    \
+        "agg(i, min(v)) :- ev(i, pair(p, q), v).\n"
+
+static int64_t compound_rows[12];
+
+static int
+compound_prepare(const wirelog_program_t *prog, insert_spec_t *ins)
+{
+    const wirelog_intern_t *in = wirelog_program_get_intern(prog);
+    if (!in)
+        return -1;
+    int64_t zz = wl_intern_get(in, "zz");
+    int64_t mm = wl_intern_get(in, "mm");
+    int64_t aa = wl_intern_get(in, "aa");
+    if (zz < 0 || mm < 0 || aa < 0 || zz >= aa)
+        return -1; /* the seed facts must have made id("zz") < id("aa") */
+
+    /* The group id is deliberately past the end of the intern table, so it
+     * renders as a number and cannot be confused with a symbol. */
+    int64_t r[12] = {
+        1000, 7, 8, zz,
+        1000, 7, 8, mm,
+        1000, 7, 8, aa,
+    };
+    memcpy(compound_rows, r, sizeof(r));
+
+    ins->relation = "ev";
+    ins->rows = compound_rows;
+    ins->num_rows = 3;
+    ins->ncols = 4;
+    return 0;
+}
+
+static void
+test_inline_compound_relation(void)
+{
+    TEST("a symbol column after an inline compound keeps its type");
+
+    collect_t c;
+    ASSERT(eval_relation_ex(COMPOUND_SRC, "agg", 1, &c, compound_prepare)
+        == 0, "evaluation failed");
+    ASSERT(c.count == 1, "expected exactly one group");
+    ASSERT(saw(&c, "1000|aa"), "min must be \"aa\"");
+    ASSERT(!saw(&c, "1000|zz"),
+        "returned the value the intern-id ordering selects");
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_count_sum_average_unchanged(void)
+{
+    TEST("count()/sum()/average() over a symbol column are unchanged");
+
+    /*
+     * These reduce over the id and always did; they are not ordering
+     * aggregates.  The guard is against extending the string path to them,
+     * which would compare or accumulate strings that have no arithmetic.
+     * SHIFT fixes the three ids at 0/1/2, so the sum is a number this test
+     * can name.
+     */
+    static const struct {
+        const char *src;
+        int64_t expect;
+    } cases[] = {
+        { SHIFT S_FACTS ".decl C(g: symbol, n: int64)\n"
+          "C(g, count(v)) :- S(g, v).\n", 3 },
+        /* ids: "aa"=0, "mm"=1, "zz"=2 -- SHIFT interns them in that order */
+        { SHIFT S_FACTS ".decl C(g: symbol, n: int64)\n"
+          "C(g, sum(v)) :- S(g, v).\n", 0 + 1 + 2 },
+        /*
+         * average() is not reduced by col_op_reduce() at all -- its switch
+         * has no AVG arm -- so it keeps the first operand it sees, which
+         * SHIFT pins to id("zz") = 2.  That is orthogonal to this issue and
+         * is asserted as-is: what must not happen is average() acquiring the
+         * ordering path, which is the arm right next to it.
+         */
+        { SHIFT S_FACTS ".decl C(g: symbol, n: int64)\n"
+          "C(g, average(v)) :- S(g, v).\n", 2 },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        collect_t c;
+        ASSERT(eval_relation(cases[i].src, "C", &c) == 0,
+            "evaluation failed");
+        ASSERT(c.count == 1, "expected exactly one group");
+        ASSERT(saw_value_at(&c, 1, cases[i].expect),
+            "a non-ordering aggregate changed value");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+int
+main(void)
+{
+    printf("=== min()/max() over symbol columns (Issue #965) ===\n");
+
+    test_min_lexicographic();
+    test_max_lexicographic();
+    test_recursive_min_workers();
+    test_recursive_max_workers();
+    test_join_chain_aggregate();
+    test_min_of_to_upper();
+    test_integer_aggregates_unchanged();
+    test_mistyped_symbol_column_recursive();
+    test_mixed_interned_and_uninterned_group();
+    test_undeclared_relation();
+    test_inline_compound_relation();
+    test_count_sum_average_unchanged();
+
+    printf("\n%d/%d passed, %d failed\n", pass_count, test_count, fail_count);
+    return fail_count == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -401,7 +401,7 @@ col_relation_recursive_reduce_op(const wl_plan_relation_t *rp)
 
 static int
 col_canonicalize_recursive_aggregate_relation(col_rel_t *rel,
-    const wl_plan_op_t *reduce_op)
+    const wl_plan_op_t *reduce_op, const wl_intern_t *intern)
 {
     if (!rel || !reduce_op || rel->nrows < 2)
         return 0;
@@ -423,8 +423,11 @@ col_canonicalize_recursive_aggregate_relation(col_rel_t *rel,
         if (found != UINT32_MAX) {
             int64_t cur = col_rel_get(rel, found, gc);
             int64_t val = col_rel_get(rel, row, gc);
-            bool better = (reduce_op->agg_fn == WIRELOG_AGG_MIN)
-                ? val < cur : val > cur;
+            /* Same comparator as col_op_reduce(): a fixpoint that ordered
+             * lexicographically within an iteration and by intern id across
+             * iterations would be worse than the original bug (#965). */
+            bool better = col_agg_better(reduce_op->agg_fn,
+                    reduce_op->agg_operand_type, intern, val, cur);
             if (better) {
                 col_rel_set(rel, found, gc, val);
                 if (rel->timestamps)
@@ -464,7 +467,8 @@ col_canonicalize_recursive_aggregates(const wl_plan_stratum_t *sp,
         if (!reduce_op)
             continue;
         col_rel_t *rel = session_find_rel(sess, rp->name);
-        int rc = col_canonicalize_recursive_aggregate_relation(rel, reduce_op);
+        int rc = col_canonicalize_recursive_aggregate_relation(rel, reduce_op,
+                sess->intern);
         if (rc != 0)
             return rc;
         col_session_invalidate_arrangements(&sess->base, rp->name);

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -490,6 +490,82 @@ col_rel_binary_search_row(const col_rel_t *rel, uint32_t lo, uint32_t hi,
     return false;
 }
 
+/**
+ * col_agg_better - does @cand beat the running @cur for a MIN/MAX reduce?
+ *                  (Issue #965)
+ *
+ * MIN/MAX used to compare the raw int64 in every case, which for a `symbol`
+ * column is its interned id.  Ids are handed out in first-appearance order,
+ * so prepending one unrelated fact flipped min() from "zz" to "aa" with no
+ * change to the data being reduced.  When the plan says the operand is a
+ * string, the comparison is therefore over the strings.
+ *
+ * There are two reducers -- col_op_reduce() in ops.c and the recursive
+ * canonicalisation in eval.c -- and they must agree.  Two copies could
+ * drift into a fixpoint that is lexicographic within an iteration and
+ * id-ordered across iterations, which is worse than the original bug, so
+ * both call this.
+ *
+ * Ordering, given the intern table @intern:
+ *
+ *   rank(v) = 1 if wl_intern_reverse(intern, v) != NULL, else 0
+ *
+ *   - different rank: the rank-1 value wins, for MIN *and* for MAX.
+ *   - both rank 1: strcmp of the two strings.
+ *   - both rank 0: the int64 comparison, i.e. today's behaviour.
+ *
+ * A genuine symbol column has rank 1 everywhere and reduces purely
+ * lexicographically; rank 0 only appears for a column declared `symbol`
+ * whose values were never interned.  Following #963, that mistype is not
+ * failed closed: `.decl E(x: symbol, y: symbol)` with integer facts is
+ * accepted by the parser and evaluates fine today, and erroring out would
+ * turn a working query into no output at all.  The mistype is reported at
+ * plan generation instead.
+ *
+ * Termination.  The naive argument -- "the stored value descends a fixed
+ * total order, which is finite, so the fixpoint stops" -- does not hold if
+ * rank is read as a property of the value: wl_intern_reverse() succeeds iff
+ * `0 <= id < count`, and count *grows during evaluation*, because cat(),
+ * substr(), to_upper(), to_lower(), str_replace(), trim() and to_string()
+ * all intern their results.  The same pair of values can therefore compare
+ * one way early and the other way later, and the order is not fixed.
+ *
+ * What is true is that rank is monotone.  count never shrinks and entry v
+ * is written before count exceeds v, so `rank(v) = 0 -> 1` happens at most
+ * once per v and never reverses; and rank 1 always wins.  So a rank change
+ * moves a value strictly *towards* better, whichever aggregate is running.
+ * Hence at every update the stored value's key strictly improves in the
+ * fixed order on the pair set {(rank, string-or-id)}, and both the stored
+ * key before and after are drawn from the finitely many keys the finitely
+ * many distinct values V can ever take -- at most 2|V| of them, since each
+ * value realises at most two.  So each group updates at most 2|V| times and
+ * the whole reduction at most 2|G||V| times.  Finite, therefore terminating,
+ * without assuming the intern table holds still.
+ */
+static inline bool
+col_agg_better(wirelog_agg_fn_t fn, wl_plan_agg_operand_t domain,
+    const wl_intern_t *intern, int64_t cand, int64_t cur)
+{
+    bool want_max = (fn == WIRELOG_AGG_MAX);
+
+    if (domain == WL_PLAN_AGG_OPERAND_STRING) {
+        const char *a = wl_intern_reverse(intern, cand);
+        const char *b = wl_intern_reverse(intern, cur);
+        if (a && b) {
+            int c = strcmp(a, b);
+            return want_max ? c > 0 : c < 0;
+        }
+        /* At most one of the two names a string.  Prefer it -- see the
+         * termination note above; this is the step that must not depend on
+         * which direction the aggregate runs. */
+        if (a || b)
+            return a != NULL;
+        /* Neither: fall through to the int64 comparison. */
+    }
+
+    return want_max ? cand > cur : cand < cur;
+}
+
 /** Copy row src_row to dst_row within the same relation.
  *  Column-major: each column copy is independent, no temp buffer needed. */
 static inline void

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -6671,11 +6671,12 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                 }
                 break;
                 case WIRELOG_AGG_MIN:
-                    if (agg_val < cur)
-                        col_rel_set(out, o, gc, agg_val);
-                    break;
                 case WIRELOG_AGG_MAX:
-                    if (agg_val > cur)
+                    /* Ordered by the operand's declared domain, not by the
+                     * raw int64 -- for a symbol column that int64 is an
+                     * intern id (Issue #965). */
+                    if (col_agg_better(op->agg_fn, op->agg_operand_type,
+                        sess->intern, agg_val, cur))
                         col_rel_set(out, o, gc, agg_val);
                     break;
                 default:

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -278,6 +278,29 @@ typedef enum {
     WL_DELTA_FORCE_EMPTY_AFTER_SEED = 4,
 } wl_delta_mode_t;
 
+/**
+ * wl_plan_agg_operand_t:
+ *
+ * The value domain of a REDUCE operator's aggregated operand (Issue #965).
+ *
+ * Every value a plan moves is an int64_t.  What differs is whether MIN/MAX
+ * should order it as a number or as the string whose interned id it is --
+ * ids are assigned in first-appearance order, so ordering symbols by id
+ * makes the answer depend on which unrelated facts happened to be parsed
+ * first.  Only the plan generator knows which of the two a column holds,
+ * because only it has the `.decl` types.
+ *
+ * UNKNOWN is the zero value on purpose.  op_list_push() and clone_plan_op()
+ * both memset() their op before filling it in, so an op that no producer
+ * typed is structurally distinguishable from one deliberately typed
+ * SCALAR, rather than silently claiming to be numeric.
+ */
+typedef enum {
+    WL_PLAN_AGG_OPERAND_UNKNOWN = 0,
+    WL_PLAN_AGG_OPERAND_SCALAR = 1,
+    WL_PLAN_AGG_OPERAND_STRING = 2,
+} wl_plan_agg_operand_t;
+
 /* ======================================================================== */
 /* Operator Types                                                           */
 /* ======================================================================== */
@@ -425,6 +448,13 @@ typedef struct {
     * Placed after opaque_data to avoid shifting hot fields (delta_mode,
     * opaque_data) that were present in the original 136-byte layout. */
     wl_plan_expr_buffer_t right_filter_expr;
+
+    /* REDUCE only: the value domain of the aggregated operand, which is what
+     * decides whether MIN/MAX order by number or by string (Issue #965).
+     * Appended at the end so no existing field shifts.  UNKNOWN on every
+     * other operator, and on a REDUCE whose operand type could not be
+     * established. */
+    wl_plan_agg_operand_t agg_operand_type;
 } wl_plan_op_t;
 
 /* ======================================================================== */

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -702,6 +702,32 @@ expr_result_type(const wl_ir_expr_t *expr, const col_ctx_t *ctx)
 }
 
 /**
+ * Carry an IR column type across into the plan's aggregate operand domain
+ * (Issue #965).
+ *
+ * The two enumerations agree numerically today, and they are deliberately
+ * not cast into one another: wl_ir_coltype_t belongs to the IR (ir/ir.h)
+ * and wl_plan_agg_operand_t to the plan (exec_plan.h), which no IR header
+ * reaches, so a _Static_assert tying them together is not even expressible
+ * at either definition site.  An explicit switch costs nothing, and the
+ * compiler's -Wswitch flags a new IR column type here rather than letting
+ * it arrive in the backend as a silent SCALAR.
+ */
+static wl_plan_agg_operand_t
+agg_operand_from_coltype(wl_ir_coltype_t t)
+{
+    switch (t) {
+    case WL_IR_COLTYPE_SCALAR:
+        return WL_PLAN_AGG_OPERAND_SCALAR;
+    case WL_IR_COLTYPE_STRING:
+        return WL_PLAN_AGG_OPERAND_STRING;
+    case WL_IR_COLTYPE_UNKNOWN:
+        break;
+    }
+    return WL_PLAN_AGG_OPERAND_UNKNOWN;
+}
+
+/**
  * Serialize an IR expression tree into postfix (RPN) byte encoding.
  * Walks the tree recursively: children first (postfix), then operator.
  */
@@ -1488,9 +1514,35 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             }
             int agg_rc = serialize_expr_to_buffer_ctx(node->agg_expr,
                     &agg_ctx, &op->agg_expr);
+            /*
+             * The operand's domain, which is what tells REDUCE whether
+             * MIN/MAX order by number or by string (Issue #965).  It has to
+             * come from expr_result_type() rather than from a column lookup:
+             * min(to_upper(v)) parses and runs, and its operand is a
+             * runtime-interned id belonging to no column at all.
+             */
+            op->agg_operand_type = agg_operand_from_coltype(
+                expr_result_type(node->agg_expr, &agg_ctx));
             col_ctx_free(&agg_ctx);
             if (agg_rc != 0)
                 return -1;
+        }
+
+        /*
+         * Say so once, here, when an ordering aggregate cannot be typed --
+         * matching the ordering-comparison diagnostic of #962 rather than
+         * logging per row.  As there, refusing to lower these would break
+         * programs that work today: undeclared relations have no column
+         * types at all, and min() over an undeclared integer relation
+         * evaluates perfectly well.
+         */
+        if ((op->agg_fn == WIRELOG_AGG_MIN || op->agg_fn == WIRELOG_AGG_MAX)
+            && op->agg_operand_type == WL_PLAN_AGG_OPERAND_UNKNOWN) {
+            WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_WARN,
+                "'%s' over an operand with no established type: reducing by "
+                "interned id, not by string. Declare the relation "
+                "(.decl R(c: symbol)) if the column holds symbols",
+                op->agg_fn == WIRELOG_AGG_MIN ? "min" : "max");
         }
         return 0;
     }
@@ -1924,6 +1976,15 @@ clone_plan_op(const wl_plan_op_t *src, wl_plan_op_t *dst)
     dst->delta_mode = src->delta_mode;
     dst->materialized = src->materialized;
     dst->agg_fn = src->agg_fn;
+    /* Travels with agg_fn.  The join-chain (LFTJ), K-fusion and multiway
+     * rewrites all rebuild a relation's ops through here, so a REDUCE that
+     * loses its operand domain reverts to id ordering for every rule those
+     * passes touch -- in a default build the join-chain rewrite is the one
+     * that shows it: detect_lftj_chain() needs a VARIABLE plus two
+     * consecutive JOINs, so a three-atom body already triggers it
+     * (Issue #965).  The lookup itself is skipped entirely under
+     * K-fusion -- see #975, which is a separate defect. */
+    dst->agg_operand_type = src->agg_operand_type;
     dst->key_count = src->key_count;
     dst->project_count = src->project_count;
     dst->group_by_count = src->group_by_count;


### PR DESCRIPTION
Closes #965. Rebased onto `main` now that #972 has merged; it no longer carries that PR's commit.

## The defect

`min()`/`max()` over a `symbol` column compared **intern ids**. Prepending one unrelated fact flipped `min` from `"zz"` to `"aa"` with the same rules and the same facts — non-recursively through `col_op_reduce`, and through the recursive fixpoint's canonicalisation at every worker count.

## Two commits

**C1 — carry the operand domain into the plan.** No behaviour change; nothing reads the field yet. Verified neutral two ways: full suite unchanged in both mbedTLS configs, and all fourteen example programs byte-identical against a pristine build of the base.

`wirelog_agg_fn_t` is in an **installed public header**, so `MIN_STR`/`MAX_STR` would be a public enum expansion — a call this project has declined before. A new REDUCE op type is blocked by the universal/backend numeric partition. Encoding it in `agg_expr` gives two sources of truth, and `col_op_reduce` dispatches on `agg_fn`. So: a field on the internal `wl_plan_op_t`, appended last.

`UNKNOWN = 0` is the sentinel rather than SCALAR, because SCALAR is the value that keeps the old comparison — a plumbing gap would be invisible. Same reason #962 gave `wl_ir_coltype_t` a zero UNKNOWN.

`clone_plan_op` copies it. Missing that would be silent, and **the plan was wrong about which path exercises it**: not multiway/K-fusion but the LFTJ join-chain rewrite, which needs only a three-atom body. The first test written against the plan's assumption left that mutation alive.

**C2 — the comparator and both call sites**, sharing one `col_agg_better()`. Two copies could drift into a fixpoint that is lexicographic within an iteration and id-ordered across iterations — worse than the bug.

## The fallback, and why the plan's version was wrong

A declared `symbol` column can hold never-interned values — declarations are not enforced, and inline-compound expansion can put an integer under a string type outright. Those reduce numerically rather than failing: erroring would turn programs that run today into no output, which is exactly what #963 weighed for digests.

Where a group mixes the two, **the interned values win, for `min` and `max` alike**. The plan's rank — non-interned sorts high — is wrong for `max`: it lets a raw id beat every real string. Review reimplemented the plan's key and confirmed test 9 kills it, and only test 9.

## Termination

This lands on a fixpoint, so the failure mode is a hang, not a wrong answer. The plan's original argument was **broken empirically** during critique: `wl_intern_reverse` succeeds iff `id < count`, and `count` grows *during* evaluation from seven `wl_intern_put` sites in `string_ops.c`. "Reversible" is a property of the value **and the table**, so the descent argument's fixed total order does not exist.

The replacement: `wl_intern_put` publishes `count` after writing the entry and `count` never shrinks, so reversibility only ever turns on, and turning on always moves a value *toward* better in both directions. Each write strictly improves the stored key over ≤ 2|V| realizable keys.

Review verified the premises in source and could not break it — fourteen adversarial recursive programs × W ∈ {1,4,8}, interning strings mid-fixpoint. Raw ids demonstrably **do** become reversible during a run (operands come back rendered as `"AA"/"BB"`), and every program converged.

Review also corrected the framing, which is reflected in the CHANGELOG: termination does not actually hinge on the direction-symmetric rule — between two table sizes the order is fixed and each group's value strictly improves either way. That rule is a **correctness** choice.

## Tests

Twelve cases, **each a separate single-aggregate program**. A head with two aggregates silently keeps only the last (#973, filed from this work), so the compact fixture — `min` and `max` together — would have validated only `max` and reported green on the `min` half.

Every case is framed on intern-order independence: same rules and facts plus an unrelated earlier fact must give the same answer. A single-value assertion cannot see this defect, since both orderings return exactly one row per group.

Nine mutations, all killed; review re-ran them independently and added its own. `test_recursive_agg_conformance` is `int32` throughout and stays green **unchanged** — the invariance control, not coverage.

`examples/06-timestamp-lww` gains a golden test, with a comment stating what it does **not** catch: its timestamps are ~1.7e9, far past the intern table, so a `max(Ts)` mistyped as a string still falls back to numeric and still answers correctly. Verified — that mutation passes the golden. The plan had claimed it was the discriminating fixture; it is not.

## Docs that were false

Both example READMEs said lexicographic `min`/`max` was not implemented, and `docs/SEMANTICS.md` counted three places where id order leaks. Both are true again. `docs/SYNTAX.md`'s "every paragraph below applies to aggregates as well" was wrong twice — the mixed-operand rule does not apply, and the aggregate's analogous case behaves the *opposite* way.

## Filed from this work

**#973** — a head with two aggregates silently drops all but the last.
**#975** — recursive-aggregate canonicalisation is skipped under K-fusion, so dominated rows survive. Adding a *semantically redundant* rule moves a program from 5 correctly-aggregated rows to 11 un-aggregated ones. It does **not** weaken this PR's recursive coverage: single-IDB-atom rules do not take that path and report `REDUCE=1 KFUSION=0` at all four worker counts.

## Validation

Both mbedTLS configs: **263 Ok / 1 Fail / 11 Skipped** (the failure is the pre-existing environmental `sbom_snapshot`). Review ran them sequentially and independently reproduced the numbers, plus ASan-clean checks and byte-level example comparison against a pristine base build.
