### PR TITLE
fix(ir): reject rule heads with more than one aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,42 @@ All notable changes to wirelog are documented in this file.
   two of its sizes the comparator is a fixed total order and each group's
   stored value strictly improves.
 
+- **Rule heads with more than one aggregate are rejected instead of
+  miscompiled** (#973): `t(g, min(v), max(v)) :- val(g, v).` kept only the
+  last aggregate and emitted a two-column tuple against a three-column
+  `.decl`. Outside a recursive stratum that was a wrong answer with exit
+  status 0 and no diagnostic; **inside** one it was a segfault -- the
+  columnar REDUCE path sizes its output region from the emitted arity while
+  the append path reads the declared arity, so evaluation walked off the end
+  of the region. Such rules now fail to lower, surfacing as
+  `WIRELOG_ERR_PARSE`, with a `PARSER`-section `WL_LOG` error naming the fix
+  (derive each aggregate in its own rule and join them).
+
+  `wirelog_parse_string()` now calls `wl_log_init()` before parsing, so
+  `WL_LOG=PARSER:1` surfaces that message and the other lowering rejections
+  (`__graph_metadata` arity, unsafe variables). Previously the logger was
+  initialized only in plan generation and session creation, both of which run
+  after parsing, so no `WL_LOG` value could reach a lowering diagnostic.
+  Default output is unchanged; a user who sets nothing still sees only
+  `Parse error`, which is #979.
+
+  **Compatibility:** programs that previously loaded now fail to load. This
+  is not limited to wrong-arity results — `t(g, min(v), max(v))` against a
+  *two*-column `.decl t(g, a)` emitted a correctly-sized two-column relation,
+  exit status 0, and is now rejected as well. The rejection is intentional in
+  both cases: the previous result was not correct for any reading of the
+  rule, whether or not its arity happened to match.
+
+  **This does not close the whole crash class.** The underlying trigger is
+  emitted arity differing from declared arity inside a recursive stratum, and
+  multiple aggregates are only one way to produce it. A *single*-aggregate
+  head with too few arguments -- `cc(y, min(c)) :- cc(x, c, d), edge(x, y).`
+  against a three-column `cc` -- still crashes identically and is not caught
+  here. General `.decl`-versus-rule arity validation is tracked as #977; the
+  two fixes are complementary and neither subsumes the other. The check also
+  gates the parser path only: IR built directly through the API is still
+  unvalidated.
+
 - **`uuid5()` framing carries the operand's type, not only its length**
   (#968): #963 length-prefixed each operand of the three symbol-bearing
   `uuid5` opcodes, which fixed the split point but not the *domain*. Two

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -180,12 +180,30 @@ from producing semantically correct output at workers in {1, 4, 8, 16}.
   harness is the active replacement.
 - `col_op_reduce_weighted` remains a weighted Z-set helper and is not part
   of the #692 MIN/MAX recursive aggregate closure.
+- A rule head carries **at most one** aggregate (#973). `AGGREGATE` holds a
+  single `agg_fn`/`agg_expr` pair, so a head such as `t(g, min(v), max(v))`
+  kept only the last aggregate and emitted fewer columns than its `.decl`
+  declared. In a recursive stratum that mismatch is an out-of-bounds read:
+  `col_op_reduce` sizes the output region from the emitted arity while
+  `col_rel_append_all` reads the declared arity. Such heads are now rejected
+  during lowering. Supporting them only in non-recursive strata was
+  considered and rejected — stratification runs *after* rule lowering, so
+  `convert_rule` cannot know whether the head relation is recursive, and
+  `col_canonicalize_recursive_aggregate_relation` is on the hot path for
+  recursive aggregate rules regardless of the MIN/MAX guard.
+- The #973 rejection does not cover every arity mismatch. A single-aggregate
+  head with too few arguments for its `.decl` is still accepted and still
+  unsafe in a recursive stratum; general `.decl`-versus-rule arity validation
+  is tracked as #977.
 
 ### References
 
 - Issue #692 — Blocker B5: Recursive aggregation residue = 0.
+- Issue #973 — at most one aggregate per rule head.
+- Issue #977 — general `.decl`-versus-rule arity validation (open).
 - `wirelog/columnar/ops.c` — `col_op_reduce`.
 - `wirelog/columnar/eval.c` — recursive aggregate canonicalization.
+- `wirelog/ir/program.c` — `convert_rule` multi-aggregate head rejection.
 - `tests/test_recursive_agg_conformance.c` — active columnar harness.
 
 ---

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -46,8 +46,84 @@ Features:
 - **Comparisons**: `x < y`, `x = y`, `x != y`, `x >= y`, etc.
 - **Arithmetic**: `x + 1`, `x * y`, `x % 2` in head or comparisons
 - **Aggregation**: `min(x)`, `max(x)`, `sum(x)`, `count(x)`, `average(x)` in head
+  (at most one per head — see below)
 - **Wildcards**: `_` for anonymous variables
 - **Plan marker**: `.plan` before a rule for optimization hints
+
+### Limitation: one aggregate per rule head
+
+A rule head may contain **at most one** aggregate. The internal `AGGREGATE`
+node carries a single aggregate function and a single aggregate expression,
+so there is nowhere to record a second one. Programs such as
+
+```
+t(g, min(v), max(v)) :- val(g, v).      /* rejected */
+t(min(v), max(v))    :- val(g, v).      /* rejected */
+t(g, min(v), min(w)) :- val(g, v, w).   /* rejected */
+```
+
+are rejected when the rule is lowered. Loading fails with
+`WIRELOG_ERR_PARSE`, which the CLI prints as a bare `Parse error`. To see
+which relation was rejected and why, run with `WL_LOG=PARSER:1`:
+
+```
+$ WL_LOG=PARSER:1 wirelog_cli prog.dl
+[ERROR][PARSER] .../wirelog/ir/program.c:1811: relation 't' has 2 aggregates
+in one rule head; at most one is supported. Derive each aggregate in its own
+rule and join the results ...
+```
+
+Without `WL_LOG` set there is still no explanation — surfacing one by
+default is tracked as #979.
+
+Derive each aggregate in its own rule and join the results:
+
+```
+.decl val(g: int64, v: int64)
+.decl tmin(g: int64, a: int64)
+.decl tmax(g: int64, b: int64)
+.decl t(g: int64, a: int64, b: int64)
+
+tmin(g, min(v)) :- val(g, v).
+tmax(g, max(v)) :- val(g, v).
+t(g, a, b) :- tmin(g, a), tmax(g, b).
+```
+
+This rewrite is exact, not an approximation, and the reason is worth stating:
+the split rules keep **identical bodies**, so they group over the same tuple
+set and produce the same group keys. `REDUCE` emits one row per group, so the
+join is total on both sides and no group can be dropped. That property holds
+only while the bodies stay identical — if you later add a filter to one of
+them, the join stops being total and groups can disappear.
+
+This restriction is a memory-safety guard, not only a clarity one. A head
+that emits a different number of columns than its `.decl` declares causes an
+out-of-bounds read in the columnar REDUCE path when the relation is
+recursive; multiple aggregates were one way to reach that state.
+
+Two scope notes:
+
+- The check covers the **parser path only**. A caller that builds an
+  `AGGREGATE` IR node directly, without going through `wirelog_parse_string`,
+  is not validated — neither the optimizer, the plan generator, nor the
+  columnar REDUCE checks that the group-by width plus one matches the head
+  arity.
+- The check does **not** cover every arity mismatch. A single-aggregate head
+  with too few arguments for its `.decl`, such as
+  `cc(y, min(c)) :- cc(x, c, d), edge(x, y).` against a 3-column `cc`, is
+  still accepted and still unsafe in a recursive stratum. General
+  `.decl`-versus-rule arity validation is tracked separately as #977.
+
+The count is not the only constraint on aggregates in a head — the aggregate
+must also be written **last**. `t(min(v), g) :- val(g, v).` lowers with a
+single aggregate and the correct arity, but emits its columns group-by-first
+regardless of the order written, so the values land in the wrong columns with
+no diagnostic. That is tracked as #980 and is not affected by this check.
+
+Aggregate names are matched as exact keywords. `average` and `AVG` are
+recognized; `avg` and `AVERAGE` are not. An unrecognized name followed by `(`
+has no production in head-argument position, so `t(g, avg(v), max(v))` is a
+plain syntax error rather than a rule that bypasses this check.
 
 ---
 

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -972,6 +972,122 @@ test_aggregation_constant(void)
     PASS();
 }
 
+/* Issue #973: a rule head may carry at most one aggregate.  The AGGREGATE IR
+ * node has one agg_fn / one agg_expr, so lowering used to keep only the last
+ * aggregate and emit a tuple of the wrong arity with no diagnostic.
+ *
+ * make_program_with_rules() calls wl_ir_program_convert_rules() directly, so a
+ * NULL return here is exactly the lowering rejection and not some later stage.
+ * Each test pairs its negatives with a positive control so that a blanket
+ * parser breakage cannot make the negatives pass for the wrong reason. */
+static void
+test_aggregation_multi_head_rejected(void)
+{
+    TEST("Aggregation: multiple aggregates in one head are rejected");
+
+    /* Positive control: a single aggregate must still lower correctly. */
+    struct wirelog_program *ok
+        = make_program_with_rules(".decl val(g: int32, v: int32)\n"
+            ".decl t(g: int32, a: int32)\n"
+            "t(g, min(v)) :- val(g, v).\n");
+    if (!ok) {
+        FAIL("control: single-aggregate head should still lower");
+        return;
+    }
+    if (ok->rules[0].ir_root->type != WIRELOG_IR_AGGREGATE
+        || ok->rules[0].ir_root->agg_fn != WIRELOG_AGG_MIN
+        || ok->rules[0].ir_root->group_by_count != 1) {
+        wl_ir_program_free(ok);
+        FAIL("control: expected AGGREGATE/MIN/group_by_count==1");
+        return;
+    }
+    wl_ir_program_free(ok);
+
+    /* Negative: two different aggregates, with a group-by column. */
+    struct wirelog_program *bad
+        = make_program_with_rules(".decl val(g: int32, v: int32)\n"
+            ".decl t(g: int32, a: int32, b: int32)\n"
+            "t(g, min(v), max(v)) :- val(g, v).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("t(g, min(v), max(v)) should be rejected");
+        return;
+    }
+
+    /* Negative: two aggregates and no group-by column at all. */
+    bad = make_program_with_rules(".decl val(g: int32, v: int32)\n"
+            ".decl t(a: int32, b: int32)\n"
+            "t(min(v), max(v)) :- val(g, v).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("t(min(v), max(v)) should be rejected");
+        return;
+    }
+
+    /* Negative: three aggregates. */
+    bad = make_program_with_rules(".decl val(g: int32, v: int32)\n"
+            ".decl t(g: int32, a: int32, b: int32, c: int32)\n"
+            "t(g, min(v), max(v), sum(v)) :- val(g, v).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("three aggregates should be rejected");
+        return;
+    }
+
+    /* Negative: same agg_fn twice.  This one passes the downstream
+     * col_relation_recursive_reduce_op() mixed-agg_fn guard (#692 B5) and
+     * would canonicalise only one column, so it must be caught here. */
+    bad = make_program_with_rules(".decl val(g: int32, v: int32)\n"
+            ".decl t(g: int32, a: int32, b: int32)\n"
+            "t(g, min(v), min(v)) :- val(g, v).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("t(g, min(v), min(v)) should be rejected");
+        return;
+    }
+
+    /* Negative: the recursive shape.  This one is the memory-safety case --
+     * before the fix it reached col_op_reduce()/col_rel_append_all() with an
+     * emitted arity of 2 against a 3-arity .decl and segfaulted during
+     * col_eval_stratum().  Rejecting at lowering keeps it from ever getting
+     * that far.  (Note: the single-aggregate variant
+     * "cc(y, min(c)) :- cc(x, c, d), edge(x, y)." crashes the same way and is
+     * deliberately NOT caught here -- that is issue #977.) */
+    bad = make_program_with_rules(".decl edge(x: int64, y: int64)\n"
+            ".decl cc(n: int64, lo: int64, hi: int64)\n"
+            "cc(y, min(c), max(c)) :- cc(x, c, d), edge(x, y).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("recursive multi-aggregate head should be rejected");
+        return;
+    }
+
+    /* Control again: the documented workaround -- one aggregate per rule,
+     * joined -- must still lower cleanly. */
+    struct wirelog_program *workaround
+        = make_program_with_rules(".decl val(g: int32, v: int32)\n"
+            ".decl tmin(g: int32, a: int32)\n"
+            ".decl tmax(g: int32, b: int32)\n"
+            ".decl t(g: int32, a: int32, b: int32)\n"
+            "tmin(g, min(v)) :- val(g, v).\n"
+            "tmax(g, max(v)) :- val(g, v).\n"
+            "t(g, a, b) :- tmin(g, a), tmax(g, b).\n");
+    if (!workaround) {
+        FAIL("control: documented per-rule workaround must lower");
+        return;
+    }
+    if (workaround->rules[0].ir_root->type != WIRELOG_IR_AGGREGATE
+        || workaround->rules[1].ir_root->type != WIRELOG_IR_AGGREGATE
+        || workaround->rules[2].ir_root->type != WIRELOG_IR_PROJECT) {
+        wl_ir_program_free(workaround);
+        FAIL("control: workaround should lower to AGGREGATE/AGGREGATE/PROJECT");
+        return;
+    }
+    wl_ir_program_free(workaround);
+
+    PASS();
+}
+
 static void
 test_three_body_join(void)
 {
@@ -3112,6 +3228,7 @@ main(void)
     test_aggregation_simple();
     test_aggregation_with_join();
     test_aggregation_constant();
+    test_aggregation_multi_head_rejected();
     test_three_body_join();
     test_duplicate_variable();
     test_constant_in_atom();

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -3068,12 +3068,26 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
 
     *out = NULL;
 
-    /* Issue #287/#962: plan generation is the first stage that emits WL_LOG
-     * diagnostics -- cmp_to_tag() reports ordering comparisons that fall back
-     * to intern-id order -- and it runs before any session exists, so the
-     * logger would still be at its all-silent default.  wl_log_init() is
-     * idempotent and cheap on re-entry; col_session_create() calls it for the
-     * same reason.
+    /* Issue #287/#962: plan generation emits WL_LOG diagnostics -- cmp_to_tag()
+     * reports ordering comparisons that fall back to intern-id order -- and it
+     * runs before any session exists, so the logger would still be at its
+     * all-silent default.  wl_log_init() is idempotent on re-entry;
+     * col_session_create() calls it for the same reason.  It is not free,
+     * though: with WL_LOG_FILE set it reopens the sink each time, so a caller
+     * in a tight parse/plan loop pays an fopen+fclose per iteration.
+     *
+     * Correction (#973): this was never the first stage to *emit*.  Rule
+     * lowering (wl_ir_program_convert_rules, ir/program.c) rejects programs
+     * and explains why through WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR, ...)
+     * well before this point, so every such message was written into an
+     * uninitialized logger and dropped -- WL_LOG=PARSER:1 could not surface
+     * them, because parsing was over before anything read the variable.
+     * wirelog_parse_string() (ir/api.c) now calls wl_log_init() first, which
+     * is why this call is merely idempotent re-entry rather than the one that
+     * matters.  Getting a message to a user who sets nothing at all is a
+     * further step: the gate is LVL <= threshold and the default
+     * WL_LOG_NONE (0) still suppresses WL_LOG_ERROR (1), so that needs the
+     * errbuf wirelog_parse_string() builds and discards -- issue #979.
      *
      * Two caveats, both inherited rather than introduced.  It rewrites the
      * sink and thresholds without a lock, so calling it while another

--- a/wirelog/ir/api.c
+++ b/wirelog/ir/api.c
@@ -21,6 +21,7 @@
 #include "program.h"
 #include "stratify.h"
 #include "../parser/parser.h"
+#include "../util/log.h"
 #include "../wirelog-parser.h"
 
 #include <stdlib.h>
@@ -33,11 +34,42 @@
 wirelog_program_t *
 wirelog_parse_string(const char *program_text, wirelog_error_t *error)
 {
+    /* Issue #973: the post-parse stages below reject some programs and explain
+     * why through WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR, ...) -- the
+     * __graph_metadata arity guard, the #920 unsafe-variable check, and the
+     * one-aggregate-per-head check, all in ir/program.c.  Until now none of
+     * those messages could reach anyone: wl_log_thresholds is a zero-init
+     * global read only by wl_log_init(), whose two call sites
+     * (exec_plan_gen.c, columnar/session.c) both run strictly after parsing,
+     * so the process returned before the logger existed and no WL_LOG value
+     * could help.  Initializing here makes WL_LOG=PARSER:1 actually work.
+     *
+     * This does not change default output -- the gate is LVL <= threshold and
+     * the default WL_LOG_NONE (0) still suppresses WL_LOG_ERROR (1).  A user
+     * who sets nothing still sees only "Parse error" from cli/driver.c; giving
+     * them a message by default requires surfacing the errbuf below, which is
+     * issue #979.  This is the opt-in half of that.
+     *
+     * Thread-safety caveat, and note this is a *new* exposure rather than
+     * purely an inherited one.  wl_log_init() fcloses the old sink, NULLs it
+     * and memsets the thresholds before repopulating, all without a lock.
+     * With WL_LOG_FILE set, a thread parsing here can therefore fclose a
+     * FILE* another thread is mid-fprintf on.  Parsing used to be race-free
+     * against a concurrently logging thread; it no longer is.  (There is no
+     * NULL-sink deref -- wl_log_sink_get_() falls back to stderr.)  Callers
+     * that parse concurrently with evaluation should parse before starting
+     * worker threads, which is already the usual shape.
+     *
+     * Cost: with WL_LOG_FILE set this reopens the sink on every call, so a
+     * caller parsing many programs in a loop pays an fopen+fclose each time.
+     * Unset -- the default -- it is just a threshold recompute. */
     if (!program_text) {
         if (error)
             *error = WIRELOG_ERR_PARSE;
         return NULL;
     }
+
+    wl_log_init();
 
     char errbuf[512] = { 0 };
     wl_parser_ast_node_t *ast

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -1768,6 +1768,56 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
     if (head->type != WL_PARSER_AST_NODE_HEAD)
         return NULL;
 
+    /* Issue #973: at most one aggregate per rule head.  Memory safety, not
+     * just diagnostics.
+     *
+     * The AGGREGATE IR node carries one agg_fn and one agg_expr, so
+     * t(g, min(v), max(v)) has nowhere to put the second aggregate.  Step 5
+     * used to overwrite agg_node per aggregate child and set
+     * group_by_count = non_agg_count, keeping only the last and emitting a
+     * tuple narrower than the .decl.  col_op_reduce() (columnar/ops.c) then
+     * sizes its output region as group_by_count + 1 while col_rel_append_all()
+     * (columnar/relation.c) copies dst->ncols columns from it, unclamped -- an
+     * out-of-bounds read under col_eval_stratum() (columnar/eval.c):
+     *   .decl cc(n:int64, lo:int64, hi:int64)
+     *   cc(y, min(c), max(c)) :- cc(x, c, d), edge(x, y).   -> SIGSEGV
+     *
+     * This check does NOT close that crash class.  The trigger is emitted
+     * arity != declared arity in a recursive stratum; multiple aggregates are
+     * one route to it.  A single-aggregate head is another and still crashes:
+     *   cc(y, min(c)) :- cc(x, c, d), edge(x, y).           -> SIGSEGV
+     * That is issue #977, and neither fix subsumes the other -- a .decl-arity
+     * check passes t(g, min(v), max(v)), which has three textual arguments
+     * against a 3-arity .decl.  See docs/SEMANTICS.md for why this rejects
+     * rather than supports multiple aggregates.
+     *
+     * Counting direct HEAD children suffices because parse_aggregate_expr()
+     * has exactly one caller, parse_head_arg() (parser/parser.c), so an
+     * AGGREGATE node can only ever be a direct top-level head argument.
+     * The check precedes the first allocation, so return NULL cannot leak.
+     *
+     * Scope: the parser path only.  A caller building a WIRELOG_IR_AGGREGATE
+     * node directly still reaches the crash -- neither wirelog_optimize(),
+     * wl_plan_from_program() nor the columnar REDUCE validates that
+     * group_by_count + 1 matches the head arity.  Nor does this constrain
+     * aggregate *position*: t(min(v), g) emits group-by-first regardless of
+     * how it was written (issue #980). */
+    uint32_t head_agg_count = 0;
+    for (uint32_t i = 0; i < head->child_count; i++) {
+        if (head->children[i]->type == WL_PARSER_AST_NODE_AGGREGATE)
+            head_agg_count++;
+    }
+    if (head_agg_count > 1) {
+        WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+            "relation '%s' has %u aggregates in one rule head; at most one is "
+            "supported. Derive each aggregate in its own rule and join the "
+            "results (e.g. tmin(g, min(v)) :- val(g, v); "
+            "tmax(g, max(v)) :- val(g, v); "
+            "t(g, a, b) :- tmin(g, a), tmax(g, b))",
+            head->name ? head->name : "?", head_agg_count);
+        return NULL;
+    }
+
     uint32_t body_count = rule_node->child_count - 1;
 
     /* ---- Step 1: Collect positive atoms -> SCANs ---- */


### PR DESCRIPTION
Closes #973.

## What was wrong

`t(g, min(v), max(v))` kept only the **last** aggregate. The `AGGREGATE` IR node carries one `agg_fn`/`agg_expr`, so `convert_rule()` Step 5 overwrote `agg_node` on each aggregate child and emitted a tuple narrower than the `.decl`.

**This is a memory-safety bug, not the silent-truncation bug it was filed as.** Outside a recursive stratum it is a wrong answer with exit 0 and empty stderr. Inside one it segfaults — `col_op_reduce()` sizes its output region as `group_by_count + 1` while `col_rel_append_all()` copies `dst->ncols` columns from it with no clamp against `src->ncols`:

```
.decl cc(n:int64, lo:int64, hi:int64)
cc(y, min(c), max(c)) :- cc(x, c, d), edge(x, y).    # SIGSEGV before, exit 1 after
```

ASAN: `heap-buffer-overflow READ of size 8` in `col_rel_append_all`, 0 bytes past a 16-byte region from `col_op_reduce`.

## What this does NOT fix

The trigger is *emitted arity != declared arity in a recursive stratum*; multiple aggregates are one route to it. A single-aggregate head still crashes identically:

```
cc(y, min(c)) :- cc(x, c, d), edge(x, y).            # still SIGSEGV
```

That is #977, and **neither fix subsumes the other** — a `.decl`-arity check passes `t(g, min(v), max(v))` (three textual args against a 3-arity `.decl`), and this check passes the single-aggregate case. Both are needed. Verified in both directions, before and after.

## Making the diagnostic reachable

The rejection logs via `WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR, ...)` — which **no user could ever see**. `wl_log_thresholds` is a zero-init global read only by `wl_log_init()`, whose two call sites (`exec_plan_gen.c`, `columnar/session.c`) both run *after* parsing. The process returned before the logger existed, so no `WL_LOG` value could help, and `util/log.h` is enforced-internal so embedders could not initialize it either.

`wirelog_parse_string()` now calls `wl_log_init()` first. This also unblocks two pre-existing lowering diagnostics that were being dropped for the same reason: the `__graph_metadata` arity guard and the #920 unsafe-variable check.

Default output is unchanged — the gate is `LVL <= threshold` and the default `WL_LOG_NONE` (0) still suppresses `WL_LOG_ERROR` (1). A user who sets nothing still sees only `Parse error`; that is #979.

## Compatibility

Programs that previously loaded now fail to load — and not only wrong-arity ones. `t(g, min(v), max(v))` against a **two**-column `.decl t(g, a)` emitted a correctly-sized relation with exit 0 and is now rejected too. In both cases the previous result was not correct for any reading of the rule. No program in the tree — tests, bench workloads, examples, docs — has a multi-aggregate head.

## Validation

- Full suite **261 Ok / 1 Fail / 11 Skipped** — baseline; the failure is the pre-existing `sbom_snapshot` SBOM drift.
- ASAN+UBSAN+LSan: `test_program` 69/69, rejection path leak-clean.
- `check_log_header_not_public.sh` and `check-log-erasure.sh` both `rc=0`.
- Mutation-tested: `> 1` → `> 2` fails the negatives; `> 1` → `> 0` fails the positive controls, so the controls are load-bearing.
- Workaround verified to compute the right answer, not merely to be plausible advice.

## Filed while validating this

- **#979** — `wirelog_parse_string()` builds a 512-byte errbuf and discards it; rule lowering has no error channel at all.
- **#980** — aggregate *position* in a head is ignored: `t(min(v), g)` emits group-by-first, so values land in the wrong columns with correct arity and exit 0. Not caught by this check or by #977.
