### PR TITLE
fix(exec_plan): record recursive aggregate domination at lowering, not by scanning plan operators

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1163,6 +1163,32 @@ test_symbol_aggregates_exe = executable(
 # The whole binary runs in well under a second; the timeout bounds the hang.
 test('symbol_aggregates', test_symbol_aggregates_exe, timeout: 60)
 
+# Issue #975: recursive min()/max() canonicalisation never ran on a relation
+# rewrite_multiway_delta() had fused, because the decision to run was taken
+# by scanning the relation's operator list for a REDUCE and the rewrite had
+# moved it into the K_FUSION operator's opaque_data.  Adding a rule that
+# derives nothing changed the answer.
+test_recursive_agg_kfusion_exe = executable(
+  'test_recursive_agg_kfusion',
+  files('test_recursive_agg_kfusion.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+# Every case runs at W = 1, 4, 8 and 16; the 16-worker recursive cases are
+# the slow ones.  The timeout also bounds the failure mode where a relation
+# reduced under a comparator that is not a total order never converges.
+test('recursive_agg_kfusion', test_recursive_agg_kfusion_exe,
+     suite: 'semantics', timeout: 120)
+
 # Issue #978: average() was never implemented -- col_op_reduce() had no AVG
 # arm, so each group kept the first operand the scan happened to reach.  With
 # no float type to return a mean in, it is rejected at lowering instead.

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -1035,8 +1035,11 @@ test_aggregation_multi_head_rejected(void)
     }
 
     /* Negative: same agg_fn twice.  This one passes the downstream
-     * col_relation_recursive_reduce_op() mixed-agg_fn guard (#692 B5) and
-     * would canonicalise only one column, so it must be caught here. */
+     * mixed-agg_fn guard (#692 B5) -- since #975 that guard lives in
+     * agg_spec_observe() (exec_plan_gen.c), which records the relation's
+     * whole-relation reduction at lowering rather than rediscovering it by
+     * scanning ops -- and would canonicalise only one column, so it must be
+     * caught here. */
     bad = make_program_with_rules(".decl val(g: int32, v: int32)\n"
             ".decl t(g: int32, a: int32, b: int32)\n"
             "t(g, min(v), min(v)) :- val(g, v).\n");

--- a/tests/test_recursive_agg_kfusion.c
+++ b/tests/test_recursive_agg_kfusion.c
@@ -1,0 +1,757 @@
+/*
+ * tests/test_recursive_agg_kfusion.c - recursive min()/max() under K-fusion
+ *                                      (#975)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * A recursive relation whose head carries min()/max() is reduced twice: once
+ * per rule by col_op_reduce(), and once over the whole relation at fixpoint
+ * by the recursive-aggregate canonicalisation in columnar/eval.c.  Only the
+ * second one can see across rules, so only it can turn the union of each
+ * rule's partial minimum into the relation's minimum.
+ *
+ * That second reducer used to decide whether to run by scanning the
+ * relation's plan operators for a REDUCE.  rewrite_multiway_delta()
+ * (exec_plan_gen.c) replaces the operator list with a single K_FUSION
+ * operator, moving the originals into its opaque_data, so the scan found
+ * nothing and the canonicalisation was skipped entirely -- silently, exit
+ * status 0.
+ *
+ * Note what actually triggers that rewrite: count_delta_positions() >= 2,
+ * counting the in-stratum IDB VARIABLE operators and IDB-right JOINs across
+ * *all* of the relation's rules.  It is a per-relation count of recursive
+ * references, not a per-rule count of body atoms, so two ordinary
+ * single-atom recursive rules fuse just as one two-atom rule does.  Both
+ * spellings are covered below; the cross-rule one is the shape real
+ * programs have.
+ *
+ * Adding one semantically redundant rule to a working program was enough:
+ *
+ *     Label(x, min(x)) :- Edge(x, y).
+ *     Label(y, min(y)) :- Edge(x, y).
+ *     Label(x, min(l)) :- Label(y, l), Edge(y, x).           -> 4 rows
+ *     Label(x, min(l)) :- Label(y, l), Label(y, m), Edge(y, x).
+ *                                                            -> 10 rows
+ *
+ * The second rule adds no derivations of its own -- Label(y, m) is satisfied
+ * by the same tuple that satisfies Label(y, l) -- but it makes the relation
+ * eligible for fusion, and every group then kept all its candidate values.
+ *
+ * The fix records the aggregate-domination guarantee as relation state at IR
+ * lowering, before any rewrite runs, so no rewrite can hide it.  Every case
+ * here is therefore framed as *redundant-rule invariance*: the same program
+ * with and without a rule that derives nothing must give the same answer.
+ *
+ * Cardinality alone cannot see this defect in either direction: 10 rows is
+ * a plausible answer for a program whose correct answer is 4, and a fix that
+ * collapsed groups by the wrong comparator would also return 4.  Every case
+ * asserts the exact tuples, and most positive cases additionally assert the
+ * absence of each specific row the pre-fix answer contained.  (The two
+ * group-by columns case relies on saw_exactly() alone; its twelve pre-fix
+ * extras are not enumerated.)
+ *
+ * Case map:
+ *
+ *   test_min_redundant_rule_invariance / test_max_redundant_rule_invariance
+ *       The defect report over an int64 column, for min and for max.  The
+ *       max half exists because a fix that hardcoded MIN passes the min
+ *       half.
+ *
+ *   test_symbol_operand_under_fusion
+ *       The same shape over a `symbol` column, run alone and behind an
+ *       unrelated relation whose facts claim the low intern ids.  This is
+ *       the only case that can see a recorded specification that carries the
+ *       aggregate function and the group width but not the operand's domain:
+ *       an unset domain reduces by intern id (#965), which agrees with the
+ *       lexicographic answer in most orderings and disagrees here.
+ *
+ *   test_cross_rule_fusion
+ *       Two ordinary single-atom recursive rules, forward and backward
+ *       along the edges.  No rule carries two IDB body atoms, yet the
+ *       relation fuses, because count_delta_positions() sums recursive
+ *       references across all of the relation's rules.  This is the shape
+ *       real programs have -- the redundant-rule cases above are the
+ *       compact reproduction, not the common trigger -- and without it
+ *       every positive case here would reach fusion by the same contrived
+ *       route.
+ *
+ *   test_single_idb_atom_control
+ *       The same program minus the redundant rule.  It is not fused, so it
+ *       answered correctly before the fix as well; it is here to show the
+ *       fix did not move the case that already worked, and it is what
+ *       catches a fix narrowed to fused relations only.
+ *
+ *   test_group_by_two_columns
+ *       Two grouping columns and an aggregate, fused.  The group comparison
+ *       is over group_by_count columns, so a specification that recorded the
+ *       aggregate function but defaulted the width to 1 collapses distinct
+ *       groups together.
+ *
+ *   test_count_not_canonicalized
+ *       count() is not an ordering aggregate and the canonicalisation
+ *       refuses relations whose REDUCE is anything but MIN or MAX.  The
+ *       recorded specification must refuse them identically -- both when the
+ *       relation is fused and when it is not.
+ *
+ *   test_mixed_min_max_not_canonicalized
+ *       Two rules of one head disagreeing on the aggregate function.  The
+ *       canonicalisation refuses these, and the accumulator that records the
+ *       specification has to *clear* it on conflict rather than let the last
+ *       rule win -- last-writer-wins would newly canonicalise relations that
+ *       are correctly skipped today.
+ *
+ *   test_operand_type_last_rule_wins
+ *       Records, rather than endorses, what happens when two rules of one
+ *       head agree on the aggregate function and group width but disagree on
+ *       the operand's domain: the last one decides.  See the comment on the
+ *       case itself.
+ *
+ * Not covered here, and not silently skipped:
+ *
+ *   - incremental (--watch) evaluation of a fused aggregate relation.
+ *     Affected-strata detection scans the same operator lists and is blinded
+ *     by the same K_FUSION hiding, so the insert is dropped before any
+ *     aggregate runs.  That is issue #1019.
+ *
+ *   - a -DENABLE_K_FUSION=0 build as a cross-check oracle.  That build
+ *     aborts on this program family; issue #1020.
+ *
+ *   - a same-stratum consumer of a relation whose labels are dominated away
+ *     at fixpoint can retain rows derived from labels that no longer exist,
+ *     which is internally contradictory output.  That is issue #1021 and is
+ *     a property of canonicalising at fixpoint rather than per iteration.
+ */
+
+#include "../wirelog/backend.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/intern.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int test_count;
+static int pass_count;
+static int fail_count;
+
+#define TEST(name)                                      \
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
+
+#define PASS()            \
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                    \
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
+
+#define ASSERT(cond, msg) \
+        do {                  \
+            if (!(cond))      \
+            FAIL(msg);    \
+        } while (0)
+
+#define MAX_SEEN 64
+
+/* Column rendered as the string its interned id names; -1 for none.  Only
+ * the plan knows a column's declared type and the snapshot callback is not
+ * told, so the case says which column holds symbols.  Rendering every value
+ * that happens to have an intern entry would be ambiguous here: the group
+ * keys are small integers and collide with the low intern ids. */
+#define NO_SYMBOL_COLUMN (-1)
+
+typedef struct {
+    const char *rel;
+    uint32_t count;
+    uint32_t ncols;
+    int sym_col;
+    const wirelog_intern_t *intern;
+    /* Rows rendered for assertion, columns joined with '|'. */
+    char seen[MAX_SEEN][256];
+} collect_t;
+
+static void
+collect_cb(const char *relation, const int64_t *row, uint32_t ncols, void *user)
+{
+    collect_t *c = (collect_t *)user;
+
+    if (!c->rel || !relation || strcmp(relation, c->rel) != 0)
+        return;
+    if (c->count < MAX_SEEN) {
+        char *dst = c->seen[c->count];
+        size_t pos = 0;
+        dst[0] = '\0';
+        c->ncols = ncols;
+        for (uint32_t i = 0; i < ncols && pos + 1 < sizeof(c->seen[0]); i++) {
+            const char *v = (c->intern && (int)i == c->sym_col)
+                ? wl_intern_reverse(c->intern, row[i]) : NULL;
+            int n;
+            if (v)
+                n = snprintf(dst + pos, sizeof(c->seen[0]) - pos, "%s%s",
+                        i ? "|" : "", v);
+            else
+                n = snprintf(dst + pos, sizeof(c->seen[0]) - pos,
+                        "%s%" PRId64, i ? "|" : "", row[i]);
+            if (n < 0)
+                break;
+            pos += (size_t)n;
+        }
+    }
+    c->count++;
+}
+
+/* True if any collected row renders as @want. */
+static bool
+saw(const collect_t *c, const char *want)
+{
+    uint32_t n = c->count < MAX_SEEN ? c->count : MAX_SEEN;
+
+    for (uint32_t i = 0; i < n; i++) {
+        if (strcmp(c->seen[i], want) == 0)
+            return true;
+    }
+    return false;
+}
+
+/* True if every row in the NULL-terminated @want list was collected and
+ * nothing else was. */
+static bool
+saw_exactly(const collect_t *c, const char *const *want)
+{
+    uint32_t n = 0;
+
+    while (want[n])
+        n++;
+    if (c->count != n)
+        return false;
+    for (uint32_t i = 0; i < n; i++) {
+        if (!saw(c, want[i]))
+            return false;
+    }
+    return true;
+}
+
+/*
+ * Evaluate @src with @workers workers, filling @out with @relation's tuples.
+ * Column @sym_col is rendered as a string, everything else as decimal.
+ * Returns 0 on success.
+ */
+static int
+eval_relation_at(const char *src, const char *relation, uint32_t workers,
+    int sym_col, collect_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    out->rel = relation;
+    out->sym_col = sym_col;
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+
+    if (!prog) {
+        fprintf(stderr, "  parse error: %d\n", (int)err);
+        return -1;
+    }
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_session_t *sess = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, workers, &sess) != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    out->intern = wirelog_program_get_intern(prog);
+
+    int result = -1;
+    if (wl_session_load_facts(sess, prog) == 0
+        && wl_session_snapshot(sess, collect_cb, out) == 0)
+        result = 0;
+
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return result;
+}
+
+/* The worker counts test_recursive_agg_conformance.c already pins. */
+static const uint32_t k_worker_counts[] = { 1, 4, 8, 16 };
+#define N_WORKER_COUNTS \
+        (sizeof(k_worker_counts) / sizeof(k_worker_counts[0]))
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * A three-edge path.  Both seeding rules give every node its own id as a
+ * label; the recursive rule pushes labels forward along edges.  With the
+ * relation reduced as a whole, every node ends up carrying the minimum id
+ * reachable backwards from it, which for a path rooted at 1 is 1.
+ */
+#define PATH_EDGES                                  \
+        ".decl Edge(x: int64, y: int64)\n"          \
+        ".decl Label(x: int64, l: int64)\n"         \
+        "Edge(1,2).  Edge(2,3).  Edge(3,4).\n"
+
+/* Each case appends its own redundant rule.  Label(y, m) is satisfied by the
+ * very tuple that satisfies Label(y, l), so the rule derives nothing -- but
+ * it takes the relation to two delta positions, which is what
+ * rewrite_multiway_delta() fuses on.  Two atoms in one rule is only the
+ * most compact way to reach that count; see the forward/backward case for
+ * the cross-rule spelling. */
+
+#define MIN_BASE                                             \
+        PATH_EDGES                                           \
+        "Label(x, min(x)) :- Edge(x, y).\n"                  \
+        "Label(y, min(y)) :- Edge(x, y).\n"                  \
+        "Label(x, min(l)) :- Label(y, l), Edge(y, x).\n"
+
+#define MAX_BASE                                             \
+        PATH_EDGES                                           \
+        "Label(x, max(x)) :- Edge(x, y).\n"                  \
+        "Label(y, max(y)) :- Edge(x, y).\n"                  \
+        "Label(x, max(l)) :- Label(y, l), Edge(y, x).\n"
+
+static void
+test_min_redundant_rule_invariance(void)
+{
+    TEST("min(): a redundant K-fusing rule does not change the answer");
+
+    static const char *src = MIN_BASE
+        "Label(x, min(l)) :- Label(y, l), Label(y, m), Edge(y, x).\n";
+    static const char *const want[] = {
+        "1|1", "2|1", "3|1", "4|1", NULL
+    };
+    /* The rows the pre-fix answer carried: every group kept each candidate
+     * value instead of its minimum. */
+    static const char *const unwanted[] = {
+        "2|2", "3|2", "3|3", "4|2", "4|3", "4|4", NULL
+    };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(src, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) == 0,
+            "evaluation failed");
+        ASSERT(c.count == 4, "expected one row per node");
+        ASSERT(saw_exactly(&c, want), "expected exactly {(1,1),..,(4,1)}");
+        for (size_t i = 0; unwanted[i]; i++)
+            ASSERT(!saw(&c, unwanted[i]), "a dominated label survived");
+    }
+    PASS();
+}
+
+static void
+test_max_redundant_rule_invariance(void)
+{
+    TEST("max(): a redundant K-fusing rule does not change the answer");
+
+    static const char *src = MAX_BASE
+        "Label(x, max(l)) :- Label(y, l), Label(y, m), Edge(y, x).\n";
+    /* max propagates forwards, so each node keeps its own id. */
+    static const char *const want[] = {
+        "1|1", "2|2", "3|3", "4|4", NULL
+    };
+    static const char *const unwanted[] = {
+        "2|1", "3|1", "3|2", "4|1", "4|2", "4|3", NULL
+    };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(src, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) == 0,
+            "evaluation failed");
+        ASSERT(c.count == 4, "expected one row per node");
+        ASSERT(saw_exactly(&c, want), "expected exactly {(1,1),..,(4,4)}");
+        for (size_t i = 0; unwanted[i]; i++)
+            ASSERT(!saw(&c, unwanted[i]), "a dominated label survived");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * "zz" is written first and therefore holds the lower intern id, while "aa"
+ * sorts first as a string, so the two orderings disagree on group 2 -- whose
+ * candidates are "aa" (its own seed) and "zz" (pushed forward from node 1).
+ *
+ * SHIFT is an unrelated relation whose facts are parsed first and claim the
+ * low ids, reversing the id order of "aa" against "zz".  Prepending it must
+ * change nothing.
+ */
+#define SHIFT                                                    \
+        ".decl Unrelated(x: symbol)\n"                           \
+        "Unrelated(\"aa\"). Unrelated(\"mm\"). Unrelated(\"zz\").\n"
+
+#define SYM_BASE                                                 \
+        ".decl Seed(x: int64, l: symbol)\n"                      \
+        ".decl Edge(x: int64, y: int64)\n"                       \
+        ".decl Label(x: int64, l: symbol)\n"                     \
+        "Seed(1,\"zz\"). Seed(2,\"aa\"). Seed(2,\"mm\").\n"      \
+        "Edge(1,2). Edge(2,3).\n"                                \
+        "Label(x, min(l)) :- Seed(x, l).\n"                      \
+        "Label(x, min(l)) :- Label(y, l), Edge(y, x).\n"
+
+#define SYM_REDUNDANT \
+        "Label(x, min(l)) :- Label(y, l), Label(y, m), Edge(y, x).\n"
+
+static void
+test_symbol_operand_under_fusion(void)
+{
+    TEST("min() over a symbol column stays lexicographic under fusion");
+
+    static const char *cases[] = {
+        SYM_BASE SYM_REDUNDANT,
+        SHIFT SYM_BASE SYM_REDUNDANT,
+    };
+    static const char *const want[] = {
+        "1|zz", "2|aa", "3|aa", NULL
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+            collect_t c;
+            ASSERT(eval_relation_at(cases[i], "Label",
+                k_worker_counts[w], 1, &c) == 0, "evaluation failed");
+            ASSERT(c.count == 3, "expected one row per node");
+            ASSERT(saw_exactly(&c, want),
+                "expected exactly {(1,zz),(2,aa),(3,aa)}");
+            /* The answer an unset operand domain gives: "zz" was interned
+             * first, so it is the smaller id (#965). */
+            ASSERT(!saw(&c, "2|zz") && !saw(&c, "3|zz"),
+                "reduced by intern id, not lexicographically");
+        }
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_cross_rule_fusion(void)
+{
+    TEST("min(): two single-atom recursive rules fuse and still reduce");
+
+    /*
+     * The shape real programs have, and the one every other positive case
+     * here misses.  No rule carries two IDB body atoms; the relation still
+     * fuses, because count_delta_positions() sums recursive references
+     * across all of the relation's rules and these two contribute one each.
+     *
+     * Labels propagate both along and against edges, so all four nodes are
+     * one component and every label is the component minimum, 1.  Pre-fix
+     * this returned 13 rows -- every node keeping every label that ever
+     * reached it.
+     */
+    static const char *src = PATH_EDGES
+        "Label(x, min(x)) :- Edge(x, y).\n"
+        "Label(y, min(y)) :- Edge(x, y).\n"
+        "Label(x, min(l)) :- Label(y, l), Edge(y, x).\n"
+        "Label(y, min(l)) :- Label(x, l), Edge(y, x).\n";
+    static const char *const want[] = {
+        "1|1", "2|1", "3|1", "4|1", NULL
+    };
+    /* The nine extra rows the pre-fix answer carried. */
+    static const char *const unwanted[] = {
+        "1|2", "2|2", "2|3", "3|2", "3|3", "3|4", "4|2", "4|3", "4|4", NULL
+    };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(src, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) == 0,
+            "evaluation failed");
+        ASSERT(c.count == 4, "expected one row per node");
+        ASSERT(saw_exactly(&c, want), "expected exactly {(1,1),..,(4,1)}");
+        for (size_t i = 0; unwanted[i]; i++)
+            ASSERT(!saw(&c, unwanted[i]), "a dominated label survived");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_single_idb_atom_control(void)
+{
+    TEST("min(): the unfused single-IDB-atom shape is unchanged");
+
+    /* MIN_BASE has exactly one recursive rule, so the relation reaches only
+     * one delta position, count_delta_positions() returns 1, and
+     * rewrite_multiway_delta() does not fire -- the REDUCE stays visible in
+     * the operator list.  (One recursive rule, not "no rule with two body
+     * atoms": a second single-atom recursive rule would fuse this, which is
+     * what the forward/backward case covers.)  This answered correctly
+     * before the fix; it is the control that shows the fix moved nothing on
+     * that path, and it is what fails if a fix narrows canonicalisation to
+     * fused relations only. */
+    static const char *src = MIN_BASE;
+    static const char *const want[] = {
+        "1|1", "2|1", "3|1", "4|1", NULL
+    };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(src, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) == 0,
+            "evaluation failed");
+        ASSERT(saw_exactly(&c, want), "expected exactly {(1,1),..,(4,1)}");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * Two grouping columns.  Tag is an unrelated EDB that widens each label into
+ * one label per tag, so the group key is (node, tag) and a canonicalisation
+ * that grouped by the first column alone would collapse the two tags into
+ * one row per node.
+ */
+#define GROUP2_BASE                                                     \
+        ".decl Edge(x: int64, y: int64)\n"                              \
+        ".decl Tag(t: int64)\n"                                         \
+        ".decl Label(x: int64, t: int64, l: int64)\n"                   \
+        "Edge(1,2). Edge(2,3). Edge(3,4).\n"                            \
+        "Tag(7). Tag(8).\n"                                             \
+        "Label(x, t, min(x)) :- Edge(x, y), Tag(t).\n"                  \
+        "Label(y, t, min(y)) :- Edge(x, y), Tag(t).\n"                  \
+        "Label(x, t, min(l)) :- Label(y, t, l), Edge(y, x).\n"
+
+static void
+test_group_by_two_columns(void)
+{
+    TEST("min(): two grouping columns collapse per (node, tag), fused");
+
+    static const char *src = GROUP2_BASE
+        "Label(x, t, min(l)) :- Label(y, t, l), Label(y, t, m), Edge(y, x).\n";
+    static const char *const want[] = {
+        "1|7|1", "1|8|1", "2|7|1", "2|8|1",
+        "3|7|1", "3|8|1", "4|7|1", "4|8|1", NULL
+    };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(src, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) == 0,
+            "evaluation failed");
+        ASSERT(c.count == 8, "expected one row per (node, tag)");
+        ASSERT(saw_exactly(&c, want), "expected one label per (node, tag)");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * count() is not an ordering aggregate: there is no sense in which one of a
+ * group's counts dominates the others, so the canonicalisation refuses any
+ * relation whose REDUCE is not MIN or MAX and leaves every row standing.
+ * Both spellings of the program are asserted -- fused and not -- because the
+ * refusal has to survive the rewrite that hid the REDUCE.
+ */
+#define COUNT_BASE                                                      \
+        ".decl Edge(x: int64, y: int64)\n"                              \
+        ".decl Label(x: int64, l: int64)\n"                             \
+        "Edge(1,3). Edge(2,3). Edge(3,4).\n"                            \
+        "Label(x, count(y)) :- Edge(x, y).\n"                           \
+        "Label(y, count(x)) :- Edge(x, y).\n"                           \
+        "Label(x, count(l)) :- Label(y, l), Edge(y, x).\n"
+
+static void
+test_count_not_canonicalized(void)
+{
+    TEST("count(): groups keep every value, fused and unfused");
+
+    static const char *unfused = COUNT_BASE;
+    static const char *fused = COUNT_BASE
+        "Label(x, count(l)) :- Label(y, l), Label(y, m), Edge(y, x).\n";
+    /* Groups 3 and 4 hold more than one count.  Canonicalising this relation
+     * would keep one row per group, which is what the assertion detects. */
+    static const char *const want_unfused[] = {
+        "1|1", "2|1", "3|1", "3|2", "4|1", "4|2", NULL
+    };
+    static const char *const want_fused[] = {
+        "1|1", "2|1", "3|1", "3|2", "4|1", "4|2", "4|4", NULL
+    };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(unfused, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) == 0,
+            "evaluation failed");
+        ASSERT(saw_exactly(&c, want_unfused),
+            "unfused count() relation was reduced");
+
+        ASSERT(eval_relation_at(fused, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) == 0,
+            "evaluation failed");
+        ASSERT(saw_exactly(&c, want_fused),
+            "fused count() relation was reduced");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * One head, one rule reducing by min and another by max.  There is no single
+ * order the relation can be canonicalised under, so it is left alone.
+ *
+ * This is the case an accumulator that simply overwrites its record per
+ * REDUCE gets wrong in the dangerous direction: it would adopt whichever
+ * aggregate the last rule named and start collapsing a relation that is
+ * correctly left alone today.  The unfused spelling is the one that catches
+ * it -- that relation reaches the canonicalisation on both sides of the fix.
+ */
+#define MIXED_BASE                                                      \
+        ".decl Edge(x: int64, y: int64)\n"                              \
+        ".decl Label(x: int64, l: int64)\n"                             \
+        "Edge(1,2). Edge(2,3). Edge(3,4).\n"                            \
+        "Label(x, min(x)) :- Edge(x, y).\n"                             \
+        "Label(y, max(y)) :- Edge(x, y).\n"                             \
+        "Label(x, min(l)) :- Label(y, l), Edge(y, x).\n"
+
+static void
+test_mixed_min_max_not_canonicalized(void)
+{
+    TEST("min()/max() in one head: the relation is left un-canonicalised");
+
+    static const char *unfused = MIXED_BASE;
+    static const char *fused = MIXED_BASE
+        "Label(x, max(l)) :- Label(y, l), Label(y, m), Edge(y, x).\n";
+    static const char *const want[] = {
+        "1|1", "2|1", "2|2", "3|1", "3|2", "3|3",
+        "4|1", "4|2", "4|3", "4|4", NULL
+    };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(unfused, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) == 0,
+            "evaluation failed");
+        ASSERT(saw_exactly(&c, want),
+            "unfused mixed-aggregate relation was reduced");
+
+        ASSERT(eval_relation_at(fused, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) == 0,
+            "evaluation failed");
+        ASSERT(saw_exactly(&c, want),
+            "fused mixed-aggregate relation was reduced");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * Records current behaviour; it is not a statement that this behaviour is
+ * right.
+ *
+ * Where two rules of one head agree on the aggregate function and the number
+ * of grouping columns but disagree on the operand's domain -- here a
+ * declared `symbol` column against an undeclared relation, which has no
+ * column types at all -- the relation is canonicalised under whichever
+ * domain the *last* rule established.  The two programs below differ only in
+ * the order of their last two rules and answer differently: with the
+ * undeclared rule last the whole relation is reduced by intern id and
+ * answers "zz", and with the declared rule last it is reduced
+ * lexicographically and answers "aa".
+ *
+ * That is what the pre-fix scan did (it compared the aggregate function and
+ * the group width across REDUCEs but never the operand domain, and kept the
+ * last operator it saw), and it is reproduced deliberately so the fix does
+ * not change any program's answer.  It is a latent variant of #965: plan
+ * order, not the data, decides whether min() orders by string or by intern
+ * id.  Fixing it means deciding what a relation whose rules genuinely
+ * disagree should do, which is a separate question from where the
+ * specification is stored.
+ */
+#define LASTWINS_FACTS                                                  \
+        ".decl Edge(x: int64, y: int64)\n"                              \
+        ".decl Sym(x: int64, v: symbol)\n"                              \
+        ".decl Label(x: int64, l: symbol)\n"                            \
+        "Sym(1,\"zz\"). Sym(1,\"aa\"). Sym(2,\"zz\"). Sym(2,\"aa\").\n" \
+        "Edge(1,2).\n"                                                  \
+        "M(x, v) :- Sym(x, v).\n"                                       \
+        "Label(x, min(v)) :- Label(y, v), Edge(y, x).\n"
+
+static void
+test_operand_type_last_rule_wins(void)
+{
+    TEST("operand domain: the last rule of the head decides (recorded)");
+
+    /* Untyped rule last: the whole relation reduces by intern id. */
+    static const char *untyped_last = LASTWINS_FACTS
+        "Label(x, min(v)) :- Sym(x, v).\n"
+        "Label(x, min(v)) :- M(x, v).\n";
+    /* Typed rule last: the whole relation reduces lexicographically. */
+    static const char *typed_last = LASTWINS_FACTS
+        "Label(x, min(v)) :- M(x, v).\n"
+        "Label(x, min(v)) :- Sym(x, v).\n";
+    static const char *const want_untyped[] = { "1|zz", "2|zz", NULL };
+    static const char *const want_typed[] = { "1|aa", "2|aa", NULL };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(untyped_last, "Label",
+            k_worker_counts[w], 1, &c) == 0, "evaluation failed");
+        ASSERT(saw_exactly(&c, want_untyped),
+            "untyped-last no longer reduces by intern id");
+
+        ASSERT(eval_relation_at(typed_last, "Label",
+            k_worker_counts[w], 1, &c) == 0, "evaluation failed");
+        ASSERT(saw_exactly(&c, want_typed),
+            "typed-last no longer reduces lexicographically");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+int
+main(void)
+{
+    printf("=== Recursive aggregates under K-fusion (#975) ===\n\n");
+
+    test_min_redundant_rule_invariance();
+    test_max_redundant_rule_invariance();
+    test_symbol_operand_under_fusion();
+    test_cross_rule_fusion();
+    test_single_idb_atom_control();
+    test_group_by_two_columns();
+    test_count_not_canonicalized();
+    test_mixed_min_max_not_canonicalized();
+    test_operand_type_last_rule_wins();
+
+    printf("\n=== %d/%d passed, %d failed ===\n", pass_count, test_count,
+        fail_count);
+    return fail_count == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -377,36 +377,14 @@ col_reduce_output_group_equal(const col_rel_t *rel, uint32_t a, uint32_t b,
     return true;
 }
 
-static const wl_plan_op_t *
-col_relation_recursive_reduce_op(const wl_plan_relation_t *rp)
-{
-    const wl_plan_op_t *reduce_op = NULL;
-
-    for (uint32_t oi = 0; oi < rp->op_count; oi++) {
-        const wl_plan_op_t *op = &rp->ops[oi];
-        if (op->op != WL_PLAN_OP_REDUCE)
-            continue;
-        if (op->agg_fn != WIRELOG_AGG_MIN && op->agg_fn != WIRELOG_AGG_MAX)
-            return NULL;
-        if (reduce_op
-            && (reduce_op->agg_fn != op->agg_fn
-            || reduce_op->group_by_count != op->group_by_count)) {
-            return NULL;
-        }
-        reduce_op = op;
-    }
-
-    return reduce_op;
-}
-
 static int
 col_canonicalize_recursive_aggregate_relation(col_rel_t *rel,
-    const wl_plan_op_t *reduce_op, const wl_intern_t *intern)
+    const wl_plan_agg_spec_t *spec, const wl_intern_t *intern)
 {
-    if (!rel || !reduce_op || rel->nrows < 2)
+    if (!rel || !spec || !spec->has_spec || rel->nrows < 2)
         return 0;
 
-    uint32_t gc = reduce_op->group_by_count;
+    uint32_t gc = spec->group_by_count;
     if (rel->ncols <= gc)
         return EINVAL;
 
@@ -426,8 +404,8 @@ col_canonicalize_recursive_aggregate_relation(col_rel_t *rel,
             /* Same comparator as col_op_reduce(): a fixpoint that ordered
              * lexicographically within an iteration and by intern id across
              * iterations would be worse than the original bug (#965). */
-            bool better = col_agg_better(reduce_op->agg_fn,
-                    reduce_op->agg_operand_type, intern, val, cur);
+            bool better = col_agg_better(spec->fn, spec->operand_type,
+                    intern, val, cur);
             if (better) {
                 col_rel_set(rel, found, gc, val);
                 if (rel->timestamps)
@@ -461,14 +439,29 @@ static int
 col_canonicalize_recursive_aggregates(const wl_plan_stratum_t *sp,
     wl_col_session_t *sess)
 {
+    /*
+     * Reading the recorded specification rather than looking for a REDUCE in
+     * rp->ops is the whole of #975: rewrite_multiway_delta() replaces a fused
+     * relation's operators with a single K_FUSION and moves the originals into
+     * its opaque_data, so the operator was not there to be found and this ran
+     * on every recursive aggregate relation *except* the ones fusion applies
+     * to.  wl_plan_relation_t.recursive_agg is filled at IR lowering, before
+     * any rewrite runs.
+     *
+     * Timing is unchanged: this is the fixpoint, not per-iteration
+     * consolidation.  A same-stratum consumer can therefore hold rows derived
+     * from labels this reduction then dominates away, leaving output that
+     * contradicts itself.  Moving it into consolidation needs
+     * wl_plan_stratum_t.is_monotone, which is hardcoded false and never
+     * computed -- that is issue #1021, not this one.
+     */
     for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
         const wl_plan_relation_t *rp = &sp->relations[ri];
-        const wl_plan_op_t *reduce_op = col_relation_recursive_reduce_op(rp);
-        if (!reduce_op)
+        if (!rp->recursive_agg.has_spec)
             continue;
         col_rel_t *rel = session_find_rel(sess, rp->name);
-        int rc = col_canonicalize_recursive_aggregate_relation(rel, reduce_op,
-                sess->intern);
+        int rc = col_canonicalize_recursive_aggregate_relation(rel,
+                &rp->recursive_agg, sess->intern);
         if (rc != 0)
             return rc;
         col_session_invalidate_arrangements(&sess->base, rp->name);

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -5867,6 +5867,7 @@ col_op_k_fusion_serial(const wl_plan_op_t *op, eval_stack_t *stack,
     _phase_t0 = now_ns();
     for (uint32_t d = 0; d < k; d++) {
         wl_plan_relation_t plan_data;
+        memset(&plan_data, 0, sizeof(plan_data));
         plan_data.name = "<k_fusion_copy>";
         plan_data.delta_name = NULL;
         plan_data.ops = meta->k_ops[d];
@@ -6037,6 +6038,7 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
     uint32_t live_count = 0;
     for (uint32_t d = 0; d < k; d++) {
         wl_plan_relation_t plan_data;
+        memset(&plan_data, 0, sizeof(plan_data));
         plan_data.name = "<k_fusion_copy>";
         plan_data.delta_name = NULL;
         plan_data.ops = meta->k_ops[d];

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -301,6 +301,49 @@ typedef enum {
     WL_PLAN_AGG_OPERAND_STRING = 2,
 } wl_plan_agg_operand_t;
 
+/**
+ * wl_plan_agg_spec_t:
+ *
+ * The order a recursive relation's rows may be reduced under as a whole
+ * (Issue #975).
+ *
+ * A relation whose every rule reduces by the same ordering aggregate over
+ * the same grouping columns has one row per group at the fixpoint, not one
+ * row per group per rule: each rule computes a partial minimum (or maximum)
+ * and the union of those partials still has to be reduced once more.  This
+ * records that the relation admits that final reduction, and under which
+ * order.
+ *
+ * It is a property of the relation, established at IR lowering, and NOT
+ * something to be recovered by scanning the operator list.  The scan is what
+ * #975 was: rewrite_multiway_delta() (exec_plan_gen.c) replaces a fused
+ * relation's operators with a single K_FUSION and moves the originals into
+ * its opaque_data, so a REDUCE lookup over ops found nothing and the final
+ * reduction was skipped -- silently, on exactly the relations fusion exists
+ * to accelerate.  Recorded before any rewrite runs, a rewrite cannot delete
+ * a field that is not an operator.
+ *
+ * has_spec == false is the zero value, matching the discipline documented
+ * for wl_plan_agg_operand_t above: a relation nobody typed is structurally
+ * distinguishable from one deliberately admitted.  It is also the answer for
+ * every relation the final reduction must refuse -- see the accumulator in
+ * exec_plan_gen.c for the conflicts that clear it.
+ *
+ * @has_spec:       True when the relation admits whole-relation reduction.
+ * @fn:             The aggregate every rule of the relation agreed on.
+ *                  Only WIRELOG_AGG_MIN and WIRELOG_AGG_MAX are admitted.
+ * @operand_type:   The aggregated operand's domain, which decides whether
+ *                  the order is numeric or lexicographic (Issue #965).
+ * @group_by_count: Number of leading grouping columns; the aggregated
+ *                  value sits at column @group_by_count.
+ */
+typedef struct {
+    bool has_spec;
+    wirelog_agg_fn_t fn;
+    wl_plan_agg_operand_t operand_type;
+    uint32_t group_by_count;
+} wl_plan_agg_spec_t;
+
 /* ======================================================================== */
 /* Operator Types                                                           */
 /* ======================================================================== */
@@ -484,6 +527,15 @@ typedef struct {
     char *delta_name;
     const wl_plan_op_t *ops;
     uint32_t op_count;
+
+    /* Whether this relation's rows may be reduced as a whole at the
+     * fixpoint, and under which order (Issue #975).  Established at IR
+     * lowering, before any plan rewrite runs, precisely so that a rewrite
+     * which reshapes @ops cannot take it away.  Appended at the end so no
+     * existing field shifts, matching the discipline wl_plan_op_t follows
+     * above.  Zeroed (has_spec == false) on every relation that is not a
+     * recursive ordering aggregate. */
+    wl_plan_agg_spec_t recursive_agg;
 } wl_plan_relation_t;
 
 /* ======================================================================== */

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -891,6 +891,11 @@ typedef struct {
     wl_plan_op_t *ops;
     uint32_t count;
     uint32_t capacity;
+
+    /* The whole-relation reduction this operator list admits, accumulated as
+     * the REDUCEs are emitted (Issue #975).  See agg_spec_observe(). */
+    wl_plan_agg_spec_t agg;
+    bool agg_vetoed;
 } op_list_t;
 
 static int
@@ -898,8 +903,69 @@ op_list_init(op_list_t *list)
 {
     list->capacity = 8;
     list->count = 0;
+    memset(&list->agg, 0, sizeof(list->agg));
+    list->agg_vetoed = false;
     list->ops = (wl_plan_op_t *)calloc(list->capacity, sizeof(wl_plan_op_t));
     return list->ops ? 0 : -1;
+}
+
+/*
+ * Fold one emitted REDUCE into the relation's whole-relation reduction
+ * specification (Issue #975).
+ *
+ * This reproduces, exactly, the admission rules the columnar backend used to
+ * rediscover by scanning the finished operator list -- the scan #975 deleted,
+ * because a fused relation has no REDUCE left to find.  The rules are:
+ *
+ *   - an aggregate other than MIN or MAX has no domination order, so the
+ *     relation is refused outright;
+ *   - two rules of one head that disagree on the aggregate, or on the number
+ *     of grouping columns, leave no single order to reduce under, so the
+ *     relation is refused as well.
+ *
+ * Both refusals are *sticky*: agg_vetoed latches, so a later agreeing REDUCE
+ * cannot resurrect a specification an earlier conflict rejected.  Overwriting
+ * per REDUCE instead of vetoing would be a behaviour change in the wrong
+ * direction -- it would start collapsing relations that are correctly left
+ * alone today, under an order only one of their rules asked for.
+ *
+ * The operand's domain is the one field NOT compared: where several REDUCEs
+ * agree on the aggregate and the group width, the last one's domain decides,
+ * which is what the deleted scan did (it kept the last operator it saw and
+ * never looked at agg_operand_type).  Reproduced deliberately so that no
+ * program's answer moves with this change, but it is a latent variant of
+ * #965: WL_PLAN_AGG_OPERAND_UNKNOWN and _STRING can coexist across two rules
+ * of one head -- a declared `symbol` column in one and an undeclared
+ * relation in the other -- and then rule order, not the data, decides whether
+ * min() orders by string or by interned id.  Deciding what genuinely
+ * disagreeing rules should do is a separate question from where the
+ * specification is stored, and is not settled here.
+ */
+static void
+agg_spec_observe(op_list_t *list, const wl_plan_op_t *reduce)
+{
+    if (list->agg_vetoed)
+        return;
+
+    if (reduce->agg_fn != WIRELOG_AGG_MIN
+        && reduce->agg_fn != WIRELOG_AGG_MAX) {
+        list->agg_vetoed = true;
+        memset(&list->agg, 0, sizeof(list->agg));
+        return;
+    }
+
+    if (list->agg.has_spec
+        && (list->agg.fn != reduce->agg_fn
+        || list->agg.group_by_count != reduce->group_by_count)) {
+        list->agg_vetoed = true;
+        memset(&list->agg, 0, sizeof(list->agg));
+        return;
+    }
+
+    list->agg.has_spec = true;
+    list->agg.fn = reduce->agg_fn;
+    list->agg.group_by_count = reduce->group_by_count;
+    list->agg.operand_type = reduce->agg_operand_type;
 }
 
 static wl_plan_op_t *
@@ -1615,6 +1681,12 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
                 "(.decl R(c: symbol)) if the column holds symbols",
                 op->agg_fn == WIRELOG_AGG_MIN ? "min" : "max");
         }
+
+        /* Record whether the relation as a whole may be reduced under this
+         * aggregate, while the operator is still an operator (Issue #975).
+         * Last statement of the arm: nothing below pushes, so @op is still
+         * the operator just emitted. */
+        agg_spec_observe(ops, op);
         return 0;
     }
 
@@ -3431,6 +3503,12 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
 
                 rels[u].ops = ol.ops;
                 rels[u].op_count = ol.count;
+                /* Issue #975: recorded here, before rewrite_lftj_chains(),
+                 * rewrite_multiway_delta(), rewrite_join_project_fusion() and
+                 * rewrite_insert_exchanges() run below.  Those reshape and in
+                 * the fusion case hide @ops entirely; none of them can reach a
+                 * field that is not an operator. */
+                rels[u].recursive_agg = ol.agg;
             } else {
                 rels[u].ops = NULL;
                 rels[u].op_count = 0;
@@ -3504,6 +3582,9 @@ col_plan_split_at_exchange(const wl_plan_relation_t *rplan)
             result.segments[seg].name = rplan->name;
             result.segments[seg].ops = rplan->ops + seg_start;
             result.segments[seg].op_count = i - seg_start;
+            /* Carried, not recomputed: it is a property of the relation, and
+             * every segment is a view of the same relation (Issue #975). */
+            result.segments[seg].recursive_agg = rplan->recursive_agg;
             seg++;
             seg_start = i + 1; /* skip the EXCHANGE op */
         }


### PR DESCRIPTION
Closes #975.

A recursive relation whose head carries `min()`/`max()` is reduced twice: per rule by `col_op_reduce()`, and once over the whole relation at fixpoint. Only the second can see across rules, so only it turns each rule's partial minimum into the relation's minimum.

That second reducer decided whether to run by **scanning the relation's plan operators for a REDUCE**. `rewrite_multiway_delta()` replaces the operator list with a single `K_FUSION` and moves the originals into `opaque_data` -- so the scan found nothing and the reduction was skipped entirely, silently, at exit 0, on exactly the relations fusion exists to accelerate.

Adding one **semantically redundant** rule to a working program was enough:

```
Label(x, min(x)) :- Edge(x, y).
Label(y, min(y)) :- Edge(x, y).
Label(x, min(l)) :- Label(y, l), Edge(y, x).                 -> 4 rows, correct
Label(x, min(l)) :- Label(y, l), Label(y, m), Edge(y, x).    -> 10 rows
```

The added rule derives nothing (`Label(y, m)` is satisfied by the same tuple as `Label(y, l)`). The answer went from 4 correctly aggregated rows to 10, the same key carrying three different labels at once.

## What actually triggers fusion -- the issue and my first draft both had this wrong

Fusion fires when `count_delta_positions()` reaches 2, counting in-stratum IDB `VARIABLE` operators and IDB-right `JOIN`s **across all of the relation's rules**. It is a per-relation count of recursive references, **not** a per-rule count of body atoms.

So two ordinary single-atom recursive rules -- propagate forward, propagate backward -- fuse just as one two-atom rule does. **That is the shape real programs have**; the redundant-rule program is the compact reproduction, not the common trigger. Review caught that every positive test case reached fusion by the same contrived route, so a case for the cross-rule shape was added (13 rows pre-fix, 4 post-fix).

## Approach

#975 proposed two fixes -- peek inside `opaque_data`, or make the rewrite preserve the REDUCE. Both are ruled out by the standing directive that K-fusion defects are resolved by improving the Timely-Differential path rather than patching K-fusion, and both would leave the next consumer of a hidden operator to rediscover the same blinding.

So the guarantee stops being discovered by scanning and becomes **relation state**: `wl_plan_relation_t.recursive_agg`, filled in `translate_ir_node()` and assigned **before** all four rewrites run. A rewrite can reshape or hide operators; it cannot reach a field that is not an operator. `col_relation_recursive_reduce_op()` is **deleted**, not extended -- and it was the only consumer that discovered this fact by scanning.

**Stated plainly: this satisfies the directive in letter, not in substance.** It hoists a plan-time fact past the rewrite; it does not improve the differential path. The substantive change is eager per-iteration domination in `col_op_consolidate_diff()`, which needs `is_monotone` -- declared but hardcoded false and never computed. That is #1021.

## No behaviour moved except the intended fix

Review instrumented `wl_plan_from_program` to recompute the **old** post-rewrite scan and compare it field-by-field against the new recorded spec, across the full 281-test suite plus 406 `.dl` programs:

| divergence | count |
|---|---|
| old had a spec, new doesn't | **0** |
| aggregate / group width / operand differ | **0** |
| newly gained (the fix) | 42, all fused `Label` relations |

Independently, all 64 `.dl` programs in the tree at W in {1,4} produce **byte-identical** sorted output before and after.

## Deliberate non-changes

- **Timing unchanged** (still fixpoint, not per-iteration). A same-stratum consumer can still hold rows derived from labels the reduction then dominates away -- internally contradictory output. Second half of #1021.
- **`operand_type` last-rule-wins preserved.** The deleted scan never compared it. Reproduced so no existing answer moves; it is a latent #965 variant, recorded in a test and filed as #1024 rather than endorsed.
- **`group_by_indices` omitted on purpose.** Those index the REDUCE's *input*; canonicalisation runs on its *output*, where the grouping columns are already at `0..gc-1`.

## Cost

`O(nrows x ngroups)` once per fixpoint, now on relations that previously escaped it. Same-program A/B at w=1 (self-loop edges, so both builds emit byte-identical output while the old one still skips the pass): **+3.5%** on the four-rule template, **+9.0%** on the leanest fused shape, both flat in n, **under 1%** wherever groups collapse. At w=4 a lean relation reads +32%, but the absolute delta is unchanged -- Amdahl, since this pass stays serial.

For scale: `col_op_reduce()` has the same linear group lookup, runs per rule per iteration rather than once per stratum, and is **95% of cycles** on these programs; this pass is 3.5%. Both are #1023.

## Testing

`tests/test_recursive_agg_kfusion.c` -- **9 cases at W in {1,4,8,16}, of which 5 fail against the previous build.** Every case asserts exact tuples, not cardinality: 10 rows is plausible for a program whose answer is 4, and a fix collapsing by the wrong comparator also returns 4.

Two shapes could **not** be covered, and are called out rather than skipped quietly: incremental `--watch` on a fused relation (#1019 -- affected-strata detection is blinded the same way and drops the insert before any aggregate runs) and `-DENABLE_K_FUSION=0` as a cross-check oracle (#1020 -- that build aborts on this program family). Both predate this change.

Full suite **269 ok / 1 fail / 11 skipped** in release and under ASAN+UBSAN; the one failure is the pre-existing `sbom_snapshot` pin drift. `optimizer_equivalence` (all 16 masks) did not move. uncrustify clean on all seven changed files.

## Follow-ups filed, not fixed here

#1019, #1020, #1021, #1023, #1024.