### PR TITLE
fix(jpp): size join scratch arrays by the chain's width, not a per-scan guess

### DIFF
--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -11,6 +11,7 @@
 #include "../wirelog/ir/program.h"
 #include "../wirelog/wirelog-parser.h"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1050,6 +1051,695 @@ test_jpp_idb_idb_tie_unchanged(void)
 }
 
 /* ======================================================================== */
+/* Wide-relation scratch sizing (Issue #1002)                               */
+/* ======================================================================== */
+
+/*
+ * jpp sized its scratch arrays from fixed per-scan constants (nscan * 16,
+ * nscan * 32) rather than from the chain's actual column count, so a chain
+ * of three or more atoms over wide relations wrote past the end of them.
+ *
+ * The shapes below are far too wide to write out literally, so the sources
+ * are generated.  This target links no evaluator, so these cases can only
+ * assert that wl_jpp_apply() completes and reports sane statistics -- never
+ * answer correctness.  tests/test_wide_relation.c covers the answers.
+ */
+
+typedef struct {
+    char *data;
+    size_t len;
+    size_t cap;
+    int oom;
+} sbuf_t;
+
+static void
+sb_init(sbuf_t *s)
+{
+    s->data = NULL;
+    s->len = 0;
+    s->cap = 0;
+    s->oom = 0;
+}
+
+static void
+sb_free(sbuf_t *s)
+{
+    free(s->data);
+    sb_init(s);
+}
+
+static void
+sb_reserve(sbuf_t *s, size_t extra)
+{
+    if (s->oom)
+        return;
+    if (s->len + extra + 1 <= s->cap)
+        return;
+    size_t cap = s->cap ? s->cap : 1024;
+    while (cap < s->len + extra + 1)
+        cap *= 2;
+    char *p = (char *)realloc(s->data, cap);
+    if (!p) {
+        s->oom = 1;
+        return;
+    }
+    s->data = p;
+    s->cap = cap;
+}
+
+static void
+sb_puts(sbuf_t *s, const char *text)
+{
+    size_t n = strlen(text);
+    sb_reserve(s, n);
+    if (s->oom)
+        return;
+    memcpy(s->data + s->len, text, n);
+    s->len += n;
+    s->data[s->len] = '\0';
+}
+
+static void
+sb_printf(sbuf_t *s, const char *fmt, ...)
+{
+    char tmp[256];
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(tmp, sizeof(tmp), fmt, ap);
+    va_end(ap);
+    if (n < 0 || (size_t)n >= sizeof(tmp)) {
+        s->oom = 1;
+        return;
+    }
+    sb_puts(s, tmp);
+}
+
+/*
+ * One body atom.  Column j is named:
+ *   - the same as column 0, when @dup is set and j == 1 (a variable repeated
+ *     inside a single atom, which program.c wraps in a FILTER -- the leaf
+ *     collect_scans() then returns carries column_count == 0);
+ *   - "s<j>"      when j < @shared (drawn from the pool shared by all atoms);
+ *   - "v<k>_<j>"  otherwise (private to atom k).
+ */
+typedef struct {
+    unsigned cols;
+    unsigned shared;
+    int dup;
+} atom_t;
+
+static void
+sb_var(sbuf_t *s, unsigned k, const atom_t *a, unsigned j)
+{
+    unsigned src = (a->dup && j == 1) ? 0u : j;
+    if (src < a->shared)
+        sb_printf(s, "s%u", src);
+    else
+        sb_printf(s, "v%u_%u", k, src);
+}
+
+static void
+sb_decl(sbuf_t *s, const char *name, unsigned n)
+{
+    sb_printf(s, ".decl %s(", name);
+    for (unsigned i = 0; i < n; i++)
+        sb_printf(s, "%sc%u: int64", i ? ", " : "", i);
+    sb_puts(s, ")\n");
+}
+
+/*
+ * ".decl r0(..)  ..  .decl o(..)   o(<head_args>) :- r0(..), .., r{n-1}(..)."
+ */
+static void
+build_join_src(sbuf_t *s, const atom_t *atoms, unsigned natoms,
+    const char *head_args, unsigned head_cols)
+{
+    for (unsigned k = 0; k < natoms; k++) {
+        char name[16];
+        snprintf(name, sizeof(name), "r%u", k);
+        sb_decl(s, name, atoms[k].cols);
+    }
+    sb_decl(s, "o", head_cols);
+
+    /* sb_puts, not sb_printf: a 51-variable head is longer than sb_printf's
+     * formatting buffer. */
+    sb_puts(s, "o(");
+    sb_puts(s, head_args);
+    sb_puts(s, ") :- ");
+    for (unsigned k = 0; k < natoms; k++) {
+        sb_printf(s, "%sr%u(", k ? ", " : "", k);
+        for (unsigned j = 0; j < atoms[k].cols; j++) {
+            if (j)
+                sb_puts(s, ", ");
+            sb_var(s, k, &atoms[k], j);
+        }
+        sb_puts(s, ")");
+    }
+    sb_puts(s, ".\n");
+}
+
+/*
+ * Parse @src and run wl_jpp_apply on it.  Returns 0 and fills @stats on
+ * success; on failure fills @msg and returns -1.
+ */
+static int
+run_jpp(const char *src, wl_jpp_stats_t *stats, char *msg, size_t msg_size)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+
+    if (!prog) {
+        snprintf(msg, msg_size, "parse failed");
+        return -1;
+    }
+
+    wl_jpp_stats_t local = { 0, 0, 0 };
+    int rc = wl_jpp_apply(prog, &local);
+    wirelog_program_free(prog);
+
+    if (rc != 0) {
+        snprintf(msg, msg_size, "wl_jpp_apply returned %d, expected 0", rc);
+        return -1;
+    }
+    *stats = local;
+    return 0;
+}
+
+/*
+ * Shared driver: build the shape, run the pass, and require that it survives
+ * with chains_examined == 1 and exactly @expect_projections intermediate
+ * PROJECTs.
+ *
+ * Asserting projections_inserted is the load-bearing half.  chains_examined
+ * is incremented in optimize_tree() before any of the scratch allocations,
+ * so it stays 1 even when every one of them fails and the pass silently
+ * gives up on the chain -- it cannot tell "optimized correctly" from "did
+ * nothing".  projections_inserted can.
+ */
+static void
+check_wide_shape(const char *name, const atom_t *atoms, unsigned natoms,
+    const char *head_args, unsigned head_cols, uint32_t expect_projections)
+{
+    TEST(name);
+
+    sbuf_t s;
+    sb_init(&s);
+    build_join_src(&s, atoms, natoms, head_args, head_cols);
+    if (s.oom) {
+        sb_free(&s);
+        FAIL("source generation OOM");
+        return;
+    }
+
+    wl_jpp_stats_t stats = { 0, 0, 0 };
+    char msg[256];
+    if (run_jpp(s.data, &stats, msg, sizeof(msg)) != 0) {
+        sb_free(&s);
+        FAIL(msg);
+        return;
+    }
+    sb_free(&s);
+
+    if (stats.chains_examined != 1
+        || stats.projections_inserted != expect_projections) {
+        char buf[160];
+        snprintf(buf, sizeof(buf),
+            "expected chains=1 projections=%u, got chains=%u projections=%u",
+            expect_projections, stats.chains_examined,
+            stats.projections_inserted);
+        FAIL(buf);
+        return;
+    }
+    PASS();
+}
+
+/* n atoms of @cols all-distinct columns; head projects one body variable. */
+static void
+check_all_distinct(unsigned natoms, unsigned cols, uint32_t expect_projections)
+{
+    atom_t atoms[8];
+    char name[160];
+
+    /* Caller bug, not a shape the pass declines to handle: silently
+     * returning here would report a pass the test never ran. */
+    if (natoms > sizeof(atoms) / sizeof(atoms[0])) {
+        TEST("jpp #1002: check_all_distinct atom budget");
+        FAIL("natoms exceeds the atoms[] buffer; raise it");
+        return;
+    }
+    for (unsigned k = 0; k < natoms; k++) {
+        atoms[k].cols = cols;
+        atoms[k].shared = 0;
+        atoms[k].dup = 0;
+    }
+    snprintf(name, sizeof(name),
+        "jpp #1002: %u atoms x %u all-distinct columns", natoms, cols);
+    check_wide_shape(name, atoms, natoms, "v0_0", 1, expect_projections);
+}
+
+static void
+test_jpp_wide_greedy_acc(void)
+{
+    /*
+     * greedy_order()'s acc[] was sized `acc_count + nscan * 16` and then
+     * filled with one entry per column of every later-selected scan, so it
+     * overruns once the chain's total column count passes that bound.
+     * 3 atoms: clean at 24 columns, heap-buffer-overflow WRITE at 25.
+     * 4 atoms: clean at 21, overflow at 22.
+     */
+    check_all_distinct(3, 24, 1);
+    check_all_distinct(3, 25, 1);
+    check_all_distinct(4, 21, 2);
+    check_all_distinct(4, 22, 2);
+}
+
+static void
+test_jpp_wide_projection_seed(void)
+{
+    /*
+     * insert_projections()'s acc[] was sized `nscan * 16` with no room for
+     * the seed copy of scans[0]'s columns, so a 3-atom chain whose first
+     * atom alone is wider than 3 * 16 overruns on the seed copy -- before
+     * any merging happens.
+     */
+    atom_t atoms[3] = { { 50, 0, 0 }, { 2, 0, 0 }, { 2, 0, 0 } };
+
+    check_wide_shape(
+        "jpp #1002: 3-atom chain, 50-column first atom (seed copy)",
+        atoms, 3, "v0_0", 1, 1);
+}
+
+static void
+test_jpp_wide_projection_merge(void)
+{
+    /*
+     * The same acc[]: seed copy fits (40 <= 48) but merging the second
+     * atom's 11 new variables runs past the end.
+     */
+    atom_t atoms[3] = { { 40, 1, 0 }, { 12, 1, 0 }, { 4, 0, 0 } };
+
+    check_wide_shape("jpp #1002: 3-atom chain, 40+12 columns (acc merge)",
+        atoms, 3, "s0", 1, 1);
+}
+
+static void
+test_jpp_wide_physical_layout(void)
+{
+    /*
+     * phys_names[] was sized `nscan * 32` (96 here) but receives every
+     * column of every scan: 40 + 40 for the first two atoms, then 30 more
+     * for the third -- 110 writes.
+     *
+     * Every accumulated variable is live here (the head keeps the 11 that
+     * the third atom does not mention), so no PROJECT is inserted and the
+     * layout is never compacted.
+     *
+     * This one overruns phys_names[]. The sanitizer job
+     * (-Db_sanitize=address,undefined) is the reliable detector and the one
+     * to trust.  A release run is not guaranteed to be silent either:
+     * measured here with only this site reverted, the release build aborted
+     * at exactly this case with glibc's "corrupted size vs. prev_size"
+     * (rc=134).  Whether glibc trips at all depends on its version and on
+     * the allocation layout, so a green release run is not evidence the fix
+     * is present -- but neither is a red one a surprise.
+     */
+    atom_t atoms[3] = { { 40, 39, 0 }, { 40, 39, 0 }, { 30, 30, 0 } };
+    sbuf_t head;
+
+    sb_init(&head);
+    for (unsigned i = 30; i < 39; i++)
+        sb_printf(&head, "%ss%u", i > 30 ? ", " : "", i);
+    sb_puts(&head, ", v0_39, v1_39");
+    if (head.oom) {
+        sb_free(&head);
+        TEST("jpp #1002: 3-atom chain, physical layout tracking");
+        FAIL("head generation OOM");
+        return;
+    }
+
+    check_wide_shape("jpp #1002: 3-atom chain, physical layout tracking",
+        atoms, 3, head.data, 11, 0);
+    sb_free(&head);
+}
+
+static void
+test_jpp_wide_needed_set(void)
+{
+    /*
+     * The per-iteration needed[] was sized `nscan * 16` (48 here) but is
+     * filled with the head variables first -- its bound omitted
+     * head_var_count entirely, so a head of 51 variables overruns it before
+     * a single future-scan column is added.
+     *
+     * Measured pre-fix: heap-buffer-overflow WRITE at jpp.c:638 under ASAN.
+     * As with the case above, the sanitizer job is the reliable detector.
+     * With only this site reverted the release build also aborted (glibc
+     * "malloc(): unaligned tcache chunk detected", rc=134) -- but after this
+     * case had already reported PASS, at the next allocation, not here.  With
+     * the site above reverted as well the run dies earlier still, at that
+     * case, and never reaches this one.  Allocator-layout luck, not a
+     * guarantee: do not read a green non-sanitizer run as coverage.
+     */
+    atom_t atoms[3] = { { 17, 0, 0 }, { 17, 0, 0 }, { 17, 0, 0 } };
+    sbuf_t head;
+
+    sb_init(&head);
+    for (unsigned k = 0; k < 3; k++) {
+        for (unsigned j = 0; j < 17; j++)
+            sb_printf(&head, "%sv%u_%u", (k || j) ? ", " : "", k, j);
+    }
+    if (head.oom) {
+        sb_free(&head);
+        TEST("jpp #1002: 3-atom chain, 51-variable head");
+        FAIL("head generation OOM");
+        return;
+    }
+
+    check_wide_shape("jpp #1002: 3-atom chain, 51-variable head (needed set)",
+        atoms, 3, head.data, 51, 0);
+    sb_free(&head);
+}
+
+static void
+test_jpp_wide_filter_wrapped_leaves(void)
+{
+    /*
+     * Atoms 2 and 3 repeat their first variable, so program.c wraps those
+     * SCANs in a FILTER and collect_scans() returns the FILTER as the leaf.
+     * Such a leaf carries column_count == 0, so any capacity computed from
+     * the leaf's own column_count would be far too small; the width has to
+     * come through scan_vars(), which skips the wrapper.
+     *
+     * The shape is deliberately MIXED -- atom 1 is a bare SCAN, atoms 2 and
+     * 3 are wrapped -- and that matters for what this case can prove.
+     *
+     * An all-wrapped chain makes the mis-computed total 0, which is now
+     * clamped to 1 (see scan_columns_total): still undersized, so it would
+     * also be caught.  But it would be caught only via that clamp.  Before
+     * the clamp existed, a 0 total was treated as an allocation failure and
+     * the pass declined the chain, so the all-wrapped shape sailed past a
+     * mutation of scan_columns_total() to scans[i]->column_count with
+     * nothing but chains_examined to show for it.  The mixed shape does not
+     * depend on that: one bare 60-column leaf makes the mis-computed total
+     * 60 against a real 180, an ordinary undersized array that gets written
+     * past no matter how the zero case is handled.  It is also the shape
+     * real programs produce -- some atoms repeat a variable, most do not.
+     *
+     * Measured with the mutation applied: heap-buffer-overflow WRITE of
+     * size 8 in greedy_order, from this case.
+     */
+    atom_t atoms[3] = { { 60, 0, 0 }, { 60, 0, 1 }, { 60, 0, 1 } };
+
+    check_wide_shape("jpp #1002: 3-atom chain, bare + 2 FILTER-wrapped "
+        "60-column leaves", atoms, 3, "v0_0", 1, 1);
+}
+
+static void
+test_jpp_wide_two_atom_noop(void)
+{
+    /*
+     * Negative control.  optimize_chain() returns before any of the scratch
+     * allocations when nscan < 3, so a two-atom chain is clean at every
+     * width.  That contradicts issue #1002's claim that "wider relations
+     * will fail at 2 [atoms]": the early return is at the top of
+     * optimize_chain(), so no scratch array is ever allocated, let alone
+     * overrun, below three atoms.  chains_examined still counts the chain.
+     */
+    atom_t atoms[2] = { { 40, 0, 0 }, { 40, 0, 0 } };
+
+    check_wide_shape("jpp #1002: 2-atom chain x 40 columns is unaffected",
+        atoms, 2, "v0_0", 1, 0);
+}
+
+/* Append the SCAN relation names of @n, left to right, to @s. */
+static void
+sb_scan_order(sbuf_t *s, const wirelog_ir_node_t *n)
+{
+    if (!n)
+        return;
+    if (n->type == WIRELOG_IR_SCAN) {
+        sb_printf(s, "%s%s", s->len ? " " : "",
+            n->relation_name ? n->relation_name : "(null)");
+        return;
+    }
+    for (uint32_t i = 0; i < n->child_count; i++)
+        sb_scan_order(s, n->children[i]);
+}
+
+static void
+test_jpp_nullary_chain(void)
+{
+    TEST("jpp #1002: nullary chain still reordered (.decl p() is legal)");
+
+    /*
+     * `.decl p()` parses and leaves column_count == 0 (wirelog/ir/program.h),
+     * and a zero-arity fact against it is accepted (tests/test_program.c), so
+     * a chain whose every atom is nullary totals ZERO scan columns.
+     *
+     * That is a legitimate chain, not an error.  Sizing the scratch arrays
+     * from the column total must not fold "total == 0" into the
+     * allocation-failure path: doing so silently disables the pass for these
+     * programs.  Measured against unpatched origin/main, that regressed this
+     * exact rule from reordered=1 / scan order "a e b" to reordered=0 / scan
+     * order "a b e" -- the EDB tie-break of issue #394 no longer firing,
+     * because e (an EDB) was never preferred over b (an IDB) on the
+     * zero-shared-variable tie.
+     *
+     * Answers are unaffected here (a nullary join is a cross product), so
+     * nothing but the plan shows the difference.  Pin the plan.
+     */
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(".decl e()\n"
+            ".decl a()\n"
+            ".decl b()\n"
+            ".decl o(x: int64)\n"
+            "e().\n"
+            "a() :- e().\n"
+            "b() :- e().\n"
+            "o(1) :- a(), b(), e().\n",
+            &err);
+
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_jpp_stats_t stats = { 0, 0, 0 };
+    int rc = wl_jpp_apply(prog, &stats);
+    if (rc != 0) {
+        FAIL("expected 0");
+        wirelog_program_free(prog);
+        return;
+    }
+
+    if (stats.chains_examined != 1 || stats.joins_reordered != 1
+        || stats.projections_inserted != 0) {
+        char buf[160];
+        snprintf(buf, sizeof(buf),
+            "expected chains=1 reordered=1 projections=0, got %u/%u/%u",
+            stats.chains_examined, stats.joins_reordered,
+            stats.projections_inserted);
+        FAIL(buf);
+        wirelog_program_free(prog);
+        return;
+    }
+
+    sbuf_t order;
+    sb_init(&order);
+    sb_scan_order(&order, find_relation_ir(prog, "o"));
+    if (order.oom || !order.data || strcmp(order.data, "a e b") != 0) {
+        char buf[160];
+        snprintf(buf, sizeof(buf), "expected scan order \"a e b\", got \"%s\"",
+            order.data ? order.data : "(oom)");
+        FAIL(buf);
+        sb_free(&order);
+        wirelog_program_free(prog);
+        return;
+    }
+    sb_free(&order);
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_jpp_plan_unchanged_narrow(void)
+{
+    TEST("jpp: narrow 3-atom plan (order and projection count) unchanged");
+
+    /*
+     * Plan-equivalence guard for the re-sizing above.  Correct capacities
+     * must not change any decision the pass makes, so pin both outputs on a
+     * shape narrow enough that neither the old nor the new bound is ever
+     * reached: the greedy order (a, b, c -- c last, since it shares nothing
+     * with a) and the exact number of intermediate projections.
+     */
+    wirelog_error_t err;
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl a(x: int32, y: int32)\n"
+            ".decl b(y: int32, w: int32)\n"
+            ".decl c(w: int32, z: int32)\n"
+            ".decl path(x: int32, z: int32)\n"
+            "path(x, z) :- a(x, y), c(w, z), b(y, w).\n",
+            &err);
+
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_jpp_stats_t stats = { 0, 0, 0 };
+    int rc = wl_jpp_apply(prog, &stats);
+    if (rc != 0) {
+        FAIL("expected 0");
+        wirelog_program_free(prog);
+        return;
+    }
+
+    if (stats.chains_examined != 1 || stats.joins_reordered != 1
+        || stats.projections_inserted != 1) {
+        char buf[160];
+        snprintf(buf, sizeof(buf),
+            "expected chains=1 reordered=1 projections=1, got %u/%u/%u",
+            stats.chains_examined, stats.joins_reordered,
+            stats.projections_inserted);
+        FAIL(buf);
+        wirelog_program_free(prog);
+        return;
+    }
+
+    wirelog_ir_node_t *ir = find_relation_ir(prog, "path");
+    wirelog_ir_node_t *join_root = ir ? find_join_root(ir) : NULL;
+    if (!join_root || join_root->type != WIRELOG_IR_JOIN) {
+        FAIL("expected JOIN at root");
+        wirelog_program_free(prog);
+        return;
+    }
+
+    wirelog_ir_node_t *deep = find_deepest_join(join_root);
+    if (!deep || deep->child_count < 2) {
+        FAIL("no deepest join or missing children");
+        wirelog_program_free(prog);
+        return;
+    }
+
+    const char *first = get_scan_relation(deep->children[0]);
+    const char *second = get_scan_relation(deep->children[1]);
+    const char *third = join_root->child_count >= 2
+        ? get_scan_relation(join_root->children[1]) : NULL;
+
+    if (!first || !second || !third || strcmp(first, "a") != 0
+        || strcmp(second, "b") != 0 || strcmp(third, "c") != 0) {
+        char buf[160];
+        snprintf(buf, sizeof(buf),
+            "expected scan order a, b, c; got %s, %s, %s",
+            first ? first : "(null)", second ? second : "(null)",
+            third ? third : "(null)");
+        FAIL(buf);
+        wirelog_program_free(prog);
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * The fifth site: head_vars[] in optimize_tree(), which was a fixed
+ * char *[64] on the stack.  This one case pins both halves of it.
+ *
+ *   o(h0..h64) :- r0(h0..h31, j), r1(j, h32..h64, k), r2(j), !neg(k).
+ *
+ *   IR: PROJECT(ANTIJOIN(JOIN(JOIN(r0, r1), r2), SCAN(neg)))
+ *
+ * head_vars must end up holding 66 names: the 65 projected h* variables,
+ * plus k, which only the ANTIJOIN's join key contributes.  The chain's
+ * accumulated set after the first join is exactly those 66 plus j, and j is
+ * kept alive by r2, so every accumulated variable is live and NO
+ * intermediate PROJECT is inserted.  projections_inserted == 0 is therefore
+ * the assertion that the head set was collected in full.
+ *
+ * Drop any one name from it and the corresponding column looks dead, so a
+ * PROJECT appears and the count goes to 1.  Two independent ways to drop
+ * one:
+ *
+ *   - a head_vars capacity below 66 (the old fixed 64 truncates two: h64
+ *     and k).  This is the only case in this file with a head wider than
+ *     64, so without it site 5 is pinned nowhere in its own test target.
+ *   - count_head_vars() failing to account for the ANTIJOIN join keys
+ *     (`count += node->join_key_count`).  The 65 PROJECT variables fill the
+ *     array exactly, and collect_head_vars()'s `count < max` guard then
+ *     discards k.
+ *
+ * Both are undercounts of the head set, which is the failure this pre-pass
+ * exists to prevent.  Note what the guard converts them into: truncation and
+ * a wrong plan, not a buffer overrun -- see the comment on
+ * collect_head_vars().
+ */
+static void
+test_jpp_wide_head_antijoin_key(void)
+{
+    TEST("jpp #1002: 65-variable head plus an ANTIJOIN-only variable");
+
+    sbuf_t s;
+    sb_init(&s);
+
+    /* r0(h0..h31, j) */
+    sb_puts(&s, ".decl r0(");
+    for (unsigned i = 0; i < 32; i++)
+        sb_printf(&s, "c%u: int64, ", i);
+    sb_puts(&s, "cj: int64)\n");
+    /* r1(j, h32..h64, k) */
+    sb_puts(&s, ".decl r1(cj: int64, ");
+    for (unsigned i = 32; i < 65; i++)
+        sb_printf(&s, "c%u: int64, ", i);
+    sb_puts(&s, "ck: int64)\n");
+    sb_puts(&s, ".decl r2(cj: int64)\n");
+    sb_puts(&s, ".decl neg(ck: int64)\n");
+    sb_puts(&s, ".decl o(");
+    for (unsigned i = 0; i < 65; i++)
+        sb_printf(&s, "%sc%u: int64", i ? ", " : "", i);
+    sb_puts(&s, ")\n");
+
+    sb_puts(&s, "o(");
+    for (unsigned i = 0; i < 65; i++)
+        sb_printf(&s, "%sh%u", i ? ", " : "", i);
+    sb_puts(&s, ") :- r0(");
+    for (unsigned i = 0; i < 32; i++)
+        sb_printf(&s, "h%u, ", i);
+    sb_puts(&s, "j), r1(j, ");
+    for (unsigned i = 32; i < 65; i++)
+        sb_printf(&s, "h%u, ", i);
+    sb_puts(&s, "k), r2(j), !neg(k).\n");
+
+    if (s.oom) {
+        sb_free(&s);
+        FAIL("source generation OOM");
+        return;
+    }
+
+    wl_jpp_stats_t stats = { 0, 0, 0 };
+    char msg[256];
+    if (run_jpp(s.data, &stats, msg, sizeof(msg)) != 0) {
+        sb_free(&s);
+        FAIL(msg);
+        return;
+    }
+    sb_free(&s);
+
+    if (stats.chains_examined != 1 || stats.projections_inserted != 0) {
+        char buf[192];
+        snprintf(buf, sizeof(buf),
+            "expected chains=1 projections=0 (every accumulated variable "
+            "live), got chains=%u projections=%u",
+            stats.chains_examined, stats.projections_inserted);
+        FAIL(buf);
+        return;
+    }
+    PASS();
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -1088,6 +1778,18 @@ main(void)
     /* EDB tie-breaker (issue #394) */
     test_jpp_edb_tiebreak();
     test_jpp_idb_idb_tie_unchanged();
+
+    /* Wide-relation scratch sizing (issue #1002) */
+    test_jpp_wide_greedy_acc();
+    test_jpp_wide_projection_seed();
+    test_jpp_wide_projection_merge();
+    test_jpp_wide_physical_layout();
+    test_jpp_wide_needed_set();
+    test_jpp_wide_filter_wrapped_leaves();
+    test_jpp_wide_two_atom_noop();
+    test_jpp_wide_head_antijoin_key();
+    test_jpp_nullary_chain();
+    test_jpp_plan_unchanged_narrow();
 
     printf("\n  Total: %d  Passed: %d  Failed: %d\n\n", tests_run, tests_passed,
         tests_failed);

--- a/tests/test_wide_relation.c
+++ b/tests/test_wide_relation.c
@@ -664,28 +664,6 @@ test_recursive_selfjoin_wide(void)
                 atoms, n);
             TEST(name);
 
-            /*
-             * Three or more body atoms reach col_rel_merge_k's k >= 3 branch,
-             * but they cannot be evaluated at any of these widths yet: the
-             * join-project-plan pass sizes three scratch arrays as
-             * `nscan * 16` (wirelog/passes/jpp.c:290, :589, :646) and then
-             * fills them with one entry per column per scan, so a 3-atom
-             * join over relations wider than 16 columns writes out of
-             * bounds inside wl_jpp_apply -- before evaluation begins.
-             *
-             * That is a separate defect in a different module (a sizing
-             * guess in the optimizer, not a COL_STACK_MAX row buffer), with
-             * its own reproducer and its own fix; it is deliberately not
-             * addressed here.  The k >= 3 branch shares the MERGE_K_SETUP /
-             * MERGE_K_APPEND macros with the k == 2 branch that the
-             * 2-atom cases above do cover at 33 and 200 columns.
-             */
-            if (atoms == 3) {
-                SKIP("blocked by jpp.c nscan*16 sizing overflow "
-                    "(separate defect; see comment)");
-                continue;
-            }
-
             sbuf_t s;
             sb_init(&s);
             build_tc_src(&s, n, atoms);

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -12,8 +12,10 @@
 #include "jpp.h"
 #include "../ir/ir.h"
 #include "../ir/program.h"
+#include "../util/log.h"
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -73,6 +75,58 @@ scan_vars(const wirelog_ir_node_t *scan, uint32_t *count)
     }
     *count = scan->column_count;
     return scan->column_names;
+}
+
+/* Largest element count a char *[] allocation can express. */
+#define JPP_PTR_ARRAY_MAX ((uint64_t)(SIZE_MAX / sizeof(char *)))
+
+/*
+ * Total number of scan columns in a chain, for sizing the scratch arrays.
+ *
+ * The count MUST come from scan_vars(), not from scans[i]->column_count: a
+ * leaf may be a FILTER wrapping the SCAN (program.c wraps an atom that
+ * repeats a variable), and such a leaf carries column_count == 0 while the
+ * inner SCAN holds the real width.
+ *
+ * Returns false only when the element count would exceed what a char *[]
+ * allocation can express; that is the one case a caller must treat as "give
+ * up".  On success *out is at least 1.
+ *
+ * A total of 0 is reachable and is NOT a failure: `.decl p()` is legal and
+ * leaves column_count == 0 (see wirelog/ir/program.h), so a chain of nullary
+ * atoms totals 0 while still being a chain the pass should optimize.  *out is
+ * clamped to 1 there rather than reported as failure, because calloc(0, ..)
+ * may return NULL and a caller cannot tell that apart from OOM.
+ *
+ * The clamp is safe for the two arrays sized directly from this value --
+ * acc[] and phys_names[] -- because every write into those is bounded by some
+ * scan's own column count, so a chain totalling 0 columns performs no writes
+ * at all.  It is NOT the whole story for needed[], which also receives the
+ * head variables and so can take a write even when this returns 0-clamped-to-1
+ * (`o(x) :- a(), b(), e().` over nullary a/b/e reaches exactly that).  That
+ * array is sized head_var_count + this value; see needed_cap in
+ * insert_projections().
+ */
+static bool
+scan_columns_total(wirelog_ir_node_t **scans, uint32_t nscan, size_t *out)
+{
+    uint64_t total = 0;
+
+    for (uint32_t i = 0; i < nscan; i++) {
+        uint32_t count = 0;
+        (void)scan_vars(scans[i], &count);
+        total += count;
+        if (total > JPP_PTR_ARRAY_MAX) {
+            WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_WARN,
+                "jpp: join chain of %u scans exceeds %llu columns; scratch "
+                "arrays cannot be sized, leaving the chain unoptimized",
+                nscan, (unsigned long long)JPP_PTR_ARRAY_MAX);
+            return false;
+        }
+    }
+
+    *out = total > 0 ? (size_t)total : (size_t)1;
+    return true;
 }
 
 /*
@@ -286,8 +340,22 @@ greedy_order(wirelog_ir_node_t **scans, uint32_t nscan, uint32_t *order,
     /* Accumulated variable set */
     uint32_t acc_count;
     char **acc_vars = scan_vars(scans[0], &acc_count);
-    /* We need a mutable copy for merging */
-    char **acc = (char **)calloc(acc_count + nscan * 16, sizeof(char *));
+    /* We need a mutable copy for merging.  The chain's total column count is
+     * an exact upper bound -- but note the bound is TOTAL columns, not
+     * DISTINCT ones, and it has to be.  acc[] is seeded with scans[0]'s
+     * columns verbatim, duplicates and NULLs included (an atom that repeats a
+     * variable, r0(p, p, q), carries cols=3 [p,p,q]); only the columns merged
+     * from later scans are deduplicated.  Do not tighten this to a distinct
+     * count -- that reintroduces the overflow this pass was fixed for. */
+    size_t acc_cap;
+    if (!scan_columns_total(scans, nscan, &acc_cap)) {
+        free(is_idb);
+        free(used);
+        for (uint32_t i = 0; i < nscan; i++)
+            order[i] = i;
+        return false;
+    }
+    char **acc = (char **)calloc(acc_cap, sizeof(char *));
     if (!acc) {
         free(is_idb);
         free(used);
@@ -445,6 +513,16 @@ collect_joins(wirelog_ir_node_t *node, wirelog_ir_node_t **out, uint32_t max)
  * Walk from the IR root through wrapper nodes to collect all variable
  * names that are referenced by the head projection or filter expressions.
  * This tells us which variables must survive to the top of the join chain.
+ *
+ * DO NOT REMOVE the `max` checks here (the `*count >= max` guard below and
+ * the `count < max` guard in collect_head_vars()'s ANTIJOIN arm).  The caller
+ * sizes `out` from count_head_vars(), which is intended to be an exact upper
+ * bound, so the checks look redundant -- and they are, as long as that
+ * function stays in step with this one.  The two walk the same node types by
+ * hand, in two places; if they ever diverge and count_head_vars() undercounts,
+ * these checks are the only thing that makes the consequence a truncated head
+ * set (a wrong plan) instead of a heap-buffer-overflow WRITE.  That is the
+ * failure mode issue #1002 was filed for.
  */
 static void
 collect_head_vars_from_expr(const wl_ir_expr_t *expr, char **out,
@@ -519,6 +597,75 @@ collect_head_vars(wirelog_ir_node_t *ir, char **out, uint32_t max)
     return count;
 }
 
+static uint64_t
+count_head_vars_in_expr(const wl_ir_expr_t *expr)
+{
+    if (!expr)
+        return 0;
+    uint64_t count
+        = (expr->type == WL_IR_EXPR_VAR && expr->var_name) ? 1u : 0u;
+    for (uint32_t i = 0; i < expr->child_count; i++)
+        count += count_head_vars_in_expr(expr->children[i]);
+    return count;
+}
+
+/*
+ * Upper bound on what collect_head_vars() will return.
+ *
+ * Walks exactly the same wrapper chain and counts every VAR leaf plus every
+ * ANTIJOIN join key, without collect_head_vars()'s deduplication, so the
+ * result is always >= the deduplicated count.  Used to size the output array
+ * up front: a fixed cap silently truncates, and a dropped head variable that
+ * does not also appear in a later scan of the chain -- the "needed" loop in
+ * insert_projections() re-adds the ones that do -- is projected away, which
+ * yields wrong column values with a zero exit status and no diagnostic.
+ *
+ * Accumulates in uint64_t and saturates at UINT32_MAX.  Saturation needs more
+ * than 2^32 VAR nodes in one rule and so is unreachable in practice; it is
+ * here so that the bound can never wrap to a small number, which would put us
+ * straight back into the undersized-array failure this pass exists to avoid.
+ * A saturated count is still a valid upper bound, so it is safe either way:
+ * the calloc() in optimize_tree() will usually fail at that size and leave the
+ * chain unoptimized, but it may also succeed under Linux overcommit, and a
+ * 2^32-entry array is not too small.
+ */
+static uint32_t
+count_head_vars(const wirelog_ir_node_t *ir)
+{
+    uint64_t count = 0;
+    const wirelog_ir_node_t *node = ir;
+
+    while (node) {
+        if (node->type == WIRELOG_IR_PROJECT) {
+            if (node->project_exprs) {
+                for (uint32_t i = 0; i < node->project_count; i++)
+                    count += count_head_vars_in_expr(node->project_exprs[i]);
+            }
+        } else if (node->type == WIRELOG_IR_FLATMAP) {
+            if (node->project_exprs) {
+                for (uint32_t i = 0; i < node->project_count; i++)
+                    count += count_head_vars_in_expr(node->project_exprs[i]);
+            }
+            if (node->filter_expr)
+                count += count_head_vars_in_expr(node->filter_expr);
+        } else if (node->type == WIRELOG_IR_FILTER) {
+            if (node->filter_expr)
+                count += count_head_vars_in_expr(node->filter_expr);
+        } else if (node->type == WIRELOG_IR_ANTIJOIN) {
+            count += node->join_key_count;
+        } else {
+            break;
+        }
+
+        if (node->child_count > 0)
+            node = node->children[0];
+        else
+            break;
+    }
+
+    return count > UINT32_MAX ? UINT32_MAX : (uint32_t)count;
+}
+
 /* ======================================================================== */
 /* Internal: insert intermediate projections in a join chain                */
 /* ======================================================================== */
@@ -565,12 +712,23 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
 
     uint32_t projections = 0;
 
+    /* Bound for acc[] and phys_names[] below: neither ever holds more than
+     * one alias per scan column in the chain.  needed[] is sized separately
+     * -- it holds the head variables as well, so its bound adds
+     * head_var_count on top of this. */
+    size_t total_cols;
+    if (!scan_columns_total(scans, nscan, &total_cols)) {
+        free(scans);
+        free(joins);
+        return 0;
+    }
+
     /* For each intermediate join (all except the outermost = joins[depth-1]),
      * check if we can project away variables. */
     uint32_t acc_count;
     char **acc_vars = scan_vars(scans[0], &acc_count);
     /* Build mutable accumulated set */
-    char **acc = (char **)calloc(nscan * 16, sizeof(char *));
+    char **acc = (char **)calloc(total_cols, sizeof(char *));
     if (!acc) {
         free(scans);
         free(joins);
@@ -597,7 +755,7 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
      * appearing in both children.  When a PROJECT is inserted it shrinks the
      * layout; subsequent scans are appended on top.  This is the layout that
      * project_indices must reference. */
-    char **phys_names = (char **)calloc(nscan * 32, sizeof(char *));
+    char **phys_names = (char **)calloc(total_cols, sizeof(char *));
     uint32_t phys_count = 0;
     if (!phys_names) {
         free(acc);
@@ -624,10 +782,27 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
      *     and head_vars
      *   - If any are dead, insert a PROJECT
      */
+    /* The needed set holds at most every head variable plus every scan
+     * column, deduplicated.  0 means only that the size would overflow;
+     * total_cols is already at least 1, so 0 is never a legitimate bound. */
+    uint64_t needed_total = (uint64_t)head_var_count + (uint64_t)total_cols;
+    size_t needed_cap = 0;
+    if (needed_total > JPP_PTR_ARRAY_MAX) {
+        WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_WARN,
+            "jpp: %u head variables plus %zu scan columns exceed %llu; the "
+            "needed set cannot be sized, leaving the chain unoptimized",
+            head_var_count, total_cols,
+            (unsigned long long)JPP_PTR_ARRAY_MAX);
+    } else {
+        needed_cap = (size_t)needed_total;
+    }
+
     for (uint32_t i = 0; i < depth - 1; i++) {
         /* Compute "needed" vars: head_vars + vars in future scans */
         /* Build needed set */
-        char **needed = (char **)calloc(nscan * 16, sizeof(char *));
+        char **needed = needed_cap > 0
+            ? (char **)calloc(needed_cap, sizeof(char *))
+            : NULL;
         uint32_t needed_count = 0;
         if (!needed)
             break;
@@ -897,12 +1072,26 @@ optimize_tree(wirelog_ir_node_t *ir, uint32_t *chains_examined,
 
     (*chains_examined)++;
 
-    /* Collect head variables from wrapper nodes */
-    char *head_vars[64];
-    uint32_t head_var_count = collect_head_vars(ir, head_vars, 64);
+    /* Collect head variables from wrapper nodes, into an array sized by a
+     * counting pre-pass so that none is dropped. */
+    uint32_t head_var_max = count_head_vars(ir);
+    char **head_vars = NULL;
+    if (head_var_max > 0) {
+        head_vars = (char **)calloc(head_var_max, sizeof(char *));
+        if (!head_vars) {
+            /* Without the head variables every accumulated variable looks
+             * dead, which would project away live columns.  Leave this tree
+             * unoptimized instead. */
+            return;
+        }
+    }
+    uint32_t head_var_count
+        = head_vars ? collect_head_vars(ir, head_vars, head_var_max) : 0;
 
     jpp_chain_result_t result
         = optimize_chain(root, head_vars, head_var_count, idb_names, idb_count);
+
+    free(head_vars);
 
     if (result.reordered)
         (*joins_reordered)++;


### PR DESCRIPTION
Closes #1002.

`wirelog/passes/jpp.c` sized five scratch arrays from constants assuming a fixed number of columns per scan (`nscan * 16`, `nscan * 32`, `char *[64]`), then filled them with one entry per column of every scan in the chain. Any chain of three or more atoms over relations wider than the guess wrote past the end.

## Scope: the issue names three sites, this fixes five

| site | was | now |
|---|---|---|
| `greedy_order` `acc[]` | `acc_count + nscan * 16` | `scan_columns_total()` |
| `insert_projections` `acc[]` | `nscan * 16` | `total_cols` |
| `insert_projections` `phys_names[]` | `nscan * 32` | `total_cols` |
| `insert_projections` `needed[]` | `nscan * 16` | `head_var_count + total_cols` |
| `optimize_tree` `head_vars[]` | `char *[64]` | `count_head_vars()` pre-pass |

Sites 1-4 are out-of-bounds writes; two abort in a plain release build as well as under ASAN.

**Site 5 is not a crash, and it is the one that matters most.** `collect_head_vars()` has an internal `count < max` guard, so a head wider than 64 variables is silently *truncated*. Each dropped head variable looks dead to `insert_projections()`, which projects its column away. The result is a **wrong answer with exit status 0 and no diagnostic**. Measured with only this site reverted and the other four fixed, the 200-column case in `tests/test_wide_relation.c` returns the wrong tuple set, ASAN silent.

## A plan regression this caught before it shipped

`.decl p()` is legal and leaves `column_count == 0` (see `wirelog/ir/program.h`; `tests/test_program.c` asserts nullary facts must be accepted). An earlier revision folded a zero column-total into the allocation-failure path, which silently disabled join reordering for nullary chains:

```
o(1) :- a(), b(), e().     over nullary a/b/e

base:      reordered=1   scan order  a e b     (the #394 EDB tie-break fires)
regressed: reordered=0   scan order  a b e
fixed:     reordered=1   scan order  a e b
```

Answers are unaffected -- a nullary join is a cross product -- so only the plan shows it. `scan_columns_total()` now returns `bool`, fails only on overflow, and clamps a zero total to one. `tests/test_jpp.c` pins it.

## Correction to the issue text

#1002 states that wider relations "will fail at 2 [atoms]". They do not: `optimize_chain()` returns before any scratch allocation when `nscan < 3`, so a two-atom chain is clean at every width. Added as an explicit negative control.

## Testing

Ten generated-source cases in `tests/test_jpp.c`, each at a **measured** boundary (3 atoms clean at 24 / overflowing at 25; 4 atoms at 21 / 22) rather than at round numbers. They assert `projections_inserted`, not just `chains_examined` -- the latter is incremented *before* any scratch allocation, so it stays 1 even when every allocation fails and the pass silently declines the chain. That distinction is not hypothetical: an earlier revision of the FILTER-wrapped test could not detect its own mutation for exactly this reason.

The three `merge_k` k>=3 cases in `tests/test_wide_relation.c` that #1000 left `SKIP` are un-skipped and pass at 32/33/200 columns. They are the answer-correctness half (`test_jpp` links no evaluator), and they are why this is one commit rather than several: the 200-column case fails on wrong answers unless all five sites are fixed together.

**Mutation-verified.** Reverting each site individually, and each of `scan_columns_total()`'s two load-bearing properties, is killed by a named test. No mutation survived.

## Validation

- Full suite **268 ok / 1 fail / 11 skipped**, release and ASAN+UBSAN+LSAN. The one failure is the pre-existing `sbom_snapshot` drift (an `msys2/setup-msys2` pin in a workflow file), which this change's three C files cannot affect.
- `test_jpp` 28/28, `test_wide_relation` 21/21 (was 18 + 3 SKIP).
- 12,000-seed ASAN/UBSAN/LSAN fuzz clean; 8,000-seed plan-equivalence differential vs base with zero unexplained divergence.
- uncrustify clean; `meson test --suite abi` 33/33, including log-erasure under `-Dwirelog_log_max_level=error`.

## Follow-ups filed, not fixed here

#1009 (magic_sets fixed caps), #1016 (#1008's test covers only the heap render path), #1017 (the CI clang-tidy gate matches zero files and has never analysed anything).