### PR TITLE
fix(columnar): handle wide row buffer allocation failures

### DIFF
--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1464,6 +1464,18 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
             continue;
 
         uint32_t ncols = r->ncols;
+        int64_t row_stack[COL_STACK_MAX];
+        int64_t *src_buf = row_stack;
+        if (ncols > COL_STACK_MAX) {
+            src_buf = (int64_t *)malloc(ncols * sizeof(int64_t));
+            if (!src_buf) {
+                for (uint32_t i = 0; i < rc_cnt; i++)
+                    free(retract_data[i]);
+                free(retract_data);
+                free(retract_nrows);
+                return ENOMEM;
+            }
+        }
 
         for (uint32_t del_idx = 0; del_idx < retract_nrows[ri]; del_idx++) {
             const int64_t *to_remove
@@ -1473,15 +1485,9 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
             uint32_t out_r = 0;
             bool found = false;
             for (uint32_t src_idx = 0; src_idx < r->nrows; src_idx++) {
-                int64_t sbuf[COL_STACK_MAX];
-                int64_t *src_buf = sbuf;
-                if (ncols > COL_STACK_MAX)
-                    src_buf = (int64_t *)malloc(ncols * sizeof(int64_t));
                 col_rel_row_copy_out(r, src_idx, src_buf);
                 if (memcmp(src_buf, to_remove, sizeof(int64_t) * ncols)
                     == 0) {
-                    if (src_buf != sbuf)
-                        free(src_buf);
                     /* Found matching row; skip it (removal) */
                     found = true;
                     /* Copy remaining rows forward */
@@ -1497,8 +1503,6 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
                     if (out_r != src_idx)
                         col_rel_row_copy_in(r, out_r, src_buf);
                     out_r++;
-                    if (src_buf != sbuf)
-                        free(src_buf);
                 }
             }
 
@@ -1508,6 +1512,8 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
                     sess->delta_data);
             }
         }
+        if (src_buf != row_stack)
+            free(src_buf);
     }
 
     /* Cleanup: free stolen retraction buffers */

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1795,25 +1795,25 @@ col_session_remove(wl_session_t *session, const char *relation,
     if (r->ncols != num_cols)
         return EINVAL;
 
+    int64_t row_stack[COL_STACK_MAX];
+    int64_t *row_buf = row_stack;
+    if (num_cols > COL_STACK_MAX) {
+        row_buf = (int64_t *)malloc(num_cols * sizeof(int64_t));
+        if (!row_buf)
+            return ENOMEM;
+    }
+
     /* Compact: remove matching rows */
     for (uint32_t di = 0; di < num_rows; di++) {
         const int64_t *del = data + (size_t)di * num_cols;
         uint32_t out_r = 0;
         for (uint32_t ri = 0; ri < r->nrows; ri++) {
-            int64_t rbuf[COL_STACK_MAX];
-            int64_t *row_buf = rbuf;
-            if (num_cols > COL_STACK_MAX)
-                row_buf = (int64_t *)malloc(num_cols * sizeof(int64_t));
             col_rel_row_copy_out(r, ri, row_buf);
             if (memcmp(row_buf, del, sizeof(int64_t) * num_cols) != 0) {
                 if (out_r != ri)
                     col_rel_row_copy_in(r, out_r, row_buf);
                 out_r++;
-                if (row_buf != rbuf)
-                    free(row_buf);
             } else {
-                if (row_buf != rbuf)
-                    free(row_buf);
                 /* Remove first matching row only */
                 di = num_rows; /* break outer loop after this one */
                 for (uint32_t rest = ri + 1; rest < r->nrows; rest++, out_r++)
@@ -1825,6 +1825,8 @@ col_session_remove(wl_session_t *session, const char *relation,
         r->nrows = out_r;
 next_del:;
     }
+    if (row_buf != row_stack)
+        free(row_buf);
     session_invalidate_relation_caches(sess, r->name);
     sess->pending_input_change = true;
     sess->snapshot_stable_valid = false;
@@ -1900,25 +1902,25 @@ col_session_remove_incremental(wl_session_t *session, const char *relation,
         return rc;
     }
 
+    int64_t row_stack[COL_STACK_MAX];
+    int64_t *row_buf = row_stack;
+    if (num_cols > COL_STACK_MAX) {
+        row_buf = (int64_t *)malloc(num_cols * sizeof(int64_t));
+        if (!row_buf)
+            return ENOMEM;
+    }
+
     /* Remove rows from the EDB using existing compact logic */
     for (uint32_t di = 0; di < num_rows; di++) {
         const int64_t *del = data + (size_t)di * num_cols;
         uint32_t out_r = 0;
         for (uint32_t ri = 0; ri < r->nrows; ri++) {
-            int64_t rbuf[COL_STACK_MAX];
-            int64_t *row_buf = rbuf;
-            if (num_cols > COL_STACK_MAX)
-                row_buf = (int64_t *)malloc(num_cols * sizeof(int64_t));
             col_rel_row_copy_out(r, ri, row_buf);
             if (memcmp(row_buf, del, sizeof(int64_t) * num_cols) != 0) {
                 if (out_r != ri)
                     col_rel_row_copy_in(r, out_r, row_buf);
                 out_r++;
-                if (row_buf != rbuf)
-                    free(row_buf);
             } else {
-                if (row_buf != rbuf)
-                    free(row_buf);
                 /* Remove first matching row only */
                 di = num_rows; /* break outer loop after this one */
                 for (uint32_t rest = ri + 1; rest < r->nrows; rest++, out_r++)
@@ -1930,6 +1932,8 @@ col_session_remove_incremental(wl_session_t *session, const char *relation,
         r->nrows = out_r;
 next_del_incr:;
     }
+    if (row_buf != row_stack)
+        free(row_buf);
 
     /* Clamp base_nrows to current row count */
     if (r->base_nrows > r->nrows)


### PR DESCRIPTION
## Summary

- check wide row scratch-buffer allocations for ENOMEM
- hoist the wide row buffer out of per-row deletion loops

## Validation

- meson test -C build session --print-errorlogs
- ASAN/UBSAN focused session test
- uncrustify and git diff --check

Broad validation was attempted but the parallel LTO build hit the environment /tmp disk quota.

Closes #1003