### PR TITLE
fix(magic_sets): read the head projection, not the root's node type

### DIFF
--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -371,11 +371,12 @@ entry-point symbols are:
 
 An adornment is "all-free" when `bound_mask == 0`: every argument position
 of the adorned predicate is free at the Magic Sets demand site. The Magic
-Sets pass handles this at `wirelog/passes/magic_sets.c:571-575` by taking
-a skip path — no demand propagation is emitted because there are no bound
-columns to propagate. The other three passes (SIP, Logic Fusion, JPP) have
-no equivalent adornment concept and therefore no analogous counter or skip
-path.
+Sets pass handles this at `wirelog/passes/magic_sets.c:761-765` (a demand
+root) and `wirelog/passes/magic_sets.c:874-877` (an IDB body atom in the
+Phase 2 BFS) by taking a skip path — no demand propagation is emitted
+because there are no bound columns to propagate. The other three passes
+(SIP, Logic Fusion, JPP) have no equivalent adornment concept and therefore
+no analogous counter or skip path.
 
 ### Definition of "aggregate-skip"
 
@@ -397,7 +398,12 @@ testing the actual optimizer pipeline.
 - `wirelog/wirelog-optimizer.h:57-64` — `wirelog_opt_pass_t` enum.
 - `wirelog/wirelog-optimizer.h:71-79` — `wirelog_opt_config_t` struct.
 - `wirelog/wirelog-optimizer.h:134-137` — `wirelog_optimize_with_config` declaration.
-- `wirelog/passes/magic_sets.c:251-275` — aggregate-skip in Magic Sets head extraction.
-- `wirelog/passes/magic_sets.c:571-575` — all-free adornment skip path.
+- `wirelog/passes/magic_sets.c:212-226` — `relation_has_aggregate_rule()`, the
+  aggregate-skip predicate. It is what excludes aggregate rules, not head
+  extraction: since Issue #990 `get_head_vars()` no longer names AGGREGATE and
+  returns 0 for such a root only because it carries no head projection. Applied
+  at `:767-771` (demand root) and `:848-852` (Phase 2 BFS body atom).
+- `wirelog/passes/magic_sets.c:761-765`, `:874-877` — all-free adornment skip
+  paths.
 - `tests/test_optimizer_equivalence.c` — 16-combination equivalence matrix.
 - `stable-release-plan.md` — v0.43 milestone scope.

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -385,6 +385,12 @@ result sizes for recursive programs.
 > result rather than restricted. Adding a bound `.query` to a working program
 > will make it derive fewer tuples, not the same tuples faster. Leave `.query`
 > off, or use all-free adornments, until seeding lands.
+>
+> Seeding alone will not be enough. Issue #1027 tracks two further defects that
+> only become observable once the demand relation is populated: a rule can be
+> guarded on a demand no propagation rule ever generates, and two adornments of
+> one relation conjoin into a single rule body rather than forming separate
+> adorned predicates. Both lose answers.
 
 ### Syntax
 
@@ -449,11 +455,19 @@ Query with a mixed pattern on a ternary relation:
   (e.g. `q(1, y) :- ...` under `.query q(b, f)`) is left unguarded: there is no
   variable to key the guard on. Such rules are reported by the pass's
   `skipped_constant_head` counter.
+- A rule whose head is wider than 64 columns is left unguarded: the adornment
+  is carried in a 64-bit mask, so there is no bit for the remaining positions.
+  Such rules are reported by the `skipped_unsupported_head` counter.
 - A rule that Logic Fusion has collapsed into a fused root — which includes any
-  rule with a filter — is also left unguarded, because the pass reads head
-  variable names off a `PROJECT` node that no longer exists. Such rules are
-  reported by `skipped_unsupported_head`. Both counters describe a rule that
-  evaluates unrestricted: sound, but not the pruning `.query` asks for.
+  rule with a filter — **is** guarded, as of Issue #990. It reads its head
+  variable names off the head projection the root still carries, not off the
+  root's node type, so the rewrite fusion performs does not hide the head. Such
+  rules were previously reported by `skipped_unsupported_head`; they are now
+  counted in `original_rules_modified` like any other guarded rule.
+- Both skip counters describe a rule that evaluates unrestricted: sound, but
+  not the pruning `.query` asks for. Absence from both means the rule was
+  guarded, which is a weaker statement than "correctly restricted" — see the
+  status note above and Issue #1027.
 - Multiple `.query` directives may appear in a single program for different
   relations.
 

--- a/tests/test_magic_sets.c
+++ b/tests/test_magic_sets.c
@@ -1492,24 +1492,341 @@ test_constant_head_position_not_counted(void)
 }
 
 /*
- * Test: a rule fused to a non-PROJECT root gets no guard, because
- * get_head_vars() has no head to read variable names from.  Logic Fusion runs
- * before Magic Sets in the shipping pipeline and any rule with a filter is a
- * fusion candidate, so this is the common way for a guard to go missing.  The
- * pass must say so rather than skip in silence (#990).
+ * Source shared by the two fused-head tests (#990).
+ *
+ * p's second rule is the fusion candidate: PROJECT(FILTER(JOIN(...)))
+ * collapses to a FLATMAP root carrying the `y < 4` filter.  Logic Fusion runs
+ * before Magic Sets in the shipping pipeline, so this is the ordinary shape a
+ * filtered rule reaches the pass in.  p also has a PROJECT-rooted sibling
+ * rule, so the two roots must both plan under the same UNION.
+ *
+ * With no magic sets the program yields five tuples:
+ *
+ *     (1,2) (1,3) (1,9) (2,3) (9,5)
+ *
+ * Seeded at $m$p_bf = {1} the answer is the three with x = 1: (1,2), (1,3),
+ * (1,9).  (2,3) and (9,5) are exactly what the demand prunes, so the seeded
+ * answer is *not* the unrestricted one -- a test that got all five back would
+ * mean the guards matched everything.
+ *
+ * Two tuples carry the load.  p(1,3) comes only from the fused rule
+ * (edge(1,2), b(2,3)), so it is lost outright when the fused rule's demand
+ * propagation rule is not generated.  p(1,5) -- edge(1,9), b(9,5) -- is the
+ * one the `y < 4` filter rejects, so it appears if guard insertion splices
+ * over the FLATMAP instead of under it and drops the filter.  The filter is
+ * therefore load-bearing on the answer, not only on the tree shape.
+ */
+static const char *k_fused_head_src = ".decl edge(x: int32, y: int32)\n"
+    ".decl b(x: int32, y: int32)\n"
+    ".decl p(x: int32, y: int32)\n"
+    ".output p\n"
+    "edge(1, 2).\n"
+    "edge(2, 3).\n"
+    "edge(1, 9).\n"
+    "edge(9, 5).\n"
+    "b(x, y) :- edge(x, y).\n"
+    "p(x, y) :- b(x, y).\n"
+    "p(x, y) :- edge(x, z), b(z, y), y < 4.\n";
+
+/*
+ * Test: a rule fused to a FLATMAP root still gets its magic guard, and the
+ * demand it propagates still reaches the IDB it reads.
+ *
+ * This is the answer test.  get_head_vars() used to key off the root's node
+ * type, which fusion rewrites in place, so a fused rule was skipped in all
+ * three phases.  The Phase 4a skip is the one that loses tuples: no demand
+ * propagation rule is generated for the fused rule, so b is under-populated
+ * and p(1, 3) never derives.
+ *
+ * magic_rules_generated is the assertion that pins Phase 4a.  A shape-only
+ * assertion passes with Phase 4a still broken, because Phase 4b inserts the
+ * guard from the same head variables independently.
  */
 static void
-test_fused_head_reported_as_unsupported(void)
+test_fused_head_guard_answers_exact(void)
 {
-    TEST("test_fused_head_reported_as_unsupported");
+    TEST("test_fused_head_guard_answers_exact");
 
-    static const char *src = ".decl e(x: int32, y: int32)\n"
-        ".decl f(y: int32, z: int32)\n"
-        ".decl hot(x: int32, z: int32)\n"
-        ".output hot\n"
-        "e(1, 2).\n"
-        "f(2, 90).\n"
-        "hot(x, z) :- e(x, y), f(y, z), z > 80.\n";
+    static const int64_t seed[] = { 1 };
+    static const int64_t expected[][2] = { { 1, 2 }, { 1, 3 }, { 1, 9 } };
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "p";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    wl_magic_sets_stats_t stats;
+    struct wirelog_program *prog = magic_program_with_seed(k_fused_head_src,
+            demands, 1, "$m$p_bf", seed, 1, 1, &stats);
+    if (!prog) {
+        FAIL("setup failed");
+        return;
+    }
+
+    /* Three guards: both rules of p, plus the single rule of b, which is
+     * adorned in turn as p's body atom.  Only 2 of the 3 land without the
+     * fix, because the fused rule of p is skipped. */
+    if (stats.original_rules_modified != 3) {
+        printf(" [original_rules_modified=%u]", stats.original_rules_modified);
+        wirelog_program_free(prog);
+        FAIL("expected both rules of p to be guarded");
+        return;
+    }
+    if (stats.skipped_unsupported_head != 0) {
+        printf(" [skipped_unsupported_head=%u]",
+            stats.skipped_unsupported_head);
+        wirelog_program_free(prog);
+        FAIL("the fused rule must not be skipped as an unsupported head");
+        return;
+    }
+
+    /* Phase 4a: one demand propagation rule per rule of p that reads an IDB.
+     * With the fused rule skipped this is 1, and b loses its demand. */
+    if (stats.magic_rules_generated != 2) {
+        printf(" [magic_rules_generated=%u]", stats.magic_rules_generated);
+        wirelog_program_free(prog);
+        FAIL("the fused rule generated no demand propagation rule");
+        return;
+    }
+
+    ms_row_set_t rows;
+    if (!ms_evaluate(prog, "p", 1, &rows)) {
+        wirelog_program_free(prog);
+        FAIL("evaluation failed");
+        return;
+    }
+    if (!ms_rows_match(&rows, &expected[0][0], 3, 2)) {
+        printf(" [got %u rows, want 3]", rows.count);
+        wirelog_program_free(prog);
+        FAIL("p != {(1, 2), (1, 3), (1, 9)}");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Test: the guard inserted into a fused rule has the same shape as the guard
+ * inserted into a PROJECT-rooted one -- a JOIN whose right child is the magic
+ * demand SCAN (#989).
+ *
+ * Asserted per rule over every rule of p, including the fused one.  A bare
+ * count of $m$ SCANs would not do: a right-deep guard still contains exactly
+ * one, so it cannot tell #989's bug from a correct guard.
+ */
+static void
+test_fused_head_guard_shape(void)
+{
+    TEST("test_fused_head_guard_shape");
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "p";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    struct wirelog_program *prog = parse_and_optimize(k_fused_head_src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    /* Precondition: fusion must actually have replaced a PROJECT root.  If it
+     * stops firing this test would otherwise pass for the wrong reason. */
+    uint32_t nrules = rule_count_for(prog, "p");
+    bool saw_fused = false;
+    for (uint32_t r = 0; r < nrules; r++) {
+        const wirelog_ir_node_t *root = rule_ir_root(prog, "p", r);
+        if (root && root->type == WIRELOG_IR_FLATMAP)
+            saw_fused = true;
+    }
+    if (nrules != 2 || !saw_fused) {
+        wirelog_program_free(prog);
+        FAIL("expected fusion to replace the PROJECT root of one rule of p");
+        return;
+    }
+
+    wl_magic_sets_stats_t stats;
+    if (wl_magic_sets_apply_with_demands(prog, demands, 1, &stats) != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    for (uint32_t r = 0; r < nrules; r++) {
+        const wirelog_ir_node_t *root = rule_ir_root(prog, "p", r);
+        const wirelog_ir_node_t *guard = rule_body_root(prog, "p", r);
+        if (!guard || guard->type != WIRELOG_IR_JOIN
+            || guard->child_count != 2) {
+            printf(" [rule %u]", r);
+            wirelog_program_free(prog);
+            FAIL("guard JOIN missing");
+            return;
+        }
+        const wirelog_ir_node_t *right = guard->children[1];
+        if (!right || !right->relation_name
+            || strncmp(right->relation_name, "$m$", 3) != 0) {
+            printf(" [rule %u]", r);
+            wirelog_program_free(prog);
+            FAIL("guard JOIN right child is not the magic demand scan");
+            return;
+        }
+        /* The fused rule keeps its filter: the guard is spliced under the
+         * FLATMAP, not in place of it. */
+        if (root && root->type == WIRELOG_IR_FLATMAP && !root->filter_expr) {
+            wirelog_program_free(prog);
+            FAIL("guard insertion dropped the fused rule's filter");
+            return;
+        }
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Test: Phase 2's own call to get_head_vars() reads the fused root.
+ *
+ * The BFS in Phase 2 is what turns a demand on p into an adornment on p's
+ * body atoms; a rule it cannot read the head of contributes no adorned
+ * predicates.  k_fused_head_src does not test that call site: p there also has
+ * a PROJECT-rooted sibling rule, which adorns b on its own, so gating Phase 2
+ * alone changes nothing observable.  Here the fused rule is p's *only* rule,
+ * so it is the only path from the demand on p to b, and $m$b_bf exists only if
+ * Phase 2 read the FLATMAP root's head projection.
+ *
+ * original_rules_modified == 2 is the same statement counted: p's one rule
+ * plus b's one rule.  b is guarded only because it was adorned.
+ */
+static void
+test_fused_head_is_the_only_path_to_the_idb(void)
+{
+    TEST("test_fused_head_is_the_only_path_to_the_idb");
+
+    static const char *src = ".decl edge(x: int32, y: int32)\n"
+        ".decl b(x: int32, y: int32)\n"
+        ".decl p(x: int32, y: int32)\n"
+        ".output p\n"
+        "edge(1, 2).\n"
+        "edge(2, 3).\n"
+        "edge(1, 9).\n"
+        "edge(9, 5).\n"
+        "b(x, y) :- edge(x, y).\n"
+        "p(x, y) :- edge(x, z), b(z, y), y < 4.\n";
+
+    static const int64_t seed[] = { 1 };
+    static const int64_t expected[][2] = { { 1, 3 } };
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "p";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    /* Precondition: p's single rule must really be fused, or the test proves
+     * nothing about a FLATMAP root. */
+    struct wirelog_program *shape = parse_and_optimize(src);
+    if (!shape) {
+        FAIL("parse failed");
+        return;
+    }
+    const wirelog_ir_node_t *root = rule_ir_root(shape, "p", 0);
+    bool fused = rule_count_for(shape, "p") == 1 && root
+        && root->type == WIRELOG_IR_FLATMAP;
+    wirelog_program_free(shape);
+    if (!fused) {
+        FAIL("expected p to have exactly one rule, fused to a FLATMAP root");
+        return;
+    }
+
+    wl_magic_sets_stats_t stats;
+    struct wirelog_program *prog = magic_program_with_seed(src, demands, 1,
+            "$m$p_bf", seed, 1, 1, &stats);
+    if (!prog) {
+        FAIL("setup failed");
+        return;
+    }
+
+    /* Phase 2: the adornment reached b through the fused rule.  Without it the
+     * BFS never leaves p and no magic relation for b is created. */
+    if (!has_relation(prog, "$m$b_bf")) {
+        wirelog_program_free(prog);
+        FAIL("no $m$b_bf: the demand did not propagate through the fused rule");
+        return;
+    }
+    if (stats.original_rules_modified != 2) {
+        printf(" [original_rules_modified=%u]", stats.original_rules_modified);
+        wirelog_program_free(prog);
+        FAIL("expected p's fused rule and b's rule to be guarded");
+        return;
+    }
+    if (stats.skipped_unsupported_head != 0) {
+        printf(" [skipped_unsupported_head=%u]",
+            stats.skipped_unsupported_head);
+        wirelog_program_free(prog);
+        FAIL("the fused rule must not be skipped as an unsupported head");
+        return;
+    }
+
+    /* p(1, 3) needs b(2, 3), which exists only if b's guard saw the demand the
+     * fused rule propagated. */
+    ms_row_set_t rows;
+    if (!ms_evaluate(prog, "p", 1, &rows)) {
+        wirelog_program_free(prog);
+        FAIL("evaluation failed");
+        return;
+    }
+    if (!ms_rows_match(&rows, &expected[0][0], 1, 2)) {
+        printf(" [got %u rows, want 1]", rows.count);
+        wirelog_program_free(prog);
+        FAIL("p != {(1, 3)}");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Test: a head wider than the 64-bit adornment mask is reported as an
+ * unsupported head.
+ *
+ * This is what keeps skipped_unsupported_head reachable after #990.
+ * get_head_vars() returns 0 for such a head even though the root's
+ * project_exprs are present and readable -- the pass declines because it has
+ * no adornment bit for column 64 and beyond -- and Phase 4b counts the rule
+ * rather than guarding it.  Nothing else covered this counter.
+ */
+static void
+test_wide_head_is_an_unsupported_head(void)
+{
+    TEST("test_wide_head_is_an_unsupported_head");
+
+    /* 65 columns: one past the mask.  Same generator idea as
+     * test_body_atom_limit_is_reported(). */
+    char src[32768];
+    size_t used = 0;
+    used += (size_t)snprintf(src + used, sizeof(src) - used, ".decl src(");
+    for (uint32_t i = 0; i < 65; i++) {
+        used += (size_t)snprintf(src + used, sizeof(src) - used,
+                "%sc%u: int32", i == 0 ? "" : ", ", i);
+    }
+    used += (size_t)snprintf(src + used, sizeof(src) - used, ")\n.decl wide(");
+    for (uint32_t i = 0; i < 65; i++) {
+        used += (size_t)snprintf(src + used, sizeof(src) - used,
+                "%sc%u: int32", i == 0 ? "" : ", ", i);
+    }
+    used += (size_t)snprintf(src + used, sizeof(src) - used,
+            ")\n.output wide\nwide(");
+    for (uint32_t i = 0; i < 65; i++) {
+        used += (size_t)snprintf(src + used, sizeof(src) - used,
+                "%sv%u", i == 0 ? "" : ", ", i);
+    }
+    used += (size_t)snprintf(src + used, sizeof(src) - used, ") :- src(");
+    for (uint32_t i = 0; i < 65; i++) {
+        used += (size_t)snprintf(src + used, sizeof(src) - used,
+                "%sv%u", i == 0 ? "" : ", ", i);
+    }
+    snprintf(src + used, sizeof(src) - used, ").\n");
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -1517,10 +1834,72 @@ test_fused_head_reported_as_unsupported(void)
         return;
     }
 
-    /* Guard the guard: if fusion stops producing a non-PROJECT root this
-     * test would otherwise pass for the wrong reason. */
+    /* The head projection is present -- this is not the AGGREGATE shape. */
+    const wirelog_ir_node_t *root = rule_ir_root(prog, "wide", 0);
+    if (!root || !root->project_exprs || root->project_count != 65) {
+        wirelog_program_free(prog);
+        FAIL("expected a 65-column head projection on the rule root");
+        return;
+    }
+
+    wl_magic_demand_t demand = { "wide", 0x1, 65 };
+    wl_magic_sets_stats_t stats;
+    if (wl_magic_sets_apply_with_demands(prog, &demand, 1, &stats) != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    if (stats.skipped_unsupported_head != 1) {
+        printf(" [skipped_unsupported_head=%u]",
+            stats.skipped_unsupported_head);
+        wirelog_program_free(prog);
+        FAIL("expected skipped_unsupported_head == 1");
+        return;
+    }
+    if (stats.original_rules_modified != 0) {
+        printf(" [original_rules_modified=%u]", stats.original_rules_modified);
+        wirelog_program_free(prog);
+        FAIL("an over-wide head must not be guarded");
+        return;
+    }
+    if (stats.skipped_constant_head != 0) {
+        printf(" [skipped_constant_head=%u]", stats.skipped_constant_head);
+        wirelog_program_free(prog);
+        FAIL("a capability gap must not be reported as a policy skip");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Test: a constant in the bound head position of a *fused* rule is a policy
+ * skip, not a capability gap.  Before #990 the fused root made
+ * get_head_vars() return 0 and the rule was misreported as an unsupported
+ * head; reading project_exprs instead sees the constant for what it is.
+ */
+static void
+test_fused_constant_head_is_a_policy_skip(void)
+{
+    TEST("test_fused_constant_head_is_a_policy_skip");
+
+    static const char *src = ".decl e(x: int32, y: int32)\n"
+        ".decl hot(x: int32, y: int32)\n"
+        ".output hot\n"
+        "e(1, 2).\n"
+        "e(2, 3).\n"
+        "hot(1, y) :- e(x, y), y > 1.\n";
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
     const wirelog_ir_node_t *root = rule_ir_root(prog, "hot", 0);
-    if (!root || root->type == WIRELOG_IR_PROJECT) {
+    if (!root || root->type != WIRELOG_IR_FLATMAP) {
         wirelog_program_free(prog);
         FAIL("expected fusion to replace the PROJECT root");
         return;
@@ -1544,17 +1923,17 @@ test_fused_head_reported_as_unsupported(void)
         FAIL("no guard was inserted, yet the rule was counted as modified");
         return;
     }
-    if (stats.skipped_unsupported_head != 1) {
+    if (stats.skipped_constant_head != 1) {
+        printf(" [skipped_constant_head=%u]", stats.skipped_constant_head);
+        wirelog_program_free(prog);
+        FAIL("expected skipped_constant_head == 1");
+        return;
+    }
+    if (stats.skipped_unsupported_head != 0) {
         printf(" [skipped_unsupported_head=%u]",
             stats.skipped_unsupported_head);
         wirelog_program_free(prog);
-        FAIL("expected skipped_unsupported_head == 1");
-        return;
-    }
-    if (stats.skipped_constant_head != 0) {
-        printf(" [skipped_constant_head=%u]", stats.skipped_constant_head);
-        wirelog_program_free(prog);
-        FAIL("a capability gap must not be reported as a policy skip");
+        FAIL("a constant head must not be reported as an unsupported head");
         return;
     }
 
@@ -1633,7 +2012,11 @@ main(void)
     test_guard_over_antijoin_exact();
     test_guard_over_semijoin_exact();
     test_constant_head_position_not_counted();
-    test_fused_head_reported_as_unsupported();
+    test_fused_head_guard_answers_exact();
+    test_fused_head_guard_shape();
+    test_fused_head_is_the_only_path_to_the_idb();
+    test_wide_head_is_an_unsupported_head();
+    test_fused_constant_head_is_a_policy_skip();
     test_body_atom_limit_is_reported();
 
     printf("\n=== Results ===\n");

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -26,6 +26,7 @@
 #include "magic_sets.h"
 #include "../ir/ir.h"
 #include "../ir/program.h"
+#include "../util/log.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -195,6 +196,19 @@ is_idb(const struct wirelog_program *prog, const char *rel_name)
     return false;
 }
 
+/*
+ * Whether any rule defining @rel_name has an AGGREGATE root.
+ *
+ * The type test is the right one here and must stay: this asks what kind of
+ * rule it is, not what the root's payload holds.  It is also load-bearing in a
+ * way that is not local -- since #990, get_head_vars() no longer names
+ * AGGREGATE, and returns 0 for such a root only because an AGGREGATE root
+ * carries no project_exprs.  This function is therefore the sole thing keeping
+ * aggregate rules out of the guard loop; it is called before adornment in
+ * Phase 1 and again in the Phase 2 BFS, so such relations never enter
+ * `processed`.  Widening AGGREGATE to carry a head projection would need this
+ * to still hold.
+ */
 static bool
 relation_has_aggregate_rule(const struct wirelog_program *prog,
     const char *rel_name)
@@ -331,10 +345,20 @@ ms_lookup_var_type(const wirelog_ir_node_t *node, const char *var)
 /* ======================================================================== */
 
 /*
- * Extract variable names from the rule's PROJECT head.
+ * Extract variable names from the rule's head projection.
  * vars[i] = variable name at head position i, or NULL for constants/wildcards.
  * Returns the head arity (number of head arguments).
- * Returns 0 for AGGREGATE rules (not currently supported for magic guards).
+ *
+ * Returns 0 for AGGREGATE rules, but only as a consequence of the test below:
+ * an AGGREGATE root carries project_count == 0 and project_exprs == NULL, so
+ * it has no head projection to read.  Nothing here names the type.  If an
+ * AGGREGATE root ever grows project_exprs, this returns its head variables
+ * and the pass will guard aggregate rules -- see the note on
+ * relation_has_aggregate_rule(), which is what actually keeps them out.
+ *
+ * Also returns 0 for a head wider than @max_vars, which is a different thing:
+ * there the head projection is present and readable, and the pass declines it
+ * because the adornment mask is 64 bits wide.  Callers see one 0 for both.
  */
 static uint32_t
 get_head_vars(const wirelog_ir_node_t *ir_root, const char **vars,
@@ -343,7 +367,27 @@ get_head_vars(const wirelog_ir_node_t *ir_root, const char **vars,
     if (!ir_root)
         return 0;
 
-    if (ir_root->type == WIRELOG_IR_PROJECT) {
+    /*
+     * Key off the head projection payload, not the node type (Issue #990).
+     *
+     * A rule root does not keep the type it was parsed with.  Logic Fusion
+     * rewrites PROJECT -> FLATMAP in place (fusion.c), leaving project_exprs /
+     * project_count untouched, and it runs before Magic Sets in the shipping
+     * pipeline -- so testing for WIRELOG_IR_PROJECT silently skipped every
+     * filtered rule, losing answers.  Nor is fusion the only rewriter:
+     * program.c re-types SCAN -> COMPOUND_INLINE/_SIDE the same way.
+     * Enumerating root types is a losing game; the payload is what this
+     * function actually needs.
+     *
+     * This is the existing convention, not a new one: exec_plan_gen.c decides
+     * a node projects with literally `node->project_exprs &&
+     * node->project_count > 0`, keying off the pointer rather than the type.
+     *
+     * Safe against the one PROJECT built without project_exprs -- jpp.c's
+     * dead-variable projection -- because that one is spliced strictly
+     * between JOINs in a chain and never becomes a rule root.
+     */
+    if (ir_root->project_exprs && ir_root->project_count > 0) {
         if (ir_root->project_count > max_vars) {
             fprintf(stderr,
                 "warning: magic sets skipped rule with %u head columns; "
@@ -364,7 +408,12 @@ get_head_vars(const wirelog_ir_node_t *ir_root, const char **vars,
         return n;
     }
 
-    /* AGGREGATE rules: skip magic guard insertion for now */
+    /* No head projection to read variable names from.  Two shapes reach here:
+     * an AGGREGATE root, excluded upstream by relation_has_aggregate_rule(),
+     * and a zero-arity head (`.decl p()`), which parses to a PROJECT with
+     * project_count == 0 and has no position a demand could bind.  The
+     * over-wide head above returns 0 without reaching this line, so a 0
+     * return does not imply this path. */
     return 0;
 }
 
@@ -762,7 +811,8 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
             if (!ir_root)
                 continue;
 
-            /* Get head variable names (PROJECT only) */
+            /* Head variable names, read off whatever head projection the root
+             * carries -- not off its node type (#990). */
             const char *head_vars[64] = { 0 };
             uint32_t head_arity = get_head_vars(ir_root, head_vars, 64);
             if (head_arity == 0)
@@ -994,8 +1044,10 @@ next_4a_atom:
      * === Phase 4b: Insert magic guards into original rules (MUTATING) ===
      *
      * Now that all demand propagation rules have been generated from the
-     * original (unmodified) IR, we can safely mutate the original rule
-     * bodies by prepending JOIN(SCAN($m$rel), body).
+     * original (unmodified) IR, we can safely mutate the original rule bodies
+     * by splicing in JOIN(body, SCAN($m$rel)).  The guard SCAN is the right
+     * child and the body stays on the left; see insert_magic_guard() for why
+     * the other order does not survive plan translation (#989).
      */
 
     for (uint32_t pi = 0; pi < processed.count; pi++) {
@@ -1018,18 +1070,32 @@ next_4a_atom:
             const char *head_vars[64] = { 0 };
             uint32_t head_arity = get_head_vars(ir_root, head_vars, 64);
             if (head_arity == 0) {
-                /* No PROJECT head to read variable names from, so the guard
-                 * cannot be keyed and the rule runs unrestricted.  This is a
-                 * capability gap, not a policy decision: a rule fused to a
-                 * FLATMAP root lands here -- Logic Fusion runs before Magic
-                 * Sets in the shipping pipeline and any rule with a filter is
-                 * a candidate.  That is the only shape that reaches this in
-                 * practice; an AGGREGATE root cannot, because
-                 * relation_has_aggregate_rule() filters those relations before
-                 * adornment so they never enter `processed`.  Counting it is
-                 * what makes the omission visible at all (see #990). */
+                /* No head variable names the guard could be keyed on, so the
+                 * rule runs unrestricted -- sound but unoptimized.  A
+                 * capability gap, not a policy decision.
+                 *
+                 * Reachable.  get_head_vars() also returns 0 for a head wider
+                 * than the 64-bit adornment mask, and that path needs only a
+                 * bound demand on a relation with more than 64 columns; it is
+                 * pinned by test_wide_head_is_an_unsupported_head().  What
+                 * #990 changed is that a rule fused to a FLATMAP root no
+                 * longer lands here: it keeps its project_exprs and is guarded
+                 * normally.  An AGGREGATE root cannot reach here either --
+                 * relation_has_aggregate_rule() excludes those relations
+                 * before they can enter `processed`.
+                 *
+                 * Guarding a rule is not on its own enough to make the demand
+                 * correct: the guard prunes only what the demand relation was
+                 * actually populated with, so a rule guarded on a demand that
+                 * no propagation rule ever fills loses answers rather than
+                 * saving work.  See #1027; nothing seeds $m$ today, so it is
+                 * not a shipping regression. */
                 if (stats)
                     stats->skipped_unsupported_head++;
+                WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_WARN,
+                    "magic sets left rule for '%s' unguarded: its head has no "
+                    "variable names the demand relation '%s' can be keyed on",
+                    ap->rel_name, guard_magic);
                 continue;
             }
 

--- a/wirelog/passes/magic_sets.h
+++ b/wirelog/passes/magic_sets.h
@@ -48,26 +48,53 @@ struct wirelog_program;
  * @arity_mismatch_skipped: Demands skipped due to adornment count/arity mismatch.
  * @skipped_aggregate:     Aggregate rules skipped because Magic Sets cannot
  *                         safely insert magic guards into them yet.
- * @skipped_constant_head: Rules left unguarded because every bound head
- *                         position holds a constant rather than a variable,
- *                         leaving no join key to guard on.  A *policy* skip:
- *                         the rule is well-formed and the pass declines.
- * @skipped_unsupported_head: Rules left unguarded because the head is not a
- *                         PROJECT the pass can read variable names from --
- *                         in practice a rule fused to a FLATMAP root (#990).
- *                         A *capability* gap, not a decision.  An AGGREGATE
- *                         root cannot reach here: relation_has_aggregate_rule()
- *                         filters such relations before adornment, in Phase 1
- *                         and again in the Phase 2 BFS, so they never enter
- *                         `processed` and the guard loop never sees them.
+ * @skipped_constant_head: Rules left unguarded because no bound head position
+ *                         holds a variable the guard could be keyed on.
+ *                         Read the name loosely.  A literal constant in the
+ *                         bound position is the common case and is a genuine
+ *                         policy skip -- the rule is well-formed and the pass
+ *                         declines.  But an arithmetic head expression in the
+ *                         bound position (`p(x + 1, y) :- ...` under
+ *                         `.query p(b, f)`) also lands here, and that is
+ *                         neither a constant nor a decision: the pass simply
+ *                         cannot key a guard on a computed head column yet.
+ *                         The counter conflates the two.  Only the *bound*
+ *                         positions are read, so `p(x, y + 1)` under the same
+ *                         query is guarded normally -- position 0 is the plain
+ *                         variable x.  Before #990 an arithmetic head in a
+ *                         bound position reached this only when unfused, and
+ *                         counted as an unsupported head when fused; now it
+ *                         counts here either way, which is at least
+ *                         consistent, but still mislabeled.
+ * @skipped_unsupported_head: Rules left unguarded because the pass found no
+ *                         head variable names to key the guard on.  A
+ *                         *capability* gap.  Two shapes reach it, and the
+ *                         counter does not separate them: a head wider than
+ *                         the 64-bit adornment mask (more than 64 columns),
+ *                         and a root carrying no head projection at all.
+ *                         Since #990 a rule fused to a FLATMAP root -- once
+ *                         the common way to get here -- keeps its
+ *                         project_exprs and is guarded normally.  An AGGREGATE
+ *                         root cannot reach here either:
+ *                         relation_has_aggregate_rule() filters such relations
+ *                         before adornment, in Phase 1 and again in the Phase
+ *                         2 BFS, so they never enter `processed` and the guard
+ *                         loop never sees them.  The wide head is what remains
+ *                         reachable in practice.
  *
  * Both skip counters describe a rule that is evaluated unrestricted, which is
  * sound but unoptimized.  They are the only signal that a demand did not reach
  * it -- but only for a caller that supplies a stats struct.  The library's own
  * pipeline passes NULL (api_facade.c), so in a shipping build nothing reads
  * them; they are observability for tests and embedders, not a runtime warning.
- * They are kept apart because closing the capability gap is work, while
- * the policy skip is correct as it stands.
+ * A rule missing from both counters is guarded, which is not the same as
+ * correctly restricted: a guard prunes only what its demand relation was
+ * populated with, so a rule guarded on a demand no propagation rule ever fills
+ * loses answers instead of saving work (#1027).  Guarding is complete only
+ * when the demand actually propagates; these counters measure the first half.
+ * They are kept apart because they are reported at different points, not
+ * because the split is clean: as noted above, one capability gap is currently
+ * counted on the policy side.
  *
  * @original_rules_modified counts guards actually inserted.  A rule counted in
  * either skip counter is not counted there.


### PR DESCRIPTION
Closes #990.

Logic Fusion rewrites a rule root `PROJECT` -> `FLATMAP` **in place**, leaving `project_exprs`/`project_count` untouched, and runs *before* magic sets in the shipping pipeline. `get_head_vars()` tested `ir_root->type == WIRELOG_IR_PROJECT`, so every fused rule -- any rule carrying a filter -- was invisible to the pass.

## It loses answers

Not, as the issue supposed, "sound but inert". `get_head_vars()` has **three** call sites; the one in phase 4a generates the demand-propagation rules. A fused rule contributed none, so an IDB it reads came out under-populated:

```
edge(1,2). edge(2,3). edge(1,9).
b(x, y) :- edge(x, y).
p(x, y) :- b(x, y).
p(x, y) :- edge(x, z), b(z, y), y > 0.    /* fused */
```

With `$m$p_bf` seeded to `{1}`:

```
no magic sets            (1,2) (1,3) (1,9) (2,3)
magic + fusion           (1,2)       (1,9)          <- (1,3) lost
magic, fusion disabled   (1,2) (1,3) (1,9)
```

Exit 0, no diagnostic. `magic_rules_generated` is 1 with fusion, 2 without -- that stat is the mechanism.

## The fix

```c
if (ir_root->project_exprs && ir_root->project_count > 0)
```

Key off the head-projection payload rather than the node type. A rule root does not keep the type it was parsed with, and **fusion is not the only rewriter** -- `program.c` re-types `SCAN` -> `COMPOUND_INLINE`/`_SIDE` the same way. Enumerating root types is a losing game; `jpp.c` and `sip.c` each maintain their own `{PROJECT, FLATMAP}` list and this pass was simply the one not updated. It is also the existing convention: `exec_plan_gen.c` already uses literally `node->project_exprs && node->project_count > 0`.

## Evidence

Differential testing against the same programs with magic sets off, 38 shapes (recursion, mutual recursion, UNION, ANTIJOIN, SEMIJOIN, compound columns, arithmetic and constant head positions, multiple adornments), each as {fusion on, off} x {magic on, off}.

**After the change every stat counter in the fused run equals the unfused run, in all 38 cases. On the parent commit they diverged in 17.** That equality is the invariant: fusion is now transparent to magic sets. The same harness finds the bug on base (12 failures, 6 fusion-only).

`adorned_predicates` does grow -- to exactly the value the unfused run already had.

## Three things reviewers found that this does *not* hide

- **A >64-column head still returns 0**, and that path is genuinely reachable (`skipped_unsupported_head` increments with `project_exprs` set). An earlier round of this work asserted in three comments that the counter had become unreachable and omitted a diagnostic on that basis. **The assertion was false.** Corrected, and the site now logs at `WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_WARN)` and is pinned by a test.
- **#1027** -- the pass can guard a rule whose demand rule was never generated, and conjoins guards for two adornments into `JOIN(JOIN(body, $m$r_bf), $m$r_fb)`. Pre-existing (reproduces on base with fusion off), but the missing guard was accidentally masking it; four corpus programs go from complete to lost here. Not a shipping regression -- nothing seeds `$m$` yet (#989).
- **#1028** -- a head mixing constant and variable bound positions builds a guard SCAN with fewer columns than the magic relation. Pre-existing, newly reached.

## Docs

`docs/SYNTAX.md` documented the defect this removes and said fused rules are reported by `skipped_unsupported_head`. Both false now; corrected, plus a note that absence from the skip counters does not by itself mean a rule was correctly restricted.

## Tests

Five in `tests/test_magic_sets.c`, replacing `test_fused_head_reported_as_unsupported` -- which **pinned the defect as a contract** and was the only test in the suite that failed with this fix.

The replacement asserts the exact answer set and `magic_rules_generated` (the only assertion pinning the phase 4a half -- a guard-shape assertion alone passes with phase 4a still broken), guard *shape* rather than a `$m$` scan count (a count cannot distinguish the right-deep orientation #989 fixed), the constant-head reclassification, adornment reaching an IDB whose only path is the fused rule, and the wide-head counter.

**Mutation-checked**: gating each `get_head_vars()` call site individually, deleting the wide-head return, clearing the fused rule's `filter_expr`, and reverting the fix each kill a named test. Gating phase 2 alone killed nothing until the new adornment test was added.

## Validation

Suite **268 ok / 1 fail / 11 skipped** release and ASAN+UBSAN; the failure is the pre-existing `sbom_snapshot` pin drift. `abi` 33/33 including log erasure at `-Dwirelog_log_max_level=error`. `test_magic_sets` 24/24. gcc + clang `-Wall -Wextra -Wconversion -Wshadow -Wpedantic` clean. uncrustify clean on all changed files, on base and after.