### PR TITLE
fix: harden wide input, planning, and row buffers

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -872,7 +872,8 @@ test_optimizer_equivalence_exe = executable(
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
 
-test('optimizer_equivalence', test_optimizer_equivalence_exe, suite: 'optimizer')
+test('optimizer_equivalence', test_optimizer_equivalence_exe, suite: 'optimizer',
+     timeout: 120)
 
 test_plan_gen_exe = executable(
   'test_plan_gen',
@@ -3138,7 +3139,7 @@ test_diff_integration_exe = executable(
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
 
-test('diff_integration', test_diff_integration_exe)
+test('diff_integration', test_diff_integration_exe, timeout: 120)
 
 test_diff_recursive_arrangement_exe = executable(
   'test_diff_recursive_arrangement',

--- a/tests/test_cli_watch.c
+++ b/tests/test_cli_watch.c
@@ -24,10 +24,21 @@ main(void)
         fprintf(stderr, "cannot create watch input file\n");
         return 1;
     }
-    fprintf(in, "person \"Alice\"\n");
+    const size_t value_len = 5000;
+    char *value = (char *)malloc(value_len + 1);
+    if (!value) {
+        fclose(in);
+        remove(inpath);
+        fprintf(stderr, "cannot allocate watch value\n");
+        return 1;
+    }
+    memset(value, 'A', value_len);
+    value[value_len] = '\0';
+    fprintf(in, "person \"%s\"\n", value);
     fclose(in);
 
     if (!freopen(inpath, "r", stdin)) {
+        free(value);
         remove(inpath);
         fprintf(stderr, "cannot redirect stdin\n");
         return 1;
@@ -37,6 +48,7 @@ main(void)
     test_tmppath(outpath, sizeof(outpath), "wirelog_test_watch_string.out");
     FILE *out = fopen(outpath, "w");
     if (!out) {
+        free(value);
         remove(inpath);
         fprintf(stderr, "cannot create output file\n");
         return 1;
@@ -49,6 +61,7 @@ main(void)
     int rc = wl_run_pipeline(src, 1, false, true, 0, out);
     fclose(out);
     if (rc != 0) {
+        free(value);
         remove(inpath);
         remove(outpath);
         fprintf(stderr, "wl_run_pipeline returned %d\n", rc);
@@ -57,17 +70,22 @@ main(void)
 
     char *output = wl_read_file(outpath);
     if (!output) {
+        free(value);
         remove(inpath);
         remove(outpath);
         fprintf(stderr, "cannot read output file\n");
         return 1;
     }
 
-    int ok = strstr(output, "\"Alice\"") != NULL;
+    int ok = strstr(output, value) != NULL;
+    char *first = strstr(output, "seen(");
+    if (first && strstr(first + 5, "seen(") != NULL)
+        ok = 0;
     if (!ok)
-        fprintf(stderr, "expected watch output to contain Alice: %s\n", output);
+        fprintf(stderr, "expected one complete wide watch tuple\n");
 
     free(output);
+    free(value);
     remove(inpath);
     remove(outpath);
     return ok ? 0 : 1;

--- a/tests/test_csv.c
+++ b/tests/test_csv.c
@@ -538,6 +538,68 @@ test_parse_line_ex_all_int(void)
     PASS();
 }
 
+static void
+test_parse_line_rejects_erange(void)
+{
+    TEST("parse_line: rejects integer overflow");
+
+    int64_t values[1];
+    uint32_t count = 0;
+    int rc = wl_csv_parse_line("999999999999999999999999", ',', values, 1,
+            &count);
+    if (rc == 0) {
+        FAIL("out-of-range integer was accepted");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_parse_line_ex_rejects_malformed_fields(void)
+{
+    TEST("parse_line_ex: rejects malformed fields and preserves empty final");
+
+    wl_intern_t *intern = wl_intern_create();
+    if (!intern) {
+        FAIL("intern create failed");
+        return;
+    }
+
+    wirelog_column_type_t types[]
+        = { WIRELOG_TYPE_STRING, WIRELOG_TYPE_STRING,
+            WIRELOG_TYPE_STRING };
+    int64_t values[3];
+    uint32_t count = 0;
+
+    int rc = wl_csv_parse_line_ex("\"unterminated", ',', types, 3, values,
+            3, &count, intern);
+    if (rc == 0) {
+        FAIL("unterminated quote was accepted");
+        wl_intern_free(intern);
+        return;
+    }
+    rc = wl_csv_parse_line_ex("\"ok\"junk,x,y", ',', types, 3, values,
+            3, &count, intern);
+    if (rc == 0) {
+        FAIL("junk after quote was accepted");
+        wl_intern_free(intern);
+        return;
+    }
+    rc = wl_csv_parse_line_ex("a,b,", ',', types, 3, values, 3, &count,
+            intern);
+    const char *empty = (rc == 0 && count == 3)
+        ? wl_intern_reverse(intern, values[2]) : NULL;
+    if (rc != 0 || count != 3
+        || !empty || strcmp(empty, "") != 0) {
+        FAIL("trailing delimiter did not preserve empty final field");
+        wl_intern_free(intern);
+        return;
+    }
+
+    wl_intern_free(intern);
+    PASS();
+}
+
 /* ======================================================================== */
 /* Test: wl_csv_read_file_via_ctx (callback-based, #455)                    */
 /* ======================================================================== */
@@ -637,6 +699,8 @@ main(void)
     test_parse_line_ex_mixed();
     test_parse_line_ex_unquoted_strings();
     test_parse_line_ex_all_int();
+    test_parse_line_rejects_erange();
+    test_parse_line_ex_rejects_malformed_fields();
 
     printf("\n--- File Reading ---\n");
     test_read_file_basic();

--- a/tests/test_magic_sets.c
+++ b/tests/test_magic_sets.c
@@ -1562,6 +1562,45 @@ test_fused_head_reported_as_unsupported(void)
     PASS();
 }
 
+static void
+test_body_atom_limit_is_reported(void)
+{
+    TEST("body atom limit is reported");
+
+    char src[32768];
+    size_t used = 0;
+    used += (size_t)snprintf(src + used, sizeof(src) - used,
+            ".decl out(x: int32)\n.output out\n.query out(b) .\n");
+    for (uint32_t i = 0; i < 65; i++) {
+        used += (size_t)snprintf(src + used, sizeof(src) - used,
+                ".decl r%u(x: int32)\n", i);
+    }
+    used += (size_t)snprintf(src + used, sizeof(src) - used,
+            "out(x) :- ");
+    for (uint32_t i = 0; i < 65; i++) {
+        used += (size_t)snprintf(src + used, sizeof(src) - used,
+                "%sr%u(x)", i == 0 ? "" : ", ", i);
+    }
+    snprintf(src + used, sizeof(src) - used, ".\n");
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        FAIL("failed to parse over-limit rule");
+        return;
+    }
+
+    wl_magic_demand_t demand = { "out", 1, 1 };
+    int rc = wl_magic_sets_apply_with_demands(prog, &demand, 1, NULL);
+    bool rejected = rc != 0 && !prog->magic_sets_applied;
+    wirelog_program_free(prog);
+    if (!rejected) {
+        FAIL("over-limit rule was silently rewritten");
+        return;
+    }
+    PASS();
+}
+
 /* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
@@ -1595,6 +1634,7 @@ main(void)
     test_guard_over_semijoin_exact();
     test_constant_head_position_not_counted();
     test_fused_head_reported_as_unsupported();
+    test_body_atom_limit_is_reported();
 
     printf("\n=== Results ===\n");
     printf("Tests run:    %d\n", tests_run);

--- a/tests/test_optimizer_equivalence.c
+++ b/tests/test_optimizer_equivalence.c
@@ -25,7 +25,7 @@
 #include <string.h>
 
 #define MAX_ROWS 128
-#define MAX_COLS 4
+#define MAX_COLS 6
 
 typedef struct {
     const char *relation;
@@ -490,6 +490,20 @@ main(void)
         "c(6, 11).\n"
         "c(7, 12).\n"
         "out(x, w) :- a(x, y), b(y, z), c(z, w).\n";
+    static const char *wide_chain_src =
+        ".decl a(x: int32, y: int32)\n"
+        ".decl b(y: int32, z: int32)\n"
+        ".decl c(z: int32, u: int32)\n"
+        ".decl d(u: int32, v: int32)\n"
+        ".decl e(v: int32, w: int32)\n"
+        ".decl chain(x: int32, y: int32, z: int32, u: int32, v: int32, w: int32)\n"
+        ".output chain\n"
+        "a(1, 2).\n"
+        "b(2, 3).\n"
+        "c(3, 4).\n"
+        "d(4, 5).\n"
+        "e(5, 6).\n"
+        "chain(x, y, z, u, v, w) :- a(x, y), b(y, z), c(z, u), d(u, v), e(v, w).\n";
     static const char *jpp_src =
         ".decl a(x: int32, y: int32)\n"
         ".decl b(y: int32, z: int32)\n"
@@ -547,6 +561,8 @@ main(void)
             expect_fusion);
     failed += check_matrix_case("optimizer matrix: sip", sip_src, "out",
             expect_sip);
+    failed += check_matrix_case("optimizer matrix: wide chain", wide_chain_src,
+            "chain", expect_none);
     failed += check_matrix_case("optimizer matrix: jpp", jpp_src, "out",
             expect_jpp);
     failed += check_matrix_case("optimizer matrix: bounded magic",

--- a/wirelog/cli/driver.c
+++ b/wirelog/cli/driver.c
@@ -21,6 +21,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -28,6 +29,40 @@
 #define WL_WATCH_MAX_COLS 64
 /* Maximum length of a relation name in watch-mode input lines */
 #define WL_WATCH_MAX_RELATION 256
+
+/* Read one complete watch-mode record without fabricating records at a
+ * fixed-buffer boundary.  The returned line is NUL-terminated and owned by
+ * the caller; the buffer is retained for reuse by the next call. */
+static int
+read_watch_line(FILE *in, char **line, size_t *capacity)
+{
+    if (!in || !line || !capacity)
+        return -1;
+
+    size_t length = 0;
+    int ch;
+    while ((ch = fgetc(in)) != EOF) {
+        if (length + 1 >= *capacity) {
+            size_t new_capacity = *capacity ? *capacity * 2 : 4096;
+            if (new_capacity <= *capacity)
+                return -1;
+            char *grown = (char *)realloc(*line, new_capacity);
+            if (!grown)
+                return -1;
+            *line = grown;
+            *capacity = new_capacity;
+        }
+        (*line)[length++] = (char)ch;
+        if (ch == '\n')
+            break;
+    }
+
+    if (ferror(in) || (ch == EOF && length == 0))
+        return ferror(in) ? -1 : 0;
+
+    (*line)[length] = '\0';
+    return 1;
+}
 
 char *
 wl_read_file(const char *path)
@@ -475,11 +510,13 @@ wl_run_pipeline(const char *source, uint32_t num_workers, bool delta_mode,
         (void)watch_interval_ms; /* reserved for future polling interval use */
         fprintf(stderr, "Watch mode: reading from stdin...\n");
 
-        char line[4096];
+        char *line = NULL;
+        size_t line_capacity = 0;
         char relation[WL_WATCH_MAX_RELATION] = { 0 };
         int64_t values[WL_WATCH_MAX_COLS];
+        int read_rc;
 
-        while (fgets(line, (int)sizeof(line), stdin)) {
+        while ((read_rc = read_watch_line(stdin, &line, &line_capacity)) > 0) {
             uint32_t ncols = 0;
 
             if (parse_watch_line(line, relation, sizeof(relation), values,
@@ -501,9 +538,15 @@ wl_run_pipeline(const char *source, uint32_t num_workers, bool delta_mode,
             }
         }
 
-        /* Treat normal EOF as success */
-        if (feof(stdin))
+        free(line);
+
+        if (read_rc < 0) {
+            fprintf(stderr, "error: failed to read watch input\n");
+            rc = -1;
+        } else if (feof(stdin)) {
+            /* Treat normal EOF as success */
             rc = 0;
+        }
     }
 
     /* 7. Close per-relation output files */

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1464,6 +1464,18 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
             continue;
 
         uint32_t ncols = r->ncols;
+        int64_t row_stack[COL_STACK_MAX];
+        int64_t *src_buf = row_stack;
+        if (ncols > COL_STACK_MAX) {
+            src_buf = (int64_t *)malloc(ncols * sizeof(int64_t));
+            if (!src_buf) {
+                for (uint32_t i = 0; i < rc_cnt; i++)
+                    free(retract_data[i]);
+                free(retract_data);
+                free(retract_nrows);
+                return ENOMEM;
+            }
+        }
 
         for (uint32_t del_idx = 0; del_idx < retract_nrows[ri]; del_idx++) {
             const int64_t *to_remove
@@ -1473,15 +1485,9 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
             uint32_t out_r = 0;
             bool found = false;
             for (uint32_t src_idx = 0; src_idx < r->nrows; src_idx++) {
-                int64_t sbuf[COL_STACK_MAX];
-                int64_t *src_buf = sbuf;
-                if (ncols > COL_STACK_MAX)
-                    src_buf = (int64_t *)malloc(ncols * sizeof(int64_t));
                 col_rel_row_copy_out(r, src_idx, src_buf);
                 if (memcmp(src_buf, to_remove, sizeof(int64_t) * ncols)
                     == 0) {
-                    if (src_buf != sbuf)
-                        free(src_buf);
                     /* Found matching row; skip it (removal) */
                     found = true;
                     /* Copy remaining rows forward */
@@ -1497,8 +1503,6 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
                     if (out_r != src_idx)
                         col_rel_row_copy_in(r, out_r, src_buf);
                     out_r++;
-                    if (src_buf != sbuf)
-                        free(src_buf);
                 }
             }
 
@@ -1508,6 +1512,8 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
                     sess->delta_data);
             }
         }
+        if (src_buf != row_stack)
+            free(src_buf);
     }
 
     /* Cleanup: free stolen retraction buffers */

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1795,25 +1795,25 @@ col_session_remove(wl_session_t *session, const char *relation,
     if (r->ncols != num_cols)
         return EINVAL;
 
+    int64_t row_stack[COL_STACK_MAX];
+    int64_t *row_buf = row_stack;
+    if (num_cols > COL_STACK_MAX) {
+        row_buf = (int64_t *)malloc(num_cols * sizeof(int64_t));
+        if (!row_buf)
+            return ENOMEM;
+    }
+
     /* Compact: remove matching rows */
     for (uint32_t di = 0; di < num_rows; di++) {
         const int64_t *del = data + (size_t)di * num_cols;
         uint32_t out_r = 0;
         for (uint32_t ri = 0; ri < r->nrows; ri++) {
-            int64_t rbuf[COL_STACK_MAX];
-            int64_t *row_buf = rbuf;
-            if (num_cols > COL_STACK_MAX)
-                row_buf = (int64_t *)malloc(num_cols * sizeof(int64_t));
             col_rel_row_copy_out(r, ri, row_buf);
             if (memcmp(row_buf, del, sizeof(int64_t) * num_cols) != 0) {
                 if (out_r != ri)
                     col_rel_row_copy_in(r, out_r, row_buf);
                 out_r++;
-                if (row_buf != rbuf)
-                    free(row_buf);
             } else {
-                if (row_buf != rbuf)
-                    free(row_buf);
                 /* Remove first matching row only */
                 di = num_rows; /* break outer loop after this one */
                 for (uint32_t rest = ri + 1; rest < r->nrows; rest++, out_r++)
@@ -1825,6 +1825,8 @@ col_session_remove(wl_session_t *session, const char *relation,
         r->nrows = out_r;
 next_del:;
     }
+    if (row_buf != row_stack)
+        free(row_buf);
     session_invalidate_relation_caches(sess, r->name);
     sess->pending_input_change = true;
     sess->snapshot_stable_valid = false;
@@ -1900,25 +1902,25 @@ col_session_remove_incremental(wl_session_t *session, const char *relation,
         return rc;
     }
 
+    int64_t row_stack[COL_STACK_MAX];
+    int64_t *row_buf = row_stack;
+    if (num_cols > COL_STACK_MAX) {
+        row_buf = (int64_t *)malloc(num_cols * sizeof(int64_t));
+        if (!row_buf)
+            return ENOMEM;
+    }
+
     /* Remove rows from the EDB using existing compact logic */
     for (uint32_t di = 0; di < num_rows; di++) {
         const int64_t *del = data + (size_t)di * num_cols;
         uint32_t out_r = 0;
         for (uint32_t ri = 0; ri < r->nrows; ri++) {
-            int64_t rbuf[COL_STACK_MAX];
-            int64_t *row_buf = rbuf;
-            if (num_cols > COL_STACK_MAX)
-                row_buf = (int64_t *)malloc(num_cols * sizeof(int64_t));
             col_rel_row_copy_out(r, ri, row_buf);
             if (memcmp(row_buf, del, sizeof(int64_t) * num_cols) != 0) {
                 if (out_r != ri)
                     col_rel_row_copy_in(r, out_r, row_buf);
                 out_r++;
-                if (row_buf != rbuf)
-                    free(row_buf);
             } else {
-                if (row_buf != rbuf)
-                    free(row_buf);
                 /* Remove first matching row only */
                 di = num_rows; /* break outer loop after this one */
                 for (uint32_t rest = ri + 1; rest < r->nrows; rest++, out_r++)
@@ -1930,6 +1932,8 @@ col_session_remove_incremental(wl_session_t *session, const char *relation,
         r->nrows = out_r;
 next_del_incr:;
     }
+    if (row_buf != row_stack)
+        free(row_buf);
 
     /* Clamp base_nrows to current row count */
     if (r->base_nrows > r->nrows)

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -3291,6 +3291,11 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
         wl_plan_free(plan);
         return -1;
     }
+    /* Transfer ownership before building the first stratum so every failure
+     * path can release already-completed nested allocations through
+     * wl_plan_free(). */
+    plan->strata = strata;
+    plan->stratum_count = stratum_count;
 
     for (uint32_t s = 0; s < prog->stratum_count; s++) {
         const wirelog_stratum_t *src = &prog->strata[s];
@@ -3318,7 +3323,6 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
         uint32_t max_rels = src->rule_count;
         char **unique_names = (char **)calloc(max_rels, sizeof(char *));
         if (!unique_names) {
-            free(strata);
             wl_plan_free(plan);
             return -1;
         }
@@ -3343,7 +3347,6 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
             unique_count, sizeof(wl_plan_relation_t));
         if (!rels) {
             free((void *)unique_names);
-            free(strata);
             wl_plan_free(plan);
             return -1;
         }
@@ -3378,7 +3381,6 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                 free((void *)rels[u].name);
                 free(rels[u].delta_name);
                 free(rels);
-                free(strata);
                 wl_plan_free(plan);
                 return -1;
             }
@@ -3400,7 +3402,6 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                     free((void *)rels[u].name);
                     free(rels[u].delta_name);
                     free(rels);
-                    free(strata);
                     wl_plan_free(plan);
                     return -1;
                 }
@@ -3424,7 +3425,6 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                     free((void *)rels[u].name);
                     free(rels[u].delta_name);
                     free(rels);
-                    free(strata);
                     wl_plan_free(plan);
                     return -1;
                 }
@@ -3441,9 +3441,6 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
         dst->relations = rels;
         dst->relation_count = unique_count;
     }
-
-    plan->strata = strata;
-    plan->stratum_count = stratum_count;
 
     /* Rewrite K-atom recursive rules for complete semi-naive evaluation.
      * For rules with K >= 2 IDB body atoms, emit K copies with CSE

--- a/wirelog/io/csv_reader.c
+++ b/wirelog/io/csv_reader.c
@@ -11,6 +11,7 @@
 #include "csv_reader.h"
 
 #include <ctype.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,17 +39,23 @@ wl_csv_parse_line(const char *line, char delimiter, int64_t *values,
         while (*p && *p != delimiter && isspace((unsigned char)*p))
             p++;
 
-        if (*p == '\0')
-            break;
+        if (*p == '\0') {
+            if (*count == 0)
+                break;
+            return -1; /* trailing delimiter or empty integer field */
+        }
 
         if (*count >= max_cols)
             return -2;
 
         char *end;
+        errno = 0;
         int64_t val = strtoll(p, &end, 10);
 
         if (end == p)
             return -1; /* not a valid integer */
+        if (errno == ERANGE)
+            return -1; /* do not silently clamp out-of-range values */
 
         values[*count] = val;
         (*count)++;
@@ -470,8 +477,18 @@ csv_parse_line_via_ctx(const char *line, char delimiter,
         while (*p && *p != delimiter && *p != '"' && isspace((unsigned char)*p))
             p++;
 
-        if (*p == '\0' && col < num_cols - 1)
+        if (*p == '\0') {
+            /* A trailing delimiter denotes an empty final string field. */
+            if (col == num_cols - 1 && col > 0 && p[-1] == delimiter
+                && col_types[col] == WIRELOG_TYPE_STRING) {
+                values[col] = intern_cb(opaque, "");
+                if (values[col] < 0)
+                    return -1;
+                (*count)++;
+                break;
+            }
             return -2; /* too few columns */
+        }
 
         if (col_types[col] == WIRELOG_TYPE_STRING) {
             /* Parse string field: quoted or unquoted */
@@ -484,9 +501,15 @@ csv_parse_line_via_ctx(const char *line, char delimiter,
                 start = p;
                 while (*p && *p != '"')
                     p++;
+                if (*p != '"')
+                    return -1; /* unterminated quoted field */
                 slen = (size_t)(p - start);
-                if (*p == '"')
-                    p++; /* skip closing quote */
+                p++; /* skip closing quote */
+                while (*p && *p != delimiter && *p != '\n' && *p != '\r'
+                    && isspace((unsigned char)*p))
+                    p++;
+                if (*p && *p != delimiter && *p != '\n' && *p != '\r')
+                    return -1; /* junk after closing quote */
             } else {
                 /* Unquoted field: read until delimiter or end */
                 start = p;
@@ -510,9 +533,12 @@ csv_parse_line_via_ctx(const char *line, char delimiter,
         } else {
             /* Parse integer field */
             char *end;
+            errno = 0;
             values[col] = strtoll(p, &end, 10);
             if (end == p)
                 return -1; /* not a valid integer */
+            if (errno == ERANGE)
+                return -1; /* do not silently clamp out-of-range values */
             p = end;
 
             /* Skip trailing whitespace */
@@ -526,6 +552,16 @@ csv_parse_line_via_ctx(const char *line, char delimiter,
         if (col < num_cols - 1) {
             if (*p == delimiter)
                 p++;
+            else
+                return -2; /* missing field separator */
+        } else if (col_types[col] != WIRELOG_TYPE_STRING) {
+            /* The string reader historically ignores fields beyond the
+            * declared width; preserve that adapter behavior (#982). */
+            while (*p && (*p == '\n' || *p == '\r'
+                || isspace((unsigned char)*p)))
+                p++;
+            if (*p != '\0')
+                return -2; /* extra field after the declared width */
         }
     }
 

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -48,12 +48,14 @@
 typedef struct {
     const char *vars[MS_MAX_VARS]; /* borrowed pointers from IR nodes */
     uint32_t count;
+    bool overflow;
 } ms_varset_t;
 
 static void
 varset_clear(ms_varset_t *vs)
 {
     vs->count = 0;
+    vs->overflow = false;
 }
 
 static bool
@@ -71,10 +73,13 @@ varset_contains(const ms_varset_t *vs, const char *var)
 static void
 varset_add(ms_varset_t *vs, const char *var)
 {
-    if (!var || vs->count >= MS_MAX_VARS)
+    if (!var || varset_contains(vs, var))
         return;
-    if (!varset_contains(vs, var))
-        vs->vars[vs->count++] = var;
+    if (vs->count >= MS_MAX_VARS) {
+        vs->overflow = true;
+        return;
+    }
+    vs->vars[vs->count++] = var;
 }
 
 /* ======================================================================== */
@@ -92,15 +97,32 @@ typedef struct {
 /* ======================================================================== */
 
 typedef struct {
-    char rel_name[128];
+    const char *rel_name; /* borrowed from the program IR */
     uint64_t bound_mask;
     uint32_t arity;
 } ms_adorned_t;
 
 typedef struct {
-    ms_adorned_t items[MS_MAX_ADORNED];
+    ms_adorned_t *items;
     uint32_t count;
+    bool overflow;
 } ms_adorned_set_t;
+
+static bool
+adorned_set_init(ms_adorned_set_t *s)
+{
+    memset(s, 0, sizeof(*s));
+    s->items = (ms_adorned_t *)calloc(MS_MAX_ADORNED, sizeof(*s->items));
+    return s->items != NULL;
+}
+
+static void
+adorned_set_free(ms_adorned_set_t *s)
+{
+    free(s->items);
+    s->items = NULL;
+    s->count = 0;
+}
 
 static bool
 adorned_contains(const ms_adorned_set_t *s, const char *name, uint64_t mask)
@@ -120,10 +142,11 @@ adorned_add(ms_adorned_set_t *s, const char *name, uint64_t mask,
 {
     if (adorned_contains(s, name, mask))
         return false;
-    if (s->count >= MS_MAX_ADORNED)
+    if (s->count >= MS_MAX_ADORNED) {
+        s->overflow = true;
         return false;
-    snprintf(s->items[s->count].rel_name, sizeof(s->items[s->count].rel_name),
-        "%s", name);
+    }
+    s->items[s->count].rel_name = name;
     s->items[s->count].bound_mask = mask;
     s->items[s->count].arity = arity;
     s->count++;
@@ -207,10 +230,14 @@ get_arity(const struct wirelog_program *prog, const char *rel_name)
 
 static void
 collect_scans_r(const wirelog_ir_node_t *node, ms_atom_t *atoms,
-    uint32_t *count)
+    uint32_t *count, bool *overflow)
 {
-    if (!node || *count >= MS_MAX_ATOMS)
+    if (!node)
         return;
+    if (*count >= MS_MAX_ATOMS) {
+        *overflow = true;
+        return;
+    }
 
     switch (node->type) {
     case WIRELOG_IR_SCAN:
@@ -231,12 +258,12 @@ collect_scans_r(const wirelog_ir_node_t *node, ms_atom_t *atoms,
          *           filtering only, not a real body atom.
          */
         if (node->child_count > 0)
-            collect_scans_r(node->children[0], atoms, count);
+            collect_scans_r(node->children[0], atoms, count, overflow);
         break;
 
     default:
         for (uint32_t i = 0; i < node->child_count; i++)
-            collect_scans_r(node->children[i], atoms, count);
+            collect_scans_r(node->children[i], atoms, count, overflow);
         break;
     }
 }
@@ -247,12 +274,13 @@ collect_scans_r(const wirelog_ir_node_t *node, ms_atom_t *atoms,
  * Returns the number of atoms collected.
  */
 static uint32_t
-collect_body_atoms(const wirelog_ir_node_t *ir_root, ms_atom_t *atoms)
+collect_body_atoms(const wirelog_ir_node_t *ir_root, ms_atom_t *atoms,
+    bool *overflow)
 {
     if (!ir_root || ir_root->child_count == 0)
         return 0;
     uint32_t count = 0;
-    collect_scans_r(ir_root->children[0], atoms, &count);
+    collect_scans_r(ir_root->children[0], atoms, &count, overflow);
     return count;
 }
 
@@ -316,6 +344,13 @@ get_head_vars(const wirelog_ir_node_t *ir_root, const char **vars,
         return 0;
 
     if (ir_root->type == WIRELOG_IR_PROJECT) {
+        if (ir_root->project_count > max_vars) {
+            fprintf(stderr,
+                "warning: magic sets skipped rule with %u head columns; "
+                "the 64-bit adornment mask supports at most %u\n",
+                ir_root->project_count, max_vars);
+            return 0;
+        }
         uint32_t n = (ir_root->project_count < max_vars)
                          ? ir_root->project_count
                          : max_vars;
@@ -660,7 +695,8 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
     /* === Phase 1: Seed the worklist from explicit demands === */
 
     ms_adorned_set_t processed;
-    memset(&processed, 0, sizeof(processed));
+    if (!adorned_set_init(&processed))
+        return -1;
 
     /* Simple queue over processed items (indices 0..count-1) */
     uint32_t wl_head = 0; /* index of next item to process */
@@ -702,6 +738,13 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
         }
 
         adorned_add(&processed, d->relation_name, d->bound_mask, arity);
+        if (processed.overflow) {
+            fprintf(stderr,
+                "warning: magic sets skipped program with more than %u "
+                "adorned predicates\n", MS_MAX_ADORNED);
+            adorned_set_free(&processed);
+            return -1;
+        }
     }
 
     /* === Phase 2: BFS adorned program === */
@@ -735,7 +778,16 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
 
             /* Collect body atoms in join order */
             ms_atom_t atoms[MS_MAX_ATOMS];
-            uint32_t atom_count = collect_body_atoms(ir_root, atoms);
+            bool atom_overflow = false;
+            uint32_t atom_count = collect_body_atoms(ir_root, atoms,
+                    &atom_overflow);
+            if (atom_overflow) {
+                fprintf(stderr,
+                    "warning: magic sets skipped rule with more than %u "
+                    "body atoms\n", MS_MAX_ATOMS);
+                adorned_set_free(&processed);
+                return -1;
+            }
 
             for (uint32_t ai = 0; ai < atom_count; ai++) {
                 const ms_atom_t *atom = &atoms[ai];
@@ -761,6 +813,14 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
                     if (atom_mask != 0) {
                         adorned_add(&processed, atom->rel_name, atom_mask,
                             atom->col_count);
+                        if (processed.overflow) {
+                            fprintf(stderr,
+                                "warning: magic sets skipped program with "
+                                "more than %u adorned predicates\n",
+                                MS_MAX_ADORNED);
+                            adorned_set_free(&processed);
+                            return -1;
+                        }
                     } else {
                         if (stats)
                             stats->skipped_all_free++;
@@ -773,6 +833,13 @@ next_atom:
                     if (atom->col_names && atom->col_names[ci])
                         varset_add(&bound, atom->col_names[ci]);
                 }
+                if (bound.overflow) {
+                    fprintf(stderr,
+                        "warning: magic sets skipped rule with more than "
+                        "%u variables\n", MS_MAX_VARS);
+                    adorned_set_free(&processed);
+                    return -1;
+                }
             }
         }
     }
@@ -780,8 +847,10 @@ next_atom:
     if (stats)
         stats->adorned_predicates = processed.count;
 
-    if (processed.count == 0)
+    if (processed.count == 0){
+        adorned_set_free(&processed);
         return 0; /* Nothing to do */
+    }
 
     /* === Phase 3: Create magic relations === */
 
@@ -843,7 +912,16 @@ next_atom:
             }
 
             ms_atom_t atoms[MS_MAX_ATOMS];
-            uint32_t atom_count = collect_body_atoms(ir_root, atoms);
+            bool atom_overflow = false;
+            uint32_t atom_count = collect_body_atoms(ir_root, atoms,
+                    &atom_overflow);
+            if (atom_overflow) {
+                fprintf(stderr,
+                    "warning: magic sets skipped rule with more than %u "
+                    "body atoms\n", MS_MAX_ATOMS);
+                adorned_set_free(&processed);
+                return -1;
+            }
 
             ms_varset_t bound;
             varset_clear(&bound);
@@ -898,6 +976,13 @@ next_4a_atom:
                 for (uint32_t ci = 0; ci < atom->col_count; ci++) {
                     if (atom->col_names && atom->col_names[ci])
                         varset_add(&bound, atom->col_names[ci]);
+                }
+                if (bound.overflow) {
+                    fprintf(stderr,
+                        "warning: magic sets skipped rule with more than "
+                        "%u variables\n", MS_MAX_VARS);
+                    adorned_set_free(&processed);
+                    return -1;
                 }
             }
         }
@@ -976,6 +1061,7 @@ next_4a_atom:
     }
 
     prog->magic_sets_applied = true;
+    adorned_set_free(&processed);
     return 0;
 }
 


### PR DESCRIPTION
## Summary

This stacked PR groups seven independent fixes into one reviewable branch:

- #1006: read complete watch-mode records without a fixed 4096-byte buffer
- #1005: reject CSV overflow and malformed field boundaries
- #998: release partially built execution-plan strata on failure
- #1003: handle wide row-buffer allocation failures and avoid per-row allocations
- #1009: prevent Magic Sets from silently rewriting inputs beyond supported limits and move the adorned set off the stack
- #992: give allocation-heavy equivalence and diff tests a reliable timeout
- #960: extend optimizer equivalence coverage to a six-column, five-atom chain

## Validation

- focused CSV, Magic Sets, optimizer equivalence, diff integration, CLI watch, plan-generation, and session tests passed
- full Meson build completed successfully
- broad Meson test run: 268 passed, 11 skipped
- `csv_limits` now passes on the previously failing wide line split across chunks
- `git diff --check` passed

One unrelated repository baseline mismatch remains in `sbom_snapshot`: the current workflow references `msys2/setup-msys2@v2`, while the checked-in SBOM baseline records a pinned commit. This is not caused by the CSV change.

Closes #1006
Closes #1005
Closes #998
Closes #1003
Closes #1009
Closes #992
Closes #960
