### PR TITLE
fix(magic_sets): build the demand guard left-deep so the plan can represent it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,63 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **Magic guards are built left-deep** (#989): `insert_magic_guard` produced
+  `JOIN(magic_scan, body)`. When the body was itself composite -- a JOIN chain,
+  an ANTIJOIN from a negated atom, a SIP-inserted SEMIJOIN -- that is a
+  right-deep JOIN, and a right-deep JOIN is structurally unrepresentable in the
+  execution plan: `wl_plan_op_t.right_relation` is a relation *name*, and
+  `translate_ir_node` collapses `children[1]` to `rn->relation_name`. The
+  operator was emitted with `right_relation = NULL`, matched nothing, and the
+  rule silently derived zero tuples. Measured on the `docs/SYNTAX.md` `.query
+  Path(b, f)` example with the demand relation seeded by hand: 3 of the 6
+  closure tuples, the base rule's only. A non-recursive three-way join under a
+  guard produced zero rows, as did a guarded rule with a negated atom.
+
+  The guard SCAN is now the *right* child, matching the parser's rule chain and
+  jpp's chain rebuild, which already build left-deep. One producer does not:
+  `convert_rule` nests a side-compound atom's `JOIN(scan, side_scan)` subtree
+  on the right whenever that atom is not first in the body, which has always
+  been unrepresentable and has always silently matched nothing. That shape is
+  now a plan-generation error rather than an empty result; it is tracked as
+  #994 and is not fixed here. The swap also inverts which side a bound-variable
+  comparison resolves against: the guard's columns now come last in the layout,
+  and each is named after a body column that resolves first, so the guard's
+  `column_types` (#962) are no longer reachable by name. They are still filled
+  in, since `col_ctx_lookup_type` has a positional `colN` fallback that can
+  land in the guard's range.
+
+  **This does not make a bound `.query` work.** Nothing seeds the demand
+  relation, so the guards still reject everything; see the status note in
+  `docs/SYNTAX.md`. What is fixed is the rewrite itself, which is a
+  prerequisite.
+
+- **Plan generation rejects an unrepresentable JOIN right child** (#989):
+  translating a JOIN whose right child carries no relation name now returns an
+  error instead of emitting `right_relation = NULL`. That NULL was an entire
+  silent-wrong-answer class -- the operator matches nothing and the rule
+  quietly under-derives; it is now a plan-generation failure. No in-tree
+  program, benchmark, or example produces such a JOIN.
+
+- **`original_rules_modified` counts guards actually inserted** (#989):
+  `insert_magic_guard` returns 0 both when it inserts a guard and when it
+  declines to, and the caller incremented the counter unconditionally. A rule
+  whose bound head position holds a constant (`q(1, y) :- ...` under `.query
+  q(b, f)`) gets no guard, because there is no variable to key on -- yet was
+  reported as modified. A program with two real guards reported three. The
+  function now returns a distinguishable outcome, and skipped rules are counted
+  separately.
+
+  Two skip counters are added, kept apart because they mean different things.
+  `skipped_constant_head` is a *policy* skip: the rule is well-formed and the
+  pass declines. `skipped_unsupported_head` is a *capability* gap: the pass
+  reads head variables off a PROJECT root, and a rule fused to a FLATMAP root
+  -- Logic Fusion runs before Magic Sets in the shipping pipeline, and any rule
+  with a filter is a fusion candidate -- has no such root, so it was skipped in
+  total silence. That is the common way for a guard to go missing and the
+  headline shape of #990; teaching the pass to handle a fused head is separate
+  work, but the skip is now visible. Together these counters are the only
+  mechanism that can detect a guard silently not being inserted.
+
 - **Inline facts are validated against their relation's declared arity**
   (#977): `collect_fact` packed `fact_data` using each fact's *own*
   argument count as the row stride, while both readers of that buffer --

--- a/docs/COMPOUND_TERMS.md
+++ b/docs/COMPOUND_TERMS.md
@@ -336,6 +336,36 @@ destructuring.
 flagged(ID) :- candidate(ID), !event(ID, metadata(_, _, _, 99)).
 ```
 
+### Also not supported: a `side` destructure in a non-first body atom
+
+A positive `side` destructure must be the **first** atom in the body.
+
+```
+.decl event(id: int64, payload: metadata/4 side)
+.decl gate(id: int64)
+.decl hot(id: int64, r: int64)
+
+/* Plan-generation error: the compound atom is not first */
+hot(ID, R) :- gate(ID), event(ID, metadata(_, _, _, R)).
+
+/* Accepted: same rule, compound atom first */
+hot(ID, R) :- event(ID, metadata(_, _, _, R)), gate(ID).
+```
+
+A `side` destructure lowers to a composite `JOIN(scan, side_scan)` subtree.
+When it is not the first atom, that subtree is installed as the right child of
+the body's join chain — and the execution plan cannot represent a composite
+right child, since `wl_plan_op_t.right_relation` is a relation *name*.
+
+Before 0.54.0 this produced no diagnostic: the rule silently matched nothing
+and returned zero rows, while the identical rule with the atoms reordered
+returned the correct answer. It is now a plan-generation error naming the
+cause. Reordering the body is the workaround; conjunction is commutative, so
+the reordered rule is logically identical.
+
+Tracked as issue #994, which proposes flattening the subtree into the left
+spine so that either ordering works.
+
 ### Supported workaround
 
 Extract the compound fields in a **positive** rule first (positive side-compound

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -287,6 +287,15 @@ free (to be computed). This enables the Magic Sets optimization pass to restrict
 evaluation to only the tuples reachable from the query, reducing intermediate
 result sizes for recursive programs.
 
+> **Status (Issue #989): a bound `.query` currently prunes nothing.**
+> The Magic Sets pass builds the magic demand relations and guards the rules
+> with them, but there is no syntax for supplying the bound *values* and
+> nothing seeds the demand relation. The demand relation therefore stays
+> empty, the guards match nothing, and the guarded rules are removed from the
+> result rather than restricted. Adding a bound `.query` to a working program
+> will make it derive fewer tuples, not the same tuples faster. Leave `.query`
+> off, or use all-free adornments, until seeding lands.
+
 ### Syntax
 
 ```
@@ -313,8 +322,14 @@ Path(x, y) :- Edge(x, z), Path(z, y).
 
 Here `.query Path(b, f)` declares that the first argument of `Path` is bound
 (e.g., we only want paths starting from a specific node). The engine generates
-magic demand relations (`$m$Path_bf`) that restrict evaluation to only reachable
-tuples, avoiding full materialization of the transitive closure.
+the magic demand relation `$m$Path_bf` and guards both `Path` rules with it,
+which is *intended* to restrict evaluation to only reachable tuples and avoid
+full materialization of the transitive closure.
+
+As written, this program prints nothing. There is no way to say *which* source
+node is bound, so `$m$Path_bf` is never populated and both guards reject every
+tuple. Deleting the `.query` line prints the full closure. See the status note
+above and Issue #989.
 
 Query with all arguments bound (point query):
 
@@ -334,8 +349,21 @@ Query with a mixed pattern on a ternary relation:
   `.output` relations fully (all-free adornment), which is the default behavior.
 - When `.query` is present, the Magic Sets pass generates demand propagation
   rules that prune the search space based on the bound positions.
+- A `.query` with at least one bound position currently yields an **empty**
+  result for the guarded relation, because nothing seeds the demand relation
+  (Issue #989). Do not use it to speed a program up; it changes the answer.
 - An all-free `.query` (e.g., `.query Path(f, f)`) is equivalent to no `.query`
-  and results in no optimization (the pass is a no-op).
+  and results in no optimization (the pass is a no-op). All-free is the only
+  adornment that is safe today.
+- A rule whose bound head position holds a *constant* rather than a variable
+  (e.g. `q(1, y) :- ...` under `.query q(b, f)`) is left unguarded: there is no
+  variable to key the guard on. Such rules are reported by the pass's
+  `skipped_constant_head` counter.
+- A rule that Logic Fusion has collapsed into a fused root — which includes any
+  rule with a filter — is also left unguarded, because the pass reads head
+  variable names off a `PROJECT` node that no longer exists. Such rules are
+  reported by `skipped_unsupported_head`. Both counters describe a rule that
+  evaluates unrestricted: sound, but not the pruning `.query` asks for.
 - Multiple `.query` directives may appear in a single program for different
   relations.
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2797,10 +2797,16 @@ test_magic_sets_exe = executable(
   parser_src,
   ir_src,
   optimizer_src,
+  # Issue #989: the guard-order tests evaluate magic-rewritten programs, so
+  # this target needs the plan generator's backend (columnar) and its arena
+  # and work-queue dependencies, not just the IR passes.
+  backend_src,
   io_src,
+  arena_src,
   thread_src,
+  workqueue_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
-  dependencies: [threads_dep],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
 
 test('magic_sets', test_magic_sets_exe)

--- a/tests/test_magic_sets.c
+++ b/tests/test_magic_sets.c
@@ -20,14 +20,20 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/passes/fusion.h"
 #include "../wirelog/passes/subsumption.h"
+#include "../wirelog/ir/ir.h"
 #include "../wirelog/ir/program.h"
 #include "../wirelog/ir/stratify.h"
+#include "../wirelog/backend.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
 #include "../wirelog/wirelog-parser.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 /* ======================================================================== */
 /* Test Helpers                                                             */
@@ -97,6 +103,217 @@ parse_and_optimize(const char *src)
     wl_jpp_apply(prog, NULL);
     wl_sip_apply(prog, NULL);
     return prog;
+}
+
+/* ======================================================================== */
+/* Helpers: magic guard structure (Issue #989)                             */
+/* ======================================================================== */
+
+/*
+ * The body root of the @nth rule whose head is @head, i.e. child[0] of the
+ * rule's PROJECT.  After Magic Sets this is the guard JOIN.
+ */
+static const wirelog_ir_node_t *
+rule_body_root(const struct wirelog_program *prog, const char *head,
+    uint32_t nth)
+{
+    uint32_t seen = 0;
+    for (uint32_t i = 0; i < prog->rule_count; i++) {
+        if (!prog->rules[i].head_relation
+            || strcmp(prog->rules[i].head_relation, head) != 0)
+            continue;
+        if (seen++ != nth)
+            continue;
+        const wirelog_ir_node_t *root = prog->rules[i].ir_root;
+        if (!root || root->child_count == 0)
+            return NULL;
+        return root->children[0];
+    }
+    return NULL;
+}
+
+static const wirelog_ir_node_t *
+rule_ir_root(const struct wirelog_program *prog, const char *head, uint32_t nth)
+{
+    uint32_t seen = 0;
+    for (uint32_t i = 0; i < prog->rule_count; i++) {
+        if (!prog->rules[i].head_relation
+            || strcmp(prog->rules[i].head_relation, head) != 0)
+            continue;
+        if (seen++ == nth)
+            return prog->rules[i].ir_root;
+    }
+    return NULL;
+}
+
+static uint32_t
+rule_count_for(const struct wirelog_program *prog, const char *head)
+{
+    uint32_t n = 0;
+    for (uint32_t i = 0; i < prog->rule_count; i++) {
+        if (prog->rules[i].head_relation
+            && strcmp(prog->rules[i].head_relation, head) == 0)
+            n++;
+    }
+    return n;
+}
+
+static bool
+ir_contains_type(const wirelog_ir_node_t *node, wirelog_ir_node_type_t type)
+{
+    if (!node)
+        return false;
+    if (node->type == type)
+        return true;
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        if (ir_contains_type(node->children[i], type))
+            return true;
+    }
+    return false;
+}
+
+/* ======================================================================== */
+/* Helpers: seeded evaluation (Issue #989)                                 */
+/* ======================================================================== */
+
+/*
+ * Seed a relation's inline facts directly.  This is test-only scaffolding:
+ * the shipped path that seeds a magic demand relation from a bound `.query`
+ * does not exist yet, so the tests below stand in for it in order to reach
+ * the guarded rule bodies at all.
+ */
+static bool
+seed_relation_facts(struct wirelog_program *prog, const char *name,
+    const int64_t *rows, uint32_t row_count, uint32_t ncols)
+{
+    for (uint32_t i = 0; i < prog->relation_count; i++) {
+        wl_ir_relation_info_t *rel = &prog->relations[i];
+        if (!rel->name || strcmp(rel->name, name) != 0)
+            continue;
+        if (rel->column_count != ncols)
+            return false;
+        size_t total = (size_t)row_count * ncols;
+        free(rel->fact_data);
+        rel->fact_data = (int64_t *)malloc(total * sizeof(int64_t));
+        if (!rel->fact_data)
+            return false;
+        memcpy(rel->fact_data, rows, total * sizeof(int64_t));
+        rel->fact_count = row_count;
+        rel->fact_capacity = (uint32_t)total;
+        return true;
+    }
+    return false;
+}
+
+#define MS_MAX_ROWS 64
+#define MS_MAX_COLS 4
+
+typedef struct {
+    const char *relation;
+    uint32_t ncols;
+    int64_t rows[MS_MAX_ROWS][MS_MAX_COLS];
+    uint32_t count;
+    bool overflow;
+} ms_row_set_t;
+
+static void
+ms_collect_rows(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    ms_row_set_t *set = (ms_row_set_t *)user_data;
+    if (!relation || strcmp(relation, set->relation) != 0)
+        return;
+    if (ncols > MS_MAX_COLS || set->count >= MS_MAX_ROWS) {
+        set->overflow = true;
+        return;
+    }
+    set->ncols = ncols;
+    for (uint32_t i = 0; i < ncols; i++)
+        set->rows[set->count][i] = row[i];
+    set->count++;
+}
+
+static bool
+ms_rows_match(const ms_row_set_t *actual, const int64_t *expected,
+    uint32_t expected_rows, uint32_t ncols)
+{
+    if (actual->overflow || actual->count != expected_rows)
+        return false;
+    if (expected_rows == 0)
+        return true;
+    if (actual->ncols != ncols)
+        return false;
+    for (uint32_t r = 0; r < expected_rows; r++) {
+        bool found = false;
+        for (uint32_t a = 0; a < actual->count && !found; a++) {
+            bool same = true;
+            for (uint32_t c = 0; c < ncols; c++) {
+                if (actual->rows[a][c] != expected[(size_t)r * ncols + c]) {
+                    same = false;
+                    break;
+                }
+            }
+            found = same;
+        }
+        if (!found)
+            return false;
+    }
+    return true;
+}
+
+/*
+ * Parse + optimize @src, apply @demands, re-stratify, and seed @magic_rel
+ * with @seed.  Returns the program ready for plan generation, or NULL.
+ */
+static struct wirelog_program *
+magic_program_with_seed(const char *src, const wl_magic_demand_t *demands,
+    uint32_t demand_count, const char *magic_rel, const int64_t *seed,
+    uint32_t seed_rows, uint32_t seed_cols, wl_magic_sets_stats_t *stats)
+{
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog)
+        return NULL;
+
+    if (wl_magic_sets_apply_with_demands(prog, demands, demand_count, stats)
+        != 0)
+        goto fail;
+    if (wl_ir_program_rebuild_relation_irs(prog) != 0)
+        goto fail;
+    wl_ir_program_free_strata(prog);
+    if (wl_ir_stratify_program(prog) != 0)
+        goto fail;
+    if (magic_rel
+        && !seed_relation_facts(prog, magic_rel, seed, seed_rows, seed_cols))
+        goto fail;
+    return prog;
+
+fail:
+    wirelog_program_free(prog);
+    return NULL;
+}
+
+static bool
+ms_evaluate(struct wirelog_program *prog, const char *out_rel,
+    uint32_t workers, ms_row_set_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    out->relation = out_rel;
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0 || !plan)
+        return false;
+
+    wl_session_t *session = NULL;
+    int rc = wl_session_create(wl_backend_columnar(), plan, workers, &session);
+    if (rc == 0)
+        rc = wl_session_load_facts(session, prog);
+    if (rc == 0)
+        rc = wl_session_snapshot(session, ms_collect_rows, out);
+
+    if (session)
+        wl_session_destroy(session);
+    wl_plan_free(plan);
+    return rc == 0 && !out->overflow;
 }
 
 /* ======================================================================== */
@@ -912,6 +1129,440 @@ test_stratify_no_oob_on_graph_absent_head(void)
 }
 
 /* ======================================================================== */
+/* Issue #989: guard JOIN order                                            */
+/* ======================================================================== */
+
+/* The `.query Path(b, f)` example from docs/SYNTAX.md. */
+static const char *k_syntax_doc_src
+    = ".decl Edge(x: int32, y: int32)\n"
+    ".decl Path(x: int32, y: int32)\n"
+    ".output Path\n"
+    "Edge(1, 2).\n"
+    "Edge(2, 3).\n"
+    "Edge(3, 4).\n"
+    "Path(x, y) :- Edge(x, y).\n"
+    "Path(x, y) :- Edge(x, z), Path(z, y).\n";
+
+/* Non-recursive three-way join: the guarded body is a JOIN chain. */
+static const char *k_three_way_src
+    = ".decl a(x: int32, y: int32)\n"
+    ".decl b(y: int32, z: int32)\n"
+    ".decl c(z: int32, w: int32)\n"
+    ".decl out(x: int32, w: int32)\n"
+    ".output out\n"
+    "a(1, 2).\n"
+    "a(9, 2).\n"
+    "b(2, 3).\n"
+    "c(3, 4).\n"
+    "out(x, w) :- a(x, y), b(y, z), c(z, w).\n";
+
+/*
+ * Test: the guard JOIN's right child must be a relation-bearing node.
+ *
+ * wl_plan_op_t.right_relation is a relation name, not a subtree, so a JOIN
+ * whose right child is itself a JOIN/ANTIJOIN/SEMIJOIN cannot be expressed
+ * in the plan at all: translate_ir_node() emits right_relation = NULL and
+ * the operator matches nothing.
+ */
+static void
+test_guard_join_right_child_is_representable(void)
+{
+    TEST("test_guard_join_right_child_is_representable");
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "Path";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    struct wirelog_program *prog = magic_program_with_seed(k_syntax_doc_src,
+            demands, 1, NULL, NULL, 0, 0, NULL);
+    if (!prog) {
+        FAIL("setup failed");
+        return;
+    }
+
+    uint32_t nrules = rule_count_for(prog, "Path");
+    if (nrules != 2) {
+        wirelog_program_free(prog);
+        FAIL("expected 2 rules for Path");
+        return;
+    }
+
+    for (uint32_t r = 0; r < nrules; r++) {
+        const wirelog_ir_node_t *guard = rule_body_root(prog, "Path", r);
+        if (!guard || guard->type != WIRELOG_IR_JOIN
+            || guard->child_count != 2) {
+            wirelog_program_free(prog);
+            FAIL("guard JOIN missing");
+            return;
+        }
+        const wirelog_ir_node_t *right = guard->children[1];
+        if (!right || !right->relation_name) {
+            wirelog_program_free(prog);
+            FAIL("guard JOIN right child carries no relation name "
+                "(right_relation would be NULL)");
+            return;
+        }
+        if (strncmp(right->relation_name, "$m$", 3) != 0) {
+            wirelog_program_free(prog);
+            FAIL("guard JOIN right child is not the magic demand scan");
+            return;
+        }
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Test: the docs/SYNTAX.md recursive example, with the demand relation
+ * seeded by hand, must produce the full transitive closure reachable from
+ * the seed.  With the guard built right-deep the recursive rule computes
+ * nothing and only the base rule's 3 tuples survive.
+ */
+static void
+test_guard_recursive_eval_exact(void)
+{
+    TEST("test_guard_recursive_eval_exact");
+
+    /* Seed the demand at 2, not at 1.
+     *
+     * Seeding at 1 would expect all six closure tuples -- which is exactly
+     * what an *unguarded* program produces over this graph, since every node
+     * is reachable from 1.  Such a test detects the #989 failure (the guard
+     * rejecting everything) but cannot detect the guard being absent or
+     * over-deriving, because the correct and the broken answers coincide.
+     *
+     * Seeding at 2 makes the expected set a strict subset: the three tuples
+     * rooted at nodes reachable from 2.  A missing or ineffective guard
+     * yields six rows and fails. */
+    static const int64_t seed[] = { 2 };
+    static const int64_t expected[][2] = {
+        { 2, 3 }, { 3, 4 }, { 2, 4 },
+    };
+
+    const uint32_t worker_counts[] = { 1, 4, 8 };
+    for (uint32_t wi = 0; wi < 3; wi++) {
+        wl_magic_demand_t demands[1];
+        demands[0].relation_name = "Path";
+        demands[0].bound_mask = 0x1;
+        demands[0].arity = 2;
+
+        struct wirelog_program *prog
+            = magic_program_with_seed(k_syntax_doc_src, demands, 1,
+                "$m$Path_bf", seed, 1, 1, NULL);
+        if (!prog) {
+            FAIL("setup failed");
+            return;
+        }
+
+        ms_row_set_t rows;
+        if (!ms_evaluate(prog, "Path", worker_counts[wi], &rows)) {
+            wirelog_program_free(prog);
+            FAIL("evaluation failed");
+            return;
+        }
+        if (!ms_rows_match(&rows, &expected[0][0], 3, 2)) {
+            printf(" [workers=%u got %u rows, want 3]", worker_counts[wi],
+                rows.count);
+            wirelog_program_free(prog);
+            FAIL("Path != the demand-restricted closure from seed {2}");
+            return;
+        }
+        wirelog_program_free(prog);
+    }
+
+    PASS();
+}
+
+/*
+ * Test: a non-recursive three-way join under a guard.  The body is a JOIN
+ * chain, so a right-deep guard makes the whole rule produce zero rows.
+ */
+static void
+test_guard_nonrecursive_join_chain_exact(void)
+{
+    TEST("test_guard_nonrecursive_join_chain_exact");
+
+    static const int64_t seed[] = { 1 };
+    static const int64_t expected[][2] = { { 1, 4 } };
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "out";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    struct wirelog_program *prog = magic_program_with_seed(k_three_way_src,
+            demands, 1, "$m$out_bf", seed, 1, 1, NULL);
+    if (!prog) {
+        FAIL("setup failed");
+        return;
+    }
+
+    ms_row_set_t rows;
+    if (!ms_evaluate(prog, "out", 1, &rows)) {
+        wirelog_program_free(prog);
+        FAIL("evaluation failed");
+        return;
+    }
+    if (!ms_rows_match(&rows, &expected[0][0], 1, 2)) {
+        printf(" [got %u rows, want 1]", rows.count);
+        wirelog_program_free(prog);
+        FAIL("out != {(1, 4)}");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Regression: a guarded rule whose body is an ANTIJOIN.  The ANTIJOIN is a
+ * composite node, so it is equally unusable as a JOIN right child.
+ */
+static void
+test_guard_over_antijoin_exact(void)
+{
+    TEST("test_guard_over_antijoin_exact");
+
+    static const char *src = ".decl e(x: int32, y: int32)\n"
+        ".decl s(y: int32)\n"
+        ".decl p(x: int32, y: int32)\n"
+        ".output p\n"
+        "e(1, 2).\n"
+        "e(1, 3).\n"
+        "e(2, 3).\n"
+        "s(3).\n"
+        "p(x, y) :- e(x, y), !s(y).\n";
+
+    static const int64_t seed[] = { 1 };
+    static const int64_t expected[][2] = { { 1, 2 } };
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "p";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    struct wirelog_program *prog = magic_program_with_seed(src, demands, 1,
+            "$m$p_bf", seed, 1, 1, NULL);
+    if (!prog) {
+        FAIL("setup failed");
+        return;
+    }
+
+    const wirelog_ir_node_t *guard = rule_body_root(prog, "p", 0);
+    if (!ir_contains_type(guard, WIRELOG_IR_ANTIJOIN)) {
+        wirelog_program_free(prog);
+        FAIL("expected an ANTIJOIN under the guard");
+        return;
+    }
+
+    ms_row_set_t rows;
+    if (!ms_evaluate(prog, "p", 1, &rows)) {
+        wirelog_program_free(prog);
+        FAIL("evaluation failed");
+        return;
+    }
+    if (!ms_rows_match(&rows, &expected[0][0], 1, 2)) {
+        printf(" [got %u rows, want 1]", rows.count);
+        wirelog_program_free(prog);
+        FAIL("p != {(1, 2)}");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Regression: a guarded rule whose body carries a SIP-inserted SEMIJOIN.
+ */
+static void
+test_guard_over_semijoin_exact(void)
+{
+    TEST("test_guard_over_semijoin_exact");
+
+    static const char *src = ".decl a(x: int32, y: int32)\n"
+        ".decl b(y: int32, z: int32)\n"
+        ".decl c(z: int32, w: int32)\n"
+        ".decl out(x: int32, w: int32)\n"
+        ".output out\n"
+        "a(1, 2).\n"
+        "a(2, 3).\n"
+        "a(3, 4).\n"
+        "b(2, 5).\n"
+        "b(3, 6).\n"
+        "b(4, 7).\n"
+        "c(5, 10).\n"
+        "c(6, 11).\n"
+        "c(7, 12).\n"
+        "out(x, w) :- a(x, y), b(y, z), c(z, w).\n";
+
+    static const int64_t seed[] = { 1 };
+    static const int64_t expected[][2] = { { 1, 10 } };
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "out";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    struct wirelog_program *prog = magic_program_with_seed(src, demands, 1,
+            "$m$out_bf", seed, 1, 1, NULL);
+    if (!prog) {
+        FAIL("setup failed");
+        return;
+    }
+
+    const wirelog_ir_node_t *guard = rule_body_root(prog, "out", 0);
+    if (!ir_contains_type(guard, WIRELOG_IR_SEMIJOIN)) {
+        wirelog_program_free(prog);
+        FAIL("expected a SEMIJOIN under the guard (SIP did not fire)");
+        return;
+    }
+
+    ms_row_set_t rows;
+    if (!ms_evaluate(prog, "out", 1, &rows)) {
+        wirelog_program_free(prog);
+        FAIL("evaluation failed");
+        return;
+    }
+    if (!ms_rows_match(&rows, &expected[0][0], 1, 2)) {
+        printf(" [got %u rows, want 1]", rows.count);
+        wirelog_program_free(prog);
+        FAIL("out != {(1, 10)}");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Test: a constant in the bound head position leaves the rule unguarded, so
+ * it must not be counted as modified.
+ */
+static void
+test_constant_head_position_not_counted(void)
+{
+    TEST("test_constant_head_position_not_counted");
+
+    static const char *src = ".decl edge(x: int32, y: int32)\n"
+        ".decl q(x: int32, y: int32)\n"
+        ".output q\n"
+        "q(1, 1).\n"
+        "q(1, 2).\n"
+        "edge(1, 2).\n"
+        "edge(2, 3).\n"
+        "edge(3, 4).\n"
+        "q(1, y) :- q(1, z), edge(z, y).\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "q";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    wl_magic_sets_stats_t stats;
+    if (wl_magic_sets_apply_with_demands(prog, demands, 1, &stats) != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    if (stats.original_rules_modified != 0) {
+        printf(" [original_rules_modified=%u]", stats.original_rules_modified);
+        wirelog_program_free(prog);
+        FAIL("no guard was inserted, yet the rule was counted as modified");
+        return;
+    }
+    if (stats.skipped_constant_head != 1) {
+        printf(" [skipped_constant_head=%u]", stats.skipped_constant_head);
+        wirelog_program_free(prog);
+        FAIL("expected skipped_constant_head == 1");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Test: a rule fused to a non-PROJECT root gets no guard, because
+ * get_head_vars() has no head to read variable names from.  Logic Fusion runs
+ * before Magic Sets in the shipping pipeline and any rule with a filter is a
+ * fusion candidate, so this is the common way for a guard to go missing.  The
+ * pass must say so rather than skip in silence (#990).
+ */
+static void
+test_fused_head_reported_as_unsupported(void)
+{
+    TEST("test_fused_head_reported_as_unsupported");
+
+    static const char *src = ".decl e(x: int32, y: int32)\n"
+        ".decl f(y: int32, z: int32)\n"
+        ".decl hot(x: int32, z: int32)\n"
+        ".output hot\n"
+        "e(1, 2).\n"
+        "f(2, 90).\n"
+        "hot(x, z) :- e(x, y), f(y, z), z > 80.\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    /* Guard the guard: if fusion stops producing a non-PROJECT root this
+     * test would otherwise pass for the wrong reason. */
+    const wirelog_ir_node_t *root = rule_ir_root(prog, "hot", 0);
+    if (!root || root->type == WIRELOG_IR_PROJECT) {
+        wirelog_program_free(prog);
+        FAIL("expected fusion to replace the PROJECT root");
+        return;
+    }
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "hot";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    wl_magic_sets_stats_t stats;
+    if (wl_magic_sets_apply_with_demands(prog, demands, 1, &stats) != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    if (stats.original_rules_modified != 0) {
+        printf(" [original_rules_modified=%u]", stats.original_rules_modified);
+        wirelog_program_free(prog);
+        FAIL("no guard was inserted, yet the rule was counted as modified");
+        return;
+    }
+    if (stats.skipped_unsupported_head != 1) {
+        printf(" [skipped_unsupported_head=%u]",
+            stats.skipped_unsupported_head);
+        wirelog_program_free(prog);
+        FAIL("expected skipped_unsupported_head == 1");
+        return;
+    }
+    if (stats.skipped_constant_head != 0) {
+        printf(" [skipped_constant_head=%u]", stats.skipped_constant_head);
+        wirelog_program_free(prog);
+        FAIL("a capability gap must not be reported as a policy skip");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -935,6 +1586,15 @@ main(void)
     test_magic_correctness_noop();
     test_magic_rebuild_and_stratify();
     test_stratify_no_oob_on_graph_absent_head();
+
+    printf("\nGuard Order Tests (Issue #989):\n");
+    test_guard_join_right_child_is_representable();
+    test_guard_recursive_eval_exact();
+    test_guard_nonrecursive_join_chain_exact();
+    test_guard_over_antijoin_exact();
+    test_guard_over_semijoin_exact();
+    test_constant_head_position_not_counted();
+    test_fused_head_reported_as_unsupported();
 
     printf("\n=== Results ===\n");
     printf("Tests run:    %d\n", tests_run);

--- a/tests/test_plan_gen.c
+++ b/tests/test_plan_gen.c
@@ -9,6 +9,7 @@
 #include "../wirelog/backend.h"
 #include "../wirelog/columnar/columnar_nanoarrow.h"
 #include "../wirelog/intern.h"
+#include "../wirelog/ir/ir.h"
 #include "../wirelog/ir/program.h"
 #include "../wirelog/passes/fusion.h"
 #include "../wirelog/passes/jpp.h"
@@ -606,6 +607,151 @@ test_semijoin_head_projection_values(void)
 }
 
 /* ----------------------------------------------------------------
+ * Test: a JOIN whose right child is not a relation is rejected
+ *
+ * wl_plan_op_t.right_relation is a relation name, not a subtree.  A JOIN
+ * whose right child is itself a composite node cannot be represented; if
+ * plan generation emits it anyway the operator silently matches nothing
+ * (Issue #989).
+ * ---------------------------------------------------------------- */
+
+static wirelog_ir_node_t *
+find_right_deep_candidate(wirelog_ir_node_t *node)
+{
+    if (!node)
+        return NULL;
+    if (node->type == WIRELOG_IR_JOIN && node->child_count == 2
+        && node->children[0]
+        && node->children[0]->type == WIRELOG_IR_JOIN)
+        return node;
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        wirelog_ir_node_t *hit = find_right_deep_candidate(node->children[i]);
+        if (hit)
+            return hit;
+    }
+    return NULL;
+}
+
+static void
+test_join_with_composite_right_child_rejected(void)
+{
+    TEST("JOIN with composite right child is rejected");
+
+    const char *src = ".decl a(x: int32, y: int32)\n"
+        ".decl b(y: int32, z: int32)\n"
+        ".decl c(z: int32, w: int32)\n"
+        ".decl out(x: int32, w: int32)\n"
+        "a(1, 2). b(2, 3). c(3, 4).\n"
+        "out(x, w) :- a(x, y), b(y, z), c(z, w).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    ASSERT(prog != NULL, "parse failed");
+
+    /* The parser builds JOIN(JOIN(a, b), c).  Swap the outer JOIN's
+     * children to obtain the right-deep JOIN(c, JOIN(a, b)). */
+    wirelog_ir_node_t *outer = NULL;
+    for (uint32_t r = 0; r < prog->rule_count && !outer; r++) {
+        if (prog->rules[r].head_relation
+            && strcmp(prog->rules[r].head_relation, "out") == 0)
+            outer = find_right_deep_candidate(prog->rules[r].ir_root);
+    }
+    if (!outer) {
+        wirelog_program_free(prog);
+        FAIL("no left-deep JOIN chain to invert");
+        return;
+    }
+
+    wirelog_ir_node_t *tmp = outer->children[0];
+    outer->children[0] = outer->children[1];
+    outer->children[1] = tmp;
+
+    if (wl_ir_program_rebuild_relation_irs(prog) != 0) {
+        wirelog_program_free(prog);
+        FAIL("rebuild_relation_irs failed");
+        return;
+    }
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    if (rc == 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("plan generation accepted an unrepresentable JOIN right child");
+        return;
+    }
+    ASSERT(plan == NULL, "plan must not be returned on error");
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Issue #994: the same rejection reached from ordinary source, with no IR
+ * surgery and no magic sets.
+ *
+ * build_atom_scan() returns a composite JOIN(scan, side_scan) for a `side`
+ * compound pattern, and convert_rule() installs that whole subtree as the
+ * right child of the outer chain join -- so any body whose *non-first* atom
+ * carries a side compound is right-deep.  That has always been
+ * unrepresentable: before #989 it produced a plan that silently matched
+ * nothing, and the rule returned no rows while the identical rule with the
+ * atoms swapped returned the right answer.
+ *
+ * Pinning the rejection here records that this is a deliberate trade -- a
+ * plan-generation error in place of a silent wrong answer -- and not an
+ * accident.  It is not the fix; #994 tracks flattening the subtree into the
+ * left spine so the rule works in either atom position.
+ */
+static void
+test_side_compound_in_non_first_atom_rejected(void)
+{
+    TEST("side compound in a non-first body atom is rejected (#994)");
+
+    const char *src = ".decl event(id: int64, payload: metadata/4 side)\n"
+        ".decl gate(id: int64)\n"
+        ".decl hot(id: int64, r: int64)\n"
+        "hot(ID, R) :- gate(ID), event(ID, metadata(_, _, _, R)).\n";
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    ASSERT(prog != NULL, "parse failed");
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    if (rc == 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("side compound in a non-first atom should be rejected");
+        return;
+    }
+    ASSERT(plan == NULL, "plan must not be returned on error");
+    wirelog_program_free(prog);
+
+    /* Control: the same rule with the compound atom first is representable
+     * and must still be accepted -- the rejection is positional, not a ban
+     * on side compounds. */
+    const char *ok_src = ".decl event(id: int64, payload: metadata/4 side)\n"
+        ".decl gate(id: int64)\n"
+        ".decl hot(id: int64, r: int64)\n"
+        "hot(ID, R) :- event(ID, metadata(_, _, _, R)), gate(ID).\n";
+
+    wirelog_program_t *ok = wirelog_parse_string(ok_src, &err);
+    ASSERT(ok != NULL, "control parse failed");
+
+    wl_plan_t *ok_plan = NULL;
+    if (wl_plan_from_program(ok, &ok_plan) != 0) {
+        wirelog_program_free(ok);
+        FAIL("control: compound-first rule must still lower");
+        return;
+    }
+    wl_plan_free(ok_plan);
+    wirelog_program_free(ok);
+
+    PASS();
+}
+
+/* ----------------------------------------------------------------
  * Test: wl_plan_free NULL-safe
  * ---------------------------------------------------------------- */
 
@@ -648,6 +794,8 @@ main(void)
     test_semijoin_does_not_shift_column_indices();
     test_semijoin_chain_end_to_end();
     test_semijoin_head_projection_values();
+    test_join_with_composite_right_child_rejected();
+    test_side_compound_in_non_first_atom_rejected();
     test_plan_free_null();
     test_load_facts_null_safe();
 

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -416,6 +416,12 @@ typedef struct {
     wl_plan_op_type_t op;
 
     const char *relation_name;
+    /* A relation *name*, not a subplan.  The plan therefore cannot represent
+     * a JOIN/ANTIJOIN/SEMIJOIN whose right child is itself composite: any
+     * such tree must be built left-deep, with the composite side on the left.
+     * translate_ir_node() rejects a JOIN that violates this rather than
+     * emitting NULL here, which used to yield a plan that silently computed
+     * nothing (#989). */
     const char *right_relation;
 
     const char *const *left_keys;

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -1395,7 +1395,19 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             const wirelog_ir_node_t *rn
                 = unwrap_filters_collect(node->children[1],
                     &op->right_filter_expr);
-            op->right_relation = dup_str(rn ? rn->relation_name : NULL);
+            /* right_relation is a relation *name*, so a composite right
+             * child (JOIN/ANTIJOIN/SEMIJOIN/...) cannot be represented at
+             * all.  Emitting NULL here yields an operator that matches
+             * nothing and a silently empty result -- fail the plan instead
+             * (Issue #989). */
+            if (!rn || !rn->relation_name) {
+                WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_ERROR,
+                    "JOIN right child (IR node type %d) carries no relation "
+                    "name: the plan cannot represent a right-deep join",
+                    (int)(rn ? rn->type : node->children[1]->type));
+                return -1;
+            }
+            op->right_relation = dup_str(rn->relation_name);
         }
         /* Resolve join key variable names to "colN" positional format */
         op->left_keys = (const char *const *)resolve_keys_to_colN(

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -260,11 +260,19 @@ collect_body_atoms(const wirelog_ir_node_t *ir_root, ms_atom_t *atoms)
  * The value domain of variable @var as bound somewhere under @node.
  *
  * Used to type the magic guard SCAN, whose columns hold the same values as
- * the body variables they are named after.  The guard SCAN is joined in as
- * the LEFT child, so its columns come first in the rule's column layout and
- * a comparison on a bound variable resolves against them.  Leaving them
- * untyped would silently return string comparisons in magic-set-rewritten
- * rules to comparing intern ids (Issue #962).
+ * the body variables they are named after.
+ *
+ * The guard SCAN is joined in as the RIGHT child (Issue #989), so its
+ * columns come *last* in the rule's column layout, after the body's.  Every
+ * guard column is named after a bound head variable, which by construction
+ * also names an earlier body column, and collect_output_columns() /
+ * serialize_expr() both resolve a name to its first match -- so a comparison
+ * on a bound variable now resolves against the body's column, not the
+ * guard's.  These types are therefore unreachable by name.  They remain
+ * reachable positionally: col_ctx_lookup_type() falls back to parsing "colN"
+ * against the concatenated layout, whose tail is the guard.  Leaving them
+ * untyped would silently return a string comparison landing there to
+ * comparing intern ids (Issue #962), so they are still filled in.
  *
  * First match wins, which is the same rule collect_output_columns() and
  * serialize_expr() use to resolve a name to a column.
@@ -514,32 +522,55 @@ build_demand_rule_ir(const char *body_magic_name, const char *guard_magic_name,
 /* Magic Guard Insertion                                                    */
 /* ======================================================================== */
 
+/* Outcome of insert_magic_guard(); see the counters in magic_sets.h. */
+typedef enum {
+    MS_GUARD_ERROR = -1,
+    MS_GUARD_INSERTED = 0,
+    /* Every bound head position holds a constant, so there is no variable
+     * to key the guard on and the rule is left unrestricted. */
+    MS_GUARD_SKIPPED_CONSTANT_HEAD = 1,
+    /* Malformed input: nothing to attach a guard to. */
+    MS_GUARD_SKIPPED_NO_BODY = 2,
+} ms_guard_result_t;
+
 /*
  * Insert a magic guard JOIN at the top of a rule's body.
  *
  * Transforms:
  *   PROJECT(head) -> body_tree
  * into:
- *   PROJECT(head) -> JOIN(SCAN($magic, [bound_vars]), body_tree)
+ *   PROJECT(head) -> JOIN(body_tree, SCAN($magic, [bound_vars]))
  *
  * The JOIN filters the body to only tuples where the bound variables
  * appear in the magic demand relation.
+ *
+ * The guard SCAN is the RIGHT child, not the left (Issue #989).  A JOIN's
+ * right child is not a subtree in the execution plan: wl_plan_op_t carries
+ * a `right_relation` *name*, and translate_ir_node() collapses children[1]
+ * to its relation_name.  Putting the body on the right therefore produces
+ * right_relation = NULL whenever the body is composite (a JOIN chain, an
+ * ANTIJOIN from a negated atom, a SIP SEMIJOIN), and the rule derives
+ * nothing.  Every other producer of JOIN nodes -- the parser, compound
+ * side-bindings, jpp's chain rebuild -- already builds left-deep; this
+ * keeps that invariant.
  */
-static int
+static ms_guard_result_t
 insert_magic_guard(wirelog_ir_node_t *ir_root, const char *magic_name,
     const char **bound_vars, uint32_t bound_count)
 {
-    if (!ir_root || !magic_name || bound_count == 0)
-        return 0;
+    if (!ir_root || !magic_name)
+        return MS_GUARD_SKIPPED_NO_BODY;
+    if (bound_count == 0)
+        return MS_GUARD_SKIPPED_CONSTANT_HEAD;
     if (ir_root->child_count == 0)
-        return 0;
+        return MS_GUARD_SKIPPED_NO_BODY;
 
     wirelog_ir_node_t *body = ir_root->children[0];
 
     /* SCAN($m$rel_adorn, column_names = [bound_var_0, ...]) */
     wirelog_ir_node_t *magic_scan = wl_ir_node_create(WIRELOG_IR_SCAN);
     if (!magic_scan)
-        return -1;
+        return MS_GUARD_ERROR;
     wl_ir_node_set_relation(magic_scan, magic_name);
 
     magic_scan->column_names = (char **)calloc(bound_count, sizeof(char *));
@@ -547,7 +578,7 @@ insert_magic_guard(wirelog_ir_node_t *ir_root, const char *magic_name,
         = (wl_ir_coltype_t *)calloc(bound_count, sizeof(wl_ir_coltype_t));
     if (!magic_scan->column_names || !magic_scan->column_types) {
         wl_ir_node_free(magic_scan);
-        return -1;
+        return MS_GUARD_ERROR;
     }
     magic_scan->column_count = bound_count;
     for (uint32_t i = 0; i < bound_count; i++) {
@@ -555,19 +586,20 @@ insert_magic_guard(wirelog_ir_node_t *ir_root, const char *magic_name,
             magic_scan->column_names[i] = strdup_safe(bound_vars[i]);
             /* The magic relation carries the same values as the body
              * variables it is keyed on, so it inherits their types.
-             * Not observable today -- no expression is serialized against
-             * this guard's layout -- but wrong types here would be a
-             * silent mistype if one ever were (Issue #962). */
+             * Unreachable by name now that the guard is the right child --
+             * the body's identically named column resolves first (#989) --
+             * but still reachable through the "colN" positional fallback,
+             * where a wrong type would be a silent mistype (Issue #962). */
             magic_scan->column_types[i]
                 = ms_lookup_var_type(body, bound_vars[i]);
         }
     }
 
-    /* JOIN(magic_scan, body) keyed on bound variables */
+    /* JOIN(body, magic_scan) keyed on bound variables */
     wirelog_ir_node_t *guard_join = wl_ir_node_create(WIRELOG_IR_JOIN);
     if (!guard_join) {
         wl_ir_node_free(magic_scan);
-        return -1;
+        return MS_GUARD_ERROR;
     }
 
     guard_join->join_left_keys = (char **)calloc(bound_count, sizeof(char *));
@@ -575,7 +607,7 @@ insert_magic_guard(wirelog_ir_node_t *ir_root, const char *magic_name,
     if (!guard_join->join_left_keys || !guard_join->join_right_keys) {
         wl_ir_node_free(guard_join);
         wl_ir_node_free(magic_scan);
-        return -1;
+        return MS_GUARD_ERROR;
     }
     guard_join->join_key_count = bound_count;
     for (uint32_t i = 0; i < bound_count; i++) {
@@ -585,12 +617,15 @@ insert_magic_guard(wirelog_ir_node_t *ir_root, const char *magic_name,
         }
     }
 
-    wl_ir_node_add_child(guard_join, magic_scan); /* left: magic demand */
-    wl_ir_node_add_child(guard_join, body);       /* right: original body */
+    /* Left-deep: the composite body stays on the left, where the plan can
+     * express it as a subtree.  The right child must be a single relation
+     * (Issue #989). */
+    wl_ir_node_add_child(guard_join, body);       /* left: original body */
+    wl_ir_node_add_child(guard_join, magic_scan); /* right: magic demand */
 
     /* Replace body in parent */
     ir_root->children[0] = guard_join;
-    return 0;
+    return MS_GUARD_INSERTED;
 }
 
 /* ======================================================================== */
@@ -618,6 +653,8 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
         stats->skipped_all_free = 0;
         stats->arity_mismatch_skipped = 0;
         stats->skipped_aggregate = 0;
+        stats->skipped_constant_head = 0;
+        stats->skipped_unsupported_head = 0;
     }
 
     /* === Phase 1: Seed the worklist from explicit demands === */
@@ -895,8 +932,21 @@ next_4a_atom:
 
             const char *head_vars[64] = { 0 };
             uint32_t head_arity = get_head_vars(ir_root, head_vars, 64);
-            if (head_arity == 0)
+            if (head_arity == 0) {
+                /* No PROJECT head to read variable names from, so the guard
+                 * cannot be keyed and the rule runs unrestricted.  This is a
+                 * capability gap, not a policy decision: a rule fused to a
+                 * FLATMAP root lands here -- Logic Fusion runs before Magic
+                 * Sets in the shipping pipeline and any rule with a filter is
+                 * a candidate.  That is the only shape that reaches this in
+                 * practice; an AGGREGATE root cannot, because
+                 * relation_has_aggregate_rule() filters those relations before
+                 * adornment so they never enter `processed`.  Counting it is
+                 * what makes the omission visible at all (see #990). */
+                if (stats)
+                    stats->skipped_unsupported_head++;
                 continue;
+            }
 
             const char *guard_bvars[64];
             uint32_t guard_bcount = 0;
@@ -905,14 +955,21 @@ next_4a_atom:
                     guard_bvars[guard_bcount++] = head_vars[i];
             }
 
-            int rc = insert_magic_guard(ir_root, guard_magic, guard_bvars,
-                    guard_bcount);
-            if (rc != 0) {
+            ms_guard_result_t gr = insert_magic_guard(ir_root, guard_magic,
+                    guard_bvars, guard_bcount);
+            if (gr == MS_GUARD_ERROR) {
                 free(guard_magic);
                 return -1;
             }
-            if (stats)
-                stats->original_rules_modified++;
+            if (stats) {
+                /* Count guards actually inserted.  A rule whose bound head
+                 * positions are all constants keeps running unrestricted;
+                 * that is what skipped_constant_head records. */
+                if (gr == MS_GUARD_INSERTED)
+                    stats->original_rules_modified++;
+                else if (gr == MS_GUARD_SKIPPED_CONSTANT_HEAD)
+                    stats->skipped_constant_head++;
+            }
         }
 
         free(guard_magic);

--- a/wirelog/passes/magic_sets.h
+++ b/wirelog/passes/magic_sets.h
@@ -48,6 +48,29 @@ struct wirelog_program;
  * @arity_mismatch_skipped: Demands skipped due to adornment count/arity mismatch.
  * @skipped_aggregate:     Aggregate rules skipped because Magic Sets cannot
  *                         safely insert magic guards into them yet.
+ * @skipped_constant_head: Rules left unguarded because every bound head
+ *                         position holds a constant rather than a variable,
+ *                         leaving no join key to guard on.  A *policy* skip:
+ *                         the rule is well-formed and the pass declines.
+ * @skipped_unsupported_head: Rules left unguarded because the head is not a
+ *                         PROJECT the pass can read variable names from --
+ *                         in practice a rule fused to a FLATMAP root (#990).
+ *                         A *capability* gap, not a decision.  An AGGREGATE
+ *                         root cannot reach here: relation_has_aggregate_rule()
+ *                         filters such relations before adornment, in Phase 1
+ *                         and again in the Phase 2 BFS, so they never enter
+ *                         `processed` and the guard loop never sees them.
+ *
+ * Both skip counters describe a rule that is evaluated unrestricted, which is
+ * sound but unoptimized.  They are the only signal that a demand did not reach
+ * it -- but only for a caller that supplies a stats struct.  The library's own
+ * pipeline passes NULL (api_facade.c), so in a shipping build nothing reads
+ * them; they are observability for tests and embedders, not a runtime warning.
+ * They are kept apart because closing the capability gap is work, while
+ * the policy skip is correct as it stands.
+ *
+ * @original_rules_modified counts guards actually inserted.  A rule counted in
+ * either skip counter is not counted there.
  */
 typedef struct {
     uint32_t demand_roots;
@@ -57,6 +80,8 @@ typedef struct {
     uint32_t skipped_all_free;
     uint32_t arity_mismatch_skipped;
     uint32_t skipped_aggregate;
+    uint32_t skipped_constant_head;
+    uint32_t skipped_unsupported_head;
 } wl_magic_sets_stats_t;
 
 /* ======================================================================== */


### PR DESCRIPTION
Partial fix for #989 — the half that is unblocked. A bound `.query` still returns zero rows after this; see "What is deliberately not here".

## What was wrong

`insert_magic_guard` built `JOIN(magic_scan, body)`. When the body is itself a join, that is **right-deep** — and a right-deep join is *structurally unrepresentable*: `wl_plan_op_t.right_relation` is a `const char *` relation **name**, not a subplan, so `translate_ir_node` collapsed the composite child to `NULL` and emitted a plan that computed nothing.

The guard SCAN is now the right child.

## Evidence it is the right fix

With the demand relation seeded by hand (test-only scaffolding), the candidate produces:

| shape | before | after |
|---|---|---|
| recursive `docs/SYNTAX.md` example | 3 of 6 tuples | exact, at workers 1/4/8 |
| non-recursive three-way join | 0 rows | correct |
| guarded rule over ANTIJOIN | 0 rows | correct |
| guarded rule over SEMIJOIN | 0 rows | correct |

That is positive evidence the remaining gap is a **seeding** problem, not a **rewrite** problem — which is exactly the premise the split rests on.

## What is deliberately not here

`.query` has no syntax for a constant, so the demand relation has no base case and a bound `.query` still returns nothing. Two defects block that work:

- **#990** — Logic Fusion rewrites rule roots to `FLATMAP`; `get_head_vars` handles only `PROJECT`, so a fused rule silently gets no guard. Fusion runs *before* magic sets, so this is the default path. After seeding, `.query` would be **sound but inert** on any rule with a filter — quieter than today's bug.
- A seeded magic relation is IDB, so `col_session_clear_idb_rows` wipes it on re-evaluation, and the internal `$m$` name leaks to stdout in watch mode.

Shipping seeding on top of those trades one loud bug for two quieter ones. `docs/SYNTAX.md` now says plainly that a bound `.query` does not prune, instead of documenting a feature that does not work.

## Also in this PR

**Plan generation rejects a JOIN whose right child carries no relation name**, instead of emitting `NULL`. This converts a whole silent-wrong-answer class into a plan-generation error, and it would have caught #989 on the first test run. Scoped to JOIN — ANTIJOIN's right child is always `neg_scan` and SIP bails unless its right child is a SCAN, so neither has a producer that can violate the invariant today (**#993** tracks extending it; the ANTIJOIN case is the unsound one).

**That check also rejects a shape reached from ordinary source, with no magic sets**: a `side` compound destructure in a non-first body atom. `convert_rule` installs the compound's `JOIN(scan, side_scan)` subtree as the chain's right child, which has always been unrepresentable — the rule silently matched nothing while the identical rule with the atoms reordered returned the right answer. Now a loud failure, documented in `docs/COMPOUND_TERMS.md` and pinned by a test. **#994** tracks flattening it so either ordering works.

**Honest stats.** `original_rules_modified` previously counted rules the pass had *declined* to guard. It now counts only real insertions, with `skipped_constant_head` (policy) and `skipped_unsupported_head` (capability gap — a fused FLATMAP root, i.e. #990) recording the skips. These are observability for tests and embedders; the library's own pipeline passes `NULL` for stats, and the header says so.

## On test discrimination

The recursive test seeds the demand at **2**, not 1. Seeding at 1 would expect all six closure tuples — which is also what an *unguarded* program produces over that graph, so it could detect the #989 failure but not a missing guard. Seeded at 2 the expected set is a strict subset, and a mutation that never inserts the guard fails it with **6 rows against 3**.

## Validation

Suite **264 Ok / 1 Fail / 11 Skipped**, matching baseline; the failure is the pre-existing `sbom_snapshot` drift. ASAN+UBSAN with `detect_leaks=1` clean, including the new plan-gen error path. Three independent review gates; all findings addressed or filed (#993, #994, #995).

Unit 1b verified to reject nothing in-tree: full suite, all 15 bench workloads at workers 1/4/8 with real data, all 32 `.dl` files, and every example binary.
