### PR TITLE
fix(io): validate CSV width against the declared arity on the integer .input path

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4566,6 +4566,31 @@ test_io_dispatch_exe = executable(
 test('io_dispatch', test_io_dispatch_exe)
 
 # ============================================================================
+# .input CSV Arity Validation Tests (#977)
+# Drives the full pipeline (parse -> plan -> load .input -> evaluate) so the
+# columnar insert path sees the loaded rows; a width mismatch between the CSV
+# and the .decl must fail the load instead of re-striding (or over-reading).
+# ============================================================================
+
+test_input_arity_exe = executable(
+  'test_input_arity',
+  files('test_input_arity.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  driver_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+  install: false,
+)
+test('input_arity', test_input_arity_exe)
+
+# ============================================================================
 # Concurrent I/O Adapter Registry Stress Test (#459)
 # Exercises mutex safety under TSan: concurrent find, register/unregister,
 # and mixed readers+writers.  Linux/macOS only (pthreads; skipped on Windows).

--- a/tests/test_input_arity.c
+++ b/tests/test_input_arity.c
@@ -1,0 +1,420 @@
+/*
+ * test_input_arity.c - .input CSV arity validation tests (Issue #977)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * The built-in CSV adapter auto-detects the column count of an
+ * integer-only file from its first line.  The caller then inserts the
+ * rows at the *declared* arity of the relation, so a file whose width
+ * disagrees with the .decl is packed at one stride and read back at
+ * another: a heap over-read when the file is narrower than the .decl,
+ * silently re-strided tuples when it is wider.
+ *
+ * These tests drive the real pipeline (parse -> plan -> load .input ->
+ * evaluate) through wl_run_pipeline so both the columnar insert path
+ * and the printed results are exercised.
+ */
+
+#include "../wirelog/cli/driver.h"
+
+#include "test_tmpdir.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test Helpers                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
+
+static int
+write_text_file(const char *path, const char *text)
+{
+    FILE *f = fopen(path, "w");
+    if (!f)
+        return -1;
+    if (text && text[0] != '\0')
+        fputs(text, f);
+    fclose(f);
+    return 0;
+}
+
+/*
+ * Run the full pipeline on @src, capturing printed tuples into @outpath.
+ * On success (*out_text != NULL) the caller must free(*out_text).
+ * Returns the wl_run_pipeline return code, or -999 if the capture file
+ * could not be opened.
+ */
+static int
+run_pipeline_capture(const char *src, const char *outpath, char **out_text)
+{
+    *out_text = NULL;
+
+    FILE *f = fopen(outpath, "w");
+    if (!f)
+        return -999;
+
+    int rc = wl_run_pipeline(src, 1, false, false, 0, f);
+    fclose(f);
+
+    *out_text = wl_read_file(outpath);
+    return rc;
+}
+
+static int
+count_substr(const char *hay, const char *needle)
+{
+    int count = 0;
+    const char *p = hay;
+    while (p && (p = strstr(p, needle)) != NULL) {
+        count++;
+        p++;
+    }
+    return count;
+}
+
+/* ======================================================================== */
+/* Case 1: narrow integer CSV against a wider .decl                         */
+/* ======================================================================== */
+
+/*
+ * 200-row, 1-column CSV loaded into an 8-column relation.  Before the
+ * fix the adapter detects ncols=1, allocates 256*1 int64 and the caller
+ * inserts 200 rows at stride 8 -> heap-buffer-overflow READ of size 8 in
+ * col_rel_row_copy_in (caught by ASan; silent garbage otherwise).
+ * The load must fail instead.
+ */
+static void
+test_narrow_csv_rejected(void)
+{
+    TEST("narrow integer CSV vs wider .decl is rejected");
+
+    char csv_path[512];
+    char out_path[512];
+    test_tmppath(csv_path, sizeof(csv_path), "wl_arity_narrow.csv");
+    test_tmppath(out_path, sizeof(out_path), "wl_arity_narrow_out.txt");
+
+    /* 200 single-column rows */
+    char csv[2048];
+    size_t off = 0;
+    for (int i = 0; i < 200; i++) {
+        int n = snprintf(csv + off, sizeof(csv) - off, "%d\n", i);
+        if (n < 0 || (size_t)n >= sizeof(csv) - off) {
+            FAIL("csv buffer too small");
+            return;
+        }
+        off += (size_t)n;
+    }
+    if (write_text_file(csv_path, csv) != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    char src[2048];
+    snprintf(src, sizeof(src),
+        ".decl wide(a: int32, b: int32, c: int32, d: int32,"
+        " e: int32, f: int32, g: int32, h: int32)\n"
+        ".input wide(filename=\"%s\", delimiter=\",\")\n"
+        ".decl seen(a: int32, b: int32, c: int32, d: int32,"
+        " e: int32, f: int32, g: int32, h: int32)\n"
+        "seen(A, B, C, D, E, F, G, H) :- "
+        "wide(A, B, C, D, E, F, G, H).\n",
+        csv_path);
+
+    char *output = NULL;
+    int rc = run_pipeline_capture(src, out_path, &output);
+
+    remove(csv_path);
+    remove(out_path);
+
+    if (rc == 0) {
+        FAIL("expected non-zero rc for 1-column CSV vs 8-column .decl");
+        free(output);
+        return;
+    }
+
+    free(output);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Case 2: wide integer CSV against a narrower .decl                        */
+/* ======================================================================== */
+
+/*
+ * A 3-column CSV loaded into a 2-column relation.  Before the fix this
+ * exits 0 after emitting re-strided tuples (row 0 becomes (1,2), row 1
+ * becomes (3,4) ...), silently corrupting the EDB.  The load must fail.
+ */
+static void
+test_wide_csv_rejected(void)
+{
+    TEST("wide integer CSV vs narrower .decl is rejected");
+
+    char csv_path[512];
+    char out_path[512];
+    test_tmppath(csv_path, sizeof(csv_path), "wl_arity_wide.csv");
+    test_tmppath(out_path, sizeof(out_path), "wl_arity_wide_out.txt");
+
+    if (write_text_file(csv_path, "1,2,3\n4,5,6\n7,8,9\n") != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    char src[1024];
+    snprintf(src, sizeof(src),
+        ".decl edge(x: int32, y: int32)\n"
+        ".input edge(filename=\"%s\", delimiter=\",\")\n"
+        ".decl reach(x: int32, y: int32)\n"
+        "reach(X, Y) :- edge(X, Y).\n",
+        csv_path);
+
+    char *output = NULL;
+    int rc = run_pipeline_capture(src, out_path, &output);
+
+    remove(csv_path);
+    remove(out_path);
+
+    if (rc == 0) {
+        char msg[256];
+        snprintf(msg, sizeof(msg),
+            "expected non-zero rc for 3-column CSV vs 2-column .decl; "
+            "got 0 with output:\n%s", output ? output : "(null)");
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    free(output);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Case 3: positive control - matching integer widths still evaluate        */
+/* ======================================================================== */
+
+static void
+test_matching_width_evaluates(void)
+{
+    TEST("matching-width integer CSV loads and evaluates");
+
+    char csv_path[512];
+    char out_path[512];
+    test_tmppath(csv_path, sizeof(csv_path), "wl_arity_match.csv");
+    test_tmppath(out_path, sizeof(out_path), "wl_arity_match_out.txt");
+
+    if (write_text_file(csv_path, "1,2\n2,3\n3,4\n") != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    char src[1024];
+    snprintf(src, sizeof(src),
+        ".decl edge(x: int32, y: int32)\n"
+        ".input edge(filename=\"%s\", delimiter=\",\")\n"
+        ".decl tc(x: int32, y: int32)\n"
+        "tc(X, Y) :- edge(X, Y).\n"
+        "tc(X, Z) :- tc(X, Y), edge(Y, Z).\n",
+        csv_path);
+
+    char *output = NULL;
+    int rc = run_pipeline_capture(src, out_path, &output);
+
+    remove(csv_path);
+    remove(out_path);
+
+    if (rc != 0 || !output) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "wl_run_pipeline returned %d", rc);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    /* Transitive closure of the 1->2->3->4 chain: exactly six tuples. */
+    static const char *expected[] = {
+        "tc(1, 2)", "tc(1, 3)", "tc(1, 4)",
+        "tc(2, 3)", "tc(2, 4)", "tc(3, 4)",
+    };
+    int ok = (count_substr(output, "tc(") == 6);
+    for (size_t i = 0; ok && i < sizeof(expected) / sizeof(expected[0]); i++)
+        ok = (count_substr(output, expected[i]) == 1);
+
+    if (!ok) {
+        char msg[512];
+        snprintf(msg, sizeof(msg), "unexpected tc tuples:\n%s", output);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    free(output);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Case 4: positive control - string relations use the guarded path         */
+/* ======================================================================== */
+
+static void
+test_symbol_relation_unaffected(void)
+{
+    TEST("symbol-bearing CSV still loads via the guarded path");
+
+    char csv_path[512];
+    char out_path[512];
+    test_tmppath(csv_path, sizeof(csv_path), "wl_arity_sym.csv");
+    test_tmppath(out_path, sizeof(out_path), "wl_arity_sym_out.txt");
+
+    if (write_text_file(csv_path, "alice,bob\nbob,charlie\n") != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    char src[1024];
+    snprintf(src, sizeof(src),
+        ".decl parent(x: symbol, y: symbol)\n"
+        ".input parent(filename=\"%s\", delimiter=\",\")\n"
+        ".decl ancestor(x: symbol, y: symbol)\n"
+        "ancestor(X, Y) :- parent(X, Y).\n"
+        "ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).\n",
+        csv_path);
+
+    char *output = NULL;
+    int rc = run_pipeline_capture(src, out_path, &output);
+
+    remove(csv_path);
+    remove(out_path);
+
+    if (rc != 0 || !output) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "wl_run_pipeline returned %d", rc);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    static const char *expected[] = {
+        "ancestor(\"alice\", \"bob\")",
+        "ancestor(\"alice\", \"charlie\")",
+        "ancestor(\"bob\", \"charlie\")",
+    };
+    int ok = (count_substr(output, "ancestor(") == 3);
+    for (size_t i = 0; ok && i < sizeof(expected) / sizeof(expected[0]); i++)
+        ok = (count_substr(output, expected[i]) == 1);
+
+    if (!ok) {
+        char msg[512];
+        snprintf(msg, sizeof(msg), "unexpected ancestor tuples:\n%s", output);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    free(output);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Case 5: empty .input file remains legal                                  */
+/* ======================================================================== */
+
+/*
+ * An empty file yields nrows == 0 and ncols == 0 with rc == 0.  There is
+ * no row to mis-stride, and rejecting it would break programs whose
+ * .input file is legitimately empty, so the arity check must not fire.
+ */
+static void
+test_empty_csv_still_loads(void)
+{
+    TEST("empty .input CSV still loads (no rows, no error)");
+
+    char csv_path[512];
+    char out_path[512];
+    test_tmppath(csv_path, sizeof(csv_path), "wl_arity_empty.csv");
+    test_tmppath(out_path, sizeof(out_path), "wl_arity_empty_out.txt");
+
+    if (write_text_file(csv_path, "") != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    char src[1024];
+    snprintf(src, sizeof(src),
+        ".decl edge(x: int32, y: int32)\n"
+        ".input edge(filename=\"%s\", delimiter=\",\")\n"
+        ".decl reach(x: int32, y: int32)\n"
+        "reach(X, Y) :- edge(X, Y).\n",
+        csv_path);
+
+    char *output = NULL;
+    int rc = run_pipeline_capture(src, out_path, &output);
+
+    remove(csv_path);
+    remove(out_path);
+
+    if (rc != 0) {
+        char msg[128];
+        snprintf(msg, sizeof(msg),
+            "empty .input file must still load; rc = %d", rc);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    if (output && count_substr(output, "reach(") != 0) {
+        char msg[512];
+        snprintf(msg, sizeof(msg),
+            "expected no reach tuples from empty input:\n%s", output);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    free(output);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("=== test_input_arity (Issue #977) ===\n");
+
+    test_narrow_csv_rejected();
+    test_wide_csv_rejected();
+    test_matching_width_evaluates();
+    test_symbol_relation_unaffected();
+    test_empty_csv_still_loads();
+
+    printf("\n=== Results: %d run, %d passed, %d failed ===\n",
+        tests_run, tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/wirelog/io/csv_adapter.c
+++ b/wirelog/io/csv_adapter.c
@@ -128,10 +128,43 @@ csv_read(wirelog_io_ctx_t *ctx, int64_t **out_data,
         return rc;
     }
 
-    /* Integer-only path */
+    /*
+     * Integer-only path.
+     *
+     * wl_csv_read_file() takes no expected width: it auto-detects the
+     * column count from the file's first line and only reports it via
+     * out_ncols.  The caller (wl_session_load_input_files) then inserts
+     * the rows at the relation's *declared* arity, so a file whose width
+     * disagrees with the .decl is packed at one stride and read back at
+     * another -- a heap over-read when the file is narrower, silently
+     * re-strided tuples when it is wider (#977).
+     *
+     * The invariant being restored is the adapter contract itself:
+     * docs/io-adapters.md requires read() to produce a buffer of
+     * *out_nrows * wirelog_io_ctx_num_cols(ctx) elements, and
+     * wirelog_io_ctx_num_cols() is set from rel->column_count
+     * (io/io_ctx.c) -- the very stride wl_session_load_input_files()
+     * inserts at.  This branch was violating the contract it publishes.
+     *
+     * -2 is the code wl_csv_read_file_via_ctx() uses for a width
+     * mismatch, reused for consistency of the return value only.  Note
+     * that path's own width check is presently unreachable (#982), so
+     * this is not an appeal to it as a working precedent.
+     *
+     * An empty file yields nrows == 0 / ncols == 0 with rc == 0; there is
+     * no row to mis-stride and an empty .input file is legal, so the
+     * check only applies once a width has actually been detected.
+     */
     uint32_t out_ncols = 0;
-    return wl_csv_read_file(resolved_path, delimiter,
-               out_data, out_nrows, &out_ncols);
+    int rc = wl_csv_read_file(resolved_path, delimiter,
+            out_data, out_nrows, &out_ncols);
+    if (rc == 0 && *out_nrows > 0 && out_ncols != num_cols) {
+        free(*out_data);
+        *out_data = NULL;
+        *out_nrows = 0;
+        return -2; /* arity mismatch */
+    }
+    return rc;
 }
 
 /* ======================================================================== */


### PR DESCRIPTION
First of four units for #977. This one closes the `.input` half; the issue stays open for the inline-fact, rule-head and body-atom halves.

## What was wrong

The `.input` CSV loader branches on whether any declared column is a string:

- **string present** → `wl_csv_read_file_via_ctx()`, which receives `num_cols`.
- **all integers** → `wl_csv_read_file()`, which takes **no expected width at all**. It auto-detects the column count from the file's first line and reports it through an out-param that `csv_adapter.c` declared and then discarded.

`wl_session_load_input_files()` inserts at the relation's declared arity regardless, so a file whose width disagrees with its `.decl` is packed at one stride and read back at another.

| CSV vs `.decl` | before |
|---|---|
| narrower (many rows) | `heap-buffer-overflow` in `col_rel_row_copy_in` ← `col_rel_append_row` ← `col_session_insert` ← `wl_session_load_input_files` |
| narrower (few rows) | **exit 0, uninitialised heap emitted as query results, no ASAN report** — the over-read stays inside the allocated capacity |
| wider | exit 0, re-strided tuples, real rows dropped |

The quiet one is the worst: a 2-column CSV against a 3-column `.decl` produces `0xBEBEBEBE...` as answer values with a clean exit and nothing to catch it.

This is the same defect as the inline-fact half of #977 — `collect_fact` packs at the fact's own arity, `wl_session_load_facts` reads at the declared one — one layer down and on a second call site.

## The invariant

`docs/io-adapters.md` already specifies that `read()` must produce a buffer of `*out_nrows * wirelog_io_ctx_num_cols(ctx)` elements, and `io/io_ctx.c` sets that from `rel->column_count` — the exact stride the insert uses. The built-in CSV adapter was violating the contract it publishes. This restores conformance at the violating site rather than inventing a new rule.

## Why reject rather than pad or truncate

A narrow row can only be completed by inventing a value; a wide one only by discarding user data. The source is genuinely ambiguous, so any silent reconciliation resolves the ambiguity by fabrication — which is the bug, not the fix.

## Compatibility

Every configuration this newly rejects was already a heap over-read or re-strided garbage, so nothing depends on it.

- All 15 `bench/workloads/` and all shipped examples: **byte-identical stdout and exit codes** with and without the change.
- 43 shipped data files checked against their `.decl` arities: **zero mismatches**.
- `bench_flowlog --workload doop`: exit 0, 3,857,201 facts, 14,096,448 tuples, 153 iterations. DOOP declares all 35 EDB relations as `string` (`bench/bench_flowlog.c`), so it loads through the *other* branch — this run confirms the change is inert there.
- `bench_flowlog --workload crdt` (integer `.input`, the changed branch): OK on both fixtures.

## Two deliberate limitations

**The message stays generic** — `error: adapter 'csv' failed to read data for '<rel>'`, with no expected-vs-actual width. The `read()` ABI has no error-message channel; only `validate()` carries an errbuf, and `wl_csv_adapter` sets `.validate = NULL`. A precise message needs an ABI change, which does not belong in a memory-safety fix.

**The string branch is left alone.** Its width check turns out to be *unreachable*: `csv_parse_line_via_ctx()` increments `*count` once per iteration of a loop bounded by `num_cols`, so `col_count != num_cols` can never be true. A row missing exactly its last field is silently padded with `""`, and extra fields are dropped. That is a wrong-answer bug with no memory-safety component — filed as **#982**. So this commit fixes the worse half of an existing asymmetry rather than creating one.

## Tests

`tests/test_input_arity.c` drives the real pipeline through `wl_run_pipeline`: narrow and wide rejection, a matching-width control asserting tuple **contents**, a symbol-relation control proving the other branch is undisturbed, and an empty-file control pinning the `*out_nrows > 0` gate.

Mutation-verified — replacing the guard with `if (0)` fails the two rejection cases; dropping the nrows gate fails only the empty-file case. Each test kills a distinct mutant.

Suite: **264 Ok / 1 Fail / 11 Skipped**. The failure is the pre-existing `sbom_snapshot` drift (`msys2/setup-msys2@v2` vs a pinned SHA), confirmed identical on base.
