### PR TITLE
fix: keep materialized joins valid across pool resets

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1591,6 +1591,24 @@ test_k_fusion_memory_exe = executable(
 
 test('k_fusion_memory', test_k_fusion_memory_exe)
 
+test_k_fusion_memory_nofusion_exe = executable(
+  'test_k_fusion_memory_nofusion',
+  files('test_k_fusion_memory.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  c_args: ['-DENABLE_K_FUSION=0'],
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('k_fusion_memory_nofusion', test_k_fusion_memory_nofusion_exe)
+
 # ============================================================================
 # Delta Timestamp Tests (Phase 3B - 3B-001)
 # ============================================================================

--- a/tests/test_k_fusion_memory.c
+++ b/tests/test_k_fusion_memory.c
@@ -40,29 +40,29 @@ static int pass_count = 0;
 static int fail_count = 0;
 
 #define TEST(name)                                      \
-    do {                                                \
-        test_count++;                                   \
-        printf("TEST %d: %s ... ", test_count, (name)); \
-    } while (0)
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
 
 #define PASS()            \
-    do {                  \
-        pass_count++;     \
-        printf("PASS\n"); \
-    } while (0)
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
 
 #define FAIL(msg)                    \
-    do {                             \
-        fail_count++;                \
-        printf("FAIL: %s\n", (msg)); \
-        return;                      \
-    } while (0)
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
 
 #define ASSERT(cond, msg) \
-    do {                  \
-        if (!(cond))      \
+        do {                  \
+            if (!(cond))      \
             FAIL(msg);    \
-    } while (0)
+        } while (0)
 
 /* ----------------------------------------------------------------
  * Tuple counting callback
@@ -76,7 +76,7 @@ struct result_ctx {
 
 static void
 count_tuples_cb(const char *relation, const int64_t *row, uint32_t ncols,
-                void *user_data)
+    void *user_data)
 {
     struct result_ctx *ctx = (struct result_ctx *)user_data;
     ctx->total++;
@@ -92,7 +92,7 @@ count_tuples_cb(const char *relation, const int64_t *row, uint32_t ncols,
 
 static int
 run_program_workers(const char *src, const char *tracked_rel, uint32_t nworkers,
-                    int64_t *out_count, uint32_t *out_iters)
+    int64_t *out_count, uint32_t *out_iters)
 {
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
@@ -160,14 +160,14 @@ test_k2_memory_opt_correctness(void)
     TEST("K=2 memory-optimised workers produce correct 6-tuple closure");
 
     const char *src = ".decl r(x: int32, y: int32)\n"
-                      "r(1, 2). r(2, 3). r(3, 4).\n"
-                      "r(x, z) :- r(x, y), r(y, z).\n";
+        "r(1, 2). r(2, 3). r(3, 4).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
 
     int64_t count = 0;
     int rc = run_program_workers(src, "r", 1, &count, NULL);
     ASSERT(rc == 0, "K=2 memory-opt program execution failed");
     ASSERT(count == 6,
-           "K=2 memory-opt: expected 6 tuples from 3-edge chain closure");
+        "K=2 memory-opt: expected 6 tuples from 3-edge chain closure");
 
     PASS();
 }
@@ -184,8 +184,8 @@ test_k4_matches_k2(void)
     TEST("K=4 multi-worker matches K=2 result (parity)");
 
     const char *src = ".decl r(x: int32, y: int32)\n"
-                      "r(1, 2). r(2, 3). r(3, 4).\n"
-                      "r(x, z) :- r(x, y), r(y, z).\n";
+        "r(1, 2). r(2, 3). r(3, 4).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
 
     int64_t count_k2 = 0, count_k4 = 0;
     int rc2 = run_program_workers(src, "r", 1, &count_k2, NULL);
@@ -212,10 +212,10 @@ test_k2_isolation_5node_chain(void)
     TEST("K=2 per-worker isolation: 5-node chain produces 10 tuples");
 
     const char *src = ".decl e(x: int32, y: int32)\n"
-                      "e(1, 2). e(2, 3). e(3, 4). e(4, 5).\n"
-                      ".decl reach(x: int32, y: int32)\n"
-                      "reach(x, y) :- e(x, y).\n"
-                      "reach(x, z) :- reach(x, y), reach(y, z).\n";
+        "e(1, 2). e(2, 3). e(3, 4). e(4, 5).\n"
+        ".decl reach(x: int32, y: int32)\n"
+        "reach(x, y) :- e(x, y).\n"
+        "reach(x, z) :- reach(x, y), reach(y, z).\n";
 
     int64_t count = 0;
     int rc = run_program_workers(src, "reach", 1, &count, NULL);
@@ -237,8 +237,8 @@ test_k2_empty_mat_cache_correctness(void)
     TEST("K=2 empty mat_cache: 2-cycle converges to 4 tuples");
 
     const char *src = ".decl r(x: int32, y: int32)\n"
-                      "r(1, 2). r(2, 1).\n"
-                      "r(x, z) :- r(x, y), r(y, z).\n";
+        "r(1, 2). r(2, 1).\n"
+        "r(x, z) :- r(x, y), r(y, z).\n";
 
     int64_t count = 0;
     uint32_t iters = 0;
@@ -246,6 +246,37 @@ test_k2_empty_mat_cache_correctness(void)
     ASSERT(rc == 0, "2-cycle K=2 program failed");
     ASSERT(count == 4, "2-cycle K=2 should produce 4 tuples");
     ASSERT(iters <= 3, "2-cycle should converge within 3 iterations");
+
+    PASS();
+}
+
+/* ================================================================
+ * Test 5: Non-fused recursive materialization is cleaned before pool reset
+ *
+ * Issue #1020: with K-Fusion disabled, recursive materialized joins may
+ * leave pool-owned results in mat_cache across a sub-pass boundary.  The
+ * cache must release those results before delta_pool_reset clears the pool
+ * slot metadata.
+ * ================================================================ */
+static void
+test_nonfused_materialized_join_cleanup(void)
+{
+    TEST("non-fused recursive materialized join cleanup");
+
+    const char *src = ".decl Edge(x: int64, y: int64)\n"
+        ".decl Label(x: int64, l: int64)\n"
+        ".output Label\n"
+        "Edge(1,2). Edge(2,3). Edge(3,4).\n"
+        "Label(x, min(x)) :- Edge(x, y).\n"
+        "Label(y, min(y)) :- Edge(x, y).\n"
+        "Label(x, min(l)) :- Label(y, l), Edge(y, x).\n"
+        "Label(x, min(l)) :- Label(y, l), Label(y, m), Edge(y, x).\n";
+
+    int64_t count = 0;
+    int rc = run_program_workers(src, "Label", 1, &count, NULL);
+    ASSERT(rc == 0, "non-fused materialized recursive program failed");
+    ASSERT(count == 4,
+        "non-fused materialized recursive program should produce 4 rows");
 
     PASS();
 }
@@ -263,6 +294,7 @@ main(void)
     test_k4_matches_k2();
     test_k2_isolation_5node_chain();
     test_k2_empty_mat_cache_correctness();
+    test_nonfused_materialized_join_cleanup();
 
     printf("\nResults: %d/%d passed", pass_count, test_count);
     if (fail_count > 0)

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1031,6 +1031,20 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                 }
             }
 
+            /* Issue #176: Per-sub-pass cache eviction for recursive strata.
+             * Materialized join results may live in delta_pool, so release
+             * them before resetting the pool.  Resetting first clears the
+             * pool-owned marker and leaves the cache holding stale pointers.
+             * Use configurable eviction threshold (cache_evict_threshold):
+             * - If 0: clear entire cache each sub-pass (backward compatible)
+             * - If > 0: evict LRU entries when cache exceeds threshold */
+            if (sess->cache_evict_threshold == 0) {
+                col_mat_cache_clear(&sess->mat_cache);
+            } else {
+                col_mat_cache_evict_until(&sess->mat_cache,
+                    sess->cache_evict_threshold);
+            }
+
             delta_pool_reset(sess->delta_pool);
             sess->rotation_ops->rotate_eval_arena(sess);
             /* Issue #560: Advance the compound-arena epoch frontier at the
@@ -1047,17 +1061,6 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                 && sess->rotation_ops->gc_epoch_boundary) {
                 sess->rotation_ops->gc_epoch_boundary(sess);
             }
-            /* Issue #176: Per-sub-pass cache eviction for recursive strata.
-             * Use configurable eviction threshold (cache_evict_threshold):
-             * - If 0: clear entire cache each sub-pass (backward compatible)
-             * - If > 0: evict LRU entries when cache exceeds threshold */
-            if (sess->cache_evict_threshold == 0) {
-                col_mat_cache_clear(&sess->mat_cache);
-            } else {
-                col_mat_cache_evict_until(&sess->mat_cache,
-                    sess->cache_evict_threshold);
-            }
-
             if (!any_new) {
                 /* Fixed point reached: no new tuples in this sub-pass. */
                 converged = true;

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -3467,7 +3467,11 @@ col_op_join(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
     }
 
     uint32_t ocols = col_join_output_width(left, right, op);
-    col_rel_t *out = col_rel_pool_new_auto(sess->delta_pool, sess->eval_arena,
+    /* Materialized results outlive the current delta-pool reset while they
+     * remain in mat_cache, so cache-owned joins must be heap allocated. */
+    col_rel_t *out = (op->materialized && !projected_join)
+        ? col_rel_new_auto("$join", ocols)
+        : col_rel_pool_new_auto(sess->delta_pool, sess->eval_arena,
             "$join", ocols);
     if (!out) {
         free(lk);
@@ -7247,7 +7251,11 @@ col_op_join_diff(const wl_plan_op_t *op, eval_stack_t *stack,
     }
 
     uint32_t ocols = col_join_output_width(left, right, op);
-    col_rel_t *out = col_rel_pool_new_auto(sess->delta_pool, sess->eval_arena,
+    /* Materialized results outlive the current delta-pool reset while they
+     * remain in mat_cache, so cache-owned joins must be heap allocated. */
+    col_rel_t *out = (op->materialized && !projected_join)
+        ? col_rel_new_auto("$join_diff", ocols)
+        : col_rel_pool_new_auto(sess->delta_pool, sess->eval_arena,
             "$join_diff", ocols);
     if (!out) {
         free(lk);


### PR DESCRIPTION
## Summary
- keep materialized join results heap-owned while they are retained by mat_cache
- release recursive-stratum cache entries before resetting delta_pool
- add an ENABLE_K_FUSION=0 regression test for issue #1020

## Root cause
Recursive non-fused evaluation could retain a delta-pool relation in mat_cache across a pool reset. The reset cleared the pool-owned metadata, and later cache invalidation attempted to free the arena interior pointer.

## Validation
- meson test -C build-default k_fusion_memory k_fusion_memory_nofusion plan_gen join_overflow diff_join
- ASAN meson test -C build-nofusion-asan k_fusion_memory_nofusion
- original #1020 CLI reproduction now exits successfully and emits 4 Label rows

Closes #1020