### PR TITLE
fix(csv): reject malformed fields and overflow

### DIFF
--- a/tests/test_csv.c
+++ b/tests/test_csv.c
@@ -538,6 +538,68 @@ test_parse_line_ex_all_int(void)
     PASS();
 }
 
+static void
+test_parse_line_rejects_erange(void)
+{
+    TEST("parse_line: rejects integer overflow");
+
+    int64_t values[1];
+    uint32_t count = 0;
+    int rc = wl_csv_parse_line("999999999999999999999999", ',', values, 1,
+            &count);
+    if (rc == 0) {
+        FAIL("out-of-range integer was accepted");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_parse_line_ex_rejects_malformed_fields(void)
+{
+    TEST("parse_line_ex: rejects malformed fields and preserves empty final");
+
+    wl_intern_t *intern = wl_intern_create();
+    if (!intern) {
+        FAIL("intern create failed");
+        return;
+    }
+
+    wirelog_column_type_t types[]
+        = { WIRELOG_TYPE_STRING, WIRELOG_TYPE_STRING,
+            WIRELOG_TYPE_STRING };
+    int64_t values[3];
+    uint32_t count = 0;
+
+    int rc = wl_csv_parse_line_ex("\"unterminated", ',', types, 3, values,
+            3, &count, intern);
+    if (rc == 0) {
+        FAIL("unterminated quote was accepted");
+        wl_intern_free(intern);
+        return;
+    }
+    rc = wl_csv_parse_line_ex("\"ok\"junk,x,y", ',', types, 3, values,
+            3, &count, intern);
+    if (rc == 0) {
+        FAIL("junk after quote was accepted");
+        wl_intern_free(intern);
+        return;
+    }
+    rc = wl_csv_parse_line_ex("a,b,", ',', types, 3, values, 3, &count,
+            intern);
+    const char *empty = (rc == 0 && count == 3)
+        ? wl_intern_reverse(intern, values[2]) : NULL;
+    if (rc != 0 || count != 3
+        || !empty || strcmp(empty, "") != 0) {
+        FAIL("trailing delimiter did not preserve empty final field");
+        wl_intern_free(intern);
+        return;
+    }
+
+    wl_intern_free(intern);
+    PASS();
+}
+
 /* ======================================================================== */
 /* Test: wl_csv_read_file_via_ctx (callback-based, #455)                    */
 /* ======================================================================== */
@@ -637,6 +699,8 @@ main(void)
     test_parse_line_ex_mixed();
     test_parse_line_ex_unquoted_strings();
     test_parse_line_ex_all_int();
+    test_parse_line_rejects_erange();
+    test_parse_line_ex_rejects_malformed_fields();
 
     printf("\n--- File Reading ---\n");
     test_read_file_basic();

--- a/wirelog/io/csv_reader.c
+++ b/wirelog/io/csv_reader.c
@@ -11,6 +11,7 @@
 #include "csv_reader.h"
 
 #include <ctype.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,17 +39,23 @@ wl_csv_parse_line(const char *line, char delimiter, int64_t *values,
         while (*p && *p != delimiter && isspace((unsigned char)*p))
             p++;
 
-        if (*p == '\0')
-            break;
+        if (*p == '\0') {
+            if (*count == 0)
+                break;
+            return -1; /* trailing delimiter or empty integer field */
+        }
 
         if (*count >= max_cols)
             return -2;
 
         char *end;
+        errno = 0;
         int64_t val = strtoll(p, &end, 10);
 
         if (end == p)
             return -1; /* not a valid integer */
+        if (errno == ERANGE)
+            return -1; /* do not silently clamp out-of-range values */
 
         values[*count] = val;
         (*count)++;
@@ -470,8 +477,18 @@ csv_parse_line_via_ctx(const char *line, char delimiter,
         while (*p && *p != delimiter && *p != '"' && isspace((unsigned char)*p))
             p++;
 
-        if (*p == '\0' && col < num_cols - 1)
+        if (*p == '\0') {
+            /* A trailing delimiter denotes an empty final string field. */
+            if (col == num_cols - 1 && col > 0 && p[-1] == delimiter
+                && col_types[col] == WIRELOG_TYPE_STRING) {
+                values[col] = intern_cb(opaque, "");
+                if (values[col] < 0)
+                    return -1;
+                (*count)++;
+                break;
+            }
             return -2; /* too few columns */
+        }
 
         if (col_types[col] == WIRELOG_TYPE_STRING) {
             /* Parse string field: quoted or unquoted */
@@ -484,9 +501,15 @@ csv_parse_line_via_ctx(const char *line, char delimiter,
                 start = p;
                 while (*p && *p != '"')
                     p++;
+                if (*p != '"')
+                    return -1; /* unterminated quoted field */
                 slen = (size_t)(p - start);
-                if (*p == '"')
-                    p++; /* skip closing quote */
+                p++; /* skip closing quote */
+                while (*p && *p != delimiter && *p != '\n' && *p != '\r'
+                    && isspace((unsigned char)*p))
+                    p++;
+                if (*p && *p != delimiter && *p != '\n' && *p != '\r')
+                    return -1; /* junk after closing quote */
             } else {
                 /* Unquoted field: read until delimiter or end */
                 start = p;
@@ -510,9 +533,12 @@ csv_parse_line_via_ctx(const char *line, char delimiter,
         } else {
             /* Parse integer field */
             char *end;
+            errno = 0;
             values[col] = strtoll(p, &end, 10);
             if (end == p)
                 return -1; /* not a valid integer */
+            if (errno == ERANGE)
+                return -1; /* do not silently clamp out-of-range values */
             p = end;
 
             /* Skip trailing whitespace */
@@ -526,6 +552,14 @@ csv_parse_line_via_ctx(const char *line, char delimiter,
         if (col < num_cols - 1) {
             if (*p == delimiter)
                 p++;
+            else
+                return -2; /* missing field separator */
+        } else {
+            while (*p && (*p == '\n' || *p == '\r'
+                || isspace((unsigned char)*p)))
+                p++;
+            if (*p != '\0')
+                return -2; /* extra field after the declared width */
         }
     }
 


### PR DESCRIPTION
## Summary

- reject ERANGE integer conversions instead of silently clamping
- reject unterminated quotes, junk after quoted fields, missing fields, and extra fields
- preserve an empty final string field after a trailing delimiter
- add regression coverage for the parser defects

## Validation

- meson test -C build csv --print-errorlogs
- ASAN/UBSAN focused csv test
- uncrustify and git diff --check

Broad validation was attempted but the parallel LTO build hit the environment /tmp disk quota.

Closes #1005