### PR TITLE
fix(ir): validate inline facts against their relation declared arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,40 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **Inline facts are validated against their relation's declared arity**
+  (#977): `collect_fact` packed `fact_data` using each fact's *own*
+  argument count as the row stride, while both readers of that buffer --
+  `wl_session_load_facts` and the public `wirelog_program_get_facts`, the
+  latter reachable by an embedder with no session at all -- strided by the
+  *declared* `column_count`. Nothing reconciled the two. Depending on which
+  side was wider this produced a heap over-read, an uninitialised read
+  *inside* the allocation that AddressSanitizer cannot see (exit status 0,
+  emitting heap bytes as query answers), or a fabricated tuple: `val(1,5,7).
+  val(2,6,8).` against a two-column `.decl` emitted `t(7,2)`, a pair present
+  in no source fact, and dropped `(6,8)`.
+
+  Such facts are now rejected during metadata collection, reported through
+  `WL_LOG=PARSER:1` with the relation name and both arities, and surfaced as
+  `WIRELOG_ERR_PARSE`. The check runs as a pass after all declarations are
+  collected rather than inside `collect_fact`, because a `.decl` may legally
+  follow its own facts in source order.
+
+  Relations are tracked by a new `has_decl` flag rather than by
+  `column_count > 0`, since `.decl p()` parses and leaves `column_count` at
+  zero; without the flag exactly those relations would be skipped.
+
+  **Compatibility:** programs that previously loaded now fail to load. Every
+  rejected shape was already producing a crash, uninitialised heap, or a
+  fabricated tuple, so nothing correct is lost. One shape worth naming:
+  flattened facts against an inline-compound column -- `p(1,2,3).` against
+  `.decl p(id: int64, lbl: pair/2 inline)` -- were accepted and silently
+  dropped the third value; they are now rejected. Verified across every
+  Datalog program in the tree, including those the benchmarks generate from
+  CSV at runtime: no in-tree program changes behaviour.
+
+  This covers the inline-fact half of #977 only. Rule heads, rule bodies and
+  facts on undeclared relations remain unvalidated.
+
 - **`min()`/`max()` over a symbol column compare strings, not intern ids**
   (#965): both reduced over the raw `int64`, which for a `symbol` column is
   its interned id. Ids are handed out in first-appearance order, so

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -112,7 +112,38 @@ Two scope notes:
   with too few arguments for its `.decl`, such as
   `cc(y, min(c)) :- cc(x, c, d), edge(x, y).` against a 3-column `cc`, is
   still accepted and still unsafe in a recursive stratum. General
-  `.decl`-versus-rule arity validation is tracked separately as #977.
+  `.decl`-versus-rule arity validation is tracked separately as #977, whose
+  fact half has since landed (see below) while the rule-head half has not.
+
+### Inline facts must match their declared arity
+
+A fact whose argument count differs from its relation's `.decl` is rejected
+when the program is loaded (#977):
+
+```
+.decl val(g: int64, v: int64)
+val(1, 5, 7).       /* rejected: 3 arguments, 2 declared */
+val(1).             /* rejected: 1 argument, 2 declared */
+val(1, 5).          /* accepted */
+```
+
+The `.decl` may appear before or after its facts; the check runs once all
+declarations have been collected.
+
+This is a memory-safety guard. Facts are packed at the width they are
+written and read back at the declared width, so a mismatch previously caused
+an out-of-bounds read, or an uninitialised read that produced heap bytes as
+query answers with exit status 0, or a tuple assembled from two different
+facts. Loading fails with `WIRELOG_ERR_PARSE`; run with `WL_LOG=PARSER:1` to
+see which relation and which arities.
+
+A relation with an inline-compound column must be given the compound form,
+not a flattened one — `p(1,2,3).` against `.decl p(id: int64, lbl: pair/2
+inline)` is rejected, because the fact is compared against the declared
+*logical* width.
+
+Facts on a relation with **no** `.decl` at all are unaffected by this check
+and continue to fail later, during loading, with a less specific message.
 
 The count is not the only constraint on aggregates in a head — the aggregate
 must also be written **last**. `t(min(v), g) :- val(g, v).` lowers with a

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -2830,6 +2830,350 @@ test_fact_collection_single_relation(void)
 }
 
 /* ======================================================================== */
+/* Issue #977 (unit 2): inline fact arity must match the .decl              */
+/* ======================================================================== */
+
+/* collect_fact() packs fact_data using the *fact's own* child_count as the
+ * row stride, while both readers of that buffer stride by the *declared*
+ * rel->column_count: wl_session_load_facts (session_facts.c) and
+ * wirelog_program_get_facts (the public API, ir/api.c).
+ * Nothing reconciled the two, so an arity disagreement produced a heap
+ * over-read, an uninitialised read inside the allocation, or a silently
+ * fabricated tuple -- depending on which side was wider.
+ *
+ * Entry point: these tests go through make_program(), which calls
+ * wl_ir_program_collect_metadata() directly.  That is exactly where the
+ * validation pass lives (tail of the function, after the source-order
+ * loop), so a NULL return here is this rejection and not a later stage.
+ * ir/api.c maps the same non-zero return to WIRELOG_ERR_PARSE, which
+ * test_fact_arity_mismatch_maps_to_parse_error() pins separately.
+ *
+ * The check deliberately does NOT live inside collect_fact():
+ * wl_ir_program_collect_metadata() is a single source-order loop, so a
+ * .decl written after its facts has not been seen when collect_fact() runs.
+ * test_fact_arity_decl_after_facts_rejected() is the case that a
+ * collect_fact-internal check would wrongly accept. */
+
+static void
+test_fact_arity_narrower_than_decl_rejected(void)
+{
+    TEST("Fact arity: fact narrower than .decl is rejected");
+
+    /* 1-arity fact against a 9-column .decl.  Pre-fix the readers strided
+     * the declared width per row over a buffer packed at the fact's own
+     * width.  collect_fact seeds fact_capacity at ncols * 8, so with a
+     * 1-arity fact the buffer holds 8 slots: a 9-column read runs one slot
+     * past the allocation -- heap-buffer-overflow in col_rel_row_copy_in
+     * <- col_rel_append_row <- col_session_insert <- wl_session_load_facts.
+     *
+     * The width has to exceed 8 for that.  At exactly .decl p/8 the read
+     * lands on the last slot rather than past it, so ASAN stays silent and
+     * the program exits 0 emitting uninitialised heap as answers -- the
+     * quieter defect, covered by the second case below. */
+    struct wirelog_program *bad = make_program(
+        ".decl p(a: int32, b: int32, c: int32, d: int32, e: int32,"
+        " f: int32, g: int32, h: int32, i: int32)\n"
+        "p(1).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("p(1). against .decl p/9 should be rejected");
+        return;
+    }
+
+    /* Two 1-arity facts against .decl p/8: 2 rows * 8 columns = 16 slots
+     * read from the same 8-slot buffer, so this over-reads too even though
+     * the declared width does not exceed the seed capacity. */
+    bad = make_program(
+        ".decl p(a: int32, b: int32, c: int32, d: int32,"
+        " e: int32, f: int32, g: int32, h: int32)\n"
+        "p(1). p(2).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("p(1). p(2). against .decl p/8 should be rejected");
+        return;
+    }
+
+    /* The ASAN-silent shape: one 1-arity fact against .decl p/8 reads
+     * within the allocation but past what was written. */
+    bad = make_program(
+        ".decl p(a: int32, b: int32, c: int32, d: int32,"
+        " e: int32, f: int32, g: int32, h: int32)\n"
+        "p(1).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("p(1). against .decl p/8 should be rejected");
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_fact_arity_decl_after_facts_rejected(void)
+{
+    TEST("Fact arity: .decl written after the facts is still checked");
+
+    /* Same mismatch as above, source order reversed.  This is the case
+     * that proves the pass must re-walk the AST after the collection loop
+     * rather than validate inside collect_fact(). */
+    struct wirelog_program *bad = make_program(
+        "p(1).\n"
+        ".decl p(a: int32, b: int32, c: int32, d: int32,"
+        " e: int32, f: int32, g: int32, h: int32)\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("p(1). before .decl p/8 should be rejected");
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_fact_arity_wider_than_decl_rejected(void)
+{
+    TEST("Fact arity: fact wider than .decl is rejected");
+
+    /* Pre-fix this was the silent-corruption case: val(1,5,7). val(2,6,8).
+     * packed 3 values per row but was read back 2 per row, so the program
+     * evaluated to t(1,5) and t(7,2) -- a tuple present in no source fact --
+     * and dropped (6,8) entirely.  Exit status was 0. */
+    struct wirelog_program *bad
+        = make_program(".decl val(g: int32, v: int32)\n"
+            "val(1, 5, 7).\n"
+            "val(2, 6, 8).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("val(1,5,7). against .decl val/2 should be rejected");
+        return;
+    }
+
+    /* Inline-compound columns.  `.decl p(id, lbl: pair/2 inline)` has a
+     * *logical* width of 2 and a *physical* width of 3, and this fact is
+     * written flat.  It is rejected, because facts are compared logically:
+     * collect_fact packs one slot per written argument and both readers
+     * stride by rel->column_count, which is the logical width.
+     *
+     * Pre-fix this was accepted and silently dropped the third value.
+     * Note this is the one place where the fact rule and the coming
+     * rule-head rule diverge -- head lowering does expand compound columns,
+     * so the head check (#977 unit 3) must compare *physical* width via
+     * atom_physical_column_count().  If compound terms ever become
+     * expressible in facts, this comparison has to move with it. */
+    bad = make_program(".decl p(id: int64, lbl: pair/2 inline)\n"
+            "p(1, 2, 3).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("flat p(1,2,3). against inline-compound .decl p/2 rejected");
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_fact_arity_mixed_across_facts_rejected(void)
+{
+    TEST("Fact arity: mixed arities across facts are rejected");
+
+    /* collect_fact() computes offset = fact_count * ncols with a *per-fact*
+     * ncols, so p(1). writes index 0 and p(2,3). writes indices 2..3,
+     * leaving index 1 never written.  realloc does not zero, so the reader
+     * returned uninitialised heap (observed: 0xBEBEBEBEBEBEBEBE) with ASAN
+     * silent and exit 0, because the read stayed inside the allocation. */
+    struct wirelog_program *bad = make_program(".decl p(a: int32, b: int32)\n"
+            "p(1).\n"
+            "p(2, 3).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("p(1). p(2,3). against .decl p/2 should be rejected");
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_fact_arity_zero_param_decl_rejected(void)
+{
+    TEST("Fact arity: .decl p() with a 1-arity fact is rejected");
+
+    /* `.decl p()` parses and leaves column_count == 0 (see
+     * test_parse_decl_empty_params in test_parser.c), which is precisely
+     * why the guard keys off has_decl rather than the column_count > 0
+     * proxy -- the proxy would skip exactly these relations.
+     *
+     * Deliberate decision: p(1). against a zero-column declaration IS an
+     * arity mismatch and is rejected.  Pre-fix it reached the session and
+     * died at runtime with "error: failed to load facts for 'p'" (exit 1),
+     * so nothing that used to work stops working; the diagnostic just moves
+     * to parse time and names both arities. */
+    struct wirelog_program *bad = make_program(".decl p()\n"
+            "p(1).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("p(1). against .decl p() should be rejected");
+        return;
+    }
+
+    /* A zero-arity fact against a zero-column .decl matches and is
+     * accepted.  Note what "accepted" means here: collect_fact computes
+     * needed = fact_count * 0 == 0 and never allocates, so fact_data stays
+     * NULL and wl_session_load_facts skips the relation entirely.  The fact
+     * is silently *dropped*, and p() evaluates to false -- pre-existing
+     * behaviour this check neither causes nor fixes.  Do not read this test
+     * as evidence that zero-arity facts work. */
+    struct wirelog_program *ok = make_program(".decl p()\n"
+            "p().\n");
+    if (!ok) {
+        FAIL("p(). against .decl p() should be accepted");
+        return;
+    }
+    wl_ir_program_free(ok);
+
+    PASS();
+}
+
+static void
+test_fact_arity_matching_accepted(void)
+{
+    TEST("Fact arity: matching facts still load and lower correctly");
+
+    /* Positive control: the exact shape of the wider-fact case above, with
+     * the correct arity.  Assert the stored values, not just non-NULL --
+     * a pass that rejected everything would still return non-NULL here if
+     * we only checked for a program. */
+    struct wirelog_program *prog
+        = make_program_with_rules(".decl val(g: int32, v: int32)\n"
+            ".decl t(x: int32, y: int32)\n"
+            "val(1, 2).\n"
+            "val(3, 4).\n"
+            "t(x, y) :- val(x, y).\n");
+    if (!prog) {
+        FAIL("matching-arity program should be accepted");
+        return;
+    }
+
+    const wl_ir_relation_info_t *val = NULL;
+    for (uint32_t i = 0; i < prog->relation_count; i++) {
+        if (strcmp(prog->relations[i].name, "val") == 0)
+            val = &prog->relations[i];
+    }
+    if (!val || val->column_count != 2 || val->fact_count != 2
+        || !val->fact_data) {
+        wl_ir_program_free(prog);
+        FAIL("val should hold 2 facts of 2 columns");
+        return;
+    }
+    if (val->fact_data[0] != 1 || val->fact_data[1] != 2
+        || val->fact_data[2] != 3 || val->fact_data[3] != 4) {
+        wl_ir_program_free(prog);
+        FAIL("val fact_data should be {1,2,3,4}");
+        return;
+    }
+    if (prog->rule_count != 1 || !prog->rules[0].ir_root) {
+        wl_ir_program_free(prog);
+        FAIL("the rule should still lower");
+        return;
+    }
+    wl_ir_program_free(prog);
+
+    PASS();
+}
+
+static void
+test_fact_arity_undeclared_relations_unaffected(void)
+{
+    TEST("Fact arity: undeclared relations keep their current behaviour");
+
+    /* An undeclared *derived* head is widespread and legitimate
+     * (bench/workloads/doop.dl alone has ~90).  It must not be rejected. */
+    struct wirelog_program *derived
+        = make_program_with_rules(".decl val(g: int32, v: int32)\n"
+            "val(1, 2).\n"
+            "t(g) :- val(g, v).\n");
+    if (!derived) {
+        FAIL("undeclared derived head must still be accepted");
+        return;
+    }
+    wl_ir_program_free(derived);
+
+    /* An undeclared relation *with facts* keeps working through metadata
+     * collection: column_count is 0 because no .decl was seen, and the
+     * guard keys off has_decl, so the pass stays out of the way.  Such a
+     * program still fails later at session load ("failed to load facts for
+     * 'q'", exit 1) -- that is issue #977 unit 3, deliberately not this
+     * unit's scope.  This case is what pins the has_decl condition: drop
+     * it and this program is rejected at parse time instead. */
+    struct wirelog_program *undecl = make_program("q(1, 2).\n"
+            "q(3, 4).\n");
+    if (!undecl) {
+        FAIL("undeclared relation with facts must still collect");
+        return;
+    }
+    wl_ir_program_free(undecl);
+
+    PASS();
+}
+
+static void
+test_fact_arity_mismatch_maps_to_parse_error(void)
+{
+    TEST("Fact arity: public API reports WIRELOG_ERR_PARSE");
+
+    /* The public reader wirelog_program_get_facts() memcpy's
+     * fact_count * column_count from the mismatched buffer, so an embedder
+     * hit the over-read with no session involved at all.  Confirm the
+     * program never gets built, and that the error is the documented one. */
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *bad
+        = wirelog_parse_string(".decl val(g: int32, v: int32)\n"
+            "val(1, 5, 7).\n",
+            &err);
+    if (bad) {
+        wirelog_program_free(bad);
+        FAIL("public API should reject the arity mismatch");
+        return;
+    }
+    if (err != WIRELOG_ERR_PARSE) {
+        FAIL("error should be WIRELOG_ERR_PARSE");
+        return;
+    }
+
+    /* Control: the matching program still round-trips through the public
+     * reader with the right values. */
+    wirelog_program_t *ok = wirelog_parse_string(
+        ".decl val(g: int32, v: int32)\n"
+        "val(1, 2).\n"
+        "val(3, 4).\n",
+        &err);
+    if (!ok || err != WIRELOG_OK) {
+        if (ok)
+            wirelog_program_free(ok);
+        FAIL("control: matching program should parse");
+        return;
+    }
+    int64_t *data = NULL;
+    uint32_t nrows = 0, ncols = 0;
+    if (wirelog_program_get_facts(ok, "val", &data, &nrows, &ncols) != 0) {
+        wirelog_program_free(ok);
+        FAIL("control: get_facts should succeed");
+        return;
+    }
+    if (nrows != 2 || ncols != 2 || data[0] != 1 || data[1] != 2
+        || data[2] != 3 || data[3] != 4) {
+        free(data);
+        wirelog_program_free(ok);
+        FAIL("control: get_facts should return {1,2,3,4}");
+        return;
+    }
+    free(data);
+    wirelog_program_free(ok);
+
+    PASS();
+}
+
+/* ======================================================================== */
 /* Fact Extraction API Tests                                                */
 /* ======================================================================== */
 
@@ -3268,6 +3612,16 @@ main(void)
 
     /* Fact collection */
     test_fact_collection_single_relation();
+
+    /* Issue #977 unit 2: inline fact arity vs .decl */
+    test_fact_arity_narrower_than_decl_rejected();
+    test_fact_arity_decl_after_facts_rejected();
+    test_fact_arity_wider_than_decl_rejected();
+    test_fact_arity_mixed_across_facts_rejected();
+    test_fact_arity_zero_param_decl_rejected();
+    test_fact_arity_matching_accepted();
+    test_fact_arity_undeclared_relations_unaffected();
+    test_fact_arity_mismatch_maps_to_parse_error();
 
     /* Fact extraction API */
     test_api_get_facts();

--- a/tests/test_wirelog_easy_inline_facts.c
+++ b/tests/test_wirelog_easy_inline_facts.c
@@ -108,12 +108,90 @@ test_static_fact_joins_with_host_insert(void)
     return rc;
 }
 
+/* T3 (issue #977): inline facts whose arity matches the .decl must still
+ *     evaluate to exactly the source tuples -- values, not just row counts.
+ *
+ *     This is the positive control for the fact-arity validation pass added
+ *     in wl_ir_program_collect_metadata().  The pass rejects arity
+ *     mismatches at parse time; this asserts it did not disturb the
+ *     matching case.  Value equality matters here because the pre-fix
+ *     wider-fact bug (val(1,5,7). against .decl val/2) evaluated cleanly
+ *     with exit 0 while emitting t(7,2) -- a tuple present in no source
+ *     fact -- and dropping (6,8).  A row-count-only assertion would not
+ *     have caught that: the row count was right. */
+struct pair_state {
+    uint32_t rows;
+    int64_t seen[8][2];
+};
+
+static void
+collect_pairs(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    (void)relation;
+    struct pair_state *st = (struct pair_state *)user_data;
+    if (ncols != 2 || st->rows >= 8) {
+        st->rows = 0xFFFFFFFFu;
+        return;
+    }
+    st->seen[st->rows][0] = row[0];
+    st->seen[st->rows][1] = row[1];
+    st->rows++;
+}
+
+static int
+has_pair(const struct pair_state *st, int64_t a, int64_t b)
+{
+    for (uint32_t i = 0; i < st->rows; i++) {
+        if (st->seen[i][0] == a && st->seen[i][1] == b)
+            return 1;
+    }
+    return 0;
+}
+
+static int
+test_matching_arity_facts_evaluate_exactly(void)
+{
+    static const char *src = ".decl val(g: int32, v: int32)\n"
+        ".decl t(x: int32, y: int32)\n"
+        "val(1, 5).\n"
+        "val(2, 6).\n"
+        "t(x, y) :- val(x, y).\n";
+
+    wirelog_easy_session_t *s = NULL;
+    wirelog_error_t err = wirelog_easy_open(src, &s);
+    if (err != WIRELOG_OK || !s) {
+        fprintf(stderr, "T3 open err=%d\n", err);
+        return 1;
+    }
+
+    struct pair_state st = { 0, { { 0, 0 } } };
+    err = wirelog_easy_snapshot(s, "t", collect_pairs, &st);
+    int rc = 0;
+    if (err != WIRELOG_OK) {
+        fprintf(stderr, "T3 snapshot err=%d\n", err);
+        rc = 1;
+    } else if (st.rows != 2) {
+        fprintf(stderr, "T3: expected 2 t rows, got %u\n", st.rows);
+        rc = 1;
+    } else if (!has_pair(&st, 1, 5) || !has_pair(&st, 2, 6)) {
+        fprintf(stderr, "T3: expected exactly t(1,5) and t(2,6), got "
+            "t(%lld,%lld) and t(%lld,%lld)\n",
+            (long long)st.seen[0][0], (long long)st.seen[0][1],
+            (long long)st.seen[1][0], (long long)st.seen[1][1]);
+        rc = 1;
+    }
+    wirelog_easy_close(s);
+    return rc;
+}
+
 int
 main(void)
 {
     int failures = 0;
     failures += test_static_fact_drives_idb_snapshot();
     failures += test_static_fact_joins_with_host_insert();
+    failures += test_matching_arity_facts_evaluate_exactly();
     if (failures == 0)
         printf("test_wl_easy_inline_facts: OK\n");
     else

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -385,6 +385,12 @@ collect_decl(struct wirelog_program *prog,
     rel->has_graph_column = false;
     rel->graph_column_index = 0;
 
+    /* Issue #977: record that this relation carries a declared arity.  Set
+     * unconditionally so a second `.decl` for the same relation (#724) is
+     * idempotent -- the flag simply stays true while column_count is
+     * refreshed from the newest declaration below. */
+    rel->has_decl = true;
+
     /* Extract typed params as columns */
     uint32_t col_count = 0;
     for (uint32_t i = 0; i < decl_node->child_count; i++) {
@@ -681,6 +687,71 @@ collect_fact(struct wirelog_program *prog,
     return 0;
 }
 
+/* Issue #977: validate every inline fact against its relation's declared
+ * arity.
+ *
+ * collect_fact() packs fact_data with the *fact's own* child_count as the
+ * row stride, but both readers of that buffer -- wl_session_load_facts()
+ * (session_facts.c) and the public wirelog_program_get_facts() (ir/api.c),
+ * the latter reachable by an embedder with no session at all -- stride by
+ * the *declared* rel->column_count.  (exec_plan_gen.c only tests
+ * fact_data != NULL; it never reads the contents.)  Nothing reconciled the
+ * two, so a mismatch produced, depending on direction:
+ *
+ *   - a heap over-read (fact narrower than the .decl, crashing in
+ *     col_rel_row_copy_in via col_session_insert);
+ *   - an uninitialised read inside the allocation when facts of mixed
+ *     arity left interior slots never written (realloc does not zero);
+ *   - a silently fabricated tuple present in no source fact, plus dropped
+ *     values, when the fact was wider than the .decl.
+ *
+ * This must be a separate pass rather than a check inside collect_fact()
+ * for two reasons.  wl_ir_program_collect_metadata() walks the AST in
+ * source order, so a `.decl` that follows its facts has not been seen when
+ * collect_fact() runs on them; and collect_fact() discards each fact's
+ * arity, leaving only fact_count and a mixed-stride buffer, so the
+ * information is gone by the time the loop ends.  Hence the re-walk.
+ *
+ * Relations with no `.decl` are skipped: undeclared derived heads are
+ * widespread and legitimate (bench/workloads/doop.dl has ~90 of them).  An
+ * undeclared relation that carries facts still fails later at session load
+ * because column_count is 0; that is a separate defect and is deliberately
+ * left unchanged here.  The guard keys off has_decl rather than
+ * `column_count > 0` because `.decl p()` parses and leaves column_count
+ * == 0, and those relations must be checked, not skipped. */
+static int
+validate_fact_arities(const struct wirelog_program *program,
+    const wl_parser_ast_node_t *ast)
+{
+    for (uint32_t i = 0; i < ast->child_count; i++) {
+        const wl_parser_ast_node_t *node = ast->children[i];
+        if (node->type != WL_PARSER_AST_NODE_FACT || !node->name)
+            continue;
+
+        const wl_ir_relation_info_t *rel = NULL;
+        for (uint32_t r = 0; r < program->relation_count; r++) {
+            if (program->relations[r].name
+                && strcmp(program->relations[r].name, node->name) == 0) {
+                rel = &program->relations[r];
+                break;
+            }
+        }
+        if (!rel || !rel->has_decl)
+            continue;
+
+        if (node->child_count != rel->column_count) {
+            WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                "fact for relation '%s' has %u argument(s) but '%s' is"
+                " declared with %u column(s) (line %u)",
+                rel->name, node->child_count, rel->name, rel->column_count,
+                node->line);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
 int
 wl_ir_program_collect_metadata(struct wirelog_program *program,
     const wl_parser_ast_node_t *ast)
@@ -723,7 +794,9 @@ wl_ir_program_collect_metadata(struct wirelog_program *program,
             return rc;
     }
 
-    return 0;
+    /* Issue #977: run after the loop so that every `.decl` in the program
+    * has been seen, regardless of where it sits relative to its facts. */
+    return validate_fact_arities(program, ast);
 }
 
 /* ======================================================================== */

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -29,6 +29,21 @@ typedef struct {
     char *name;
     wirelog_column_t *columns;
     uint32_t column_count;
+    /* Issue #977: true once a `.decl` for this relation has been collected.
+     * Distinguishes "declared with zero columns" (`.decl p()`, which parses
+     * and leaves column_count == 0) from "never declared" -- a relation
+     * created implicitly by a rule head or by a fact.  `column_count > 0`
+     * cannot make that distinction, so fact-arity validation keys off this
+     * flag instead.
+     *
+     * The predicate is specifically "the user wrote a `.decl`", not "some
+     * arity is on record".  wl_ir_program_add_magic_relation() sets a real
+     * column_count without setting this, deliberately: magic relations are
+     * compiler-generated and must not be validated against user-facing
+     * arity rules.  That is inert today -- they are created after metadata
+     * collection and never carry facts -- but any future consumer of this
+     * flag should read it as "user-declared", not "has a known width". */
+    bool has_decl;
     bool has_input;
     bool has_output;
     bool has_printsize;


### PR DESCRIPTION
Second of four units for #977, covering the inline-fact half. Unit 1 (the `.input` CSV half) is PR #983. Rule heads, rule bodies and undeclared relations remain.

## What was wrong

`collect_fact` packed `fact_data` using each fact's **own** argument count as the row stride. Both readers of that buffer strided by the **declared** `column_count`:

- `wl_session_load_facts` (`session_facts.c:37`)
- `wirelog_program_get_facts` (`ir/api.c:259`) — **public**, `wirelog/wirelog.h:194`, reachable by an embedder with no session at all

Nothing reconciled the two. Same root cause, four different failures, none with a diagnostic:

| shape | before |
|---|---|
| fact narrower, enough facts to outrun the seed capacity | heap over-read in `col_rel_row_copy_in` ← `col_rel_append_row` ← `col_session_insert` |
| fact narrower, within capacity | **uninitialised read inside the allocation — ASAN cannot see it.** Exit 0, heap bytes emitted as answers |
| facts of mixed arity | same, from a buffer with no single valid stride |
| fact wider | **fabricated tuple.** `val(1,5,7). val(2,6,8).` against a 2-column `.decl` → `t(7,2)`, present in no source fact, and `(6,8)` dropped |

The capacity detail matters and cost a test: `collect_fact` seeds at `ncols * 8`, so `.decl p/8` with a single 1-arity fact reads exactly to the end of the allocation — ASAN stays silent. You need arity ≥ 9 or a second fact to get the detectable over-read. The tests now pin all three shapes.

## Why a separate pass, not a check in `collect_fact`

`wl_ir_program_collect_metadata` is a single source-order loop, so a `.decl` may not have been seen when its facts are collected — and a `.decl` legally *follows* its own facts. A check inside `collect_fact` would silently accept that ordering, which is exactly a shape the crash reproduces from. The pass runs at the tail, once every declaration is known.

It re-walks the AST because `collect_fact` discards each fact's arity — only `fact_count` and a mixed-stride buffer survive.

## Why `has_decl` rather than `column_count > 0`

`.decl p()` parses and leaves `column_count` at zero, so the proxy would skip exactly those relations. The flag means *"the user wrote a `.decl`"*, not *"some arity is on record"* — `wl_ir_program_add_magic_relation` deliberately does not set it, since compiler-generated relations must not be validated against user-facing arity rules.

## Compatibility

Programs that previously loaded now fail to load. Every rejected shape was already producing a crash, uninitialised heap, or a fabricated tuple, so nothing correct is lost.

One shape worth naming: flattened facts against an inline-compound column — `p(1,2,3).` against `.decl p(id: int64, lbl: pair/2 inline)` — were accepted and silently dropped the third value. Now rejected, because facts are compared against the declared **logical** width, which is what both readers stride by. This is the one place the fact rule and the coming rule-head rule diverge: head lowering *does* expand compound columns, so unit 3 must compare **physical** width via `atom_physical_column_count()`. Called out in the code, the tests and the CHANGELOG so unit 3 does not inherit the wrong rule.

Verified across every Datalog program in the tree — standalone `.dl`, programs embedded in C string literals, markdown fences — and across programs the benchmarks generate from CSV **at runtime** via `csv_to_inline_facts`, which emits one argument per CSV field without consulting the `.decl`. All 52 files under `bench/data/` have a uniform field count matching their template; all inline-fact workloads produce identical tuple counts. No in-tree program changes behaviour.

## Tests

Eight cases in `tests/test_program.c` — each failure mode, the `.decl`-after-facts ordering, the inline-compound shape, the zero-arity declaration, plus positive controls asserting `fact_data` contents and the public-API round-trip. One case in `test_wirelog_easy_inline_facts.c`, which links the full library and can assert a matching program still evaluates to the right **values**. Value assertions rather than row counts are deliberate: the wider-fact bug produced the correct row count with a fabricated tuple.

Mutation-verified:

| mutant | result |
|---|---|
| disable the comparison | 6 failures — all negatives, neither positive control |
| drop `has_decl` from the guard | exactly 1 — the undeclared-relation case that pins the flag |
| `!=` → `<` | 3 — the cases where the fact is wider than declared |

Suite **263 Ok / 1 Fail / 11 Skipped**, identical to baseline; the failure is the pre-existing `sbom_snapshot` drift. ASAN+UBSAN with `detect_leaks=1` clean.
