### PR TITLE
fix(io): bound the CSV string path row write by the caller capacity

### DIFF
--- a/tests/fuzz/csv_reader_fuzz.c
+++ b/tests/fuzz/csv_reader_fuzz.c
@@ -35,16 +35,33 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     uint32_t count = 0;
     (void)wl_csv_parse_line(line, ',', values, CSV_FUZZ_MAX_FIELDS, &count);
 
-    wirelog_column_type_t col_types[2] = {
+    /*
+     * Issue #997: drive num_cols from the input while holding the value
+     * buffer at a fixed 4.  Passing both as the same literal made the
+     * `num_cols > max_cols` guard statically unreachable, so the bound that
+     * fix added had no fuzz coverage at all -- which is how the original
+     * overflow survived: width was never fuzzed.  Deriving num_cols from a
+     * data byte lets the fuzzer reach both sides of the guard.
+     */
+    wirelog_column_type_t col_types[8] = {
+        WIRELOG_TYPE_INT64,
+        WIRELOG_TYPE_STRING,
+        WIRELOG_TYPE_INT64,
+        WIRELOG_TYPE_STRING,
+        WIRELOG_TYPE_INT64,
+        WIRELOG_TYPE_STRING,
         WIRELOG_TYPE_INT64,
         WIRELOG_TYPE_STRING,
     };
-    int64_t ex_values[2];
+    int64_t ex_values[4];
     uint32_t ex_count = 0;
+    /* 0..7, so roughly half the draws exceed the 4-entry capacity.
+     * `size` may be 0, in which case data[0] is not ours to read. */
+    uint32_t ex_ncols = size ? (uint32_t)(data[0] & 0x07u) : 0u;
     wl_intern_t *intern = wl_intern_create();
     if (intern) {
-        (void)wl_csv_parse_line_ex(line, ',', col_types, 2, ex_values,
-            &ex_count, intern);
+        (void)wl_csv_parse_line_ex(line, ',', col_types, ex_ncols, ex_values,
+            4, &ex_count, intern);
         wl_intern_free(intern);
     }
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4591,6 +4591,33 @@ test_input_arity_exe = executable(
 test('input_arity', test_input_arity_exe)
 
 # ============================================================================
+# Wide-relation CSV Loading Tests (Issue #997)
+# The string-aware CSV parser wrote one int64_t per declared column into a
+# fixed row_values[256] frame buffer with no capacity check, so a relation
+# with 257+ columns and at least one symbol overflowed the caller's stack.
+# Drives the pipeline, wl_csv_read_file_via_ctx(), and the public
+# wirelog_load_facts_from_csv() entry an embedder reaches the parser through.
+# ============================================================================
+
+test_csv_wide_columns_exe = executable(
+  'test_csv_wide_columns',
+  files('test_csv_wide_columns.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  driver_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+  install: false,
+)
+test('csv_wide_columns', test_csv_wide_columns_exe)
+
+# ============================================================================
 # Concurrent I/O Adapter Registry Stress Test (#459)
 # Exercises mutex safety under TSan: concurrent find, register/unregister,
 # and mixed readers+writers.  Linux/macOS only (pthreads; skipped on Windows).

--- a/tests/test_csv.c
+++ b/tests/test_csv.c
@@ -422,7 +422,7 @@ test_parse_line_ex_mixed(void)
     int64_t values[3];
     uint32_t count = 0;
     int rc = wl_csv_parse_line_ex("\"Alice\",42,\"Bob\"", ',', types, 3, values,
-            &count, intern);
+            3, &count, intern);
 
     if (rc != 0) {
         FAIL("returned non-zero");
@@ -475,8 +475,8 @@ test_parse_line_ex_unquoted_strings(void)
         = { WIRELOG_TYPE_STRING, WIRELOG_TYPE_STRING };
     int64_t values[2];
     uint32_t count = 0;
-    int rc = wl_csv_parse_line_ex("hello,world", ',', types, 2, values, &count,
-            intern);
+    int rc = wl_csv_parse_line_ex("hello,world", ',', types, 2, values, 2,
+            &count, intern);
 
     if (rc != 0) {
         FAIL("returned non-zero");
@@ -520,8 +520,8 @@ test_parse_line_ex_all_int(void)
     wirelog_column_type_t types[] = { WIRELOG_TYPE_INT32, WIRELOG_TYPE_INT32 };
     int64_t values[2];
     uint32_t count = 0;
-    int rc
-        = wl_csv_parse_line_ex("10,20", ',', types, 2, values, &count, intern);
+    int rc = wl_csv_parse_line_ex("10,20", ',', types, 2, values, 2, &count,
+            intern);
 
     if (rc != 0) {
         FAIL("returned non-zero");

--- a/tests/test_csv_wide_columns.c
+++ b/tests/test_csv_wide_columns.c
@@ -1,0 +1,560 @@
+/*
+ * test_csv_wide_columns.c - wide-relation CSV loading (Issue #997)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * The string-aware CSV line parser used to write values[col] for every
+ * column of the caller's declared width with no capacity check, into a
+ * fixed int64_t row_values[256] frame buffer in
+ * wl_csv_read_file_via_ctx().  A relation with 257 or more columns, at
+ * least one of them a symbol, therefore overflowed the caller's stack
+ * frame -- an ASan stack-buffer-overflow WRITE of size 8.  The boundary
+ * was exact: 256 columns clean, 257 over.  The integer-only parser had
+ * always taken a max_cols capacity and returned -2 once it was
+ * exceeded; the string path had simply lost that check.
+ *
+ * The fix heap-allocates the row buffer at the relation's real width and
+ * threads an explicit capacity through to the write site, which removes
+ * the 256-column ceiling rather than merely enforcing it.  These tests
+ * pin both halves: nothing is written past the buffer, and relations
+ * that used to be impossible now load with byte-exact contents.
+ *
+ * Coverage is split by what each entry point can actually observe:
+ *
+ *   - wl_csv_read_file_via_ctx() is asserted cell for cell at 256 (the
+ *     positive control), 257 (the boundary), 300 (the ceiling), and 260
+ *     mixed int/symbol.  A row-count assertion would pass on the
+ *     overflowing build, so every cell is compared to the source text.
+ *
+ *   - wl_run_pipeline() covers the .input directive path, which is how
+ *     the overflow was first reached (csv_read -> csv_parse_line_via_ctx
+ *     under wl_session_load_input_files).  Loaded EDB rows are not
+ *     observable from there -- wl_session_snapshot emits IDB tuples only,
+ *     and a projection rule wide enough to expose them would run into
+ *     the evaluator's separate 32-column COL_STACK_MAX limit -- so these
+ *     cases assert a clean load plus ASan cleanliness and leave the
+ *     content assertions to the direct reader above.
+ *
+ *   - wirelog_load_facts_from_csv() is the public API an embedder
+ *     reaches the same parser through, with no Datalog at all.
+ */
+
+#include "../wirelog/cli/driver.h"
+#include "../wirelog/io/csv_reader.h"
+#include "../wirelog/wirelog.h"
+
+#include "test_tmpdir.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ======================================================================== */
+/* Test Helpers                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
+
+/*
+ * The .decl for a 300-column relation is a few KiB.  The CSV line must
+ * also stay under the reader's 4096-byte line buffer -- that truncation
+ * limit is #953 and deliberately out of scope here -- so the field
+ * values are kept short.
+ */
+#define WIDE_SRC_BUF 32768
+#define WIDE_CSV_BUF 16384
+
+static int
+write_text_file(const char *path, const char *text)
+{
+    FILE *f = fopen(path, "w");
+    if (!f)
+        return -1;
+    if (text && text[0] != '\0')
+        fputs(text, f);
+    fclose(f);
+    return 0;
+}
+
+/*
+ * Run the full pipeline on @src, capturing printed tuples into @outpath.
+ * On success (*out_text != NULL) the caller must free(*out_text).
+ * Returns the wl_run_pipeline return code, or -999 if the capture file
+ * could not be opened.
+ */
+static int
+run_pipeline_capture(const char *src, const char *outpath, char **out_text)
+{
+    *out_text = NULL;
+
+    FILE *f = fopen(outpath, "w");
+    if (!f)
+        return -999;
+
+    int rc = wl_run_pipeline(src, 1, false, false, 0, f);
+    fclose(f);
+
+    *out_text = wl_read_file(outpath);
+    return rc;
+}
+
+/* Column @col is a symbol unless @mixed and @col is even. */
+static int
+col_is_symbol(int col, int mixed)
+{
+    return !mixed || (col % 2) != 0;
+}
+
+/* Append to @buf at *@off, returning 0 on success and -1 on overflow. */
+static int
+appendf(char *buf, size_t bufsz, size_t *off, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(buf + *off, bufsz - *off, fmt, ap);
+    va_end(ap);
+    if (n < 0 || (size_t)n >= bufsz - *off)
+        return -1;
+    *off += (size_t)n;
+    return 0;
+}
+
+/* The symbol cell at (@row, @col): "r<row>c<col>", unique per cell. */
+static void
+cell_symbol(char *buf, size_t bufsz, int row, int col)
+{
+    snprintf(buf, bufsz, "r%dc%d", row, col);
+}
+
+/* The integer cell at (@row, @col), distinct across the widths used. */
+static int64_t
+cell_int(int row, int col)
+{
+    return (int64_t)row * 100000 + col;
+}
+
+/* ".decl rel(c0: symbol, c1: int32, ...)\n" */
+static int
+build_wide_decl(char *buf, size_t bufsz, size_t *off, const char *rel,
+    int ncols, int mixed)
+{
+    if (appendf(buf, bufsz, off, ".decl %s(", rel) != 0)
+        return -1;
+    for (int i = 0; i < ncols; i++) {
+        if (appendf(buf, bufsz, off, "%sc%d: %s", i ? ", " : "", i,
+            col_is_symbol(i, mixed) ? "symbol" : "int32")
+            != 0)
+            return -1;
+    }
+    return appendf(buf, bufsz, off, ")\n");
+}
+
+static int
+build_wide_csv(char *buf, size_t bufsz, int ncols, int mixed, int nrows)
+{
+    size_t off = 0;
+    for (int r = 0; r < nrows; r++) {
+        for (int c = 0; c < ncols; c++) {
+            const char *sep = c ? "," : "";
+            int rc;
+            if (col_is_symbol(c, mixed)) {
+                char cell[64];
+                cell_symbol(cell, sizeof(cell), r, c);
+                rc = appendf(buf, bufsz, &off, "%s%s", sep, cell);
+            } else {
+                rc = appendf(buf, bufsz, &off, "%s%lld", sep,
+                        (long long)cell_int(r, c));
+            }
+            if (rc != 0)
+                return -1;
+        }
+        if (appendf(buf, bufsz, &off, "\n") != 0)
+            return -1;
+    }
+    return 0;
+}
+
+/* ======================================================================== */
+/* Cases 1-4: wl_csv_read_file_via_ctx() asserted cell for cell             */
+/* ======================================================================== */
+
+/* Interns through a real table so the loaded ids can be resolved back to
+ * the exact source text, rather than only counted. */
+static int64_t
+intern_cb(void *opaque, const char *str)
+{
+    return wl_intern_put((wl_intern_t *)opaque, str);
+}
+
+static void
+check_direct_read(const char *label, int ncols, int mixed)
+{
+    TEST(label);
+
+    static char csv[WIDE_CSV_BUF];
+    const int nrows = 3;
+    char path[512];
+    char fixture[128];
+    char msg[192];
+
+    snprintf(fixture, sizeof(fixture), "wl997_direct_%s%d.csv",
+        mixed ? "mix" : "", ncols);
+    test_tmppath(path, sizeof(path), fixture);
+
+    if (build_wide_csv(csv, sizeof(csv), ncols, mixed, nrows) != 0) {
+        FAIL("csv fixture buffer too small");
+        return;
+    }
+    if (write_text_file(path, csv) != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    wirelog_column_type_t *types
+        = (wirelog_column_type_t *)malloc((size_t)ncols * sizeof(*types));
+    wl_intern_t *intern = wl_intern_create();
+    if (!types || !intern) {
+        remove(path);
+        free(types);
+        if (intern)
+            wl_intern_free(intern);
+        FAIL("allocation failed");
+        return;
+    }
+    for (int i = 0; i < ncols; i++) {
+        types[i] = col_is_symbol(i, mixed) ? WIRELOG_TYPE_STRING
+                                           : WIRELOG_TYPE_INT32;
+    }
+
+    int64_t *data = NULL;
+    uint32_t out_nrows = 0, out_ncols = 0;
+    int rc = wl_csv_read_file_via_ctx(path, ',', types, (uint32_t)ncols, &data,
+            &out_nrows, &out_ncols, intern_cb, intern);
+
+    remove(path);
+    free(types);
+
+    if (rc != 0) {
+        snprintf(msg, sizeof(msg), "returned %d for a %d-column file", rc,
+            ncols);
+        goto fail;
+    }
+    if (out_nrows != (uint32_t)nrows || out_ncols != (uint32_t)ncols) {
+        snprintf(msg, sizeof(msg), "expected %dx%d, got %ux%u", nrows, ncols,
+            out_nrows, out_ncols);
+        goto fail;
+    }
+
+    /*
+     * Every cell, not just the row count: an overflowing build still
+     * reports the right shape.
+     */
+    for (int r = 0; r < nrows; r++) {
+        for (int c = 0; c < ncols; c++) {
+            int64_t got = data[(size_t)r * ncols + c];
+            if (col_is_symbol(c, mixed)) {
+                char want[64];
+                cell_symbol(want, sizeof(want), r, c);
+                const char *s = wl_intern_reverse(intern, got);
+                if (!s || strcmp(s, want) != 0) {
+                    snprintf(msg, sizeof(msg),
+                        "cell [%d][%d] is \"%s\", want \"%s\"", r, c,
+                        s ? s : "(unresolved)", want);
+                    goto fail;
+                }
+            } else if (got != cell_int(r, c)) {
+                snprintf(msg, sizeof(msg), "cell [%d][%d] is %lld, want %lld",
+                    r, c, (long long)got, (long long)cell_int(r, c));
+                goto fail;
+            }
+        }
+    }
+
+    free(data);
+    wl_intern_free(intern);
+    PASS();
+    return;
+
+fail:
+    free(data);
+    wl_intern_free(intern);
+    FAIL(msg);
+}
+
+/* 256 is the last width the old fixed row_values[] could hold: the
+ * positive control that must keep working. */
+static void
+test_direct_256(void)
+{
+    check_direct_read("read_file_via_ctx: 256 columns round-trip intact", 256,
+        0);
+}
+
+/* 257 is the exact overflow boundary -- one int64_t past the buffer. */
+static void
+test_direct_257(void)
+{
+    check_direct_read("read_file_via_ctx: 257 columns round-trip intact", 257,
+        0);
+}
+
+/* Proof the ceiling is removed rather than moved. */
+static void
+test_direct_300(void)
+{
+    check_direct_read("read_file_via_ctx: 300 columns round-trip intact", 300,
+        0);
+}
+
+/* The string-aware parser is selected when *any* column is a symbol, so
+ * a mostly-integer wide relation takes the same path. */
+static void
+test_direct_260_mixed(void)
+{
+    check_direct_read(
+        "read_file_via_ctx: 260 mixed int/symbol columns round-trip intact",
+        260, 1);
+}
+
+/* ======================================================================== */
+/* Cases 5-6: the .input directive path through the real pipeline           */
+/* ======================================================================== */
+
+/*
+ * This is the path the overflow was first reported on: csv_read ->
+ * wl_csv_read_file_via_ctx -> csv_parse_line_via_ctx, beneath
+ * wl_session_load_input_files.  Before the fix the 257- and 300-column
+ * cases abort here under ASan; after it they must load cleanly.
+ */
+static void
+check_pipeline_load(const char *label, int ncols, int mixed)
+{
+    TEST(label);
+
+    static char src[WIDE_SRC_BUF];
+    static char csv[WIDE_CSV_BUF];
+    char csv_path[512];
+    char out_path[512];
+    char name[64];
+    char fixture[128];
+    size_t off = 0;
+
+    snprintf(name, sizeof(name), "wide%s%d", mixed ? "mix" : "", ncols);
+    snprintf(fixture, sizeof(fixture), "wl997_%s.csv", name);
+    test_tmppath(csv_path, sizeof(csv_path), fixture);
+    snprintf(fixture, sizeof(fixture), "wl997_%s_out.txt", name);
+    test_tmppath(out_path, sizeof(out_path), fixture);
+
+    if (build_wide_csv(csv, sizeof(csv), ncols, mixed, 2) != 0) {
+        FAIL("csv fixture buffer too small");
+        return;
+    }
+    if (build_wide_decl(src, sizeof(src), &off, name, ncols, mixed) != 0
+        || appendf(src, sizeof(src), &off,
+        ".input %s(filename=\"%s\", delimiter=\",\")\n", name, csv_path)
+        != 0) {
+        FAIL("source buffer too small");
+        return;
+    }
+    if (write_text_file(csv_path, csv) != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    char *output = NULL;
+    int rc = run_pipeline_capture(src, out_path, &output);
+    free(output);
+
+    remove(csv_path);
+    remove(out_path);
+
+    if (rc != 0) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "wl_run_pipeline returned %d for %d columns",
+            rc, ncols);
+        FAIL(msg);
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_pipeline_257(void)
+{
+    check_pipeline_load(".input: 257 symbol columns load without overflow",
+        257, 0);
+}
+
+static void
+test_pipeline_300(void)
+{
+    check_pipeline_load(".input: 300 symbol columns load", 300, 0);
+}
+
+/* ======================================================================== */
+/* Case 7: the public API entry -- wirelog_load_facts_from_csv()            */
+/* ======================================================================== */
+
+/*
+ * api_facade.c forwards rel->column_count into wl_csv_read_file_ex()
+ * unchecked, so an embedder reaches the same overflow with no .input
+ * directive and no Datalog rules involved.  The relation is declared
+ * without .input so the load under test is the explicit public call and
+ * not the executor's eager seeding.
+ */
+static void
+test_public_api_wide_csv(void)
+{
+    TEST("wirelog_load_facts_from_csv: 260-column relation");
+
+    static char src[WIDE_SRC_BUF];
+    static char csv[WIDE_CSV_BUF];
+    const int ncols = 260;
+    const int nrows = 4;
+    char csv_path[512];
+    size_t off = 0;
+
+    test_tmppath(csv_path, sizeof(csv_path), "wl997_public_api.csv");
+
+    if (build_wide_csv(csv, sizeof(csv), ncols, 0, nrows) != 0) {
+        FAIL("csv fixture buffer too small");
+        return;
+    }
+    if (build_wide_decl(src, sizeof(src), &off, "wideapi", ncols, 0) != 0) {
+        FAIL("source buffer too small");
+        return;
+    }
+    if (write_text_file(csv_path, csv) != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        remove(csv_path);
+        FAIL("wirelog_parse_string failed");
+        return;
+    }
+
+    wirelog_executor_t *exec = wirelog_executor_create(prog, &err);
+    if (!exec) {
+        wirelog_program_free(prog);
+        remove(csv_path);
+        FAIL("wirelog_executor_create failed");
+        return;
+    }
+
+    bool ok = wirelog_load_facts_from_csv(exec, "wideapi", csv_path, &err);
+    remove(csv_path);
+
+    wirelog_executor_free(exec);
+    wirelog_program_free(prog);
+
+    if (!ok) {
+        FAIL("wirelog_load_facts_from_csv returned false");
+        return;
+    }
+
+    PASS();
+}
+
+/* ======================================================================== */
+/* Case 8: the capacity parameter itself rejects an undersized buffer       */
+/* ======================================================================== */
+
+/*
+ * Direct cover for the bound that replaced the silent overflow: asking
+ * for more columns than the output buffer holds must be refused, exactly
+ * as wl_csv_parse_line() has always refused it with -2.
+ */
+static void
+test_parse_line_ex_capacity_guard(void)
+{
+    TEST("parse_line_ex: num_cols beyond the buffer capacity is rejected");
+
+    wl_intern_t *intern = wl_intern_create();
+    if (!intern) {
+        FAIL("intern create failed");
+        return;
+    }
+
+    wirelog_column_type_t types[4] = { WIRELOG_TYPE_STRING,
+                                       WIRELOG_TYPE_STRING, WIRELOG_TYPE_STRING,
+                                       WIRELOG_TYPE_STRING };
+    int64_t values[2];
+    uint32_t count = 0;
+
+    int rc = wl_csv_parse_line_ex("a,b,c,d", ',', types, 4, values, 2, &count,
+            intern);
+    if (rc != -2) {
+        char msg[96];
+        snprintf(msg, sizeof(msg), "expected -2 for capacity overrun, got %d",
+            rc);
+        wl_intern_free(intern);
+        FAIL(msg);
+        return;
+    }
+
+    /* An exactly-fitting width must still succeed. */
+    rc = wl_csv_parse_line_ex("a,b", ',', types, 2, values, 2, &count, intern);
+    if (rc != 0 || count != 2) {
+        wl_intern_free(intern);
+        FAIL("exact-capacity parse should succeed");
+        return;
+    }
+
+    wl_intern_free(intern);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    /* Unbuffered: an ASan abort mid-suite must not swallow the progress
+     * printed so far, which is what identifies the failing case. */
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    printf("=== test_csv_wide_columns (Issue #997) ===\n");
+
+    test_direct_256();
+    test_direct_257();
+    test_direct_300();
+    test_direct_260_mixed();
+    test_pipeline_257();
+    test_pipeline_300();
+    test_public_api_wide_csv();
+    test_parse_line_ex_capacity_guard();
+
+    printf("\n=== Results: %d run, %d passed, %d failed ===\n", tests_run,
+        tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/wirelog/io/csv_reader.c
+++ b/wirelog/io/csv_reader.c
@@ -71,6 +71,14 @@ wl_csv_parse_line(const char *line, char delimiter, int64_t *values,
 
 /* Initial capacity for row buffer */
 #define CSV_INITIAL_CAPACITY 64
+/*
+ * Width cap for the integer-only reader below.  wl_csv_read_file()
+ * auto-detects its column count from the file's first line, so it has no
+ * expected width to size a buffer from and parses into a fixed frame
+ * array; wl_csv_parse_line() bounds the writes with -2.  The
+ * string-aware reader is told its width by the caller and sizes its row
+ * buffer from it, so it is not subject to this cap (#997).
+ */
 #define CSV_MAX_COLS 256
 #define CSV_LINE_BUF 4096
 
@@ -156,99 +164,33 @@ wl_csv_read_file(const char *path, char delimiter, int64_t **data,
 }
 
 /* ======================================================================== */
-/* Extended Line Parser (mixed int/string)                                  */
-/* ======================================================================== */
-
-int
-wl_csv_parse_line_ex(const char *line, char delimiter,
-    const wirelog_column_type_t *col_types, uint32_t num_cols,
-    int64_t *values, uint32_t *count, wl_intern_t *intern)
-{
-    if (!line || !col_types || !values || !count || num_cols == 0)
-        return -1;
-
-    *count = 0;
-    const char *p = line;
-
-    for (uint32_t col = 0; col < num_cols; col++) {
-        /* Skip leading whitespace */
-        while (*p && *p != delimiter && *p != '"' && isspace((unsigned char)*p))
-            p++;
-
-        if (*p == '\0' && col < num_cols - 1)
-            return -2; /* too few columns */
-
-        if (col_types[col] == WIRELOG_TYPE_STRING) {
-            /* Parse string field: quoted or unquoted */
-            char strbuf[4096];
-            size_t slen = 0;
-
-            if (*p == '"') {
-                /* Quoted field: read until closing quote */
-                p++; /* skip opening quote */
-                while (*p && *p != '"') {
-                    if (slen < sizeof(strbuf) - 1)
-                        strbuf[slen++] = *p;
-                    p++;
-                }
-                if (*p == '"')
-                    p++; /* skip closing quote */
-            } else {
-                /* Unquoted field: read until delimiter or end */
-                while (*p && *p != delimiter && *p != '\n' && *p != '\r') {
-                    if (slen < sizeof(strbuf) - 1)
-                        strbuf[slen++] = *p;
-                    p++;
-                }
-                /* Trim trailing whitespace */
-                while (slen > 0 && isspace((unsigned char)strbuf[slen - 1]))
-                    slen--;
-            }
-            strbuf[slen] = '\0';
-
-            if (!intern)
-                return -1;
-            values[col] = wl_intern_put(intern, strbuf);
-            if (values[col] < 0)
-                return -1;
-        } else {
-            /* Parse integer field */
-            char *end;
-            values[col] = strtoll(p, &end, 10);
-            if (end == p)
-                return -1; /* not a valid integer */
-            p = end;
-
-            /* Skip trailing whitespace */
-            while (*p && *p != delimiter && isspace((unsigned char)*p))
-                p++;
-        }
-
-        (*count)++;
-
-        /* Skip delimiter between fields */
-        if (col < num_cols - 1) {
-            if (*p == delimiter)
-                p++;
-        }
-    }
-
-    return 0;
-}
-
-/* ======================================================================== */
 /* Callback-based line parser (internal)                                    */
 /* ======================================================================== */
 
+/*
+ * The single implementation of the string-aware line parser.
+ * wl_csv_parse_line_ex() below is a thin wrapper over it; the two used to
+ * be near-identical copies, and the capacity check added for #997 had to
+ * exist in both or neither, so they are now one body.
+ *
+ * @max_cols is the capacity of @values.  Writing @num_cols cells into a
+ * buffer that does not hold them is what #997 was: the caller's declared
+ * width was trusted with no bound, overflowing a fixed 256-entry frame
+ * array.  The bound lives here, at the write site, mirroring
+ * wl_csv_parse_line().
+ */
 static int
 csv_parse_line_via_ctx(const char *line, char delimiter,
     const wirelog_column_type_t *col_types, uint32_t num_cols,
-    int64_t *values, uint32_t *count,
+    int64_t *values, uint32_t max_cols, uint32_t *count,
     int64_t (*intern_cb)(void *opaque, const char *str),
     void *opaque)
 {
     if (!line || !col_types || !values || !count || num_cols == 0 || !intern_cb)
         return -1;
+
+    if (num_cols > max_cols)
+        return -2; /* too many columns for the output buffer */
 
     *count = 0;
     const char *p = line;
@@ -317,6 +259,31 @@ csv_parse_line_via_ctx(const char *line, char delimiter,
     return 0;
 }
 
+/* Adapts the intern-table API to the callback the parser expects. */
+static int64_t
+intern_trampoline(void *opaque, const char *str)
+{
+    return wl_intern_put((wl_intern_t *)opaque, str);
+}
+
+/* ======================================================================== */
+/* Extended Line Parser (mixed int/string)                                  */
+/* ======================================================================== */
+
+int
+wl_csv_parse_line_ex(const char *line, char delimiter,
+    const wirelog_column_type_t *col_types, uint32_t num_cols,
+    int64_t *values, uint32_t max_cols, uint32_t *count, wl_intern_t *intern)
+{
+    /*
+     * A NULL @intern is only an error once a STRING column is actually
+     * reached: wl_intern_put(NULL, ...) returns -1, which the parser
+     * reports as -1.  All-integer column sets stay legal without one.
+     */
+    return csv_parse_line_via_ctx(line, delimiter, col_types, num_cols, values,
+               max_cols, count, intern_trampoline, intern);
+}
+
 /* ======================================================================== */
 /* Callback-based File Reader (#455)                                        */
 /* ======================================================================== */
@@ -353,6 +320,21 @@ wl_csv_read_file_via_ctx(
         return -3;
     }
 
+    /*
+     * One row buffer for the whole file, sized to the caller's real
+     * width.  It used to be a fixed int64_t[256] declared inside the
+     * loop, which the parser wrote past for any relation wider than that
+     * (#997).  Allocating per line instead would be visible on the DOOP
+     * load path, which streams ~760 MB through here.
+     */
+    int64_t *row_values = (int64_t *)malloc((size_t)num_cols
+            * sizeof(int64_t));
+    if (!row_values) {
+        free(buf);
+        fclose(f);
+        return -3;
+    }
+
     char line[CSV_LINE_BUF];
     while (fgets(line, sizeof(line), f)) {
         /* Strip trailing newline */
@@ -364,12 +346,12 @@ wl_csv_read_file_via_ctx(
         if (len == 0)
             continue;
 
-        int64_t row_values[CSV_MAX_COLS];
         uint32_t col_count = 0;
         int rc = csv_parse_line_via_ctx(line, delimiter, col_types, num_cols,
-                row_values, &col_count,
+                row_values, num_cols, &col_count,
                 intern_cb, opaque);
         if (rc != 0 || col_count != num_cols) {
+            free(row_values);
             free(buf);
             fclose(f);
             return -2;
@@ -381,6 +363,7 @@ wl_csv_read_file_via_ctx(
             int64_t *tmp = (int64_t *)realloc(buf, (size_t)capacity * num_cols
                     * sizeof(int64_t));
             if (!tmp) {
+                free(row_values);
                 free(buf);
                 fclose(f);
                 return -3;
@@ -394,6 +377,7 @@ wl_csv_read_file_via_ctx(
         (*out_nrows)++;
     }
 
+    free(row_values);
     fclose(f);
 
     *out_data = buf;
@@ -403,13 +387,6 @@ wl_csv_read_file_via_ctx(
 /* ======================================================================== */
 /* Extended File Reader -- thin wrapper over via_ctx                         */
 /* ======================================================================== */
-
-/* Trampoline for backward compatibility */
-static int64_t
-intern_trampoline(void *opaque, const char *str)
-{
-    return wl_intern_put((wl_intern_t *)opaque, str);
-}
 
 int
 wl_csv_read_file_ex(const char *path, char delimiter,

--- a/wirelog/io/csv_reader.h
+++ b/wirelog/io/csv_reader.h
@@ -64,7 +64,9 @@ wl_csv_read_file(const char *path, char delimiter, int64_t **data,
  * @delimiter: Field separator character.
  * @col_types: Array of column types (STRING columns are interned).
  * @num_cols:  Number of columns expected (length of @col_types).
- * @values:    Output buffer for parsed int64_t values (length >= @num_cols).
+ * @values:    Output buffer for parsed int64_t values.
+ * @max_cols:  Capacity of @values.  @num_cols > @max_cols is rejected
+ *             rather than written past (#997), as in wl_csv_parse_line().
  * @count:     (out) Number of values parsed.
  * @intern:    Intern table for string columns (must not be NULL if any
  *             column is STRING).
@@ -74,15 +76,18 @@ wl_csv_read_file(const char *path, char delimiter, int64_t **data,
  * stored as int64_t IDs.  Quoted strings (double-quote delimited) are
  * supported; quotes are stripped before interning.
  *
+ * There is no upper bound on @num_cols beyond the buffer the caller
+ * supplies.
+ *
  * Returns:
  *    0: Success.
  *   -1: Invalid arguments or parse error.
- *   -2: Column count mismatch.
+ *   -2: Column count mismatch, or @num_cols exceeds @max_cols.
  */
 int
 wl_csv_parse_line_ex(const char *line, char delimiter,
     const wirelog_column_type_t *col_types, uint32_t num_cols,
-    int64_t *values, uint32_t *count, wl_intern_t *intern);
+    int64_t *values, uint32_t max_cols, uint32_t *count, wl_intern_t *intern);
 
 /**
  * wl_csv_read_file_ex:
@@ -98,6 +103,10 @@ wl_csv_parse_line_ex(const char *line, char delimiter,
  * Read a CSV file with mixed integer and string columns. String columns
  * are interned; integer columns are parsed as int64_t. All non-empty lines
  * must have exactly @num_cols fields.
+ *
+ * @num_cols is not capped: the row buffer is sized from it once per file
+ * (#997).  Contrast wl_csv_read_file(), which auto-detects its width and
+ * therefore still parses into a fixed 256-column frame array.
  *
  * Returns:
  *    0: Success.


### PR DESCRIPTION
Closes #997.

## The bug

`csv_parse_line_via_ctx` wrote `values[col]` in a loop bounded by the caller's `num_cols`, with **no capacity check**, into a fixed `int64_t row_values[256]`. A relation with 257+ columns, at least one a string, overflowed the caller's stack frame.

```
ERROR: AddressSanitizer: stack-buffer-overflow, WRITE of size 8
  #0 csv_parse_line_via_ctx   io/csv_reader.c
  #1 wl_csv_read_file_via_ctx
  #2 csv_read                 io/csv_adapter.c
  #3 wl_session_load_input_files
[160, 2208) 'row_values' <== Memory access at offset 2208
```

Boundary exact: **256 clean, 257 overflows**. Reachable from a plain `.dl` file with an ordinary ~1500-byte line — nothing about the data is unusual.

The integer-only path was never affected — `wl_csv_parse_line` takes `max_cols` and returns `-2`. The string path simply lost that check.

## Entry points closed

| entry | note |
|---|---|
| direct reader | |
| `.input` → `csv_read` → `wl_session_load_input_files` | the reported stack |
| `wirelog_load_facts_from_csv` | **public API** |
| `wl_csv_parse_line_ex` | called directly |
| a third-party I/O adapter re-entering the CSV adapter | `io_adapter.h` is installed and `wirelog_io_find_adapter` is exported |
| **`wirelog_executor_create()`** | eagerly calls `wl_session_load_input_files`, so an embedder reached this **by creating an executor at all** |

The last two widen the blast radius beyond what the issue recorded.

## The fix

`csv_parse_line_via_ctx` takes `max_cols` and rejects `num_cols > max_cols` before writing — the bound is at the write site, not in the caller. `wl_csv_read_file_via_ctx` heap-allocates `row_values` **once per file**; measured at exactly one extra `malloc` regardless of row count (13 → 14 for one line, 7,989 → 7,990 for 100,000).

**This removes the 256-column ceiling rather than tightening it.** A 300-column symbol relation now loads, verified cell by cell.

`wl_csv_parse_line_ex` was a near-duplicate, so the check had to land in both copies or neither. It is now a one-line delegation, deleting ~75 lines. Verified behaviour-preserving by diffing both bodies — they differed only in the signature, the new guard, and NULL-intern handling. All-integer column sets remain legal without an intern table, the case that would otherwise have changed silently.

## Tests

`tests/test_csv_wide_columns.c` — direct reader at 256/257/300 and a 260-column mixed int/string case with **every cell resolved back to source text**, the `.input` pipeline at 257 and 300, the public API path, and the capacity guard directly.

Contents are asserted, not row counts — confirmed necessary by mutating a single cell's value, which the count-based version would have missed.

| mutation | result |
|---|---|
| revert bound only | fails only the `parse_line_ex` case — correct, the reader always passes `max_cols == num_cols` |
| revert heap alloc only | fails six cases with plain return-code assertions, **no sanitizer needed** |
| revert both | every entry point aborts |

**The fuzz harness had zero coverage of this.** It passed `num_cols` and `max_cols` as the same literal, making the new bound statically unreachable — and width was never fuzzed before either, which is plausibly how the original overflow survived. `num_cols` is now drawn from the input against a fixed four-entry buffer so both sides of the guard are reached.

## Validation

Suite **265 Ok / 1 Fail / 11 Skipped** (was 264; +1 is the new test), the failure being the pre-existing `sbom_snapshot`. ASAN+UBSAN with `detect_leaks=1`: zero reports across all 277 tests. Every one of the five exits from `wl_csv_read_file_via_ctx` exercised with forced `malloc`/`realloc` failure — no leaks. `malloc(0)` unreachable (`num_cols == 0` rejected earlier).

DOOP load path (`Var-DeclaringMethod.facts`, 164 MB, 884,609 lines): 1.074 s → 1.056 s. Note that is *not* "the parser got faster" — an isolated parser benchmark shows +5.5–6.4% at 8 columns and neutral-to-faster at 4. DOOP relations are 2–5 columns, the band where this is neutral.

## Relationship to #1000

Does **not** address it, and does not worsen it. #1000 — any rule over a relation wider than 32 columns overflows `COL_STACK_MAX`-sized buffers and aborts with `stack smashing detected` in a release build — is independently reachable on unfixed `main`: a 33-column all-`int32` relation loads through the *integer* CSV path (33 < 256, untouched by this bug) and aborts. Base and fixed release builds give identical `0 / 134 / 134` at 32 / 33 / 300 columns.

So for the 33–256 band this change trades silent stack corruption in the loader for fail-fast in the evaluator. A review sweep found **13** unguarded row-width buffers across `columnar/ops.c` and `columnar/mobius.c`, recorded on #1000.
