### PR TITLE
fix(exec_plan_gen): reject average() instead of returning an arbitrary row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,53 @@ All notable changes to wirelog are documented in this file.
   headline shape of #990; teaching the pass to handle a fused head is separate
   work, but the skip is now visible. Together these counters are the only
   mechanism that can detect a guard silently not being inserted.
+- **`average()` is rejected instead of answering with an arbitrary row**
+  (#978): `average()` was never implemented. `col_op_reduce` seeds each group
+  with the group's first operand, and its update `switch` has arms for
+  `COUNT`/`SUM`/`MIN`/`MAX` and `default: break;` — so `WIRELOG_AGG_AVG` fell
+  through and the seed was returned untouched. The answer followed scan
+  order, not the data: `val(1,9). val(1,5). val(1,2).` gave `t(1, 9)` where
+  the mean is 5, and the same three facts reordered as `val(1,1). val(1,2).
+  val(1,9).` gave `t(1, 1)` where the mean is 4. Both with exit status 0 and
+  no diagnostic. `sum`, `count`, `min` and `max` were and remain correct.
+
+  Rules using `average`/`AVG` are now rejected at plan generation:
+  `wl_plan_from_program()` returns `-1` and `WL_LOG=EVAL:1` names the
+  aggregate and the workaround.
+
+  **Why reject rather than implement.** There is no type to return a mean in.
+  Every value is an `int64_t`; `WIRELOG_TYPE_FLOAT` exists in the public enum
+  but is vestigial, since the lexer has type keywords for
+  `int32`/`int64`/`string`/`symbol` only and no decimal literal — `.decl
+  v(x: float)` and `1.5` are both syntax errors. So the choice was truncating
+  integer division or rejection, and the asymmetry decides it: widening a
+  rejection to a real mean later accepts strictly more programs and rewrites
+  none, whereas replacing truncation with a real mean later would silently
+  change the numbers every existing program prints. Precedent agrees —
+  Soufflé refuses integer operands to `mean()` outright, and PostgreSQL,
+  SQLite, MySQL and cozo all return a wider type rather than truncating. This
+  follows the sequence adopted for #973: reject first, support later.
+
+  The rejection is at lowering, not in the lexer. `average` and `AVG` stay
+  reserved keywords, the AST keeps its `AGGREGATE` node and
+  `WIRELOG_AGG_AVG` stays in the public enum, so no surface syntax has to be
+  un-done if a float type arrives. It deliberately does not add `avg` or
+  `AVERAGE` as keywords, which would take those identifiers away from users
+  and contradict a documented decision.
+
+  **Compatibility:** programs using `average()` now fail to load. They were
+  not producing a mean before — they were producing whichever operand the
+  scan reached first — so nothing correct is lost. No `.dl` file, benchmark
+  workload or example in the tree uses it.
+
+  Two adjacent defects are fixed with it. `wirelog_agg_fn_str()` printed
+  `"avg"` for `WIRELOG_AGG_AVG`, a spelling the lexer refuses, so every AST
+  and IR dump named an aggregate that could not be read back; it now prints
+  `"average"`, and `tests/test_parser.c` asserts the printer/lexer round trip
+  for all five aggregates. And `agg_to_tag()` mapped `WIRELOG_AGG_AVG` to
+  `WL_PLAN_EXPR_AGG_SUM` ("approximate: no AVG tag"), so a serialized plan
+  would have said SUM where the program said `average`; it now fails instead
+  of substituting.
 
 - **Inline facts are validated against their relation's declared arity**
   (#977): `collect_fact` packed `fact_data` using each fact's *own*

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -45,8 +45,10 @@ Features:
 - **Negation**: `!Rel(x)` in rule body (stratified negation)
 - **Comparisons**: `x < y`, `x = y`, `x != y`, `x >= y`, etc.
 - **Arithmetic**: `x + 1`, `x * y`, `x % 2` in head or comparisons
-- **Aggregation**: `min(x)`, `max(x)`, `sum(x)`, `count(x)`, `average(x)` in head
-  (at most one per head — see below)
+- **Aggregation**: `min(x)`, `max(x)`, `sum(x)`, `count(x)` in head
+  (at most one per head — see below). `average(x)` parses but is **rejected**
+  when the rule is lowered — see [average() is not
+  supported](#average-is-not-supported)
 - **Wildcards**: `_` for anonymous variables
 - **Plan marker**: `.plan` before a rule for optimization hints
 
@@ -117,6 +119,90 @@ Two scope notes:
   arity](#rule-heads-must-match-their-declared-arity) below (#977). The two
   are complementary: an arity check accepts `t(g, min(v), max(v))`, and the
   aggregate-count check accepts `cc(y, min(c))`.
+
+### `average()` is not supported
+
+`average(x)` and `AVG(x)` tokenize and parse, but a rule that uses either is
+**rejected when it is lowered** (#978). `min`, `max`, `sum` and `count` are
+unaffected.
+
+Before this rejection, `average()` returned an arbitrary operand rather than
+a mean. The columnar `REDUCE` kernel seeds each group with the group's first
+operand and its update step has cases for `count`, `sum`, `min` and `max`
+only, so the seed was never updated. The answer therefore tracked scan order,
+not the data:
+
+```
+val(1, 9). val(1, 5). val(1, 2).     /* answered t(1, 9);  mean is 5 */
+val(1, 1). val(1, 2). val(1, 9).     /* answered t(1, 1);  mean is 4 */
+```
+
+Both were wrong, silently, with exit status 0.
+
+It is rejected rather than implemented because there is no type to return a
+mean in. Every value in the engine is a 64-bit integer; `float` is not a
+`.decl` type keyword and there is no decimal literal, so `.decl v(x: float)`
+and `1.5` are both syntax errors. The only implementable semantics today is
+truncating integer division — and that is precisely the choice that could
+not be corrected later, because replacing it with a real mean would change
+the numbers every existing program prints, with no error anywhere. Widening
+a rejection to a real mean, by contrast, accepts strictly more programs and
+rewrites none. This follows the sequence used for the one-aggregate-per-head
+restriction above: reject first, support later.
+
+Compute the mean from `sum` and `count`, which works today:
+
+```
+.decl val(g: int64, v: int64)
+.decl s(g: int64, x: int64)
+.decl c(g: int64, y: int64)
+.decl t(g: int64, a: int64)
+
+s(g, sum(v))   :- val(g, v).
+c(g, count(v)) :- val(g, v).
+t(g, x / y)    :- s(g, x), c(g, y).
+```
+
+The division truncates, but here that is the program's own visible choice
+rather than a hidden one — the sum and the count are both available if a
+different rounding is wanted.
+
+The rejection is at plan generation, not at parsing, so unlike the
+one-aggregate-per-head check above it is not a `WIRELOG_ERR_PARSE`.
+`wl_plan_from_program()` returns `-1` and the CLI prints:
+
+```
+$ wirelog_cli prog.dl
+Plan generation failed: rc=-1
+error: execution failed
+```
+
+Run with `WL_LOG=EVAL:1` to see which aggregate was rejected and why:
+
+```
+$ WL_LOG=EVAL:1 wirelog_cli prog.dl
+[ERROR][EVAL] .../wirelog/exec_plan_gen.c:1516: 'average' is not supported:
+every value is a 64-bit integer, so there is no type to return a mean in.
+Compute it from sum and count instead: ...
+```
+
+Without `WL_LOG` set there is no explanation at all — the workaround above
+exists only inside that log line, so a user who sets nothing sees `rc=-1` and
+nothing else. Surfacing lowering diagnostics by default is tracked as #979,
+which was filed against the parse stage and needs widening to cover this
+`EVAL`-section message too.
+
+`average` stays a reserved keyword and `WIRELOG_AGG_AVG` stays in the public
+enum, so nothing about the surface syntax has to be un-done if a float type
+arrives later.
+
+**One caveat on the workaround.** It is exact for a non-recursive rule. Do not
+reach for it inside a *recursive* stratum: recursive `sum` and `count` are
+themselves broken today — canonicalisation is skipped for anything that is not
+`min`/`max`, so they emit multiple rows per group and violate the functional
+dependency the head declares, silently and at exit 0. That is issue #991. A
+recursive `average` is rejected here; substituting recursive `sum`/`count` for
+it trades a loud failure for a quiet wrong answer.
 
 ### Inline facts must match their declared arity
 
@@ -232,7 +318,11 @@ no diagnostic. That is tracked as #980 and is not affected by this check.
 Aggregate names are matched as exact keywords. `average` and `AVG` are
 recognized; `avg` and `AVERAGE` are not. An unrecognized name followed by `(`
 has no production in head-argument position, so `t(g, avg(v), max(v))` is a
-plain syntax error rather than a rule that bypasses this check.
+plain syntax error rather than a rule that bypasses this check. (`average`
+and `AVG` are recognized by the lexer but rejected at lowering — see
+[`average()` is not supported](#average-is-not-supported). The keywords are
+kept reserved so that `avg`/`AVERAGE` do not have to be taken away from user
+identifiers later.)
 
 ---
 
@@ -391,6 +481,11 @@ Supported column types:
 - `functor/arity` -- compound term handle stored in a 64-bit column
 - `functor/arity side` -- explicit side-relation compound storage
 - `functor/arity inline` -- inline compound storage, limited to arity 4
+
+There is **no floating-point type**. `float` is not a type keyword and there
+is no decimal literal, so `.decl v(x: float)` and `1.5` are both syntax
+errors; every value the engine stores and computes on is a 64-bit integer.
+This is why [`average()` is not supported](#average-is-not-supported).
 
 ---
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1162,6 +1162,28 @@ test_symbol_aggregates_exe = executable(
 # The whole binary runs in well under a second; the timeout bounds the hang.
 test('symbol_aggregates', test_symbol_aggregates_exe, timeout: 60)
 
+# Issue #978: average() was never implemented -- col_op_reduce() had no AVG
+# arm, so each group kept the first operand the scan happened to reach.  With
+# no float type to return a mean in, it is rejected at lowering instead.
+test_average_rejected_exe = executable(
+  'test_average_rejected',
+  files('test_average_rejected.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+# One case evaluates a recursive stratum; the timeout bounds a non-terminating
+# fixpoint rather than a slow one.
+test('average_rejected', test_average_rejected_exe, timeout: 60)
+
 test('option2_doop', test_option2_doop_exe,
   env: ['DOOP_DATA_DIR=' + meson.project_source_root() / 'bench/data/doop'],
 )

--- a/tests/test_average_rejected.c
+++ b/tests/test_average_rejected.c
@@ -1,0 +1,348 @@
+/*
+ * tests/test_average_rejected.c - average() is rejected at lowering (#978)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * `average()` was never implemented.  col_op_reduce() seeds each group with
+ * the group's first operand and its update switch has arms for
+ * COUNT/SUM/MIN/MAX only, so WIRELOG_AGG_AVG fell through `default: break;`
+ * and the seed was returned unchanged.  The answer therefore followed scan
+ * order, not the data:
+ *
+ *     val(1,9). val(1,5). val(1,2).  ->  t(1, 9)   [mean 5]
+ *     val(1,1). val(1,2). val(1,9).  ->  t(1, 1)   [mean 4]
+ *
+ * There is no float type to return a mean in -- storage is int64_t
+ * throughout and the lexer has no `float` type keyword or decimal literal --
+ * so the choice was truncating integer division or rejection.  Rejection was
+ * taken: widening to float later is a compatible change, whereas replacing
+ * truncation with float later would silently change every program's numbers.
+ * See docs/SYNTAX.md and the #973 precedent (reject first, support later).
+ *
+ * Case map:
+ *
+ *   test_average_rejected_at_lowering
+ *       Both accepted spellings (`average` and `AVG`) must PARSE and then
+ *       fail to lower.  The distinction matters: the fix must not be a
+ *       lexer change, because that would also have to steal the identifiers
+ *       `avg`/`AVERAGE` and would break tests/test_parser.c, which asserts
+ *       the AST node.  Includes a head-only shape and a recursive shape.
+ *
+ *   test_other_aggregates_still_evaluate
+ *       sum/count/min/max over the same facts must still lower AND still
+ *       produce the right numbers.  These are load-bearing: a guard that
+ *       rejects every aggregate would pass the negatives above.
+ *
+ *   test_documented_workaround_evaluates
+ *       The sum/count workaround named in the diagnostic must actually
+ *       work, and must give the truncated mean of the same facts.
+ */
+
+#include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int test_count;
+static int pass_count;
+static int fail_count;
+
+#define TEST(name)                                      \
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
+
+#define PASS()            \
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                    \
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
+
+#define ASSERT(cond, msg) \
+        do {                  \
+            if (!(cond))      \
+            FAIL(msg);    \
+        } while (0)
+
+/* ---------------------------------------------------------------------- */
+/* Shared source fragments                                                 */
+/* ---------------------------------------------------------------------- */
+
+/*
+ * Group 1 holds 9, 5, 2 -- sum 16, count 3, min 2, max 9, mean 5 (truncated
+ * from 5.33).  Group 2 holds a single 4, where every aggregate agrees, which
+ * is what makes a control that only checks "one row per group" useless here.
+ */
+#define FACTS                                  \
+        ".decl val(g: int64, v: int64)\n"          \
+        "val(1, 9).\n"                             \
+        "val(1, 5).\n"                             \
+        "val(1, 2).\n"                             \
+        "val(2, 4).\n"
+
+/* ---------------------------------------------------------------------- */
+/* Harness                                                                 */
+/* ---------------------------------------------------------------------- */
+
+typedef enum {
+    LOWER_OK = 0,        /* parsed and lowered */
+    LOWER_PARSE_ERROR,   /* the parser refused it */
+    LOWER_REJECTED,      /* parsed, then wl_plan_from_program() refused it */
+} lower_status_t;
+
+/*
+ * Parse @src and lower it, reporting which of the two stages refused it.
+ *
+ * Keeping the two apart is the point: "average is rejected" must mean
+ * rejected at lowering.  A test that only asserted "this program does not
+ * run" would be satisfied by a lexer change, which is the fix this issue
+ * explicitly does not want.
+ */
+static lower_status_t
+lower_status(const char *src)
+{
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return LOWER_PARSE_ERROR;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        return LOWER_REJECTED;
+    }
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return LOWER_OK;
+}
+
+#define MAX_SEEN 32
+
+typedef struct {
+    const char *rel;
+    uint32_t count;
+    int64_t rows[MAX_SEEN][2];
+} collect_t;
+
+static void
+collect_cb(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user)
+{
+    collect_t *c = (collect_t *)user;
+    if (!c->rel || !relation || strcmp(relation, c->rel) != 0)
+        return;
+    if (ncols >= 2 && c->count < MAX_SEEN) {
+        c->rows[c->count][0] = row[0];
+        c->rows[c->count][1] = row[1];
+    }
+    c->count++;
+}
+
+/* True if @rel holds exactly the row (@g, @v). */
+static bool
+saw_pair(const collect_t *c, int64_t g, int64_t v)
+{
+    uint32_t n = c->count < MAX_SEEN ? c->count : MAX_SEEN;
+    for (uint32_t i = 0; i < n; i++) {
+        if (c->rows[i][0] == g && c->rows[i][1] == v)
+            return true;
+    }
+    return false;
+}
+
+/* Evaluate @src and collect @relation's tuples.  Returns 0 on success. */
+static int
+eval_relation(const char *src, const char *relation, collect_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    out->rel = relation;
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        fprintf(stderr, "  parse error: %d\n", (int)err);
+        return -1;
+    }
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0) {
+        fprintf(stderr, "  lowering failed\n");
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_session_t *sess = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    int result = -1;
+    if (wl_session_load_facts(sess, prog) == 0
+        && wl_session_snapshot(sess, collect_cb, out) == 0)
+        result = 0;
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return result;
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_average_rejected_at_lowering(void)
+{
+    TEST("average() is rejected at lowering, not at parsing");
+
+    static const struct {
+        const char *what;
+        const char *src;
+    } cases[] = {
+        { "average(v) in a head",
+          FACTS ".decl t(g: int64, a: int64)\n"
+          "t(g, average(v)) :- val(g, v).\n" },
+        /* The uppercase spelling is a different lexer token reaching the
+         * same WIRELOG_AGG_AVG, so it needs its own case. */
+        { "AVG(v) in a head",
+          FACTS ".decl t(g: int64, a: int64)\n"
+          "t(g, AVG(v)) :- val(g, v).\n" },
+        /* No group-by column at all: a global average. */
+        { "average over the whole relation",
+          FACTS ".decl t(a: int64)\n"
+          "t(average(v)) :- val(g, v).\n" },
+        /* An expression operand still resolves to the same aggregate. */
+        { "average of an arithmetic operand",
+          FACTS ".decl t(g: int64, a: int64)\n"
+          "t(g, average(v + 1)) :- val(g, v).\n" },
+        /* Recursive shape.  The recursive reducer is a second code path and
+         * a guard placed only on the non-recursive one would miss it.
+         * (Recursive sum/count/average all violate the head relation's
+         * functional dependency; that is #991 and is not what this asserts.
+         * All this asserts is that the guard is reached here too.) */
+        { "average inside a recursive stratum",
+          ".decl edge(x: int64, y: int64)\n"
+          "edge(1, 2).\n"
+          ".decl cc(n: int64, a: int64)\n"
+          "cc(1, 5).\n"
+          "cc(y, average(c)) :- cc(x, c), edge(x, y).\n" },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        lower_status_t st = lower_status(cases[i].src);
+        if (st == LOWER_PARSE_ERROR) {
+            fprintf(stderr, "  case: %s\n", cases[i].what);
+            FAIL("must still parse -- the rejection belongs at lowering, "
+                "not in the lexer");
+        }
+        if (st != LOWER_REJECTED) {
+            fprintf(stderr, "  case: %s\n", cases[i].what);
+            FAIL("average() lowered instead of being rejected");
+        }
+    }
+    PASS();
+}
+
+static void
+test_other_aggregates_still_evaluate(void)
+{
+    TEST("sum/count/min/max still lower and still give the right numbers");
+
+    static const struct {
+        const char *fn;
+        int64_t g1; /* expected value for group 1 over {9, 5, 2} */
+        int64_t g2; /* expected value for group 2 over {4} */
+    } cases[] = {
+        { "sum", 16, 4 },
+        { "count", 3, 1 },
+        { "min", 2, 4 },
+        { "max", 9, 4 },
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        char src[512];
+        snprintf(src, sizeof(src),
+            FACTS ".decl t(g: int64, a: int64)\n"
+            "t(g, %s(v)) :- val(g, v).\n", cases[i].fn);
+
+        ASSERT(lower_status(src) == LOWER_OK,
+            "a working aggregate stopped lowering");
+
+        collect_t c;
+        ASSERT(eval_relation(src, "t", &c) == 0, "evaluation failed");
+        ASSERT(c.count == 2, "expected one row per group");
+        ASSERT(saw_pair(&c, 1, cases[i].g1), "wrong value for group 1");
+        ASSERT(saw_pair(&c, 2, cases[i].g2), "wrong value for group 2");
+    }
+    PASS();
+}
+
+static void
+test_documented_workaround_evaluates(void)
+{
+    TEST("the sum/count workaround gives the truncated mean");
+
+    /* This is the program the rejection diagnostic tells the user to write.
+     * If it stops working the diagnostic becomes a lie, so it is asserted
+     * here rather than only in prose. */
+    static const char *src
+        = FACTS ".decl s(g: int64, x: int64)\n"
+        ".decl c(g: int64, y: int64)\n"
+        ".decl t(g: int64, a: int64)\n"
+        "s(g, sum(v)) :- val(g, v).\n"
+        "c(g, count(v)) :- val(g, v).\n"
+        "t(g, x / y) :- s(g, x), c(g, y).\n";
+
+    collect_t c;
+    ASSERT(eval_relation(src, "t", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 2, "expected one row per group");
+    ASSERT(saw_pair(&c, 1, 5), "16 / 3 should be 5");
+    ASSERT(saw_pair(&c, 2, 4), "4 / 1 should be 4");
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+int
+main(void)
+{
+    printf("=== average() rejected at lowering (Issue #978) ===\n");
+
+    test_average_rejected_at_lowering();
+    test_other_aggregates_still_evaluate();
+    test_documented_workaround_evaluates();
+
+    printf("\n%d/%d passed, %d failed\n", pass_count, test_count, fail_count);
+    return fail_count == 0 ? 0 : 1;
+}

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -947,6 +947,61 @@ test_parse_avg_aggregate(void)
     PASS();
 }
 
+/*
+ * Issue #978: wirelog_agg_fn_str() must print a spelling the lexer accepts.
+ * It printed "avg" for WIRELOG_AGG_AVG, and `avg` is deliberately *not* a
+ * keyword (docs/SYNTAX.md: `average` and `AVG` are recognized, `avg` and
+ * `AVERAGE` are not), so every AST dump and IR dump named an aggregate that
+ * could not be read back.  Asserting the round trip for all five functions
+ * rather than only for AVG is what stops the next one from drifting: the
+ * other four happen to agree today, and nothing but this test says they must.
+ */
+static void
+test_agg_fn_str_round_trip(void)
+{
+    TEST("wirelog_agg_fn_str() prints a spelling the lexer accepts");
+
+    static const wirelog_agg_fn_t fns[] = {
+        WIRELOG_AGG_COUNT, WIRELOG_AGG_SUM, WIRELOG_AGG_MIN,
+        WIRELOG_AGG_MAX, WIRELOG_AGG_AVG,
+    };
+
+    for (size_t i = 0; i < sizeof(fns) / sizeof(fns[0]); i++) {
+        const char *name = wirelog_agg_fn_str(fns[i]);
+        char src[128];
+        snprintf(src, sizeof(src), "t(g, %s(v)) :- s(g, v).", name);
+
+        char errbuf[512] = { 0 };
+        wl_parser_ast_node_t *prog
+            = wl_parser_parse_string(src, errbuf, sizeof(errbuf));
+        if (!prog) {
+            char buf[700];
+            snprintf(buf, sizeof(buf),
+                "printed name \"%s\" does not lex back: %s", name, errbuf);
+            FAIL(buf);
+            return;
+        }
+
+        const wl_parser_ast_node_t *agg
+            = child(child(child(prog, 0), 0), 1);
+        if (!agg || agg->type != WL_PARSER_AST_NODE_AGGREGATE) {
+            wl_parser_ast_node_free(prog);
+            FAIL("printed name did not parse as an aggregate");
+            return;
+        }
+        if (agg->agg_fn != fns[i]) {
+            char buf[256];
+            snprintf(buf, sizeof(buf),
+                "\"%s\" round-tripped to a different aggregate", name);
+            wl_parser_ast_node_free(prog);
+            FAIL(buf);
+            return;
+        }
+        wl_parser_ast_node_free(prog);
+    }
+    PASS();
+}
+
 static void
 test_parse_aggregate_with_arithmetic(void)
 {
@@ -2013,6 +2068,7 @@ main(void)
     test_parse_sum_aggregate();
     test_parse_max_aggregate();
     test_parse_avg_aggregate();
+    test_agg_fn_str_round_trip();
     test_parse_aggregate_with_arithmetic();
     test_parse_aggregate_with_constant();
 

--- a/tests/test_symbol_aggregates.c
+++ b/tests/test_symbol_aggregates.c
@@ -83,9 +83,11 @@
  *       occupies several physical columns behind one logical one.  If the
  *       type is lost there the aggregate silently returns to ids.
  *
- *   test_count_sum_average_unchanged
- *       count()/sum()/average() over a symbol column are not ordering
- *       aggregates and must not acquire the string comparison.
+ *   test_count_sum_unchanged
+ *       count()/sum() over a symbol column are not ordering aggregates and
+ *       must not acquire the string comparison.  average() belongs to the
+ *       same non-ordering group but is rejected at lowering (#978), so the
+ *       property asserted for it is that it never reaches the reducer.
  */
 
 #include "../wirelog/backend.h"
@@ -748,9 +750,9 @@ test_inline_compound_relation(void)
 /* ---------------------------------------------------------------------- */
 
 static void
-test_count_sum_average_unchanged(void)
+test_count_sum_unchanged(void)
 {
-    TEST("count()/sum()/average() over a symbol column are unchanged");
+    TEST("count()/sum() over a symbol column are unchanged");
 
     /*
      * These reduce over the id and always did; they are not ordering
@@ -768,15 +770,6 @@ test_count_sum_average_unchanged(void)
         /* ids: "aa"=0, "mm"=1, "zz"=2 -- SHIFT interns them in that order */
         { SHIFT S_FACTS ".decl C(g: symbol, n: int64)\n"
           "C(g, sum(v)) :- S(g, v).\n", 0 + 1 + 2 },
-        /*
-         * average() is not reduced by col_op_reduce() at all -- its switch
-         * has no AVG arm -- so it keeps the first operand it sees, which
-         * SHIFT pins to id("zz") = 2.  That is orthogonal to this issue and
-         * is asserted as-is: what must not happen is average() acquiring the
-         * ordering path, which is the arm right next to it.
-         */
-        { SHIFT S_FACTS ".decl C(g: symbol, n: int64)\n"
-          "C(g, average(v)) :- S(g, v).\n", 2 },
     };
 
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
@@ -787,6 +780,35 @@ test_count_sum_average_unchanged(void)
         ASSERT(saw_value_at(&c, 1, cases[i].expect),
             "a non-ordering aggregate changed value");
     }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_average_never_reaches_the_reducer(void)
+{
+    TEST("average() over a symbol column is rejected, not reduced");
+
+    /*
+     * average() belongs with count()/sum() above -- it is not an ordering
+     * aggregate and must never acquire the string comparison that lives in
+     * the arm beside it.  It cannot be asserted by value, because
+     * col_op_reduce() never had an AVG arm: each group kept whichever
+     * operand the scan reached first, which under SHIFT was id("zz") = 2.
+     * That is not a mean of anything, and #978 rejects average() at
+     * lowering rather than freezing an arbitrary number here.
+     *
+     * Asserting the rejection is still the right guard for *this* issue:
+     * the way average() could acquire the ordering path is by being added
+     * to the reducer's string branch, and a program that does not lower can
+     * never get there.  The rejection's own coverage is
+     * tests/test_average_rejected.c.
+     */
+    collect_t c;
+    ASSERT(eval_relation(SHIFT S_FACTS ".decl C(g: symbol, n: int64)\n"
+        "C(g, average(v)) :- S(g, v).\n", "C", &c) != 0,
+        "average() should not have lowered");
     PASS();
 }
 
@@ -808,7 +830,8 @@ main(void)
     test_mixed_interned_and_uninterned_group();
     test_undeclared_relation();
     test_inline_compound_relation();
-    test_count_sum_average_unchanged();
+    test_count_sum_unchanged();
+    test_average_never_reaches_the_reducer();
 
     printf("\n%d/%d passed, %d failed\n", pass_count, test_count, fail_count);
     return fail_count == 0 ? 0 : 1;

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -627,8 +627,20 @@ cmp_to_tag(wirelog_cmp_op_t op, wl_ir_coltype_t lhs, wl_ir_coltype_t rhs)
     }
 }
 
-/* Map IR agg fn -> plan expr tag */
-static uint8_t
+/*
+ * Map IR agg fn -> plan expr tag, or -1 when the aggregate has no tag.
+ *
+ * WIRELOG_AGG_AVG used to map to WL_PLAN_EXPR_AGG_SUM, commented
+ * "approximate: no AVG tag": the serialized plan said SUM where the program
+ * said average, so a backend reading the plan could not tell the two apart
+ * and no diagnostic was emitted either way.  average() is now refused at the
+ * WIRELOG_IR_AGGREGATE arm below, which is the only route the parser can
+ * take here -- an AGGREGATE node is always a top-level head argument, so
+ * min(average(v)) and the like are parse errors and this expression form
+ * never carries AVG.  Failing rather than substituting keeps that true for
+ * any future caller that builds IR directly (Issue #978).
+ */
+static int
 agg_to_tag(wirelog_agg_fn_t fn)
 {
     switch (fn) {
@@ -641,9 +653,9 @@ agg_to_tag(wirelog_agg_fn_t fn)
     case WIRELOG_AGG_MAX:
         return WL_PLAN_EXPR_AGG_MAX;
     case WIRELOG_AGG_AVG:
-        return WL_PLAN_EXPR_AGG_SUM; /* approximate: no AVG tag */
+        return -1;
     }
-    return WL_PLAN_EXPR_AGG_COUNT; /* fallback */
+    return -1; /* not an aggregate this plan format can encode */
 }
 
 /**
@@ -818,12 +830,16 @@ serialize_expr(expr_buf_t *buf, const wl_ir_expr_t *expr,
         return expr_buf_push_u8(buf, cmp_to_tag(expr->cmp_op, lhs, rhs));
     }
 
-    case WL_IR_EXPR_AGG:
+    case WL_IR_EXPR_AGG: {
         for (uint32_t i = 0; i < expr->child_count; i++) {
             if (serialize_expr(buf, expr->children[i], ctx) != 0)
                 return -1;
         }
-        return expr_buf_push_u8(buf, agg_to_tag(expr->agg_fn));
+        int agg_tag = agg_to_tag(expr->agg_fn);
+        if (agg_tag < 0)
+            return -1;
+        return expr_buf_push_u8(buf, (uint8_t)agg_tag);
+    }
 
     case WL_IR_EXPR_STR_FN:
         /* Serialize arguments first (postfix), then emit the function opcode */
@@ -1476,6 +1492,49 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
     }
 
     case WIRELOG_IR_AGGREGATE: {
+        /*
+         * average() is not implemented and is refused here rather than
+         * answered wrongly (Issue #978).
+         *
+         * col_op_reduce() seeds each group with the group's first operand
+         * and its update switch has arms for COUNT/SUM/MIN/MAX only, so
+         * WIRELOG_AGG_AVG fell through `default: break;` and the seed was
+         * returned untouched.  The answer followed scan order rather than
+         * the data -- val(1,9). val(1,5). val(1,2). gave 9, and reordering
+         * the same three facts gave 1 -- with exit status 0 and no
+         * diagnostic.
+         *
+         * Implementing it needs a return type this engine does not have.
+         * Every value is an int64_t (columnar/internal.h), and while
+         * WIRELOG_TYPE_FLOAT exists in the public enum it is vestigial: the
+         * lexer has type keywords for int32/int64/string/symbol only and no
+         * decimal literal, so neither `.decl v(x: float)` nor `1.5` parses.
+         * The only implementable semantics today is truncating integer
+         * division, and that is the one choice that cannot be corrected
+         * later without silently changing existing programs' numbers --
+         * whereas widening a rejection to a real mean accepts strictly more
+         * programs and rewrites none.  Precedent agrees: Soufflé refuses
+         * integer operands to mean() outright, and PostgreSQL, SQLite,
+         * MySQL and cozo all widen the result type rather than truncate.
+         * This follows the sequence adopted for #973: reject first, support
+         * later.
+         *
+         * Placed at lowering, not in the lexer: `average`/`AVG` keep
+         * tokenizing, the AST keeps its AGGREGATE node and the public
+         * WIRELOG_AGG_AVG stays as it is, so nothing about the surface
+         * syntax has to be un-done when float arrives.
+         */
+        if (node->agg_fn == WIRELOG_AGG_AVG) {
+            WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_ERROR,
+                "'average' is not supported: every value is a 64-bit "
+                "integer, so there is no type to return a mean in. Compute "
+                "it from sum and count instead: "
+                "s(g, sum(v)) :- val(g, v). "
+                "c(g, count(v)) :- val(g, v). "
+                "t(g, x / y) :- s(g, x), c(g, y).");
+            return -1;
+        }
+
         /* Translate child first */
         if (node->child_count > 0) {
             if (translate_ir_node(node->children[0], ops) != 0)

--- a/wirelog/parser/ast.c
+++ b/wirelog/parser/ast.c
@@ -248,6 +248,15 @@ wirelog_arith_op_str(wirelog_arith_op_t op)
     return "?";
 }
 
+/*
+ * Every name here must be one the lexer accepts, because these strings are
+ * what AST and IR dumps print and what a reader would paste back into a
+ * program.  WIRELOG_AGG_AVG printed "avg", which is deliberately not a
+ * keyword -- docs/SYNTAX.md fixes the accepted spellings as `average` and
+ * `AVG`, and `avg`/`AVERAGE` are excluded so they stay usable as ordinary
+ * identifiers.  tests/test_parser.c asserts the round trip for all five
+ * (Issue #978).
+ */
 const char *
 wirelog_agg_fn_str(wirelog_agg_fn_t fn)
 {
@@ -261,7 +270,7 @@ wirelog_agg_fn_str(wirelog_agg_fn_t fn)
     case WIRELOG_AGG_MAX:
         return "max";
     case WIRELOG_AGG_AVG:
-        return "avg";
+        return "average";
     }
     return "?";
 }

--- a/wirelog/wirelog-types.h
+++ b/wirelog/wirelog-types.h
@@ -89,7 +89,14 @@ typedef enum {
     WIRELOG_AGG_SUM,   /* sum / SUM */
     WIRELOG_AGG_MIN,   /* min / MIN */
     WIRELOG_AGG_MAX,   /* max / MAX */
-    WIRELOG_AGG_AVG,   /* average / AVG */
+    /*
+     * average / AVG.  Parses into this value, but a rule carrying it is
+     * rejected when it is lowered (#978): every value is a 64-bit integer,
+     * so there is no type to return a mean in.  Kept in the enum, and kept
+     * a reserved keyword, so the surface syntax does not have to change if
+     * a float type arrives.  Compute a mean as sum/count.
+     */
+    WIRELOG_AGG_AVG,
 } wirelog_agg_fn_t;
 
 /* ======================================================================== */
@@ -120,6 +127,12 @@ WIRELOG_API const char *
 wirelog_cmp_op_str(wirelog_cmp_op_t op);
 WIRELOG_API const char *
 wirelog_arith_op_str(wirelog_arith_op_t op);
+/*
+ * Returns the aggregate's source spelling, i.e. a name the lexer accepts.
+ * WIRELOG_AGG_AVG returns "average", not "avg" -- `avg` is not a keyword
+ * (see docs/SYNTAX.md), so the old spelling did not parse back.  Intended
+ * for diagnostics and program dumps; the returned string is static.
+ */
 WIRELOG_API const char *
 wirelog_agg_fn_str(wirelog_agg_fn_t fn);
 

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -122,7 +122,10 @@ typedef enum {
  * - Facts (extensional database)
  * - Rules with recursion
  * - Negation (stratified)
- * - Aggregation (COUNT, SUM, MIN, MAX, AVG)
+ * - Aggregation (COUNT, SUM, MIN, MAX). AVG/average parses but is rejected
+ *   when the rule is lowered: every value is a 64-bit integer, so there is
+ *   no type to return a mean in. Compute it as sum/count -- see
+ *   docs/SYNTAX.md, "average() is not supported".
  * - Built-in predicates (=, <, >, <=, >=, !=)
  * - Comments (% line comments)
  *


### PR DESCRIPTION
Closes #978.

## What was wrong

`col_op_reduce` seeds each group with the first operand it scans, then updates it in a `switch` with arms for COUNT/SUM/MIN/MAX and a bare `default: break;`. `WIRELOG_AGG_AVG` hit the default, so the seed was written once and never updated. **`average()` was unimplemented, not implemented wrong.**

The result follows scan order, so it is not "the first fact" but an arbitrary one:

| facts | first operand | true mean | returned |
|---|---|---|---|
| `9, 5, 2` | 9 | 5 | **9** |
| `1, 2, 9` | 1 | 4 | **1** |
| `5, 9, 2` | 5 | 5 | 5 — *does not discriminate* |

That last row is the shape in the issue report. Its truncated mean and its first operand are both 5, so a regression test written from the ticket **passes on the unfixed code**.

## Why reject rather than implement

Every value in this engine is a 64-bit integer. `WIRELOG_TYPE_FLOAT` exists in the public enum but is vestigial — the lexer has no `float` token, so `.decl v(x: float)` and the literal `1.5` are both parse errors. So the choice was integer semantics or rejection, and integer semantics means committing to a rounding rule.

Truncation was proposed and overturned:

- **Soufflé does not return a float for `mean` — it refuses integer operands outright.** cozo, PostgreSQL, SQLite and MySQL all return non-integers; DDlog and Nemo have no `average` at all. The one engine that truncates documents its own behaviour as a footgun.
- **The directions are not symmetric.** Reject now → float later only *widens* what is accepted and changes no program's output. Truncate now → float later silently changes every program's *numbers*, with no error.
- **#973 set the precedent one commit earlier**: reject an underspecified aggregate first, support it once the semantics are decided.

The rejection is at **lowering, not in the lexer**, so `average` stays a reserved keyword and `WIRELOG_AGG_AVG` stays in the public enum — nothing about the surface syntax has to be undone if a float type arrives.

## Also here

**`wirelog_agg_fn_str` returned `"avg"`** — a spelling the lexer refuses, since `average` and `AVG` are keywords and `avg` deliberately is not. Print did not round-trip through parse. Now returns `"average"`, with a test asserting the round-trip for all five aggregates and asserting **identity**, not merely that the name lexes.

**`agg_to_tag` lowered AVG to `WL_PLAN_EXPR_AGG_SUM`** ("approximate: no AVG tag"), so a serialized plan said SUM where the program said AVG. That mapping turns out to be **unreachable** — `agg_to_tag` runs only from `serialize_expr` on a *nested* `WL_IR_EXPR_AGG`, and an AGGREGATE node is always a top-level head argument, so `min(average(v))` is a parse error. Instrumenting it showed **zero hits across the entire test suite**. Changed to error rather than mislabel, as defensive hardening, and the comment says that is what it is.

## Limitations, stated in the docs

- **With no `WL_LOG` set the user sees `rc=-1` and nothing else** — the workaround text lives inside the log line. That is #979, which was filed against the parse stage and needs widening to cover plan generation. This rejection surfaces as `Plan generation failed: rc=-1` and needs `WL_LOG=EVAL:1`, **not** `PARSER:1`; the docs say so rather than implying it shares an error code with the #973 check beside it.
- **The `sum`/`count` workaround is exact for a non-recursive rule only.** Recursive `sum` and `count` are themselves broken (#991) — canonicalisation is skipped for anything not `min`/`max`, so they emit multiple rows per group. A user whose recursive `average` is rejected here must not substitute them, or they trade a loud failure for a quiet wrong answer. Called out explicitly.

## Tests

`tests/test_average_rejected.c` — ten rejection shapes (both spellings, over an expression, global with no group-by, `int32`, `symbol`, recursive, negated, multi-stratum, unused relation), plus positive controls asserting `sum`/`count`/`min`/`max` **by value** and the workaround's output.

| mutation | caught by |
|---|---|
| widen guard to also reject MIN | `"a working aggregate stopped lowering"` |
| disable the guard | both negatives, in two different test files |
| reject in the lexer instead | `"the rejection belongs at lowering, not in the lexer"` |
| printer emits `"sum"` for AVG | `"round-tripped to a different aggregate"` — a lexability-only assertion would have missed this |

`tests/test_symbol_aggregates.c` previously asserted the broken value on purpose, with a comment explaining the mechanism; both are replaced.

Suite **265 Ok / 1 Fail / 11 Skipped** (was 264; +1 is the new test). The failure is the pre-existing `sbom_snapshot` drift. ASAN+UBSAN with `detect_leaks=1` clean across all ten rejection shapes. Blast radius zero — no `.dl`, workload, example or golden output uses `average`/`AVG`.

One pre-existing defect surfaced and is filed as **#998**: `wl_plan_from_program` shallow-frees its strata array on failure paths, so a rejection in a *later* relation leaks completed strata. Not introduced here — reproduced byte-identically on clean `main` with an artificial `return -1` — but this change makes it reachable for the first time.
