### PR TITLE
fix(columnar): size row buffers by the relation width, not COL_STACK_MAX

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4643,7 +4643,33 @@ test_csv_wide_columns_exe = executable(
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
   install: false,
 )
+
+# ============================================================================
+# Wide-Relation Row Buffer Tests (#1000)
+# Every columnar operator copies rows through an int64_t[COL_STACK_MAX]
+# buffer but fills it at the relation's width, so relations wider than 32
+# columns smash the stack (SIGABRT in release, not just an ASan report).
+# One rule shape per operator kind at widths 32 / 33 / 200.
+# ============================================================================
+
+test_wide_relation_exe = executable(
+  'test_wide_relation',
+  files('test_wide_relation.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  driver_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+  install: false,
+)
 test('csv_wide_columns', test_csv_wide_columns_exe)
+test('wide_relation', test_wide_relation_exe, timeout: 120)
 
 # ============================================================================
 # Concurrent I/O Adapter Registry Stress Test (#459)

--- a/tests/test_mobius_delta_formula.c
+++ b/tests/test_mobius_delta_formula.c
@@ -377,12 +377,77 @@ test_key_vanishes(void)
     PASS();
 }
 
+/* ================================================================
+ * Test 5: relations wider than COL_STACK_MAX (Issue #1000)
+ *
+ * Both passes of col_compute_delta_mobius copied rows into an
+ * int64_t[COL_STACK_MAX] (32) and filled them at the relation's width, so
+ * a 33-column collection overflowed all four buffers.  The function has
+ * no caller outside the test suite, so no .dl program reaches it and the
+ * width guard can only be exercised here.
+ *
+ * prev: key 1 (mult 2), key 2 (mult 4)     [33 columns]
+ * curr: key 1 (mult 5), key 3 (mult 7)     [33 columns]
+ *
+ * Expected delta, in emission order (pass 1 over curr, then pass 2 over
+ * prev): key 1 -> +3 (5 - 2), key 3 -> +7 (new), key 2 -> -4 (vanished).
+ * ================================================================ */
+#define WIDE_NCOLS 33u
+
+static void
+test_wide_relation_delta(void)
+{
+    TEST("33-column delta does not overflow the row buffers (#1000)");
+
+    col_rel_t *prev = test_rel_alloc(WIDE_NCOLS);
+    col_rel_t *curr = test_rel_alloc(WIDE_NCOLS);
+    col_rel_t *delta = test_rel_alloc(WIDE_NCOLS);
+    ASSERT(prev && curr && delta, "test_rel_alloc failed");
+
+    int64_t rows[3][WIDE_NCOLS];
+    for (uint32_t k = 0; k < 3; k++) {
+        for (uint32_t c = 0; c < WIDE_NCOLS; c++)
+            rows[k][c] = (c == 0) ? (int64_t)(k + 1u)
+                                  : (int64_t)(1000u * (k + 1u) + c);
+    }
+
+    ASSERT(test_rel_append_row_mult(prev, rows[0], 2) == 0, "prev key1 mult=2");
+    ASSERT(test_rel_append_row_mult(prev, rows[1], 4) == 0, "prev key2 mult=4");
+    ASSERT(test_rel_append_row_mult(curr, rows[0], 5) == 0, "curr key1 mult=5");
+    ASSERT(test_rel_append_row_mult(curr, rows[2], 7) == 0, "curr key3 mult=7");
+
+    int rc = col_compute_delta_mobius(prev, curr, delta);
+
+    ASSERT(rc == 0, "returns 0 on success");
+    ASSERT(delta->nrows == 3, "delta->nrows == 3");
+    ASSERT(delta->timestamps != NULL, "delta->timestamps is non-NULL");
+
+    static const int64_t expect_mult[3] = { 3, 7, -4 };
+    static const uint32_t expect_src[3] = { 0u, 2u, 1u };
+    for (uint32_t i = 0; i < 3; i++) {
+        ASSERT(delta->timestamps[i].multiplicity == expect_mult[i],
+            "delta multiplicity matches");
+        for (uint32_t c = 0; c < WIDE_NCOLS; c++)
+            ASSERT(col_rel_get(delta, i, c) == rows[expect_src[i]][c],
+                "every column of the delta row is intact");
+    }
+
+    test_rel_free(prev);
+    test_rel_free(curr);
+    test_rel_free(delta);
+    PASS();
+}
+
 /* ----------------------------------------------------------------
  * main
  * ---------------------------------------------------------------- */
 int
 main(void)
 {
+    /* Line-buffered: a row-buffer overflow aborts the process, and a fully
+     * buffered stdout would discard the name of the case that crashed. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
     printf("=== test_mobius_delta_formula (TDD RED PHASE) ===\n\n");
     printf(
         "NOTE: Expected to FAIL at link time until col_compute_delta_mobius\n");
@@ -392,6 +457,7 @@ main(void)
     test_collection_shrinks();
     test_new_key_appears();
     test_key_vanishes();
+    test_wide_relation_delta();
 
     printf("\n=== Results: %d passed, %d failed (of %d) ===\n", pass_count,
         fail_count, test_count);

--- a/tests/test_mobius_delta_formula.c
+++ b/tests/test_mobius_delta_formula.c
@@ -444,9 +444,14 @@ test_wide_relation_delta(void)
 int
 main(void)
 {
-    /* Line-buffered: a row-buffer overflow aborts the process, and a fully
-     * buffered stdout would discard the name of the case that crashed. */
-    setvbuf(stdout, NULL, _IOLBF, 0);
+    /* Unbuffered: a row-buffer overflow aborts the process, and a buffered
+     * stdout would discard the name of the case that crashed.  _IONBF is the
+     * only portable spelling: MSVC's UCRT rejects a size of 0 for _IOLBF and
+     * _IOFBF through the invalid-parameter handler, which terminates the
+     * process with 0xC0000409 -- an exit code that reads as a stack-cookie
+     * failure but is not one.  Win32 also maps _IOLBF onto full buffering,
+     * so it would not have flushed per line even where it was accepted. */
+    setvbuf(stdout, NULL, _IONBF, 0);
 
     printf("=== test_mobius_delta_formula (TDD RED PHASE) ===\n\n");
     printf(

--- a/tests/test_mobius_join_weighted.c
+++ b/tests/test_mobius_join_weighted.c
@@ -445,9 +445,14 @@ test_wide_relation_join(void)
 int
 main(void)
 {
-    /* Line-buffered: a row-buffer overflow aborts the process, and a fully
-     * buffered stdout would discard the name of the case that crashed. */
-    setvbuf(stdout, NULL, _IOLBF, 0);
+    /* Unbuffered: a row-buffer overflow aborts the process, and a buffered
+     * stdout would discard the name of the case that crashed.  _IONBF is the
+     * only portable spelling: MSVC's UCRT rejects a size of 0 for _IOLBF and
+     * _IOFBF through the invalid-parameter handler, which terminates the
+     * process with 0xC0000409 -- an exit code that reads as a stack-cookie
+     * failure but is not one.  Win32 also maps _IOLBF onto full buffering,
+     * so it would not have flushed per line even where it was accepted. */
+    setvbuf(stdout, NULL, _IONBF, 0);
 
     printf("=== test_mobius_join_weighted (TDD RED PHASE) ===\n\n");
     printf("NOTE: Expected to FAIL at link time until col_op_join_weighted\n");

--- a/tests/test_mobius_join_weighted.c
+++ b/tests/test_mobius_join_weighted.c
@@ -381,12 +381,74 @@ test_output_multiplicity_is_product(void)
     PASS();
 }
 
+/* ================================================================
+ * Test 4: relations wider than COL_STACK_MAX (Issue #1000)
+ *
+ * col_op_join_weighted copied both the left and the right row into an
+ * int64_t[COL_STACK_MAX] (32) and filled it at the relation's width, so
+ * a join over relations of 33 columns wrote past both buffers.  There is
+ * no .dl program that reaches this function -- it has no caller outside
+ * the test suite -- so the width guard can only be exercised here.
+ *
+ * lhs: 1 row (0, 1, .., 32) mult=2      [33 columns]
+ * rhs: 1 row (0, 100, .., 131) mult=3   [33 columns]
+ * key: column 0 (== 0 in both)
+ *
+ * Expected: one output row of 66 columns, lhs columns then rhs columns,
+ * with multiplicity 6.
+ * ================================================================ */
+#define WIDE_NCOLS 33u
+
+static void
+test_wide_relation_join(void)
+{
+    TEST("33-column JOIN does not overflow the row buffers (#1000)");
+
+    col_rel_t *lhs = test_rel_alloc(WIDE_NCOLS);
+    col_rel_t *rhs = test_rel_alloc(WIDE_NCOLS);
+    col_rel_t *dst = test_rel_alloc(0); /* ncols set by join */
+    ASSERT(lhs && rhs && dst, "test_rel_alloc failed");
+
+    int64_t lrow[WIDE_NCOLS];
+    int64_t rrow[WIDE_NCOLS];
+    for (uint32_t c = 0; c < WIDE_NCOLS; c++) {
+        lrow[c] = (int64_t)c;
+        rrow[c] = (c == 0) ? 0 : (int64_t)(100u + c - 1u);
+    }
+    ASSERT(test_rel_append_row_mult(lhs, lrow, 2) == 0, "append lhs row");
+    ASSERT(test_rel_append_row_mult(rhs, rrow, 3) == 0, "append rhs row");
+
+    int rc = col_op_join_weighted(lhs, rhs, 0, dst);
+
+    ASSERT(rc == 0, "returns 0 on success");
+    ASSERT(dst->ncols == 2u * WIDE_NCOLS, "dst->ncols == 66");
+    ASSERT(dst->nrows == 1, "dst->nrows == 1 (one matching pair)");
+    ASSERT(dst->timestamps != NULL, "dst->timestamps is non-NULL");
+    ASSERT(dst->timestamps[0].multiplicity == 6, "output mult == 6 (2 * 3)");
+
+    for (uint32_t c = 0; c < WIDE_NCOLS; c++) {
+        ASSERT(col_rel_get(dst, 0, c) == lrow[c],
+            "left half of the joined row is intact");
+        ASSERT(col_rel_get(dst, 0, WIDE_NCOLS + c) == rrow[c],
+            "right half of the joined row is intact");
+    }
+
+    test_rel_free(lhs);
+    test_rel_free(rhs);
+    test_rel_free(dst);
+    PASS();
+}
+
 /* ----------------------------------------------------------------
  * main
  * ---------------------------------------------------------------- */
 int
 main(void)
 {
+    /* Line-buffered: a row-buffer overflow aborts the process, and a fully
+     * buffered stdout would discard the name of the case that crashed. */
+    setvbuf(stdout, NULL, _IOLBF, 0);
+
     printf("=== test_mobius_join_weighted (TDD RED PHASE) ===\n\n");
     printf("NOTE: Expected to FAIL at link time until col_op_join_weighted\n");
     printf("      is implemented with extern linkage.\n\n");
@@ -394,6 +456,7 @@ main(void)
     test_simple_join_mult_multiply();
     test_multiple_keys_different_mults();
     test_output_multiplicity_is_product();
+    test_wide_relation_join();
 
     printf("\n=== Results: %d passed, %d failed (of %d) ===\n", pass_count,
         fail_count, test_count);

--- a/tests/test_wide_relation.c
+++ b/tests/test_wide_relation.c
@@ -1,0 +1,744 @@
+/*
+ * test_wide_relation.c - relations wider than COL_STACK_MAX (Issue #1000)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * The columnar operators copy a row into a fixed
+ * `int64_t buf[COL_STACK_MAX]` (32) and then fill it at the *relation's*
+ * width via col_rel_row_copy_out().  Any relation wider than 32 columns
+ * therefore writes past the end of the buffer: `stack-buffer-overflow`
+ * under ASan and `*** stack smashing detected ***` (SIGABRT, rc 134) in a
+ * plain release build, so a sanitizer-only test would miss a regression in
+ * the shipping configuration.
+ *
+ * These tests drive the real pipeline (parse -> optimize -> plan ->
+ * evaluate) through wl_run_pipeline, one rule shape per operator kind, and
+ * assert the *correct tuples* rather than merely a clean exit.  Every shape
+ * runs at three widths with the same expected answer:
+ *
+ *   32  - the boundary that is correct today (positive control)
+ *   33  - one past the boundary (the reported reproducer)
+ *   200 - well past it, to catch an off-by-one in the new bound
+ *
+ * Note that the effective limit is the width of the *intermediate*
+ * relation, not the declared width: an unprojected join materialises
+ * lhs->ncols + rhs->ncols columns, so a join chain overflows below the
+ * declared 32-column boundary.
+ */
+
+#include "../wirelog/cli/driver.h"
+
+#include "test_tmpdir.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef _WIN32
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+/* ======================================================================== */
+/* Test Helpers                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+static int tests_skipped = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
+
+#define SKIP(msg)                         \
+        do {                                  \
+            tests_skipped++;                  \
+            printf(" ... SKIP: %s\n", (msg)); \
+        } while (0)
+
+/* --- growable string buffer for generating wide Datalog sources ---------- */
+
+typedef struct {
+    char *data;
+    size_t len;
+    size_t cap;
+    int oom;
+} sbuf_t;
+
+static void
+sb_init(sbuf_t *s)
+{
+    s->data = NULL;
+    s->len = 0;
+    s->cap = 0;
+    s->oom = 0;
+}
+
+static void
+sb_free(sbuf_t *s)
+{
+    free(s->data);
+    sb_init(s);
+}
+
+static void
+sb_reserve(sbuf_t *s, size_t extra)
+{
+    if (s->oom)
+        return;
+    if (s->len + extra + 1 <= s->cap)
+        return;
+    size_t cap = s->cap ? s->cap : 1024;
+    while (cap < s->len + extra + 1)
+        cap *= 2;
+    char *p = (char *)realloc(s->data, cap);
+    if (!p) {
+        s->oom = 1;
+        return;
+    }
+    s->data = p;
+    s->cap = cap;
+}
+
+static void
+sb_puts(sbuf_t *s, const char *text)
+{
+    size_t n = strlen(text);
+    sb_reserve(s, n);
+    if (s->oom)
+        return;
+    memcpy(s->data + s->len, text, n);
+    s->len += n;
+    s->data[s->len] = '\0';
+}
+
+static void
+sb_printf(sbuf_t *s, const char *fmt, ...)
+{
+    char tmp[512];
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(tmp, sizeof(tmp), fmt, ap);
+    va_end(ap);
+    if (n < 0 || (size_t)n >= sizeof(tmp)) {
+        s->oom = 1;
+        return;
+    }
+    sb_puts(s, tmp);
+}
+
+/* ".decl name(c0: int64, ..., c{n-1}: int64)\n" */
+static void
+sb_decl(sbuf_t *s, const char *name, unsigned n)
+{
+    sb_printf(s, ".decl %s(", name);
+    for (unsigned i = 0; i < n; i++)
+        sb_printf(s, "%sc%u: int64", i ? ", " : "", i);
+    sb_puts(s, ")\n");
+}
+
+/* "name(base, base+1, ..., base+n-1).\n" */
+static void
+sb_fact_seq(sbuf_t *s, const char *name, long base, unsigned n)
+{
+    sb_printf(s, "%s(", name);
+    for (unsigned i = 0; i < n; i++)
+        sb_printf(s, "%s%ld", i ? ", " : "", base + (long)i);
+    sb_puts(s, ").\n");
+}
+
+/* "name(v0, v1, pad, pad, ..., pad).\n" */
+static void
+sb_fact_edge(sbuf_t *s, const char *name, long v0, long v1, unsigned n)
+{
+    sb_printf(s, "%s(%ld, %ld", name, v0, v1);
+    for (unsigned i = 2; i < n; i++)
+        sb_puts(s, ", 0");
+    sb_puts(s, ").\n");
+}
+
+/*
+ * Emit an argument list of n terms: "<prefix>0, <prefix>1, ...", with the
+ * entries listed in @over ("index=term" pairs, terminated by index == n)
+ * substituted.  Used to build wide rule bodies and heads.
+ */
+typedef struct {
+    unsigned index;
+    const char *term;
+} sb_override_t;
+
+static void
+sb_args(sbuf_t *s, const char *prefix, unsigned n, const sb_override_t *over,
+    unsigned over_count)
+{
+    for (unsigned i = 0; i < n; i++) {
+        const char *sub = NULL;
+        for (unsigned k = 0; k < over_count; k++) {
+            if (over[k].index == i) {
+                sub = over[k].term;
+                break;
+            }
+        }
+        if (i)
+            sb_puts(s, ", ");
+        if (sub)
+            sb_puts(s, sub);
+        else
+            sb_printf(s, "%s%u", prefix, i);
+    }
+}
+
+/*
+ * Run the full pipeline on @src, capturing printed tuples into a temp file.
+ * On success (*out_text != NULL) the caller must free(*out_text).
+ *
+ * The pre-fix failure is a SIGABRT from the stack protector, which would
+ * take the whole test binary down and hide every later case.  Where fork()
+ * is available the pipeline therefore runs in a child process, so a crash
+ * is reported as a failure of that one case (rc 128 + signal) and the
+ * remaining shapes still run.
+ *
+ * Returns 0 on success, 128 + signal if the child died on a signal, the
+ * pipeline's non-zero rc otherwise, or -999 on capture-file failure.
+ */
+static int
+run_pipeline_capture(const char *src, char **out_text)
+{
+    /* pid-suffixed: a fixed name collides when two copies of the suite run
+     * concurrently, which reproducibly failed most of the 18 pipeline cases
+     * when eight were run at once. */
+    char out_name[64];
+    snprintf(out_name, sizeof(out_name), "wl_wide_rel_out_%ld.txt",
+        (long)getpid());
+    char out_path[512];
+    test_tmppath(out_path, sizeof(out_path), out_name);
+
+    *out_text = NULL;
+
+#ifndef _WIN32
+    fflush(NULL);
+    pid_t pid = fork();
+    if (pid < 0)
+        return -999;
+    if (pid == 0) {
+        FILE *f = fopen(out_path, "w");
+        if (!f)
+            _exit(99);
+        int crc = wl_run_pipeline(src, 1, false, false, 0, f);
+        fclose(f);
+        /* exit(), not _exit(): _exit bypasses atexit, so LeakSanitizer
+         * never ran for any of the pipeline cases -- the clean
+         * detect_leaks=1 result came entirely from the other tests. */
+        exit(crc == 0 ? 0 : 1);
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0)
+        return -999;
+    int rc;
+    if (WIFSIGNALED(status))
+        rc = 128 + WTERMSIG(status);
+    else
+        rc = WIFEXITED(status) ? WEXITSTATUS(status) : -999;
+#else
+    FILE *f = fopen(out_path, "w");
+    if (!f)
+        return -999;
+    int rc = wl_run_pipeline(src, 1, false, false, 0, f);
+    fclose(f);
+#endif
+
+    *out_text = wl_read_file(out_path);
+    remove(out_path);
+    return rc;
+}
+
+static int
+count_substr(const char *hay, const char *needle)
+{
+    int count = 0;
+    const char *p = hay;
+    while (p && (p = strstr(p, needle)) != NULL) {
+        count++;
+        p++;
+    }
+    return count;
+}
+
+/*
+ * Shared checker: run @src and require that @prefix appears exactly
+ * @expect_count times and that every string in @expected appears exactly
+ * once.  Returns 0 on success; on failure fills @msg and returns -1.
+ */
+static int
+check_program(const char *src, const char *prefix, int expect_count,
+    const char *const *expected, size_t expected_count, char *msg,
+    size_t msg_size)
+{
+    char *output = NULL;
+    int rc = run_pipeline_capture(src, &output);
+
+    if (rc != 0) {
+        snprintf(msg, msg_size,
+            "wl_run_pipeline returned %d (134/SIGABRT = stack smashing)", rc);
+        free(output);
+        return -1;
+    }
+    if (!output) {
+        snprintf(msg, msg_size, "no output captured");
+        return -1;
+    }
+
+    int got = count_substr(output, prefix);
+    if (got != expect_count) {
+        snprintf(msg, msg_size, "expected %d '%s' tuples, got %d:\n%.800s",
+            expect_count, prefix, got, output);
+        free(output);
+        return -1;
+    }
+    for (size_t i = 0; i < expected_count; i++) {
+        if (count_substr(output, expected[i]) != 1) {
+            snprintf(msg, msg_size, "missing/duplicated tuple '%s' in:\n%.800s",
+                expected[i], output);
+            free(output);
+            return -1;
+        }
+    }
+    free(output);
+    return 0;
+}
+
+/* Widths every shape is exercised at: boundary, boundary+1, far past. */
+static const unsigned k_widths[] = { 32u, 33u, 200u };
+#define K_WIDTH_COUNT (sizeof(k_widths) / sizeof(k_widths[0]))
+
+/* ======================================================================== */
+/* Shape 1: MAP  (col_op_map)                                               */
+/* ======================================================================== */
+
+/*
+ *   .decl w(c0 .. c{n-1})
+ *   w(0, 1, .., n-1).  w(100, 101, .., 100+n-1).
+ *   o(v0) :- w(v0, .., v{n-1}).
+ *
+ * Reaches the per-row buffer in col_op_map -- the reported reproducer.
+ */
+static void
+build_map_src(sbuf_t *s, unsigned n)
+{
+    sb_decl(s, "w", n);
+    sb_puts(s, ".decl o(x: int64)\n.output o\n");
+    sb_fact_seq(s, "w", 0, n);
+    sb_fact_seq(s, "w", 100, n);
+    sb_puts(s, "o(v0) :- w(");
+    sb_args(s, "v", n, NULL, 0);
+    sb_puts(s, ").\n");
+}
+
+static void
+test_map_wide(void)
+{
+    static const char *const expected[] = { "o(0)", "o(100)" };
+
+    for (size_t i = 0; i < K_WIDTH_COUNT; i++) {
+        unsigned n = k_widths[i];
+        char name[128];
+        snprintf(name, sizeof(name), "MAP over %u-column relation", n);
+        TEST(name);
+
+        sbuf_t s;
+        sb_init(&s);
+        build_map_src(&s, n);
+        if (s.oom) {
+            sb_free(&s);
+            FAIL("source generation OOM");
+            continue;
+        }
+
+        char msg[1024];
+        if (check_program(s.data, "o(", 2, expected, 2, msg, sizeof(msg)) != 0)
+            FAIL(msg);
+        else
+            PASS();
+        sb_free(&s);
+    }
+}
+
+/* ======================================================================== */
+/* Shape 2: FILTER slow path  (col_op_filter, compiled-expression branch)   */
+/* ======================================================================== */
+
+/*
+ *   o(v0) :- w(v0, .., v{n-1}), v1 + v2 > 100.
+ *
+ * `v1 + v2 > 100` is not a simple column-vs-constant compare, so the
+ * fast path is skipped and the per-row buffer in the slow path is used.
+ */
+static void
+build_filter_src(sbuf_t *s, unsigned n)
+{
+    sb_decl(s, "w", n);
+    sb_puts(s, ".decl o(x: int64)\n.output o\n");
+    sb_fact_seq(s, "w", 0, n);
+    sb_fact_seq(s, "w", 100, n);
+    sb_puts(s, "o(v0) :- w(");
+    sb_args(s, "v", n, NULL, 0);
+    sb_puts(s, "), v1 + v2 > 100.\n");
+}
+
+static void
+test_filter_wide(void)
+{
+    static const char *const expected[] = { "o(100)" };
+
+    for (size_t i = 0; i < K_WIDTH_COUNT; i++) {
+        unsigned n = k_widths[i];
+        char name[128];
+        snprintf(name, sizeof(name), "FILTER (slow path) over %u columns", n);
+        TEST(name);
+
+        sbuf_t s;
+        sb_init(&s);
+        build_filter_src(&s, n);
+        if (s.oom) {
+            sb_free(&s);
+            FAIL("source generation OOM");
+            continue;
+        }
+
+        char msg[1024];
+        if (check_program(s.data, "o(", 1, expected, 1, msg, sizeof(msg)) != 0)
+            FAIL(msg);
+        else
+            PASS();
+        sb_free(&s);
+    }
+}
+
+/* ======================================================================== */
+/* Shapes 3 & 4: JOIN right-child filter  (fill_filtered_rel)              */
+/* ======================================================================== */
+
+/*
+ *   o(a, b) :- s(a), w(a, 1, b, v3, .., v{n-1}).           [const_count 1]
+ *   o(a, b) :- s(a), w(a, 1, b, 3, v4, .., v{n-1}).        [const_count 2]
+ *
+ * Constants inside the join's right atom are collected into
+ * op->right_filter_expr, which fill_filtered_rel applies over the *wide*
+ * right relation.  One constant is a simple compare (fast path); two
+ * constants form a conjunction and take the compiled-expression path.
+ */
+static void
+build_join_const_src(sbuf_t *s, unsigned n, unsigned const_count)
+{
+    sb_override_t over[4];
+    unsigned over_count = 0;
+    over[over_count].index = 0;
+    over[over_count++].term = "a";
+    over[over_count].index = 1;
+    over[over_count++].term = "1";
+    over[over_count].index = 2;
+    over[over_count++].term = "b";
+    if (const_count > 1) {
+        over[over_count].index = 3;
+        over[over_count++].term = "3";
+    }
+
+    sb_puts(s, ".decl s(x: int64)\n");
+    sb_decl(s, "w", n);
+    sb_puts(s, ".decl o(x: int64, y: int64)\n.output o\n");
+    sb_puts(s, "s(0). s(100).\n");
+    sb_fact_seq(s, "w", 0, n);
+    sb_fact_seq(s, "w", 100, n);
+    sb_puts(s, "o(a, b) :- s(a), w(");
+    sb_args(s, "v", n, over, over_count);
+    sb_puts(s, ").\n");
+}
+
+static void
+test_join_right_filter_wide(void)
+{
+    static const char *const expected[] = { "o(0, 2)" };
+
+    for (unsigned consts = 1; consts <= 2; consts++) {
+        for (size_t i = 0; i < K_WIDTH_COUNT; i++) {
+            unsigned n = k_widths[i];
+            char name[160];
+            snprintf(name, sizeof(name),
+                "JOIN right-child filter (%s path) over %u columns",
+                consts == 1 ? "fast" : "slow", n);
+            TEST(name);
+
+            sbuf_t s;
+            sb_init(&s);
+            build_join_const_src(&s, n, consts);
+            if (s.oom) {
+                sb_free(&s);
+                FAIL("source generation OOM");
+                continue;
+            }
+
+            char msg[1024];
+            if (check_program(s.data, "o(", 1, expected, 1, msg,
+                sizeof(msg)) != 0)
+                FAIL(msg);
+            else
+                PASS();
+            sb_free(&s);
+        }
+    }
+}
+
+/* ======================================================================== */
+/* Shape 5: REDUCE  (col_op_reduce)                                         */
+/* ======================================================================== */
+
+/*
+ *   w(0, 1, 2, .., n-1).  w(0, 5, 2, .., n-1).  w(7, 9, 2, .., n-1).
+ *   o(g, sum(v1)) :- w(g, v1, .., v{n-1}).
+ *
+ * Group-by on column 0 with a per-row buffer over the full input width.
+ */
+static void
+build_reduce_src(sbuf_t *s, unsigned n)
+{
+    sb_override_t over[1] = { { 0u, "g" } };
+
+    sb_decl(s, "w", n);
+    sb_puts(s, ".decl o(g: int64, t: int64)\n.output o\n");
+    for (unsigned r = 0; r < 3; r++) {
+        static const long head[3][2] = { { 0, 1 }, { 0, 5 }, { 7, 9 } };
+        sb_printf(s, "w(%ld, %ld", head[r][0], head[r][1]);
+        for (unsigned i = 2; i < n; i++)
+            sb_printf(s, ", %u", i);
+        sb_puts(s, ").\n");
+    }
+    sb_puts(s, "o(g, sum(v1)) :- w(");
+    sb_args(s, "v", n, over, 1);
+    sb_puts(s, ").\n");
+}
+
+static void
+test_reduce_wide(void)
+{
+    static const char *const expected[] = { "o(0, 6)", "o(7, 9)" };
+
+    for (size_t i = 0; i < K_WIDTH_COUNT; i++) {
+        unsigned n = k_widths[i];
+        char name[128];
+        snprintf(name, sizeof(name), "REDUCE (sum group-by) over %u columns",
+            n);
+        TEST(name);
+
+        sbuf_t s;
+        sb_init(&s);
+        build_reduce_src(&s, n);
+        if (s.oom) {
+            sb_free(&s);
+            FAIL("source generation OOM");
+            continue;
+        }
+
+        char msg[1024];
+        if (check_program(s.data, "o(", 2, expected, 2, msg, sizeof(msg)) != 0)
+            FAIL(msg);
+        else
+            PASS();
+        sb_free(&s);
+    }
+}
+
+/* ======================================================================== */
+/* Shapes 6 & 7: recursive self-join -> K-fusion merge  (col_rel_merge_k)   */
+/* ======================================================================== */
+
+/*
+ * Two recursive atoms  -> K-fusion with K = 2 -> col_rel_merge_k(k == 2).
+ * Three recursive atoms -> K-fusion with K = 3 -> col_rel_merge_k(k >= 3).
+ *
+ * Both paths carry a `last_row_buf[COL_STACK_MAX]` dedup buffer that is
+ * filled at the relation's width.  Edges 1->2->3->4 are padded with zeros
+ * in columns 2..n-1, so the answer does not depend on the width.
+ */
+static void
+build_tc_src(sbuf_t *s, unsigned n, unsigned atoms)
+{
+    sb_override_t head_over[1] = { { 1u, "z" } };
+    sb_override_t mid_over[2];
+    sb_override_t tail_over[2];
+
+    sb_decl(s, "e", n);
+    sb_decl(s, "t", n);
+    sb_puts(s, ".output t\n");
+    sb_fact_edge(s, "e", 1, 2, n);
+    sb_fact_edge(s, "e", 2, 3, n);
+    sb_fact_edge(s, "e", 3, 4, n);
+
+    sb_puts(s, "t(");
+    sb_args(s, "v", n, NULL, 0);
+    sb_puts(s, ") :- e(");
+    sb_args(s, "v", n, NULL, 0);
+    sb_puts(s, ").\n");
+
+    sb_puts(s, "t(");
+    sb_args(s, "v", n, head_over, 1);
+    sb_puts(s, ") :- t(");
+    sb_args(s, "v", n, NULL, 0);
+    sb_puts(s, ")");
+
+    if (atoms == 2) {
+        /* t(v0, z, ..) :- t(v0, v1, ..), t(v1, z, ..). */
+        mid_over[0].index = 0;
+        mid_over[0].term = "v1";
+        mid_over[1].index = 1;
+        mid_over[1].term = "z";
+        sb_puts(s, ", t(");
+        sb_args(s, "w", n, mid_over, 2);
+        sb_puts(s, ")");
+    } else {
+        /* t(v0, z, ..) :- t(v0, v1, ..), t(v1, y, ..), t(y, z, ..). */
+        mid_over[0].index = 0;
+        mid_over[0].term = "v1";
+        mid_over[1].index = 1;
+        mid_over[1].term = "y";
+        sb_puts(s, ", t(");
+        sb_args(s, "w", n, mid_over, 2);
+        sb_puts(s, ")");
+
+        tail_over[0].index = 0;
+        tail_over[0].term = "y";
+        tail_over[1].index = 1;
+        tail_over[1].term = "z";
+        sb_puts(s, ", t(");
+        sb_args(s, "x", n, tail_over, 2);
+        sb_puts(s, ")");
+    }
+    sb_puts(s, ".\n");
+}
+
+/* "t(a, b, 0, 0, ..., 0)" as printed by the CLI, for exact-tuple matching. */
+static void
+build_expected_tuple(char *dst, size_t dst_size, long a, long b, unsigned n)
+{
+    size_t off = (size_t)snprintf(dst, dst_size, "t(%ld, %ld", a, b);
+    for (unsigned i = 2; i < n && off + 4 < dst_size; i++)
+        off += (size_t)snprintf(dst + off, dst_size - off, ", 0");
+    snprintf(dst + off, dst_size - off, ")");
+}
+
+static void
+test_recursive_selfjoin_wide(void)
+{
+    /* 2 atoms: full transitive closure of 1->2->3->4 (6 pairs).
+     * 3 atoms: base edges plus the single 3-hop composition 1->4. */
+    static const long pairs2[6][2]
+        = { { 1, 2 }, { 1, 3 }, { 1, 4 }, { 2, 3 }, { 2, 4 }, { 3, 4 } };
+    static const long pairs3[4][2]
+        = { { 1, 2 }, { 1, 4 }, { 2, 3 }, { 3, 4 } };
+
+    for (unsigned atoms = 2; atoms <= 3; atoms++) {
+        for (size_t i = 0; i < K_WIDTH_COUNT; i++) {
+            unsigned n = k_widths[i];
+            char name[160];
+            snprintf(name, sizeof(name),
+                "recursive %u-atom self-join (K-fusion merge) over %u columns",
+                atoms, n);
+            TEST(name);
+
+            /*
+             * Three or more body atoms reach col_rel_merge_k's k >= 3 branch,
+             * but they cannot be evaluated at any of these widths yet: the
+             * join-project-plan pass sizes three scratch arrays as
+             * `nscan * 16` (wirelog/passes/jpp.c:290, :589, :646) and then
+             * fills them with one entry per column per scan, so a 3-atom
+             * join over relations wider than 16 columns writes out of
+             * bounds inside wl_jpp_apply -- before evaluation begins.
+             *
+             * That is a separate defect in a different module (a sizing
+             * guess in the optimizer, not a COL_STACK_MAX row buffer), with
+             * its own reproducer and its own fix; it is deliberately not
+             * addressed here.  The k >= 3 branch shares the MERGE_K_SETUP /
+             * MERGE_K_APPEND macros with the k == 2 branch that the
+             * 2-atom cases above do cover at 33 and 200 columns.
+             */
+            if (atoms == 3) {
+                SKIP("blocked by jpp.c nscan*16 sizing overflow "
+                    "(separate defect; see comment)");
+                continue;
+            }
+
+            sbuf_t s;
+            sb_init(&s);
+            build_tc_src(&s, n, atoms);
+            if (s.oom) {
+                sb_free(&s);
+                FAIL("source generation OOM");
+                continue;
+            }
+
+            unsigned count = (atoms == 2) ? 6u : 4u;
+            char *tuples = (char *)malloc((size_t)count * 1024u);
+            const char *ptrs[6];
+            if (!tuples) {
+                sb_free(&s);
+                FAIL("tuple buffer OOM");
+                continue;
+            }
+            for (unsigned k = 0; k < count; k++) {
+                long a = (atoms == 2) ? pairs2[k][0] : pairs3[k][0];
+                long b = (atoms == 2) ? pairs2[k][1] : pairs3[k][1];
+                build_expected_tuple(tuples + (size_t)k * 1024u, 1024u, a, b,
+                    n);
+                ptrs[k] = tuples + (size_t)k * 1024u;
+            }
+
+            char msg[1024];
+            if (check_program(s.data, "t(", (int)count, ptrs, count, msg,
+                sizeof(msg)) != 0)
+                FAIL(msg);
+            else
+                PASS();
+            free(tuples);
+            sb_free(&s);
+        }
+    }
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("=== test_wide_relation (Issue #1000) ===\n");
+
+    test_map_wide();
+    test_filter_wide();
+    test_join_right_filter_wide();
+    test_reduce_wide();
+    test_recursive_selfjoin_wide();
+
+    printf("\n=== Results: %d run, %d passed, %d failed, %d skipped ===\n",
+        tests_run, tests_passed, tests_failed, tests_skipped);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -406,6 +406,53 @@ col_rel_buf_bytes(const col_rel_t *r, uint32_t row_count)
 }
 
 /* ======================================================================== */
+/* Row Scratch Buffer (Issue #1000)                                         */
+/*                                                                          */
+/* col_rel_row_copy_out() writes r->ncols values, so any buffer handed to   */
+/* it must be at least that wide.  A bare int64_t[COL_STACK_MAX] smashes    */
+/* the stack for relations wider than COL_STACK_MAX columns.  Use this      */
+/* helper instead: it keeps the stack buffer for the common narrow case     */
+/* (no allocation, no free) and spills to the heap only past the bound.     */
+/*                                                                          */
+/*   col_row_buf_t rb;                                                      */
+/*   int64_t *const row = col_row_buf_init(&rb, nc);                        */
+/*   if (!row) { ...ENOMEM... }                                             */
+/*   for (...) { col_rel_row_copy_out(rel, i, row); ... }                   */
+/*   col_row_buf_release(&rb);            (on every exit path)              */
+/*                                                                          */
+/* Two things matter for the hot path.  Hoist the init/release out of       */
+/* per-row loops -- initialising inside a loop would malloc once per row    */
+/* for wide relations.  And read ->ptr once into a local, as above, rather  */
+/* than writing rb.ptr[c] inside the loop: the compiler cannot always prove */
+/* the callee did not change ->ptr, so it reloads it every iteration        */
+/* (worth ~2% on the crdt bench workload when written the naive way).       */
+/* ======================================================================== */
+
+typedef struct {
+    int64_t stack[COL_STACK_MAX];
+    int64_t *ptr; /* == stack, or heap block; NULL on allocation failure */
+} col_row_buf_t;
+
+/** Point @b at a buffer of at least @ncols int64_t.  Returns NULL on OOM. */
+static inline int64_t *
+col_row_buf_init(col_row_buf_t *b, uint32_t ncols)
+{
+    b->ptr = (ncols <= COL_STACK_MAX)
+        ? b->stack
+        : (int64_t *)malloc((size_t)ncols * sizeof(int64_t));
+    return b->ptr;
+}
+
+/** Release @b.  Safe to call on a failed or already-released buffer. */
+static inline void
+col_row_buf_release(col_row_buf_t *b)
+{
+    if (b->ptr && b->ptr != b->stack)
+        free(b->ptr);
+    b->ptr = NULL;
+}
+
+/* ======================================================================== */
 /* Row Comparison (Phase B, Issue #330; optimized Issue #334)                */
 /*                                                                          */
 /* Compare two rows using direct column access for cache efficiency.         */

--- a/wirelog/columnar/mobius.c
+++ b/wirelog/columnar/mobius.c
@@ -48,16 +48,30 @@ col_op_join_weighted(const col_rel_t *lhs, const col_rel_t *rhs,
     if (!tmp)
         return ENOMEM;
 
+    /* Row scratch for each side (#1000).  col_rel_row_copy_out() writes
+     * ->ncols values, so a bare int64_t[COL_STACK_MAX] overflows for
+     * relations wider than 32 columns.  Both buffers are hoisted out of the
+     * loops: the right-hand buffer is used by the inner loop, so allocating
+     * it there would malloc once per (li, ri) pair. */
+    col_row_buf_t lrb, rrb;
+    int64_t *lptr = col_row_buf_init(&lrb, lhs->ncols);
+    int64_t *rptr = col_row_buf_init(&rrb, rhs->ncols);
+    if (!lptr || !rptr) {
+        col_row_buf_release(&lrb);
+        col_row_buf_release(&rrb);
+        free(tmp);
+        return ENOMEM;
+    }
+
     int rc = 0;
     for (uint32_t li = 0; li < lhs->nrows && rc == 0; li++) {
-        int64_t lrow_buf[COL_STACK_MAX];
-        col_rel_row_copy_out(lhs, li, lrow_buf); const int64_t *lrow = lrow_buf;
+        col_rel_row_copy_out(lhs, li, lptr);
+        const int64_t *lrow = lptr;
         int64_t lmult = lhs->timestamps ? lhs->timestamps[li].multiplicity : 1;
 
         for (uint32_t ri = 0; ri < rhs->nrows && rc == 0; ri++) {
-            int64_t rrow_buf[COL_STACK_MAX];
-            col_rel_row_copy_out(rhs, ri, rrow_buf);
-            const int64_t *rrow = rrow_buf;
+            col_rel_row_copy_out(rhs, ri, rptr);
+            const int64_t *rrow = rptr;
 
             if (lrow[key_col] != rrow[key_col])
                 continue;
@@ -102,6 +116,8 @@ col_op_join_weighted(const col_rel_t *lhs, const col_rel_t *rhs,
         }
     }
 
+    col_row_buf_release(&lrb);
+    col_row_buf_release(&rrb);
     free(tmp);
     return rc;
 }
@@ -138,7 +154,29 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
     uint32_t ncols = prev_collection->ncols;
     out_delta->ncols = ncols;
 
+    /* Row scratch for each collection (#1000).  col_rel_row_copy_out()
+     * writes ->ncols values, so a bare int64_t[COL_STACK_MAX] overflows past
+     * 32 columns.  Both buffers are hoisted to function scope: each pass
+     * scans one collection in its inner loop, so a per-iteration allocation
+     * would malloc once per (ci, pi) pair.  Each buffer always holds a row
+     * of the same collection, in both passes. */
+    col_row_buf_t crb, prb;
+    int64_t *cptr = col_row_buf_init(&crb, curr_collection->ncols);
+    int64_t *pptr = col_row_buf_init(&prb, prev_collection->ncols);
+    if (!cptr || !pptr) {
+        col_row_buf_release(&crb);
+        col_row_buf_release(&prb);
+        return ENOMEM;
+    }
+
     /* Helper lambda (via inline block) to append a row+mult to out_delta. */
+#define DELTA_FAIL()                                                          \
+        do {                                                                      \
+            col_row_buf_release(&crb);                                            \
+            col_row_buf_release(&prb);                                            \
+            return ENOMEM;                                                        \
+        } while (0)
+
 #define DELTA_APPEND(row_ptr, mult_val)                                       \
         do {                                                                      \
             if (out_delta->nrows >= out_delta->capacity) {                        \
@@ -147,17 +185,17 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
                 if (out_delta->columns) {                                         \
                     if (col_columns_realloc(out_delta->columns, ncols,             \
                         new_cap) != 0)                                            \
-                    return ENOMEM;                                            \
+                    DELTA_FAIL();                                             \
                 } else {                                                          \
                     out_delta->columns = col_columns_alloc(ncols, new_cap);        \
                     if (!out_delta->columns)                                       \
-                    return ENOMEM;                                            \
+                    DELTA_FAIL();                                             \
                 }                                                                 \
                 col_delta_timestamp_t *nt = (col_delta_timestamp_t *)realloc(     \
                     out_delta->timestamps,                                        \
                     (size_t)new_cap * sizeof(col_delta_timestamp_t));             \
                 if (!nt)                                                          \
-                return ENOMEM;                                                \
+                DELTA_FAIL();                                                 \
                 out_delta->timestamps = nt;                                       \
                 out_delta->capacity = new_cap;                                    \
             }                                                                     \
@@ -171,9 +209,8 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
 
     /* Pass 1: iterate over curr; for each key look up in prev. */
     for (uint32_t ci = 0; ci < curr_collection->nrows; ci++) {
-        int64_t crow_buf[COL_STACK_MAX];
-        col_rel_row_copy_out(curr_collection, ci, crow_buf);
-        const int64_t *crow = crow_buf;
+        col_rel_row_copy_out(curr_collection, ci, cptr);
+        const int64_t *crow = cptr;
         int64_t cmult = curr_collection->timestamps
                             ? curr_collection->timestamps[ci].multiplicity
                             : 1;
@@ -182,9 +219,8 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
         int64_t pmult = 0;
         bool found_in_prev = false;
         for (uint32_t pi = 0; pi < prev_collection->nrows; pi++) {
-            int64_t prow_buf[COL_STACK_MAX];
-            col_rel_row_copy_out(prev_collection, pi, prow_buf);
-            const int64_t *prow = prow_buf;
+            col_rel_row_copy_out(prev_collection, pi, pptr);
+            const int64_t *prow = pptr;
             if (prow[0] == crow[0]) {
                 pmult = prev_collection->timestamps
                             ? prev_collection->timestamps[pi].multiplicity
@@ -202,18 +238,16 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
 
     /* Pass 2: iterate over prev; emit -prev_mult for keys absent in curr. */
     for (uint32_t pi = 0; pi < prev_collection->nrows; pi++) {
-        int64_t prow_buf[COL_STACK_MAX];
-        col_rel_row_copy_out(prev_collection, pi, prow_buf);
-        const int64_t *prow = prow_buf;
+        col_rel_row_copy_out(prev_collection, pi, pptr);
+        const int64_t *prow = pptr;
         int64_t pmult = prev_collection->timestamps
                             ? prev_collection->timestamps[pi].multiplicity
                             : 1;
 
         bool found_in_curr = false;
         for (uint32_t ci = 0; ci < curr_collection->nrows; ci++) {
-            int64_t crow_buf[COL_STACK_MAX];
-            col_rel_row_copy_out(curr_collection, ci, crow_buf);
-            const int64_t *crow = crow_buf;
+            col_rel_row_copy_out(curr_collection, ci, cptr);
+            const int64_t *crow = cptr;
             if (crow[0] == prow[0]) {
                 found_in_curr = true;
                 break;
@@ -229,6 +263,9 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
     }
 
 #undef DELTA_APPEND
+#undef DELTA_FAIL
 
+    col_row_buf_release(&crb);
+    col_row_buf_release(&prb);
     return 0;
 }

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -1544,10 +1544,25 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         }
     }
 
+    /* Row scratch, hoisted out of the loop: initialising it per row would
+     * malloc once per row for relations wider than COL_STACK_MAX (#1000). */
+    col_row_buf_t row_rb;
+    if (!col_row_buf_init(&row_rb, e.rel->ncols)) {
+        if (ce_map) {
+            for (uint32_t c = 0; c < ce_map_count; c++)
+                col_expr_compiled_free(ce_map[c]);
+            free(ce_map);
+        }
+        free(tmp);
+        col_rel_destroy(out);
+        if (e.owned)
+            col_rel_destroy(e.rel);
+        return ENOMEM;
+    }
+
+    int64_t *const row = row_rb.ptr;
     for (uint32_t r = 0; r < e.rel->nrows; r++) {
-        int64_t row_buf_e[COL_STACK_MAX];
-        col_rel_row_copy_out(e.rel, r, row_buf_e);
-        const int64_t *row = row_buf_e;
+        col_rel_row_copy_out(e.rel, r, row);
         for (uint32_t c = 0; c < pc; c++) {
             if (op->map_exprs && c < op->map_expr_count && op->map_exprs[c].data
                 && op->map_exprs[c].size > 0) {
@@ -1560,6 +1575,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                                 col_expr_compiled_free(ce_map[i]);
                             free(ce_map);
                         }
+                        col_row_buf_release(&row_rb);
                         free(tmp);
                         col_rel_destroy(out);
                         if (e.owned)
@@ -1577,6 +1593,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                                 col_expr_compiled_free(ce_map[i]);
                             free(ce_map);
                         }
+                        col_row_buf_release(&row_rb);
                         free(tmp);
                         col_rel_destroy(out);
                         if (e.owned)
@@ -1597,6 +1614,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                     col_expr_compiled_free(ce_map[c]);
                 free(ce_map);
             }
+            col_row_buf_release(&row_rb);
             free(tmp);
             col_rel_destroy(out);
             if (e.owned)
@@ -1610,6 +1628,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
             col_expr_compiled_free(ce_map[c]);
         free(ce_map);
     }
+    col_row_buf_release(&row_rb);
     free(tmp);
 
     if (e.owned)
@@ -2359,10 +2378,20 @@ col_op_filter(const wl_plan_op_t *op, eval_stack_t *stack,
     /* Slow path: pre-compile expression once, then evaluate per row. */
     col_expr_compiled_t *ce =
         (buf && bsz > 0) ? col_expr_compile(buf, bsz) : NULL;
+
+    /* Row scratch, hoisted out of the loop (#1000). */
+    col_row_buf_t row_rb;
+    if (!col_row_buf_init(&row_rb, e.rel->ncols)) {
+        col_expr_compiled_free(ce);
+        col_rel_destroy(out);
+        if (e.owned)
+            col_rel_destroy(e.rel);
+        return ENOMEM;
+    }
+
+    int64_t *const row = row_rb.ptr;
     for (uint32_t r = 0; r < e.rel->nrows; r++) {
-        int64_t row_buf_e[COL_STACK_MAX];
-        col_rel_row_copy_out(e.rel, r, row_buf_e);
-        const int64_t *row = row_buf_e;
+        col_rel_row_copy_out(e.rel, r, row);
         int pass;
         if (!buf || bsz == 0) {
             pass = 1;
@@ -2378,6 +2407,7 @@ col_op_filter(const wl_plan_op_t *op, eval_stack_t *stack,
         if (pass) {
             int rc = col_rel_append_row(out, row);
             if (rc != 0) {
+                col_row_buf_release(&row_rb);
                 col_expr_compiled_free(ce);
                 col_rel_destroy(out);
                 if (e.owned)
@@ -2386,6 +2416,7 @@ col_op_filter(const wl_plan_op_t *op, eval_stack_t *stack,
             }
         }
     }
+    col_row_buf_release(&row_rb);
     col_expr_compiled_free(ce);
 
     if (e.owned)
@@ -2427,24 +2458,31 @@ static int
 fill_filtered_rel(const uint8_t *buf, uint32_t bsz, col_rel_t *rel,
     col_rel_t *out, wl_intern_t *intern)
 {
+    /* Row scratch, hoisted out of both loops below (#1000). */
+    col_row_buf_t rb;
+    if (!col_row_buf_init(&rb, rel->ncols))
+        return ENOMEM;
+    int64_t *row_buf = rb.ptr;
+
     /* Fast path: simple colA CMP CONST or colA CMP colB predicate */
     simple_filter_cmp_t cmp;
     if (filter_is_simple_cmp(buf, bsz, &cmp)) {
         for (uint32_t r = 0; r < rel->nrows; r++) {
-            int64_t row_buf[COL_STACK_MAX];
             col_rel_row_copy_out(rel, r, row_buf);
             if (col_filter_cmp_row(row_buf, rel->ncols, &cmp)) {
-                if (col_rel_append_row(out, row_buf) != 0)
+                if (col_rel_append_row(out, row_buf) != 0) {
+                    col_row_buf_release(&rb);
                     return ENOMEM;
+                }
             }
         }
+        col_row_buf_release(&rb);
         return 0;
     }
 
     /* Slow path: compile once, evaluate per row */
     col_expr_compiled_t *ce = col_expr_compile(buf, bsz);
     for (uint32_t r = 0; r < rel->nrows; r++) {
-        int64_t row_buf[COL_STACK_MAX];
         col_rel_row_copy_out(rel, r, row_buf);
         int pass;
         if (ce) {
@@ -2459,10 +2497,12 @@ fill_filtered_rel(const uint8_t *buf, uint32_t bsz, col_rel_t *rel,
             pass = (err == 0) ? (val != 0 ? 1 : 0) : 0; /* fail-closed */
         }
         if (pass && col_rel_append_row(out, row_buf) != 0) {
+            col_row_buf_release(&rb);
             col_expr_compiled_free(ce);
             return ENOMEM;
         }
     }
+    col_row_buf_release(&rb);
     col_expr_compiled_free(ce);
     return 0;
 }
@@ -5217,16 +5257,16 @@ col_op_consolidate_incremental_delta(col_rel_t *rel, uint32_t old_nrows,
     if (fast_path) {
         /* All d_unique rows are novel. Emit to delta_out and append as run. */
         if (delta_out) {
-            int64_t _drb[COL_STACK_MAX];
-            int64_t *dr = nc <= COL_STACK_MAX ? _drb
-                : (int64_t *)malloc((size_t)nc * sizeof(int64_t));
+            col_row_buf_t drb;
+            int64_t *const dr = col_row_buf_init(&drb, nc);
+            if (!dr)
+                return ENOMEM;
             for (uint32_t k = 0; k < d_unique; k++) {
                 for (uint32_t c = 0; c < nc; c++)
                     dr[c] = rel->columns[c][old_nrows + k];
                 col_rel_append_row(delta_out, dr);
             }
-            if (dr != _drb)
-                free(dr);
+            col_row_buf_release(&drb);
         }
         rel->nrows = old_nrows + d_unique;
         rel->sorted_nrows = rel->nrows;
@@ -5276,14 +5316,29 @@ col_op_consolidate_incremental_delta(col_rel_t *rel, uint32_t old_nrows,
                 if (novel_count != i)
                     col_rel_row_move(rel, old_nrows + novel_count, row_idx);
                 if (delta_out) {
-                    int64_t _drb[COL_STACK_MAX];
-                    int64_t *dr = nc <= COL_STACK_MAX ? _drb
-                        : (int64_t *)malloc((size_t)nc * sizeof(int64_t));
+                    /* Issue #1000: the one converted site that is NOT
+                     * covered by a test, and the one that inits inside a
+                     * per-row loop rather than above it.
+                     *
+                     * Reaching it needs a >32-column relation *and*
+                     * d_unique <= old_nrows/16 && rel->run_count > 0, i.e.
+                     * the binary-search dedup branch on a large existing
+                     * relation with few novel rows.  Mutating this guard to
+                     * the old fixed width survives the whole suite, so the
+                     * bound here rests on inspection, not on a test.
+                     *
+                     * The per-row init is the pre-existing shape and is not
+                     * a regression -- the base code allocated here too --
+                     * but it does contradict the hoisting rule this helper
+                     * documents.  Both are tracked in #1003. */
+                    col_row_buf_t drb;
+                    int64_t *const dr = col_row_buf_init(&drb, nc);
+                    if (!dr)
+                        return ENOMEM;
                     for (uint32_t c = 0; c < nc; c++)
                         dr[c] = rel->columns[c][old_nrows + novel_count];
                     col_rel_append_row(delta_out, dr);
-                    if (dr != _drb)
-                        free(dr);
+                    col_row_buf_release(&drb);
                 }
                 novel_count++;
             }
@@ -5347,9 +5402,10 @@ col_op_consolidate_incremental_delta(col_rel_t *rel, uint32_t old_nrows,
     }
     int64_t **merged_cols = rel->merge_columns;
 
-    int64_t _delta_row_buf[COL_STACK_MAX];
-    int64_t *delta_row = nc <= COL_STACK_MAX ? _delta_row_buf
-        : (int64_t *)malloc((size_t)nc * sizeof(int64_t));
+    col_row_buf_t delta_rb;
+    if (!col_row_buf_init(&delta_rb, nc))
+        return ENOMEM;
+    int64_t *delta_row = delta_rb.ptr;
 
     /* For fallback merge, we need a single sorted prefix.
      * If multiple runs exist, compact first (#377 fix).
@@ -5360,8 +5416,7 @@ col_op_consolidate_incremental_delta(col_rel_t *rel, uint32_t old_nrows,
         uint32_t delta_phys = old_nrows; /* physical location of delta */
         int rc = col_rel_compact_runs(rel);
         if (rc != 0) {
-            if (delta_row != _delta_row_buf)
-                free(delta_row);
+            col_row_buf_release(&delta_rb);
             return rc;
         }
         uint32_t compacted = rel->nrows;
@@ -5413,8 +5468,7 @@ col_op_consolidate_incremental_delta(col_rel_t *rel, uint32_t old_nrows,
         out++;
     }
 
-    if (delta_row != _delta_row_buf)
-        free(delta_row);
+    col_row_buf_release(&delta_rb);
 
     /* Swap merge_columns and columns to avoid O(N) memcpy (issue #218). */
     {
@@ -5501,39 +5555,55 @@ col_rel_merge_k(col_rel_t **relations, uint32_t k)
     if (!out)
         return NULL;
 
+    /* Per-block scratch (#1000): both the staging row and the dedup key must
+     * be nc wide, not COL_STACK_MAX wide.  MERGE_K_SETUP declares and
+     * allocates them once per merge block -- allocating inside
+     * MERGE_K_APPEND would malloc once per row for wide relations. */
+#define MERGE_K_SETUP()                                                      \
+        col_row_buf_t _rowbuf, _lastbuf;                                         \
+        int64_t *_rb, *last_row_buf;                                             \
+        const int64_t *last_row = NULL;                                          \
+        _rb = col_row_buf_init(&_rowbuf, nc);                                    \
+        last_row_buf = col_row_buf_init(&_lastbuf, nc);                          \
+        if (!_rb || !last_row_buf) {                                             \
+            col_row_buf_release(&_rowbuf);                                       \
+            col_row_buf_release(&_lastbuf);                                      \
+            col_rel_destroy(out);                                                \
+            return NULL;                                                         \
+        }
+
+#define MERGE_K_RELEASE()                                                    \
+        do {                                                                     \
+            col_row_buf_release(&_rowbuf);                                       \
+            col_row_buf_release(&_lastbuf);                                      \
+        } while (0)
+
     /* Helper: copy row from relation into temp buf, append to out, dedup
-     * against last_row in out. Returns 0 on success, -1 on failure. */
+     * against last_row in out.  Bails out of the enclosing function on
+     * failure (after releasing the block scratch). */
 #define MERGE_K_APPEND(rel_ptr, row_idx)                                     \
         do {                                                                     \
-            int64_t _rbuf[COL_STACK_MAX];                                        \
-            int64_t *_rb = nc <= COL_STACK_MAX ? _rbuf                           \
-            : (int64_t *)malloc((size_t)nc * sizeof(int64_t));               \
-            if (!_rb) {                                                          \
-                col_rel_destroy(out);                                            \
-                return NULL;                                                     \
-            }                                                                    \
             col_rel_row_copy_out((rel_ptr), (row_idx), _rb);                     \
             if (last_row == NULL                                                 \
                 || row_cmp_dispatch(last_row, _rb, nc) != 0) {                   \
                 if (col_rel_append_row(out, _rb) != 0) {                         \
-                    if (_rb != _rbuf) free(_rb);                                 \
+                    MERGE_K_RELEASE();                                           \
                     col_rel_destroy(out);                                        \
                     return NULL;                                                 \
                 }                                                                \
                 col_rel_row_copy_out(out, out->nrows - 1, last_row_buf);         \
                 last_row = last_row_buf;                                         \
             }                                                                    \
-            if (_rb != _rbuf) free(_rb);                                         \
         } while (0)
 
     /* K=1: Copy with dedup using append (handles dynamic growth) */
     if (k == 1) {
         col_rel_t *src = relations[0];
-        int64_t last_row_buf[COL_STACK_MAX];
-        const int64_t *last_row = NULL;
+        MERGE_K_SETUP();
         for (uint32_t r = 0; r < src->nrows; r++) {
             MERGE_K_APPEND(src, r);
         }
+        MERGE_K_RELEASE();
         return out;
     }
 
@@ -5542,8 +5612,7 @@ col_rel_merge_k(col_rel_t **relations, uint32_t k)
         col_rel_t *left = relations[0];
         col_rel_t *right = relations[1];
         uint32_t li = 0, ri = 0;
-        int64_t last_row_buf[COL_STACK_MAX];
-        const int64_t *last_row = NULL;
+        MERGE_K_SETUP();
 
         while (li < left->nrows && ri < right->nrows) {
             int cmp = col_rel_row_cmp2(left, li, right, ri);
@@ -5574,6 +5643,7 @@ col_rel_merge_k(col_rel_t **relations, uint32_t k)
             ri++;
         }
 
+        MERGE_K_RELEASE();
         return out;
     }
 
@@ -5595,15 +5665,17 @@ col_rel_merge_k(col_rel_t **relations, uint32_t k)
 
     /* Move final result into output using append */
     {
-        int64_t last_row_buf[COL_STACK_MAX];
-        const int64_t *last_row = NULL;
+        MERGE_K_SETUP();
         for (uint32_t r = 0; r < temp->nrows; r++) {
             MERGE_K_APPEND(temp, r);
         }
+        MERGE_K_RELEASE();
         col_rel_destroy(temp);
     }
 
 #undef MERGE_K_APPEND
+#undef MERGE_K_RELEASE
+#undef MERGE_K_SETUP
     return out;
 }
 
@@ -6602,11 +6674,22 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
     if (op->agg_expr.data && op->agg_expr.size > 0)
         agg_ce = col_expr_compile(op->agg_expr.data, op->agg_expr.size);
 
+    /* Row scratch, hoisted out of the loop (#1000). */
+    col_row_buf_t row_rb;
+    if (!col_row_buf_init(&row_rb, in->ncols)) {
+        col_expr_compiled_free(agg_ce);
+        free(tmp);
+        col_rel_destroy(out);
+        if (e.owned)
+            col_rel_destroy(in);
+        return ENOMEM;
+    }
+
     /* Sort by group key for group-by */
     /* (Simple O(n^2) implementation; sufficient for Phase 2A) */
+    int64_t *const row = row_rb.ptr;
     for (uint32_t r = 0; r < in->nrows; r++) {
-        int64_t row_buf[COL_STACK_MAX]; col_rel_row_copy_out(in, r, row_buf);
-        const int64_t *row = row_buf;
+        col_rel_row_copy_out(in, r, row);
         int64_t agg_val = (in->ncols > gc) ? row[gc] : 1;
         if (op->agg_fn != WIRELOG_AGG_COUNT
             && op->agg_expr.data && op->agg_expr.size > 0) {
@@ -6615,6 +6698,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                 if (col_eval_expr_compiled(agg_ce, row, in->ncols, &val) == 0)
                     agg_val = val;
                 else {
+                    col_row_buf_release(&row_rb);
                     col_expr_compiled_free(agg_ce);
                     free(tmp);
                     col_rel_destroy(out);
@@ -6628,6 +6712,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                     row, in->ncols, &val, sess->intern) == 0) {
                     agg_val = val;
                 } else {
+                    col_row_buf_release(&row_rb);
                     col_expr_compiled_free(agg_ce);
                     free(tmp);
                     col_rel_destroy(out);
@@ -6660,6 +6745,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                     int64_t next;
                     if (wl_columnar_ops_checked_add_int64(cur, agg_val,
                         &next) != 0) {
+                        col_row_buf_release(&row_rb);
                         col_expr_compiled_free(agg_ce);
                         free(tmp);
                         col_rel_destroy(out);
@@ -6695,6 +6781,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
             tmp[gc] = (op->agg_fn == WIRELOG_AGG_COUNT) ? 1 : agg_val;
             int rc = col_rel_append_row(out, tmp);
             if (rc != 0) {
+                col_row_buf_release(&row_rb);
                 col_expr_compiled_free(agg_ce);
                 free(tmp);
                 col_rel_destroy(out);
@@ -6705,6 +6792,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
         }
     }
 
+    col_row_buf_release(&row_rb);
     col_expr_compiled_free(agg_ce);
     free(tmp);
     if (e.owned)


### PR DESCRIPTION
Closes #1000.

## The bug

Columnar operators copied a row into a fixed `int64_t buf[COL_STACK_MAX]` (32) and filled it at the **relation's** width. Any rule over a relation wider than 32 columns wrote past the end.

```
.decl w(c0 .. c32: int64)      /* 33 columns */
w(0, 1, ... 32).
o(v0) :- w(v0, v1, ... v32).
```

| columns | before |
|---|---|
| 32 | correct |
| **33** | `*** stack smashing detected ***`, rc=134, **in a plain release build** |

One `.decl`, one fact, one rule. No CSV, no `.input`, nothing unusual about the data.

## The fix

The tree already had the right shape in four places (`nc <= COL_STACK_MAX ? stack : malloc`). This adds `col_row_buf_t` — stack array for narrow relations, heap spill past the bound, NULL-checked, released on every exit — and applies it at 14 sites.

**Scope stated precisely**, because the site count overstates the blast radius:
- ~11 were genuine overflows
- 3 (`ops.c:5261/5320/5391`) were already width-guarded and only gained a missing NULL check — OOM hardening, not this bug
- 4 are in `col_op_join_weighted` / `col_compute_delta_mobius`, which have **no production caller** (tests only)

## Two things the mechanical pattern would have missed

**`MERGE_K_APPEND` allocated per merged row.** The pre-existing "correct" example declared its buffer *inside* the macro, which expands once per appended row — so wide merges allocated per row. Both buffers moved into a `MERGE_K_SETUP()` invoked once per block.

**Reading `->ptr` in an inner loop costs real time.** The destination aliases the struct's own stack array, so the compiler can't prove non-aliasing and reloads the pointer every iteration. Verified at the assembly level — the naive form emits a reload at the top of each iteration, the hoisted form keeps it in a register. Every site now reads the pointer into a local first.

## What is *not* covered, stated rather than implied

`ops.c:5320` still initialises inside a per-row loop, and **no test reaches it** — mutating its bound back to the fixed width survives the entire suite. Pre-existing shape, not a regression, but it contradicts the rule this helper documents. Commented at the site and tracked in **#1003**.

Three test cases are `SKIP`, not dropped: `merge_k` k≥3 needs a 3-atom join, which can't be built at these widths because `jpp.c` sizes scratch arrays from a 16-columns-per-scan guess and overflows first — a separate heap-buffer-overflow write at **26** columns, filed as **#1002**.

## Tests

`tests/test_wide_relation.c` drives the real pipeline and asserts **correct tuples** — exact count, each expected tuple exactly once — for map, filter (slow path), join right-child filter (fast and slow), reduce, and `merge_k` k==2, each at **32 / 33 / 200** columns. 32 is the boundary that works today; 200 catches an off-by-one.

The pipeline runs in a forked child so the stack-protector abort is one failing case rather than a dead binary. The child exits through `exit()` rather than `_exit()` so LeakSanitizer still runs — with `_exit()` it never did, and the clean `detect_leaks=1` result came entirely from the other tests. The temp path is pid-suffixed; a fixed name reproducibly failed most cases when copies ran concurrently.

Mutation-verified: reverting each guard individually kills **9 of 10** by a specific named test. The tenth is `ops.c:5320` above.

## Validation

265 Ok / 1 Fail / 11 Skipped against a 264/1/11 baseline; the failure is the pre-existing `sbom_snapshot` drift. ASAN+UBSAN with `detect_leaks=1` clean. Release build verified directly — the reproducer goes from rc=134 to correct output at 33, 40, 64, 200 and 500 columns.

**No timing claims.** The available machine runs a `schedutil` governor, under which every perf gate in this project skips by its own criterion, and the DOOP dataset isn't in the tree — only its download script — so no reviewer or CI run could reproduce a number measured against it. What *is* checkable: a narrow workload performs bit-identical allocation counts before and after, which is the property the guard exists to preserve.

## Merge note

Conflicts with **PR #1001** on `tests/meson.build` — both append a test block at the same anchor. Trivial; whoever merges second resolves it.
