### PR TITLE
fix(cli): read complete watch-mode records

### DIFF
--- a/tests/test_cli_watch.c
+++ b/tests/test_cli_watch.c
@@ -24,10 +24,21 @@ main(void)
         fprintf(stderr, "cannot create watch input file\n");
         return 1;
     }
-    fprintf(in, "person \"Alice\"\n");
+    const size_t value_len = 5000;
+    char *value = (char *)malloc(value_len + 1);
+    if (!value) {
+        fclose(in);
+        remove(inpath);
+        fprintf(stderr, "cannot allocate watch value\n");
+        return 1;
+    }
+    memset(value, 'A', value_len);
+    value[value_len] = '\0';
+    fprintf(in, "person \"%s\"\n", value);
     fclose(in);
 
     if (!freopen(inpath, "r", stdin)) {
+        free(value);
         remove(inpath);
         fprintf(stderr, "cannot redirect stdin\n");
         return 1;
@@ -37,6 +48,7 @@ main(void)
     test_tmppath(outpath, sizeof(outpath), "wirelog_test_watch_string.out");
     FILE *out = fopen(outpath, "w");
     if (!out) {
+        free(value);
         remove(inpath);
         fprintf(stderr, "cannot create output file\n");
         return 1;
@@ -49,6 +61,7 @@ main(void)
     int rc = wl_run_pipeline(src, 1, false, true, 0, out);
     fclose(out);
     if (rc != 0) {
+        free(value);
         remove(inpath);
         remove(outpath);
         fprintf(stderr, "wl_run_pipeline returned %d\n", rc);
@@ -57,17 +70,22 @@ main(void)
 
     char *output = wl_read_file(outpath);
     if (!output) {
+        free(value);
         remove(inpath);
         remove(outpath);
         fprintf(stderr, "cannot read output file\n");
         return 1;
     }
 
-    int ok = strstr(output, "\"Alice\"") != NULL;
+    int ok = strstr(output, value) != NULL;
+    char *first = strstr(output, "seen(");
+    if (first && strstr(first + 5, "seen(") != NULL)
+        ok = 0;
     if (!ok)
-        fprintf(stderr, "expected watch output to contain Alice: %s\n", output);
+        fprintf(stderr, "expected one complete wide watch tuple\n");
 
     free(output);
+    free(value);
     remove(inpath);
     remove(outpath);
     return ok ? 0 : 1;

--- a/wirelog/cli/driver.c
+++ b/wirelog/cli/driver.c
@@ -21,6 +21,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -28,6 +29,40 @@
 #define WL_WATCH_MAX_COLS 64
 /* Maximum length of a relation name in watch-mode input lines */
 #define WL_WATCH_MAX_RELATION 256
+
+/* Read one complete watch-mode record without fabricating records at a
+ * fixed-buffer boundary.  The returned line is NUL-terminated and owned by
+ * the caller; the buffer is retained for reuse by the next call. */
+static int
+read_watch_line(FILE *in, char **line, size_t *capacity)
+{
+    if (!in || !line || !capacity)
+        return -1;
+
+    size_t length = 0;
+    int ch;
+    while ((ch = fgetc(in)) != EOF) {
+        if (length + 1 >= *capacity) {
+            size_t new_capacity = *capacity ? *capacity * 2 : 4096;
+            if (new_capacity <= *capacity)
+                return -1;
+            char *grown = (char *)realloc(*line, new_capacity);
+            if (!grown)
+                return -1;
+            *line = grown;
+            *capacity = new_capacity;
+        }
+        (*line)[length++] = (char)ch;
+        if (ch == '\n')
+            break;
+    }
+
+    if (ferror(in) || (ch == EOF && length == 0))
+        return ferror(in) ? -1 : 0;
+
+    (*line)[length] = '\0';
+    return 1;
+}
 
 char *
 wl_read_file(const char *path)
@@ -475,11 +510,13 @@ wl_run_pipeline(const char *source, uint32_t num_workers, bool delta_mode,
         (void)watch_interval_ms; /* reserved for future polling interval use */
         fprintf(stderr, "Watch mode: reading from stdin...\n");
 
-        char line[4096];
+        char *line = NULL;
+        size_t line_capacity = 0;
         char relation[WL_WATCH_MAX_RELATION] = { 0 };
         int64_t values[WL_WATCH_MAX_COLS];
+        int read_rc;
 
-        while (fgets(line, (int)sizeof(line), stdin)) {
+        while ((read_rc = read_watch_line(stdin, &line, &line_capacity)) > 0) {
             uint32_t ncols = 0;
 
             if (parse_watch_line(line, relation, sizeof(relation), values,
@@ -501,9 +538,15 @@ wl_run_pipeline(const char *source, uint32_t num_workers, bool delta_mode,
             }
         }
 
-        /* Treat normal EOF as success */
-        if (feof(stdin))
+        free(line);
+
+        if (read_rc < 0) {
+            fprintf(stderr, "error: failed to read watch input\n");
+            rc = -1;
+        } else if (feof(stdin)) {
+            /* Treat normal EOF as success */
             rc = 0;
+        }
     }
 
     /* 7. Close per-relation output files */


### PR DESCRIPTION
## Summary

- replace the fixed 4096-byte watch input buffer with a growable complete-line reader
- add a regression test for a 5000-byte watch-mode record

## Validation

- meson test -C build cli_watch --print-errorlogs
- ASAN/UBSAN focused cli_watch test
- uncrustify and git diff --check

Broad validation was attempted but the parallel LTO build hit the environment /tmp disk quota.

Closes #1006