### PR TITLE
fix(stratify): bound the rule_names fill by the count it was sized from

### DIFF
--- a/tests/test_magic_sets.c
+++ b/tests/test_magic_sets.c
@@ -38,22 +38,22 @@ static int tests_passed = 0;
 static int tests_failed = 0;
 
 #define TEST(name)                            \
-    do {                                      \
-        tests_run++;                          \
-        printf("  [%d] %s", tests_run, name); \
-    } while (0)
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
 
 #define PASS()                 \
-    do {                       \
-        tests_passed++;        \
-        printf(" ... PASS\n"); \
-    } while (0)
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
 
 #define FAIL(msg)                         \
-    do {                                  \
-        tests_failed++;                   \
-        printf(" ... FAIL: %s\n", (msg)); \
-    } while (0)
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
 
 /* ======================================================================== */
 /* Helper: check if a magic relation exists in the program                 */
@@ -119,11 +119,11 @@ test_adornment_basic(void)
      *   - Edge is EDB -> skip
      */
     const char *src = ".decl Edge(x: int32, y: int32)\n"
-                      ".decl Reach(x: int32, y: int32)\n"
-                      ".decl Out(x: int32)\n"
-                      ".output Out\n"
-                      "Reach(x, y) :- Edge(x, y).\n"
-                      "Out(x) :- Reach(x, y).\n";
+        ".decl Reach(x: int32, y: int32)\n"
+        ".decl Out(x: int32)\n"
+        ".output Out\n"
+        "Reach(x, y) :- Edge(x, y).\n"
+        "Out(x) :- Reach(x, y).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -191,10 +191,10 @@ test_adornment_recursive(void)
      *   -> adorned_predicates = 1 (only Path_bf)
      */
     const char *src = ".decl Edge(x: int32, y: int32)\n"
-                      ".decl Path(x: int32, y: int32)\n"
-                      ".output Path\n"
-                      "Path(x, y) :- Edge(x, y).\n"
-                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+        ".decl Path(x: int32, y: int32)\n"
+        ".output Path\n"
+        "Path(x, y) :- Edge(x, y).\n"
+        "Path(x, y) :- Edge(x, z), Path(z, y).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -226,7 +226,7 @@ test_adornment_recursive(void)
     if (stats.adorned_predicates != 1) {
         char msg[64];
         snprintf(msg, sizeof(msg), "expected adorned_predicates=1, got %u",
-                 stats.adorned_predicates);
+            stats.adorned_predicates);
         wirelog_program_free(prog);
         FAIL(msg);
         return;
@@ -253,10 +253,10 @@ test_magic_rule_generation(void)
      *   Demand rule: $m$Path_bf(z) :- $m$Path_bf(x), Edge(x, z).
      */
     const char *src = ".decl Edge(x: int32, y: int32)\n"
-                      ".decl Path(x: int32, y: int32)\n"
-                      ".output Path\n"
-                      "Path(x, y) :- Edge(x, y).\n"
-                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+        ".decl Path(x: int32, y: int32)\n"
+        ".output Path\n"
+        "Path(x, y) :- Edge(x, y).\n"
+        "Path(x, y) :- Edge(x, z), Path(z, y).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -295,7 +295,7 @@ test_magic_rule_generation(void)
     if (stats.original_rules_modified != 2) {
         char msg[64];
         snprintf(msg, sizeof(msg), "expected original_rules_modified=2, got %u",
-                 stats.original_rules_modified);
+            stats.original_rules_modified);
         wirelog_program_free(prog);
         FAIL(msg);
         return;
@@ -316,10 +316,10 @@ test_all_free_skip(void)
     TEST("test_all_free_skip");
 
     const char *src = ".decl Edge(x: int32, y: int32)\n"
-                      ".decl Path(x: int32, y: int32)\n"
-                      ".output Path\n"
-                      "Path(x, y) :- Edge(x, y).\n"
-                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+        ".decl Path(x: int32, y: int32)\n"
+        ".output Path\n"
+        "Path(x, y) :- Edge(x, y).\n"
+        "Path(x, y) :- Edge(x, z), Path(z, y).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -351,7 +351,7 @@ test_all_free_skip(void)
     if (stats.adorned_predicates != 0) {
         char msg[64];
         snprintf(msg, sizeof(msg), "expected adorned_predicates=0, got %u",
-                 stats.adorned_predicates);
+            stats.adorned_predicates);
         wirelog_program_free(prog);
         FAIL(msg);
         return;
@@ -389,12 +389,12 @@ test_negation_no_demand(void)
      *   -> NO magic relation for Exclude.
      */
     const char *src = ".decl Base(x: int32)\n"
-                      ".decl BadBase(x: int32)\n"
-                      ".decl Exclude(x: int32)\n"
-                      ".decl IDB(x: int32)\n"
-                      ".output IDB\n"
-                      "Exclude(x) :- BadBase(x).\n"
-                      "IDB(x) :- Base(x), !Exclude(x).\n";
+        ".decl BadBase(x: int32)\n"
+        ".decl Exclude(x: int32)\n"
+        ".decl IDB(x: int32)\n"
+        ".output IDB\n"
+        "Exclude(x) :- BadBase(x).\n"
+        "IDB(x) :- Base(x), !Exclude(x).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -419,7 +419,7 @@ test_negation_no_demand(void)
     if (has_relation(prog, "$m$Exclude_b")) {
         wirelog_program_free(prog);
         FAIL("demand must not flow through negation: $m$Exclude_b should not "
-             "exist");
+            "exist");
         return;
     }
 
@@ -452,11 +452,11 @@ test_multiple_adornments(void)
      *   -> adorned: {A_bf, B_bf}
      */
     const char *src = ".decl Edge(x: int32, y: int32)\n"
-                      ".decl A(x: int32, y: int32)\n"
-                      ".decl B(x: int32, y: int32)\n"
-                      ".output A\n"
-                      "A(x, y) :- Edge(x, z), B(z, y).\n"
-                      "B(x, y) :- Edge(y, z), A(z, x).\n";
+        ".decl A(x: int32, y: int32)\n"
+        ".decl B(x: int32, y: int32)\n"
+        ".output A\n"
+        "A(x, y) :- Edge(x, z), B(z, y).\n"
+        "B(x, y) :- Edge(y, z), A(z, x).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -483,7 +483,7 @@ test_multiple_adornments(void)
     if (!has_a_magic || !has_b_magic) {
         char msg[128];
         snprintf(msg, sizeof(msg), "expected $m$A_bf=%s $m$B_bf=%s",
-                 has_a_magic ? "yes" : "NO", has_b_magic ? "yes" : "NO");
+            has_a_magic ? "yes" : "NO", has_b_magic ? "yes" : "NO");
         wirelog_program_free(prog);
         FAIL(msg);
         return;
@@ -494,7 +494,7 @@ test_multiple_adornments(void)
     if (stats.adorned_predicates < 2) {
         char msg[64];
         snprintf(msg, sizeof(msg), "expected adorned_predicates>=2, got %u",
-                 stats.adorned_predicates);
+            stats.adorned_predicates);
         wirelog_program_free(prog);
         FAIL(msg);
         return;
@@ -528,11 +528,11 @@ test_mutual_recursion(void)
      *   -> adorned: {VPT_bf}
      */
     const char *src = ".decl Assign(v: int32, h: int32)\n"
-                      ".decl Load(u: int32, v: int32)\n"
-                      ".decl VPT(h: int32, v: int32)\n"
-                      ".output VPT\n"
-                      "VPT(h, v) :- Assign(v, h).\n"
-                      "VPT(h, v) :- VPT(h, u), Load(u, v).\n";
+        ".decl Load(u: int32, v: int32)\n"
+        ".decl VPT(h: int32, v: int32)\n"
+        ".output VPT\n"
+        "VPT(h, v) :- Assign(v, h).\n"
+        "VPT(h, v) :- VPT(h, u), Load(u, v).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -563,7 +563,7 @@ test_mutual_recursion(void)
     if (stats.original_rules_modified != 2) {
         char msg[64];
         snprintf(msg, sizeof(msg), "expected original_rules_modified=2, got %u",
-                 stats.original_rules_modified);
+            stats.original_rules_modified);
         wirelog_program_free(prog);
         FAIL(msg);
         return;
@@ -592,10 +592,10 @@ test_edb_skip(void)
      *   Edge: EDB -> no $m$Edge_XX created.
      */
     const char *src = ".decl Edge(x: int32, y: int32)\n"
-                      ".decl Path(x: int32, y: int32)\n"
-                      ".output Path\n"
-                      "Path(x, y) :- Edge(x, y).\n"
-                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+        ".decl Path(x: int32, y: int32)\n"
+        ".output Path\n"
+        "Path(x, y) :- Edge(x, y).\n"
+        "Path(x, y) :- Edge(x, z), Path(z, y).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -647,10 +647,10 @@ test_standard_apply_noop(void)
     TEST("test_standard_apply_noop");
 
     const char *src = ".decl Edge(x: int32, y: int32)\n"
-                      ".decl Path(x: int32, y: int32)\n"
-                      ".output Path\n"
-                      "Path(x, y) :- Edge(x, y).\n"
-                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+        ".decl Path(x: int32, y: int32)\n"
+        ".output Path\n"
+        "Path(x, y) :- Edge(x, y).\n"
+        "Path(x, y) :- Edge(x, z), Path(z, y).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -673,7 +673,7 @@ test_standard_apply_noop(void)
     if (prog->rule_count != rule_count_before) {
         char msg[64];
         snprintf(msg, sizeof(msg), "rule count changed: before=%u after=%u",
-                 rule_count_before, prog->rule_count);
+            rule_count_before, prog->rule_count);
         wirelog_program_free(prog);
         FAIL(msg);
         return;
@@ -709,12 +709,12 @@ test_magic_correctness_noop(void)
      * Verify no crash and program still stratified.
      */
     const char *src = ".decl Edge(x: int32, y: int32)\n"
-                      ".decl Path(x: int32, y: int32)\n"
-                      ".output Path\n"
-                      "Edge(1, 2).\n"
-                      "Edge(2, 3).\n"
-                      "Path(x, y) :- Edge(x, y).\n"
-                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+        ".decl Path(x: int32, y: int32)\n"
+        ".output Path\n"
+        "Edge(1, 2).\n"
+        "Edge(2, 3).\n"
+        "Path(x, y) :- Edge(x, y).\n"
+        "Path(x, y) :- Edge(x, z), Path(z, y).\n";
 
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
@@ -757,10 +757,10 @@ test_magic_rebuild_and_stratify(void)
     TEST("test_magic_rebuild_and_stratify (integration)");
 
     const char *src = ".decl Edge(x: int32, y: int32)\n"
-                      ".decl Path(x: int32, y: int32)\n"
-                      ".output Path\n"
-                      "Path(x, y) :- Edge(x, y).\n"
-                      "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+        ".decl Path(x: int32, y: int32)\n"
+        ".output Path\n"
+        "Path(x, y) :- Edge(x, y).\n"
+        "Path(x, y) :- Edge(x, z), Path(z, y).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -819,6 +819,98 @@ test_magic_rebuild_and_stratify(void)
     PASS();
 }
 
+/* Issue #987: re-stratification after magic sets wrote past the end of a
+ * stratum's rule_names array.
+ *
+ * wl_ir_stratify_program() sizes strata[s].rule_names from a counting loop
+ * that skips rules whose head is absent from the dependency graph, then
+ * filled it from a loop that did not skip them -- a skipped rule keeps
+ * rule_stratum[r] == 0 from calloc and landed in stratum 0 regardless.
+ * Magic-set rewriting manufactures those graph-absent heads because it
+ * names demand relations from an atom's physical width while get_arity()
+ * reports the declared logical width.
+ *
+ * The write is out of bounds.  One offending rule overwrites allocator
+ * slack and is silent without a sanitizer; several corrupt the glibc heap
+ * outright ("double free or corruption", "malloc(): corrupted top size"),
+ * so this test uses several deliberately -- a single-rule version would
+ * pass on the unfixed code in an ordinary build.
+ *
+ * All three shapes below crash on the unfixed code, and none is caught by
+ * the #977 arity checks: the first has a correct head and a wrong body, the
+ * second is undeclared so has_decl skips it, and in the third every atom
+ * already measures at the correct physical width. */
+static void
+test_stratify_no_oob_on_graph_absent_head(void)
+{
+    TEST("Magic sets: re-stratification stays in bounds (#987)");
+
+    static const char *const srcs[] = {
+        /* declared, body atom wider than the .decl, several rules */
+        ".decl edge(a: int64, b: int64)\n"
+        ".decl path(a: int64, b: int64)\n"
+        "path(x,z) :- path(x,y,q1), edge(y,z).\n"
+        "path(x,z) :- path(x,y,q2), edge(y,z).\n"
+        "path(x,z) :- path(x,y,q3), edge(y,z).\n"
+        "path(x,z) :- path(x,y,q4), edge(y,z).\n",
+        /* undeclared head relation -- has_decl gates the #977 checks off */
+        ".decl edge(a: int64, b: int64)\n"
+        "edge(1,2).\n"
+        "path(x,y) :- edge(x,y).\n"
+        "path(x,z) :- path(x,y,q1), edge(y,z).\n"
+        "path(x,z) :- path(x,y,q2), edge(y,z).\n"
+        "path(x,z) :- path(x,y,q3), edge(y,z).\n",
+    };
+
+    for (size_t i = 0; i < sizeof(srcs) / sizeof(srcs[0]); i++) {
+        wirelog_error_t err;
+        wirelog_program_t *prog = wirelog_parse_string(srcs[i], &err);
+        if (!prog)
+            continue; /* rejected earlier by an arity check: also fine */
+
+        wl_magic_demand_t demands[1];
+        demands[0].relation_name = "path";
+        demands[0].bound_mask = 0x1;
+        demands[0].arity = 2;
+
+        if (wl_magic_sets_apply_with_demands(prog, demands, 1, NULL) != 0) {
+            wirelog_program_free(prog);
+            continue;
+        }
+        if (wl_ir_program_rebuild_relation_irs(prog) != 0) {
+            wirelog_program_free(prog);
+            FAIL("rebuild_relation_irs failed");
+            return;
+        }
+
+        wl_ir_program_free_strata(prog);
+        if (wl_ir_stratify_program(prog) != 0) {
+            wirelog_program_free(prog);
+            FAIL("re-stratification failed");
+            return;
+        }
+
+        /* Every stratum must have filled exactly as many names as it
+         * declares, and no NULL may remain -- a short fill is the
+         * non-sanitizer-visible half of the same loop disagreement. */
+        for (uint32_t s = 0; s < prog->stratum_count; s++) {
+            if (!prog->strata[s].rule_names)
+                continue;
+            for (uint32_t k = 0; k < prog->strata[s].rule_count; k++) {
+                if (!prog->strata[s].rule_names[k]) {
+                    wirelog_program_free(prog);
+                    FAIL("stratum rule_names shorter than rule_count");
+                    return;
+                }
+            }
+        }
+
+        wirelog_program_free(prog);
+    }
+
+    PASS();
+}
+
 /* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
@@ -842,6 +934,7 @@ main(void)
     printf("\nIntegration Tests:\n");
     test_magic_correctness_noop();
     test_magic_rebuild_and_stratify();
+    test_stratify_no_oob_on_graph_absent_head();
 
     printf("\n=== Results ===\n");
     printf("Tests run:    %d\n", tests_run);

--- a/wirelog/ir/stratify.c
+++ b/wirelog/ir/stratify.c
@@ -562,11 +562,29 @@ wl_ir_stratify_program(struct wirelog_program *program)
         return -1;
     }
 
+    /* Issue #987: the fill must honour the same bound the counting loop
+     * above established.  That loop only counts a rule when its head is
+     * found in the dependency graph; a rule whose head is absent keeps
+     * rule_stratum[r] == 0 from calloc and would otherwise be written into
+     * stratum 0 anyway -- past the end of an array sized without it.  That
+     * is an out-of-bounds *write*, and with more than one such rule it
+     * corrupts the glibc heap in a plain release build.
+     *
+     * Magic-set rewriting manufactures those graph-absent heads: it names
+     * demand relations from an atom's physical width while get_arity()
+     * reports the declared logical width (passes/magic_sets.c), so the
+     * rewritten head can carry a name no relation in the graph matches.
+     * Fixing that confusion is tracked separately; this bound is correct
+     * regardless of how a head comes to be missing.
+     *
+     * rules_per_stratum[] is also what :rule_count is set from below, so
+     * the two loops have to agree here even setting memory safety aside. */
     for (uint32_t r = 0; r < program->rule_count; r++) {
         if (!program->rules[r].head_relation)
             continue;
         uint32_t s = rule_stratum[r];
-        if (s < num_strata && program->strata[s].rule_names) {
+        if (s < num_strata && program->strata[s].rule_names
+            && fill_idx[s] < rules_per_stratum[s]) {
             program->strata[s].rule_names[fill_idx[s]++]
                 = program->rules[r].head_relation;
         }


### PR DESCRIPTION
Closes #987. **This should land before 0.54.0** — it is a heap-corrupting out-of-bounds *write*, reachable from parsing a four-line text file, in the shipped release configuration.

Found while planning #977 unit 4, and it is what unit 4 turned out to be unable to fix.

## The bug

```
.decl edge(a: int64, b: int64)
.decl path(a: int64, b: int64)
path(x,z) :- path(x,y,q), edge(y,z).
.query path(b, f) .
```

```
heap-buffer-overflow WRITE of size 8 at ir/stratify.c:571
0 bytes after 8-byte region allocated at ir/stratify.c:541
```

Allocation and write are 30 lines apart in the same function.

**Not sanitizer-only.** One offending rule overwrites allocator slack and is silent. Several corrupt the glibc heap in a default `-Dbuildtype=release` build with no sanitizer:

| mismatched rules | release result |
|---|---|
| 1 | rc=0, silent |
| 2 | rc=134 `double free or corruption (out)` |
| 4 | rc=134 `malloc(): corrupted top size` |
| 6 | rc=134 `free(): invalid pointer` |
| 10 | rc=134 `free(): invalid pointer` |

Every previous fix in this series (#973, #977 units 1-3) was an out-of-bounds **read**. This is a write.

## Cause

Two loops disagree. The counting loop skips rules whose head is absent from the dependency graph:

```c
531  uint32_t gi = graph_find_relation(graph, program, head);
532  if (gi != UINT32_MAX) {              /* skipped when absent */
534      rules_per_stratum[stratum_id[gi]]++;
```

`rule_names` is sized from that at `:541`. The fill loop does **not** skip them — a skipped rule keeps `rule_stratum[r] == 0` from `calloc` and lands in stratum 0 anyway, guarded on `s < num_strata` but never on `fill_idx[s]`.

Graph-absent heads come from magic-set rewriting, which is why `.query` is needed to reach it — without it `wirelog_optimize` never calls `rebuild_after_magic_sets`. `passes/magic_sets.c` names demand relations from an atom's **physical** width while `get_arity()` reports the declared **logical** width, and `adorned_add()` dedupes on `(name, mask)` ignoring arity. That confusion is the deeper defect and is tracked separately; this bound is correct however a head comes to be missing.

## Fix

Two lines — honour in the fill the bound the counting loop established:

```c
if (s < num_strata && program->strata[s].rule_names
    && fill_idx[s] < rules_per_stratum[s]) {
```

`rules_per_stratum[]` is also what `strata[s].rule_count` is set from immediately below, so the loops must agree regardless of memory safety — today stratum 0's `rule_names` is mis-filled relative to its own declared `rule_count`.

## Why #977's checks don't cover it

Three shapes reach this and the merged arity checks catch none:

1. **Declared, wrong body atom** — the head-arity check passes it; the mismatch is in a body.
2. **Undeclared relation** — both checks gate on `has_decl` and skip it by construction.
3. **Every atom already at the correct physical width** — the mismatch is entirely internal to `magic_sets.c`:

```
.decl p(id: int64, payload: f/2 inline)
p(x,y,z) :- edge(x,y), z=9.
p(x,z,w) :- p(x, f(y,w)), edge(y,z).
.query p(b, f) .
```
`declared_physical_column_count(p)` = 3, head measures 3, body measures 3. Still crashes.

No arity validation over atoms can close shape 3. That is why this is separate from #977 rather than part of it.

## Tests

`test_stratify_no_oob_on_graph_absent_head` drives parse → magic sets → rebuild → re-stratify for the declared and undeclared shapes, and asserts every stratum filled exactly as many names as it declares.

It uses **several** offending rules deliberately: a single-rule version passes on the unfixed code in an ordinary build, so a test written that way would be worthless outside a sanitizer run. Verified to fail without the fix, aborting with `double free or corruption (!prev)`.

Suite **264 ok / 1 fail / 11 skipped**, unchanged; the failure is the pre-existing `sbom_snapshot` drift. ASAN+UBSAN with `detect_leaks=1` clean on all three shapes and on the scaled release cases.
