### PR TITLE
fix(ir): validate rule head arity against the declared arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,60 @@ All notable changes to wirelog are documented in this file.
   Datalog program in the tree, including those the benchmarks generate from
   CSV at runtime: no in-tree program changes behaviour.
 
-  This covers the inline-fact half of #977 only. Rule heads, rule bodies and
-  facts on undeclared relations remain unvalidated.
+  This covers the inline-fact half of #977. Rule bodies and facts on
+  undeclared relations remain unvalidated; rule heads are covered by the
+  entry below.
+
+- **Rule heads are validated against their relation's declared arity**
+  (#977): a head emitting a different number of columns than its `.decl`
+  declares was accepted silently. In a recursive stratum it is a heap
+  over-read -- `col_op_reduce` sizes its output region as
+  `group_by_count + 1` while `col_rel_append_all` copies `dst->ncols` columns
+  out of it with no clamp, so `cc(y, min(c)) :- cc(x, c, d), edge(x, y).`
+  against a three-column `cc` seeded by a fact segfaulted (exit 139;
+  AddressSanitizer reports `heap-buffer-overflow READ of size 8` in
+  `col_rel_append_all` under `col_eval_stratum`).
+
+  Recursion is not the precondition — a producer at the declared width is.
+  The non-recursive `t(g) :- val(g, v).` against `.decl t/3` is the same
+  over-read once a `t(9,9,9).` fact fixes the relation's width, reached
+  through `col_op_map` rather than `col_op_reduce`. Absent such a producer
+  the relation materialises at the narrower width and the mismatch is a
+  silent wrong answer instead: one column emitted with exit status 0, or four
+  for `t(g,v,g,v)` against `.decl t/2`.
+
+  Such heads are now rejected during metadata collection, reported through
+  `WL_LOG=PARSER:1` with the relation name and both arities, and surfaced as
+  `WIRELOG_ERR_PARSE`. As with the fact check, the pass runs after all
+  declarations are collected, so a `.decl` may follow its rules, and it keys
+  off `has_decl`, so undeclared derived heads -- ordinary Datalog, ~90 of
+  them in `bench/workloads/doop.dl` alone -- are not checked. This completes
+  the rule-head half of the single-aggregate recursive crash that #973 could
+  not reach.
+
+  Heads are compared against the declared **physical** width, where an
+  `inline` compound column counts as its full arity and a `side` compound as
+  one handle column -- deliberately unlike the fact check above, which
+  compares logically. The head grammar has no compound-term production
+  (`pred(x, f(y, z))` is a parse error), so the flattened spelling
+  `pred(x, y, z) :- src(x, y, z).` is the only way to write an
+  inline-compound relation from a rule, and a logical comparison would reject
+  it.
+
+  **Compatibility:** programs that previously loaded now fail to load. Every
+  rejected shape was already a crash or a wrong answer. One shape worth
+  naming: the two-argument handle form `pred(x, y)` into
+  `.decl pred(id: int64, payload: f/2 inline)` is now rejected, because it
+  leaves the second inline slot unwritten and a body pattern that
+  destructures the column reads it anyway --
+  `outr(id, p, q) :- pred(id, f(p, q)).` produced `outr(1, 99, 0)`, a value
+  present in no source data. Verified across every Datalog program in the
+  tree -- standalone `.dl` files, programs embedded in C string literals and
+  markdown fences: roughly 1500 declared rule heads across some 1300
+  programs, no arity mismatch under either the logical
+  or the physical rule, and no rule head anywhere in the tree writes into a
+  relation with an inline-compound column. No in-tree program changes
+  behaviour.
 
 - **`min()`/`max()` over a symbol column compare strings, not intern ids**
   (#965): both reduced over the raw `int64`, which for a `symbol` column is
@@ -133,15 +185,17 @@ All notable changes to wirelog are documented in this file.
   both cases: the previous result was not correct for any reading of the
   rule, whether or not its arity happened to match.
 
-  **This does not close the whole crash class.** The underlying trigger is
-  emitted arity differing from declared arity inside a recursive stratum, and
-  multiple aggregates are only one way to produce it. A *single*-aggregate
-  head with too few arguments -- `cc(y, min(c)) :- cc(x, c, d), edge(x, y).`
-  against a three-column `cc` -- still crashes identically and is not caught
-  here. General `.decl`-versus-rule arity validation is tracked as #977; the
-  two fixes are complementary and neither subsumes the other. The check also
-  gates the parser path only: IR built directly through the API is still
-  unvalidated.
+  **This does not close the whole crash class on its own.** The underlying
+  trigger is emitted arity differing from declared arity inside a recursive
+  stratum, and multiple aggregates are only one way to produce it. A
+  *single*-aggregate head with too few arguments --
+  `cc(y, min(c)) :- cc(x, c, d), edge(x, y).` against a three-column `cc` --
+  crashes identically with only one aggregate; that shape is rejected by the
+  rule-head arity check, also under #977 (see the entry above). The two fixes
+  are complementary and neither subsumes the other: an arity check accepts
+  `t(g, min(v), max(v))` against a three-column `.decl`, and the
+  aggregate-count check accepts `cc(y, min(c))`. Both gate the parser path
+  only: IR built directly through the API is still unvalidated.
 
 - **`uuid5()` framing carries the operand's type, not only its length**
   (#968): #963 length-prefixed each operand of the three symbol-bearing

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -191,16 +191,26 @@ from producing semantically correct output at workers in {1, 4, 8, 16}.
   `convert_rule` cannot know whether the head relation is recursive, and
   `col_canonicalize_recursive_aggregate_relation` is on the hot path for
   recursive aggregate rules regardless of the MIN/MAX guard.
-- The #973 rejection does not cover every arity mismatch. A single-aggregate
-  head with too few arguments for its `.decl` is still accepted and still
-  unsafe in a recursive stratum; general `.decl`-versus-rule arity validation
-  is tracked as #977.
+- The #973 rejection does not, on its own, cover every arity mismatch: a
+  single-aggregate head with too few arguments for its `.decl`, such as
+  `cc(y, min(c))` against a 3-column `cc`, reaches the same out-of-bounds
+  read without ever having two aggregates. That shape is now rejected
+  separately, before lowering, by the rule-head arity check in
+  `wl_ir_program_collect_metadata` (#977). The two checks are complementary
+  and neither subsumes the other — an arity check passes
+  `t(g, min(v), max(v))`, which has three head arguments against a 3-column
+  `.decl`, and the aggregate-count check passes `cc(y, min(c))`, which has
+  one aggregate.
+- Both checks cover the parser path only. IR built directly through the API
+  still reaches the crash.
 
 ### References
 
 - Issue #692 — Blocker B5: Recursive aggregation residue = 0.
 - Issue #973 — at most one aggregate per rule head.
-- Issue #977 — general `.decl`-versus-rule arity validation (open).
+- Issue #977 — `.decl`-versus-program arity validation: inline facts and
+  rule heads are validated; rule *bodies* and facts on undeclared relations
+  are not.
 - `wirelog/columnar/ops.c` — `col_op_reduce`.
 - `wirelog/columnar/eval.c` — recursive aggregate canonicalization.
 - `wirelog/ir/program.c` — `convert_rule` multi-aggregate head rejection.

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -108,12 +108,15 @@ Two scope notes:
   is not validated — neither the optimizer, the plan generator, nor the
   columnar REDUCE checks that the group-by width plus one matches the head
   arity.
-- The check does **not** cover every arity mismatch. A single-aggregate head
-  with too few arguments for its `.decl`, such as
+- The check does **not**, by itself, cover every arity mismatch. A
+  single-aggregate head with too few arguments for its `.decl`, such as
   `cc(y, min(c)) :- cc(x, c, d), edge(x, y).` against a 3-column `cc`, is
-  still accepted and still unsafe in a recursive stratum. General
-  `.decl`-versus-rule arity validation is tracked separately as #977, whose
-  fact half has since landed (see below) while the rule-head half has not.
+  unsafe in a recursive stratum for the same reason but has only one
+  aggregate. That shape is rejected by the separate rule-head arity check
+  described in [Rule heads must match their declared
+  arity](#rule-heads-must-match-their-declared-arity) below (#977). The two
+  are complementary: an arity check accepts `t(g, min(v), max(v))`, and the
+  aggregate-count check accepts `cc(y, min(c))`.
 
 ### Inline facts must match their declared arity
 
@@ -137,13 +140,88 @@ query answers with exit status 0, or a tuple assembled from two different
 facts. Loading fails with `WIRELOG_ERR_PARSE`; run with `WL_LOG=PARSER:1` to
 see which relation and which arities.
 
-A relation with an inline-compound column must be given the compound form,
-not a flattened one — `p(1,2,3).` against `.decl p(id: int64, lbl: pair/2
-inline)` is rejected, because the fact is compared against the declared
-*logical* width.
+Facts are compared against the declared **logical** width — one argument per
+declared column. For a relation with an `inline` compound column that has an
+awkward consequence: `p(1,2,3).` against `.decl p(id: int64, lbl: pair/2
+inline)` is rejected as three arguments against two columns, while `p(1,2).`
+is accepted and writes only the first of the two inline slots.
+
+There is no compound spelling to reach for instead — `p(1, pair(2,3)).` is a
+parse error, because facts admit only integer and string constants. So an
+inline-compound relation currently cannot be populated correctly by an inline
+fact at all: the accepted form leaves a slot unwritten and produces no output.
+Use `.input` or derive the relation from a rule. Tracked as #985.
 
 Facts on a relation with **no** `.decl` at all are unaffected by this check
 and continue to fail later, during loading, with a less specific message.
+
+### Rule heads must match their declared arity
+
+A rule head that emits a different number of columns than its relation's
+`.decl` declares is rejected when the program is loaded (#977):
+
+```
+.decl val(g: int64, v: int64)
+.decl t(a: int64, b: int64)
+t(g)          :- val(g, v).    /* rejected: emits 1, declared 2 */
+t(g,v,g,v)    :- val(g, v).    /* rejected: emits 4, declared 2 */
+t(g, v)       :- val(g, v).    /* accepted */
+t(g, min(v))  :- val(g, v).    /* accepted: an aggregate is one column */
+```
+
+As with facts, the `.decl` may appear before or after its rules, and heads on
+a relation with **no** `.decl` are not checked at all — undeclared derived
+heads are ordinary Datalog and are used throughout the benchmark workloads.
+
+This is a memory-safety guard. A head narrower than its `.decl` is an
+out-of-bounds read whenever some *other* producer has already established the
+relation at the declared width: the narrow head's operator sizes its output
+region from the emitted arity, while `col_rel_append_all` copies the declared
+arity out of it with no clamp. `cc(y, min(c)) :- cc(x, c, d), edge(x, y).`
+against a 3-column `cc` seeded by a fact segfaulted.
+
+Recursion is not the precondition — a declared-width producer is. The
+non-recursive `t(g) :- val(g, v).` against a 3-column `t` is equally an
+over-read once a `t(9,9,9).` fact fixes the width, this time through
+`col_op_map` rather than `col_op_reduce`. With no such producer the relation
+simply materialises at the narrower width and the mismatch is a silent wrong
+answer instead.
+
+Loading fails with `WIRELOG_ERR_PARSE`; run with `WL_LOG=PARSER:1` to see
+which relation and which arities.
+
+Unlike the fact check, heads are compared against the declared **physical**
+width — an `inline` compound column counts as its full arity, a `side`
+compound as the single handle column it is stored in. The reason is that the
+head grammar has no compound-term production (`pred(x, f(y, z))` is a parse
+error), so the flattened spelling is the only way to write an
+inline-compound relation from a rule:
+
+```
+.decl src(a: int64, b: int64, c: int64)
+.decl pred(id: int64, payload: f/2 inline)
+pred(x, y, z) :- src(x, y, z).   /* accepted: 3 physical columns */
+pred(x, y)    :- src(x, y).      /* rejected: 2, and leaves a slot unwritten */
+```
+
+The two-argument form is rejected simply because the comparison is physical
+and 2 is not 3. Since the flattened spelling is the only one a rule can use,
+a head that writes fewer columns than the relation physically has is an
+under-write, not an alternative notation.
+
+That it is not a *false* rejection is worth demonstrating separately: the
+two-argument head leaves the second inline slot unwritten, and a body pattern
+that destructures the column reads it anyway — `outr(id, p, q) :- pred(id,
+f(p, q)).` produced `outr(1, 99, 0)`, a value present in no source data,
+where the three-argument spelling correctly produces `outr(1, 10, 20)`.
+
+The corresponding *fact* `pred(1, 99).` is accepted, because facts must be
+compared logically (see [Inline facts must match their declared
+arity](#inline-facts-must-match-their-declared-arity) above) and so cannot be
+held to the physical width. That asymmetry is real and is tracked as #985 —
+it is a limitation of the width model, not of this check.
+
+Rule **bodies** are still not validated against their `.decl`.
 
 The count is not the only constraint on aggregates in a head — the aggregate
 must also be written **last**. `t(min(v), g) :- val(g, v).` lowers with a

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -1050,9 +1050,13 @@ test_aggregation_multi_head_rejected(void)
      * before the fix it reached col_op_reduce()/col_rel_append_all() with an
      * emitted arity of 2 against a 3-arity .decl and segfaulted during
      * col_eval_stratum().  Rejecting at lowering keeps it from ever getting
-     * that far.  (Note: the single-aggregate variant
-     * "cc(y, min(c)) :- cc(x, c, d), edge(x, y)." crashes the same way and is
-     * deliberately NOT caught here -- that is issue #977.) */
+     * that far.  (The single-aggregate variant
+     * "cc(y, min(c)) :- cc(x, c, d), edge(x, y)." crashes the same way but
+     * has nothing wrong with its aggregate count, so this check cannot see
+     * it; it is rejected earlier by the #977 rule-head arity pass -- see
+     * test_head_arity_recursive_aggregate_rejected().  This head has three
+     * arguments against a 3-arity .decl, so that pass accepts it and it does
+     * reach this check.) */
     bad = make_program_with_rules(".decl edge(x: int64, y: int64)\n"
             ".decl cc(n: int64, lo: int64, hi: int64)\n"
             "cc(y, min(c), max(c)) :- cc(x, c, d), edge(x, y).\n");
@@ -2955,11 +2959,16 @@ test_fact_arity_wider_than_decl_rejected(void)
      * stride by rel->column_count, which is the logical width.
      *
      * Pre-fix this was accepted and silently dropped the third value.
-     * Note this is the one place where the fact rule and the coming
-     * rule-head rule diverge -- head lowering does expand compound columns,
-     * so the head check (#977 unit 3) must compare *physical* width via
-     * atom_physical_column_count().  If compound terms ever become
-     * expressible in facts, this comparison has to move with it. */
+     * Note this is the one place where the fact rule and the rule-head rule
+     * diverge: validate_head_arities() (#977 unit 3) compares *physical*
+     * width via atom_physical_column_count(), so the head spelling of this
+     * same shape -- pred(x,y,z) against .decl pred(id, payload: f/2 inline)
+     * -- is accepted, and is pinned by
+     * test_head_arity_inline_compound_accepted().  The divergence is not an
+     * oversight: the head grammar has no compound-term production, so the
+     * flattened spelling is the only one available to a rule, while facts
+     * are packed and read back at the logical width.  If compound terms ever
+     * become expressible in facts, this comparison has to move with it. */
     bad = make_program(".decl p(id: int64, lbl: pair/2 inline)\n"
             "p(1, 2, 3).\n");
     if (bad) {
@@ -3102,9 +3111,10 @@ test_fact_arity_undeclared_relations_unaffected(void)
      * collection: column_count is 0 because no .decl was seen, and the
      * guard keys off has_decl, so the pass stays out of the way.  Such a
      * program still fails later at session load ("failed to load facts for
-     * 'q'", exit 1) -- that is issue #977 unit 3, deliberately not this
-     * unit's scope.  This case is what pins the has_decl condition: drop
-     * it and this program is rejected at parse time instead. */
+     * 'q'", exit 1) -- facts on undeclared relations are still unvalidated
+     * under #977, and remain so after the rule-head pass (unit 3) landed.
+     * This case is what pins the has_decl condition: drop it and this
+     * program is rejected at parse time instead. */
     struct wirelog_program *undecl = make_program("q(1, 2).\n"
             "q(3, 4).\n");
     if (!undecl) {
@@ -3169,6 +3179,354 @@ test_fact_arity_mismatch_maps_to_parse_error(void)
     }
     free(data);
     wirelog_program_free(ok);
+
+    PASS();
+}
+
+/* ======================================================================== */
+/* Issue #977 (unit 3): rule-head arity must match the .decl                */
+/* ======================================================================== */
+
+/* A rule head whose arity disagrees with its relation's `.decl` was accepted
+ * silently.  In a recursive stratum that is a heap over-read: col_op_reduce()
+ * (columnar/ops.c) sizes its output region as group_by_count + 1 while
+ * col_rel_append_all() (columnar/relation.c) copies dst->ncols columns from
+ * it, unclamped against src->ncols -- ASAN reports
+ * "heap-buffer-overflow READ of size 8" in col_rel_append_all under
+ * col_eval_stratum() (columnar/eval.c), exit 139.  Outside a recursive
+ * stratum it is a silent wrong answer instead.
+ *
+ * The predicate compares PHYSICAL width, not logical, and that is the whole
+ * subtlety of this unit.  Unit 2 deliberately does the opposite for facts:
+ * collect_fact() packs one slot per written argument and both readers stride
+ * by the logical rel->column_count, so facts compare logically.  A rule head
+ * is different -- it is written flat, one head argument per *physical*
+ * column, because the head grammar has no compound-term production at all
+ * (parse_head_arg() dispatches only to aggregate and arithmetic expressions,
+ * so `pred(x, f(y,z))` is a parse error).  The only spelling available for
+ * an inline-compound relation is the expanded one, `pred(x,y,z)`, which is
+ * three head arguments against a two-column .decl.  A logical
+ * `child_count != column_count` check would reject working code;
+ * test_head_arity_inline_compound_accepted() is the case that pins this.
+ *
+ * Entry point: these tests go through make_program(), which calls
+ * wl_ir_program_collect_metadata() directly -- the same tail pass that holds
+ * the fact check -- so a NULL return is this rejection and not a later stage.
+ * The positive controls use make_program_with_rules() so they additionally
+ * prove the rule still lowers. */
+
+static void
+test_head_arity_recursive_aggregate_rejected(void)
+{
+    TEST("Head arity: the recursive single-aggregate crash shape is rejected");
+
+    /* THE memory-safety case.  Before this check the program below
+     * segfaulted (exit 139) inside col_eval_stratum().  Issue #973 rejects
+     * the *multi*-aggregate spelling of the same crash; this single-aggregate
+     * spelling reached evaluation untouched, because it is not the aggregate
+     * count that is wrong -- the head emits 2 columns into a 3-column
+     * relation that facts have already materialised at width 3. */
+    struct wirelog_program *bad
+        = make_program(".decl edge(x: int64, y: int64)\n"
+            ".decl cc(n: int64, lo: int64, hi: int64)\n"
+            "edge(1,2). edge(2,3). edge(3,1).\n"
+            "cc(1,10,10).\n"
+            "cc(y, min(c)) :- cc(x, c, d), edge(x, y).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("cc(y, min(c)) against a 3-column .decl should be rejected");
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_head_arity_narrower_than_decl_rejected(void)
+{
+    TEST("Head arity: head narrower than .decl is rejected");
+
+    /* This program has no producer of t at the declared width, so pre-fix it
+     * evaluated cleanly with exit 0 and emitted one column into a relation
+     * declared with three -- a silent wrong answer.  Add a `t(9,9,9).` fact
+     * and the same non-recursive shape becomes a heap over-read through
+     * col_op_map(); recursion is not what makes this unsafe, a
+     * declared-width producer is. */
+    struct wirelog_program *bad
+        = make_program(".decl val(g: int64, v: int64)\n"
+            ".decl t(a: int64, b: int64, c: int64)\n"
+            "val(1,10). val(2,20).\n"
+            "t(g) :- val(g, v).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("t(g) against .decl t/3 should be rejected");
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_head_arity_wider_than_decl_rejected(void)
+{
+    TEST("Head arity: head wider than .decl is rejected");
+
+    /* Emitted four columns against a two-column .decl, exit 0, printing
+     * t(1, 10, 1, 10). */
+    struct wirelog_program *bad
+        = make_program(".decl val(g: int64, v: int64)\n"
+            ".decl t(a: int64, b: int64)\n"
+            "val(1,10). val(2,20).\n"
+            "t(g, v, g, v) :- val(g, v).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("t(g,v,g,v) against .decl t/2 should be rejected");
+        return;
+    }
+
+    /* The .decl may follow its rules, exactly as it may follow its facts;
+     * the pass runs after the whole source-order collection loop. */
+    bad = make_program("t(g, v, g, v) :- val(g, v).\n"
+            ".decl val(g: int64, v: int64)\n"
+            ".decl t(a: int64, b: int64)\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL(".decl written after the rule should still be checked");
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_head_arity_inline_compound_accepted(void)
+{
+    TEST("Head arity: flattened inline-compound head is accepted");
+
+    /* POSITIVE CONTROL for the physical-width predicate.  `pred` is declared
+    * with two *logical* columns and three *physical* ones (id, plus f/2
+    * expanded into two slots).  The head writes three arguments, which is
+    * the only spelling the grammar allows, and evaluation produces
+    * pred(1, 10, 20).
+    *
+    * If anyone "simplifies" the predicate to the logical comparison unit 2
+    * uses for facts (head->child_count != rel->column_count), this test
+    * fails with "flattened inline-compound head should be accepted" --
+    * 3 != 2.  That is the entire reason this test exists.
+    *
+    * test_wirelog_easy_inline_facts.c (T4) carries the evaluation half:
+    * this binary links parser/ir/io/thread only and cannot run a program. */
+    struct wirelog_program *ok
+        = make_program_with_rules(".decl src(a: int64, b: int64, c: int64)\n"
+            ".decl pred(id: int64, payload: f/2 inline)\n"
+            "src(1,10,20).\n"
+            "pred(x, y, z) :- src(x, y, z).\n");
+    if (!ok) {
+        FAIL("flattened inline-compound head should be accepted");
+        return;
+    }
+    if (ok->rule_count != 1 || !ok->rules[0].ir_root
+        || ok->rules[0].ir_root->type != WIRELOG_IR_PROJECT
+        || ok->rules[0].ir_root->project_count != 3) {
+        wl_ir_program_free(ok);
+        FAIL("head should lower to a PROJECT of 3 physical columns");
+        return;
+    }
+    wl_ir_program_free(ok);
+
+    PASS();
+}
+
+static void
+test_head_arity_compound_handle_form_rejected(void)
+{
+    TEST("Head arity: handle-form head into a compound relation is rejected");
+
+    /* The open question this unit had to settle.  `pred(1, 99).` is a legal
+     * *fact* -- unit 2 compares facts logically, and 2 == 2 -- so it is not
+     * obvious that the head analogue `pred(x, y) :- src(x, y).` should be
+     * illegal.  It is, and the reason is not symmetry but a fabricated
+     * value: the head leaves the second inline slot never written, and a
+     * body pattern that destructures the column reads it anyway.
+     *
+     *   .decl src(a: int64, b: int64)
+     *   .decl pred(id: int64, payload: f/2 inline)
+     *   .decl outr(id: int64, p: int64, q: int64)
+     *   src(1,99).
+     *   pred(x, y)        :- src(x, y).
+     *   outr(id, p, q)    :- pred(id, f(p, q)).
+     *
+     * evaluated to outr(1, 99, 0) with exit 0 and ASAN silent -- the 0 is
+     * an unwritten physical slot, present in no source data.  The
+     * three-argument spelling of the same program yields outr(1, 10, 20)
+     * from src(1,10,20), which is correct.  So the physical width is the
+     * one the relation must be written at, and this shape is rejected.
+     *
+     * (The identical defect via the *fact* form -- `pred(1, 99).` plus the
+     * same destructuring rule, also outr(1, 99, 0) -- is still accepted,
+     * because unit 2 must compare facts logically: wl_session_load_facts()
+     * and wirelog_program_get_facts() both stride by column_count.  That
+     * asymmetry is real and is not resolved here -- issue #985 tracks it,
+     * along with the fact that an inline-compound relation cannot be
+     * populated correctly by an inline fact at all.) */
+    struct wirelog_program *bad
+        = make_program(".decl src(a: int64, b: int64)\n"
+            ".decl pred(id: int64, payload: f/2 inline)\n"
+            "src(1,99).\n"
+            "pred(x, y) :- src(x, y).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("2-argument head into an inline f/2 relation should be rejected");
+        return;
+    }
+
+    /* A `side` compound occupies one physical slot, not compound_arity of
+     * them, so the handle form is the *only* form there and must pass.
+     * This is what stops the physical-width sum from being written as a
+     * blanket `+= compound_arity`. */
+    struct wirelog_program *ok
+        = make_program_with_rules(".decl src(a: int64, b: int64)\n"
+            ".decl sref(id: int64, meta: m/4 side)\n"
+            "src(1,99).\n"
+            "sref(x, y) :- src(x, y).\n");
+    if (!ok) {
+        FAIL("2-argument head into a side-compound relation must be accepted");
+        return;
+    }
+    wl_ir_program_free(ok);
+
+    PASS();
+}
+
+static void
+test_head_arity_undeclared_head_accepted(void)
+{
+    TEST("Head arity: undeclared heads keep their current behaviour");
+
+    /* POSITIVE CONTROL for the has_decl guard.  Undeclared derived heads are
+     * widespread and legitimate -- bench/workloads/doop.dl alone has ~90 --
+     * and the check must never see them.  Drop has_decl from the guard and
+     * this fails: column_count is 0 for an undeclared relation, so the
+     * comparison becomes 1 != 0. */
+    struct wirelog_program *ok
+        = make_program_with_rules(".decl val(g: int64, v: int64)\n"
+            "val(1,10).\n"
+            "t(g) :- val(g, v).\n");
+    if (!ok) {
+        FAIL("undeclared head must still be accepted");
+        return;
+    }
+    wl_ir_program_free(ok);
+
+    PASS();
+}
+
+static void
+test_head_arity_matching_accepted(void)
+{
+    TEST("Head arity: matching plain and aggregate heads are accepted");
+
+    /* Plain head, matching arity. */
+    struct wirelog_program *plain
+        = make_program_with_rules(".decl val(g: int64, v: int64)\n"
+            ".decl t(a: int64, b: int64)\n"
+            "val(1,10).\n"
+            "t(g, v) :- val(g, v).\n");
+    if (!plain) {
+        FAIL("matching plain head should be accepted");
+        return;
+    }
+    wl_ir_program_free(plain);
+
+    /* Aggregate head, matching arity.  An AGGREGATE head argument is one
+     * direct HEAD child (parse_aggregate_expr() is reached only from
+     * parse_head_arg()), so t(g, min(v)) has child_count 2 and lowers to
+     * group_by_count + 1 == 2 emitted columns.  The head arity is therefore
+     * counted the same way for aggregate and non-aggregate heads, and the
+     * check needs no aggregate-specific case. */
+    struct wirelog_program *agg
+        = make_program_with_rules(".decl val(g: int64, v: int64)\n"
+            ".decl t(a: int64, b: int64)\n"
+            "val(1,10).\n"
+            "t(g, min(v)) :- val(g, v).\n");
+    if (!agg) {
+        FAIL("matching single-aggregate head should be accepted");
+        return;
+    }
+    if (agg->rules[0].ir_root->type != WIRELOG_IR_AGGREGATE
+        || agg->rules[0].ir_root->group_by_count != 1) {
+        wl_ir_program_free(agg);
+        FAIL("aggregate head should lower to AGGREGATE/group_by_count==1");
+        return;
+    }
+    wl_ir_program_free(agg);
+
+    /* The two live single-aggregate workloads, bench/workloads/cc.dl:6 and
+     * sssp.dl:5, in their exact declared shapes.  Both are recursive and
+     * both must keep working. */
+    struct wirelog_program *cc
+        = make_program_with_rules(".decl edge(x: int32, y: int32)\n"
+            ".decl cc(x: int32, c: int32)\n"
+            "cc(x, x) :- edge(x, _).\n"
+            "cc(x, x) :- edge(_, x).\n"
+            "cc(y, min(c)) :- cc(x, c), edge(x, y).\n");
+    if (!cc) {
+        FAIL("bench/workloads/cc.dl head shape must still lower");
+        return;
+    }
+    wl_ir_program_free(cc);
+
+    struct wirelog_program *sssp
+        = make_program_with_rules(".decl wedge(x: int32, y: int32, w: int32)\n"
+            ".decl dist(x: int32, d: int32)\n"
+            "dist(1, 0).\n"
+            "dist(y, min(d + w)) :- dist(x, d), wedge(x, y, w).\n");
+    if (!sssp) {
+        FAIL("bench/workloads/sssp.dl head shape must still lower");
+        return;
+    }
+    wl_ir_program_free(sssp);
+
+    /* Issue #980: aggregate *position* is ignored -- t(min(v), g) lowers
+     * group-by-first regardless of how it was written.  That is out of
+     * scope here, but the check must not accidentally depend on position:
+     * both spellings have the same arity and both must be accepted. */
+    struct wirelog_program *swapped
+        = make_program_with_rules(".decl val(g: int64, v: int64)\n"
+            ".decl t(a: int64, b: int64)\n"
+            "val(1,10).\n"
+            "t(min(v), g) :- val(g, v).\n");
+    if (!swapped) {
+        FAIL("aggregate-first head has matching arity and must be accepted");
+        return;
+    }
+    wl_ir_program_free(swapped);
+
+    PASS();
+}
+
+static void
+test_head_arity_mismatch_maps_to_parse_error(void)
+{
+    TEST("Head arity: public API reports WIRELOG_ERR_PARSE");
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *bad
+        = wirelog_parse_string(".decl edge(x: int64, y: int64)\n"
+            ".decl cc(n: int64, lo: int64, hi: int64)\n"
+            "edge(1,2).\n"
+            "cc(1,10,10).\n"
+            "cc(y, min(c)) :- cc(x, c, d), edge(x, y).\n",
+            &err);
+    if (bad) {
+        wirelog_program_free(bad);
+        FAIL("public API should reject the head arity mismatch");
+        return;
+    }
+    if (err != WIRELOG_ERR_PARSE) {
+        FAIL("error should be WIRELOG_ERR_PARSE");
+        return;
+    }
 
     PASS();
 }
@@ -3622,6 +3980,16 @@ main(void)
     test_fact_arity_matching_accepted();
     test_fact_arity_undeclared_relations_unaffected();
     test_fact_arity_mismatch_maps_to_parse_error();
+
+    /* Issue #977 unit 3: rule-head arity vs .decl */
+    test_head_arity_recursive_aggregate_rejected();
+    test_head_arity_narrower_than_decl_rejected();
+    test_head_arity_wider_than_decl_rejected();
+    test_head_arity_inline_compound_accepted();
+    test_head_arity_compound_handle_form_rejected();
+    test_head_arity_undeclared_head_accepted();
+    test_head_arity_matching_accepted();
+    test_head_arity_mismatch_maps_to_parse_error();
 
     /* Fact extraction API */
     test_api_get_facts();

--- a/tests/test_wirelog_easy_inline_facts.c
+++ b/tests/test_wirelog_easy_inline_facts.c
@@ -185,6 +185,81 @@ test_matching_arity_facts_evaluate_exactly(void)
     return rc;
 }
 
+/* T4 (issue #977 unit 3): the flattened inline-compound rule head must still
+ *     evaluate, and still produce all three physical columns.
+ *
+ *     This is the positive control for the rule-head arity pass comparing
+ *     *physical* width rather than the logical width unit 2 uses for facts.
+ *     `pred` is declared with two logical columns (id, payload: f/2 inline)
+ *     and three physical ones; `pred(x, y, z)` is three head arguments, and
+ *     it is the only spelling the grammar allows, because parse_head_arg()
+ *     has no compound-term production and `pred(x, f(y, z))` is a parse
+ *     error.  A logical comparison would reject this program (3 != 2).
+ *
+ *     tests/test_program.c asserts the lowering; that binary links only
+ *     parser/ir/io/thread and cannot evaluate.  This one links the full
+ *     library, so it can assert the values -- which is what distinguishes
+ *     "accepted" from "accepted and correct": the 2-argument spelling is
+ *     also accepted by a logical check and evaluates to a fabricated
+ *     unwritten slot. */
+struct triple_state {
+    uint32_t rows;
+    int64_t seen[8][3];
+};
+
+static void
+collect_triples(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    (void)relation;
+    struct triple_state *st = (struct triple_state *)user_data;
+    if (ncols != 3 || st->rows >= 8) {
+        st->rows = 0xFFFFFFFFu;
+        return;
+    }
+    st->seen[st->rows][0] = row[0];
+    st->seen[st->rows][1] = row[1];
+    st->seen[st->rows][2] = row[2];
+    st->rows++;
+}
+
+static int
+test_inline_compound_head_evaluates_exactly(void)
+{
+    static const char *src = ".decl src(a: int64, b: int64, c: int64)\n"
+        ".decl pred(id: int64, payload: f/2 inline)\n"
+        "src(1, 10, 20).\n"
+        "pred(x, y, z) :- src(x, y, z).\n";
+
+    wirelog_easy_session_t *s = NULL;
+    wirelog_error_t err = wirelog_easy_open(src, &s);
+    if (err != WIRELOG_OK || !s) {
+        fprintf(stderr, "T4 open err=%d (flattened inline-compound head must "
+            "be accepted; a logical arity check rejects it)\n", err);
+        return 1;
+    }
+
+    struct triple_state st = { 0, { { 0, 0, 0 } } };
+    err = wirelog_easy_snapshot(s, "pred", collect_triples, &st);
+    int rc = 0;
+    if (err != WIRELOG_OK) {
+        fprintf(stderr, "T4 snapshot err=%d\n", err);
+        rc = 1;
+    } else if (st.rows != 1) {
+        fprintf(stderr, "T4: expected 1 pred row, got %u\n", st.rows);
+        rc = 1;
+    } else if (st.seen[0][0] != 1 || st.seen[0][1] != 10
+        || st.seen[0][2] != 20) {
+        fprintf(stderr,
+            "T4: expected pred(1,10,20), got pred(%lld,%lld,%lld)\n",
+            (long long)st.seen[0][0], (long long)st.seen[0][1],
+            (long long)st.seen[0][2]);
+        rc = 1;
+    }
+    wirelog_easy_close(s);
+    return rc;
+}
+
 int
 main(void)
 {
@@ -192,6 +267,7 @@ main(void)
     failures += test_static_fact_drives_idb_snapshot();
     failures += test_static_fact_joins_with_host_insert();
     failures += test_matching_arity_facts_evaluate_exactly();
+    failures += test_inline_compound_head_evaluates_exactly();
     if (failures == 0)
         printf("test_wl_easy_inline_facts: OK\n");
     else

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -687,6 +687,16 @@ collect_fact(struct wirelog_program *prog,
     return 0;
 }
 
+/* Both defined further down, next to the rule-lowering code that is their
+ * other caller.  Forward-declared here so the validation passes below can
+ * measure an atom exactly the way lowering does, rather than growing a
+ * second, drifting definition of "physical width". */
+static wl_ir_relation_info_t *
+find_relation_info(const struct wirelog_program *prog, const char *name);
+static uint32_t
+atom_physical_column_count(const wl_parser_ast_node_t *atom,
+    const wl_ir_relation_info_t *rel_info, const struct wirelog_program *prog);
+
 /* Issue #977: validate every inline fact against its relation's declared
  * arity.
  *
@@ -752,6 +762,155 @@ validate_fact_arities(const struct wirelog_program *program,
     return 0;
 }
 
+/* The number of PHYSICAL columns a relation's `.decl` describes.
+ *
+ * An `inline` compound column is stored as `compound_arity` contiguous
+ * physical slots; a `side` compound is a single handle slot, and so is every
+ * scalar.  This is the same walk collect_decl() runs to assign
+ * compound_inline_col_offset -- for every declaration the parser can
+ * produce, the prefix sum there ends at exactly this value -- and the same
+ * layout col_rel_t records in compound_arity_map.
+ *
+ * The INLINE arm deliberately adds compound_arity unguarded, mirroring
+ * collect_decl() exactly rather than defending against a zero arity.  A
+ * guard such as `compound_arity > 0 ? compound_arity : 1` would look safer
+ * but is the opposite: it is the only construct that could make the two
+ * walks disagree (1 here against 0 there), turning an invariant violation
+ * into a silent width mismatch instead of an obvious one.
+ *
+ * The invariant holds regardless: parse_compound_metadata() resets the whole
+ * metadata struct -- kind included -- on every failure path, returning
+ * kind = NONE for a non-positive arity and for an inline arity above
+ * WL_IR_COMPOUND_INLINE_MAX_ARITY, and program.c's collect_decl() is the
+ * only writer of columns[].compound_kind.  So INLINE implies
+ * 1 <= compound_arity <= WL_IR_COMPOUND_INLINE_MAX_ARITY. */
+static uint32_t
+declared_physical_column_count(const wl_ir_relation_info_t *rel)
+{
+    uint32_t phys = 0;
+
+    if (!rel)
+        return 0;
+    if (!rel->columns)
+        return rel->column_count;
+
+    for (uint32_t i = 0; i < rel->column_count; i++) {
+        const wirelog_column_t *col = &rel->columns[i];
+        phys += (col->compound_kind == WIRELOG_COMPOUND_KIND_INLINE)
+            ? col->compound_arity
+            : 1u;
+    }
+    return phys;
+}
+
+/* Issue #977: validate every rule head against its relation's declared
+ * arity.
+ *
+ * A head whose arity disagrees with its `.decl` was accepted silently.  In a
+ * recursive stratum that is a heap over-read: col_op_reduce()
+ * (columnar/ops.c) sizes its output region as group_by_count + 1, while
+ * col_rel_append_all() (columnar/relation.c) copies dst->ncols columns out of
+ * it with no clamp against src->ncols.  dst->ncols comes from the declared
+ * width -- the facts materialised the relation at it -- so a narrower head
+ * reads past the region:
+ *
+ *   .decl cc(n: int64, lo: int64, hi: int64)
+ *   cc(1,10,10).
+ *   cc(y, min(c)) :- cc(x, c, d), edge(x, y).   -> SIGSEGV (exit 139)
+ *
+ * ASAN reports "heap-buffer-overflow READ of size 8" in col_rel_append_all()
+ * under col_eval_stratum() (columnar/eval.c).  Issue #973 rejects the
+ * multi-aggregate spelling of the same crash; this is the single-aggregate
+ * one, which that check cannot see because nothing about its aggregate count
+ * is wrong.
+ *
+ * Recursion is not the precondition -- a producer at the declared width is.
+ * The non-recursive `t(g) :- val(g, v).` against `.decl t/3` is the same
+ * over-read once a `t(9,9,9).` fact fixes the relation's width, reached via
+ * col_op_map() rather than col_op_reduce().  With no such producer the
+ * relation just materialises narrower and the mismatch is a silent wrong
+ * answer instead: one column emitted with exit 0, or four for `t(g,v,g,v)`
+ * against `.decl t/2`.
+ *
+ * PHYSICAL width, not logical -- this is the one thing that must not be
+ * "simplified".  Unit 2 compares facts LOGICALLY, and deliberately so:
+ * collect_fact() packs one slot per written argument and both readers
+ * (wl_session_load_facts, wirelog_program_get_facts) stride by the logical
+ * rel->column_count.  A rule head is the opposite.  The head grammar has no
+ * compound-term production at all -- parse_head_arg() (parser/parser.c)
+ * dispatches only to aggregate and arithmetic expressions, so
+ * `pred(x, f(y, z))` is a parse error -- which leaves the flattened spelling
+ * as the only way to write an inline-compound relation from a rule:
+ *
+ *   .decl pred(id: int64, payload: f/2 inline)
+ *   pred(x, y, z) :- src(x, y, z).              -> pred(1, 10, 20)
+ *
+ * Three head arguments against a two-column .decl.  `child_count !=
+ * column_count` would reject that working program.  The three arguments are
+ * three physical columns, and the declaration describes three physical
+ * columns, so measured physically it agrees.
+ *
+ * The head side is measured with atom_physical_column_count() rather than
+ * head->child_count.  Today the two are identical for heads, precisely
+ * because no head argument can be a COMPOUND_TERM; using the shared helper
+ * keeps one definition of "physical width of this atom against this
+ * relation" for heads, body scans (build_atom_scan) and any future head
+ * compound support, instead of two that can drift apart.
+ *
+ * The two-argument handle form -- `pred(x, y)` against the same .decl -- is
+ * rejected, even though the corresponding *fact* `pred(1, 99).` is accepted
+ * by the logical fact rule.  The asymmetry is deliberate: the head leaves
+ * the second inline slot never written, and a body pattern that destructures
+ * the column reads it regardless, so
+ * `outr(id, p, q) :- pred(id, f(p, q)).` evaluated to outr(1, 99, 0) with
+ * exit 0 and ASAN silent -- a fabricated value, the failure mode this issue
+ * exists to remove.  The three-argument spelling of the same program yields
+ * outr(1, 10, 20), which is correct.
+ *
+ * Aggregate heads need no special case.  parse_aggregate_expr() has exactly
+ * one caller, parse_head_arg(), so an AGGREGATE node is always a direct
+ * top-level head child and counts as one argument -- `t(g, min(v))` has
+ * child_count 2 and lowers to group_by_count + 1 == 2 emitted columns.  The
+ * check is also position-independent, so `t(min(v), g)` (issue #980, where
+ * position is ignored and the group-by is emitted first) is unaffected.
+ *
+ * Like the fact pass this runs after the whole collection loop, so a `.decl`
+ * may legally follow its rules, and it keys off has_decl rather than
+ * `column_count > 0` so that `.decl p()` is checked instead of skipped.
+ * Undeclared heads are skipped: they are widespread and legitimate
+ * (bench/workloads/doop.dl has ~90). */
+static int
+validate_head_arities(const struct wirelog_program *program,
+    const wl_parser_ast_node_t *ast)
+{
+    for (uint32_t i = 0; i < ast->child_count; i++) {
+        const wl_parser_ast_node_t *node = ast->children[i];
+        if (node->type != WL_PARSER_AST_NODE_RULE || node->child_count < 1)
+            continue;
+
+        const wl_parser_ast_node_t *head = node->children[0];
+        if (!head || head->type != WL_PARSER_AST_NODE_HEAD || !head->name)
+            continue;
+
+        const wl_ir_relation_info_t *rel
+            = find_relation_info(program, head->name);
+        if (!rel || !rel->has_decl)
+            continue;
+
+        uint32_t emitted = atom_physical_column_count(head, rel, program);
+        uint32_t declared = declared_physical_column_count(rel);
+        if (emitted != declared) {
+            WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                "rule head for relation '%s' emits %u column(s) but '%s' is"
+                " declared with %u column(s) (line %u)",
+                rel->name, emitted, rel->name, declared, head->line);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
 int
 wl_ir_program_collect_metadata(struct wirelog_program *program,
     const wl_parser_ast_node_t *ast)
@@ -795,8 +954,13 @@ wl_ir_program_collect_metadata(struct wirelog_program *program,
     }
 
     /* Issue #977: run after the loop so that every `.decl` in the program
-    * has been seen, regardless of where it sits relative to its facts. */
-    return validate_fact_arities(program, ast);
+     * has been seen, regardless of where it sits relative to its facts and
+     * rules.  Facts first only because that pass landed first; the two are
+     * independent and a program failing both is reported by whichever runs
+     * first. */
+    if (validate_fact_arities(program, ast) != 0)
+        return -1;
+    return validate_head_arities(program, ast);
 }
 
 /* ======================================================================== */
@@ -1855,14 +2019,19 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
      *   .decl cc(n:int64, lo:int64, hi:int64)
      *   cc(y, min(c), max(c)) :- cc(x, c, d), edge(x, y).   -> SIGSEGV
      *
-     * This check does NOT close that crash class.  The trigger is emitted
-     * arity != declared arity in a recursive stratum; multiple aggregates are
-     * one route to it.  A single-aggregate head is another and still crashes:
+     * This check does not close that crash class on its own.  The trigger is
+     * emitted arity != declared arity in a recursive stratum; multiple
+     * aggregates are one route to it.  A single-aggregate head is another and
+     * crashes identically:
      *   cc(y, min(c)) :- cc(x, c, d), edge(x, y).           -> SIGSEGV
-     * That is issue #977, and neither fix subsumes the other -- a .decl-arity
-     * check passes t(g, min(v), max(v)), which has three textual arguments
-     * against a 3-arity .decl.  See docs/SEMANTICS.md for why this rejects
-     * rather than supports multiple aggregates.
+     * That route is closed by validate_head_arities() (issue #977), which
+     * runs earlier, in wl_ir_program_collect_metadata().  Neither fix
+     * subsumes the other: an arity check passes t(g, min(v), max(v)), which
+     * has three textual arguments against a 3-arity .decl, so by the time
+     * control reaches here the head arity is already known to match and only
+     * the aggregate count can still be wrong.
+     * See docs/SEMANTICS.md for why this rejects rather than supports
+     * multiple aggregates.
      *
      * Counting direct HEAD children suffices because parse_aggregate_expr()
      * has exactly one caller, parse_head_arg() (parser/parser.c), so an

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -33,8 +33,8 @@ typedef struct {
      * Distinguishes "declared with zero columns" (`.decl p()`, which parses
      * and leaves column_count == 0) from "never declared" -- a relation
      * created implicitly by a rule head or by a fact.  `column_count > 0`
-     * cannot make that distinction, so fact-arity validation keys off this
-     * flag instead.
+     * cannot make that distinction, so both the fact-arity and the
+     * rule-head-arity validation passes key off this flag instead.
      *
      * The predicate is specifically "the user wrote a `.decl`", not "some
      * arity is on record".  wl_ir_program_add_magic_relation() sets a real


### PR DESCRIPTION
Third of four units for #977. Unit 1 (`.input` CSV) is #983, unit 2 (inline facts) is #984 — **this PR is stacked on #984** and should merge after it. Unit 4 (rule bodies) remains.

## This closes the crash class

```
.decl cc(n:int64, lo:int64, hi:int64)
cc(1,10,10).
cc(y, min(c)) :- cc(x, c, d), edge(x, y).
```

`exit 139` before, clean parse-time rejection now. This is the exact program #973 shipped documenting as *deliberately out of scope*: that issue rejected the multi-aggregate spelling, this rejects the arity mismatch itself, which is the actual trigger.

The two stay complementary in both directions — an arity check accepts `t(g, min(v), max(v))`, an aggregate-count check accepts `cc(y, min(c))` — so neither subsumes the other. Between them the class is closed on the parser path, and **every statement in the tree claiming otherwise has been retracted** (17 `#977` sites audited; both review gates grepped independently for stragglers and found none).

## Recursion was never the precondition

A producer at the declared width is. The *non-recursive* `t(g) :- val(g, v).` against `.decl t/3` is the same over-read once a `t(9,9,9).` fact fixes the relation's width — through `col_op_map` rather than `col_op_reduce`:

```
heap-buffer-overflow READ of size 8
  col_rel_append_all <- col_eval_stratum
0 bytes after 8-byte region <- col_op_map
```

Absent such a producer the relation just materialises narrower and the mismatch is a silent wrong answer. **Earlier descriptions of this defect, including #973's, said the non-recursive case was merely a wrong answer. That understated it**, and four places in the tree said so; all corrected here.

## Physical width, and why that is not an inconsistency

Heads compare against the declared **physical** width; facts (#984) compare **logically**. Head lowering expands an inline compound into its slots, and the head grammar has no compound-term production — `pred(x, f(y,z))` is a parse error — so the flattened spelling is the only way a rule can write such a relation:

```
.decl pred(id: int64, payload: f/2 inline)
pred(x, y, z) :- src(x, y, z).      /* 3 physical columns — accepted */
```

A logical comparison would reject that working program. Measured both ways across the tree: the physical rule flags only this PR's own negative tests; the logical rule additionally flags three working programs *and* legalises one that fabricates a value. The wrong rule is measurably wrong in both directions.

`pred(x, y)` is rejected because 2 ≠ 3. That this is not a false rejection is shown separately — it leaves the second inline slot unwritten and a destructuring body reads it, giving `outr(1, 99, 0)`, a value in no source data, where the three-argument spelling correctly gives `outr(1, 10, 20)`.

The corresponding *fact* `pred(1, 99).` stays accepted, because facts must compare logically. That asymmetry is **#985**, along with the finding that an inline-compound relation cannot presently be populated correctly by an inline fact at all — all three spellings fail, two of them silently. Neither check is relaxed to hide it; the fix belongs in the width model.

## Compatibility

~1500 declared rule heads across ~1300 programs — standalone `.dl`, C string literals grouped by concatenation run, markdown fences — plus all 16 bench workloads including a reconstructed `doop` with its 136 declared heads. **No in-tree program changes behaviour.** The check is a pure rejection and can never newly accept anything.

## Tests

Eight cases in `tests/test_program.c`: the recursive crash shape, narrower and wider heads, the inline-compound positive control, the `side`-compound handle form, undeclared heads, aggregate heads in the exact shapes `bench/workloads/cc.dl:6` and `sssp.dl:5` use, and the two-argument compound rejection. One in `test_wirelog_easy_inline_facts.c` asserting `pred(1,10,20)` **by value**, since `test_program` links only parser/ir/io/thread and cannot evaluate.

| mutation | result |
|---|---|
| check disabled | 5 failures |
| physical → logical | the 2 compound cases + the evaluation assertion |
| `has_decl` dropped | the undeclared-head controls **and** `test_symbol_aggregates` TEST 10, *"min() over an undeclared relation keeps working"* — the flag is load-bearing beyond these tests |

Suite **263 Ok / 1 Fail / 11 Skipped**, matching baseline; the failure is the pre-existing `sbom_snapshot` drift. ASAN+UBSAN with `detect_leaks=1` clean, and the crash shapes no longer reach evaluation.
