### PR TITLE
fix(columnar): record each rule's relation refs at lowering, not by scanning plan operators

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2403,6 +2403,38 @@ test_cli_watch_exe = executable(
 
 test('cli_watch', test_cli_watch_exe)
 
+# ============================================================================
+# Affected Strata Across Plan Rewrites (Issue #1019)
+# ============================================================================
+
+test_affected_strata_rewrites_exe = executable(
+  'test_affected_strata_rewrites',
+  files('test_affected_strata_rewrites.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  driver_src,
+  '../wirelog/wirelog-easy.c',
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+# Issue #1019: allocation-heavy -- ten plan builds plus four end-to-end
+# incremental runs at W in {1,2,4,8}, each stepping the session once per
+# inserted edge.  Measured under `meson test` on the dev host at 1.67s
+# (release) and 0.33s (address,undefined); the release figure is dominated by
+# MALLOC_PERTURB_, which meson sets for every test and which makes glibc
+# scrub every one of those allocations.  That leaves little margin on a
+# loaded or slower CI runner, so take the same explicit override the other
+# allocation-heavy cases here use rather than riding the 30s default.
+test('affected_strata_rewrites', test_affected_strata_rewrites_exe,
+     timeout: 120)
+
 test_cli_delta_exe = executable(
   'test_cli_delta',
   files('test_cli_delta.c'),

--- a/tests/test_affected_strata_rewrites.c
+++ b/tests/test_affected_strata_rewrites.c
@@ -1,0 +1,1059 @@
+/*
+ * test_affected_strata_rewrites.c - Affected-strata detection across plan
+ * rewrites (Issue #1019)
+ *
+ * rewrite_multiway_delta() collapses a recursive relation plan to a single
+ * K_FUSION op and rewrite_lftj_chains() collapses an EDB-only join chain to a
+ * single LFTJ op.  Both move the operators that name the relations being read
+ * into wl_plan_op_t.opaque_data, where col_compute_affected_strata()'s
+ * operator scan cannot see them.  The stratum then looks like it reads
+ * nothing: incremental inserts derive no tuples and, because
+ * col_session_step() intersects the removal mask into UINT64_MAX, retracted
+ * tuples are retained.
+ *
+ * Every case here builds a REAL plan through wl_plan_from_program() and
+ * asserts its own premise -- that the blinding operator it targets is
+ * actually present -- before asserting the mask, so the case cannot pass
+ * vacuously if a future rewrite changes shape.
+ *
+ * Coverage note: because every plan here comes from wl_plan_from_program(),
+ * every stratum carries a recorded wl_plan_stratum_t.rule_refs, so this file
+ * exercises only the refset arm of rule_references_relation().  The
+ * operator-scan fallback (rule_refs == NULL) is covered by the hand-built
+ * plans in tests/test_affected_strata.c, tests/test_affected_rules.c and
+ * tests/test_rule_level_frontier.c, which memset their strata on the stack
+ * and never call wl_plan_from_program().  Both arms need to keep passing.
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../wirelog/cli/driver.h"
+#include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/exec_plan.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/wirelog-easy.h"
+#include "../wirelog/wirelog.h"
+
+#include "test_tmpdir.h"
+
+/* ======================================================================== */
+/* TEST HARNESS MACROS                                                       */
+/* ======================================================================== */
+
+#define TEST(name)                       \
+        do {                                 \
+            printf("  [TEST] %-62s ", name); \
+            fflush(stdout);                  \
+        } while (0)
+
+#define PASS              \
+        do {                  \
+            printf("PASS\n"); \
+            tests_passed++;   \
+        } while (0)
+
+#define FAIL(msg)                  \
+        do {                           \
+            printf("FAIL: %s\n", msg); \
+            tests_failed++;            \
+        } while (0)
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+/* ======================================================================== */
+/* DATALOG PROGRAMS                                                          */
+/* ======================================================================== */
+
+/* Two IDB body atoms in one rule -> rewrite_multiway_delta fuses. */
+static const char *const SRC_FUSED_TC =
+    ".decl Edge(x: int64, y: int64)\n"
+    ".decl Path(x: int64, y: int64)\n"
+    ".output Path\n"
+    "Path(x,y) :- Edge(x,y).\n"
+    "Path(x,y) :- Path(x,z), Path(z,y).\n";
+
+/* Three rules for P, each with at most ONE IDB body atom, still fuse:
+ * count_delta_positions() counts delta positions across the whole relation
+ * plan (the union of every rule for the head), not per rule. */
+static const char *const SRC_CROSS_RULE_FUSION =
+    ".decl E(x: int64, y: int64)\n"
+    ".decl P(x: int64, y: int64)\n"
+    ".decl Q(x: int64, y: int64)\n"
+    ".decl S(x: int64, y: int64)\n"
+    ".output P\n"
+    "P(x,y) :- E(x,y).\n"
+    "P(x,y) :- Q(x,z), E(z,y).\n"
+    "P(x,y) :- S(x,z), E(z,y).\n"
+    "Q(x,y) :- P(x,y).\n"
+    "S(x,y) :- P(x,y).\n";
+
+/* Non-recursive star join.  Without the optimizer passes this lowers to a
+ * three-way EDB chain and rewrite_lftj_chains() collapses it to LFTJ. */
+static const char *const SRC_STAR_JOIN =
+    ".decl A(x: int64, y: int64)\n"
+    ".decl B(x: int64, z: int64)\n"
+    ".decl C(x: int64, w: int64)\n"
+    ".decl R(x: int64)\n"
+    ".output R\n"
+    "R(x) :- A(x,y), B(x,z), C(x,w).\n";
+
+/* One IDB body atom per rule and only one rule that recurses: no fusion. */
+static const char *const SRC_UNFUSED_TC =
+    ".decl Edge(x: int64, y: int64)\n"
+    ".decl Path(x: int64, y: int64)\n"
+    ".output Path\n"
+    "Path(x,y) :- Edge(x,y).\n"
+    "Path(x,y) :- Path(x,z), Edge(z,y).\n";
+
+/* Fused stratum 0, a stratum that depends on it, and a wholly independent
+ * stratum that must stay unmarked. */
+static const char *const SRC_FUSED_PLUS_INDEPENDENT =
+    ".decl Edge(x: int64, y: int64)\n"
+    ".decl Path(x: int64, y: int64)\n"
+    ".decl Reach(x: int64, y: int64)\n"
+    ".decl Other(x: int64, y: int64)\n"
+    ".decl Ind(x: int64, y: int64)\n"
+    ".output Reach\n"
+    ".output Ind\n"
+    "Path(x,y) :- Edge(x,y).\n"
+    "Path(x,y) :- Path(x,z), Path(z,y).\n"
+    "Reach(x,y) :- Path(x,y).\n"
+    "Ind(x,y) :- Other(x,y).\n";
+
+/* Edge -> Path (fused) -> Reach -> Far: propagation has to cross the fused
+ * stratum twice. */
+static const char *const SRC_FUSED_CHAIN =
+    ".decl Edge(x: int64, y: int64)\n"
+    ".decl Path(x: int64, y: int64)\n"
+    ".decl Reach(x: int64, y: int64)\n"
+    ".decl Far(x: int64, y: int64)\n"
+    ".output Far\n"
+    "Path(x,y) :- Edge(x,y).\n"
+    "Path(x,y) :- Path(x,z), Path(z,y).\n"
+    "Reach(x,y) :- Path(x,y).\n"
+    "Far(x,y) :- Reach(x,y).\n";
+
+/* ======================================================================== */
+/* PLAN HELPERS                                                              */
+/* ======================================================================== */
+
+/*
+ * build_plan - Lower @src to a wl_plan_t.
+ *
+ * @optimize selects which optimizer passes run, and that choice is what
+ * decides K_FUSION versus LFTJ, so every caller states it explicitly:
+ *   true  - fusion + JPP + SIP, the shape wirelog_optimize() produces.
+ *   false - no passes at all, the mode wirelog-advanced.h documents for
+ *           hosts that call wirelog_session_create() directly.
+ * The K-fusion rewrite runs in wl_plan_from_program() either way.
+ */
+static wl_plan_t *
+build_plan(const char *src, bool optimize)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return NULL;
+
+    if (optimize) {
+        wl_fusion_apply(prog, NULL);
+        wl_jpp_apply(prog, NULL);
+        wl_sip_apply(prog, NULL);
+    }
+
+    wl_plan_t *plan = NULL;
+    int rc = wl_plan_from_program(prog, &plan);
+    wirelog_program_free(prog);
+    return (rc == 0) ? plan : NULL;
+}
+
+/*
+ * find_stratum_of - Index of the stratum producing relation @name, or
+ * UINT32_MAX.
+ */
+static uint32_t
+find_stratum_of(const wl_plan_t *plan, const char *name)
+{
+    for (uint32_t si = 0; si < plan->stratum_count; si++) {
+        for (uint32_t ri = 0; ri < plan->strata[si].relation_count; ri++) {
+            const char *rn = plan->strata[si].relations[ri].name;
+            if (rn && strcmp(rn, name) == 0)
+                return si;
+        }
+    }
+    return UINT32_MAX;
+}
+
+/*
+ * relation_leading_op - Operator kind of the first op of relation @name, or
+ * -1 when the relation is absent or has no operators.  Returns int rather
+ * than wl_plan_op_type_t because the enum has no "none" member.
+ */
+static int
+relation_leading_op(const wl_plan_t *plan, const char *name)
+{
+    for (uint32_t si = 0; si < plan->stratum_count; si++) {
+        for (uint32_t ri = 0; ri < plan->strata[si].relation_count; ri++) {
+            const wl_plan_relation_t *pr = &plan->strata[si].relations[ri];
+            if (!pr->name || strcmp(pr->name, name) != 0)
+                continue;
+            if (pr->op_count == 0 || !pr->ops)
+                return -1;
+            return (int)pr->ops[0].op;
+        }
+    }
+    return -1;
+}
+
+/*
+ * strata_mask - col_compute_affected_strata() over @plan for @rel.
+ * Returns 0 and sets *ok = false when the session harness itself fails.
+ */
+static uint64_t
+strata_mask(wl_plan_t *plan, const char *rel, bool *ok)
+{
+    wl_session_t *sess = NULL;
+    *ok = false;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0 || !sess)
+        return 0;
+    uint64_t mask = col_compute_affected_strata(sess, rel);
+    wl_session_destroy(sess);
+    *ok = true;
+    return mask;
+}
+
+/*
+ * rules_mask - col_compute_affected_rules() over @plan for @rel.
+ */
+static uint64_t
+rules_mask(wl_plan_t *plan, const char *rel, bool *ok)
+{
+    wl_session_t *sess = NULL;
+    *ok = false;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0 || !sess)
+        return 0;
+    uint64_t mask = col_compute_affected_rules(sess, rel);
+    wl_session_destroy(sess);
+    *ok = true;
+    return mask;
+}
+
+/* ======================================================================== */
+/* TC1: a fused two-IDB-atom rule still marks its stratum                     */
+/* ======================================================================== */
+
+static void
+test_fused_rule_marks_stratum(void)
+{
+    TEST("K-fusion: two IDB body atoms still mark the stratum");
+
+    wl_plan_t *plan = build_plan(SRC_FUSED_TC, false);
+    if (!plan) {
+        FAIL("build_plan failed");
+        return;
+    }
+
+    uint32_t si = find_stratum_of(plan, "Path");
+    if (si == UINT32_MAX) {
+        wl_plan_free(plan);
+        FAIL("no stratum produces Path");
+        return;
+    }
+
+    /* Premise: the blinding op this case targets is really there. */
+    if (relation_leading_op(plan, "Path") != WL_PLAN_OP_K_FUSION) {
+        wl_plan_free(plan);
+        FAIL("premise: Path was not rewritten to K_FUSION");
+        return;
+    }
+
+    bool ok = false;
+    uint64_t mask = strata_mask(plan, "Edge", &ok);
+    wl_plan_free(plan);
+    if (!ok) {
+        FAIL("wl_session_create failed");
+        return;
+    }
+
+    if ((mask & ((uint64_t)1 << si)) != 0) {
+        PASS;
+    } else {
+        char buf[96];
+        snprintf(buf, sizeof(buf),
+            "Edge must mark stratum %u; mask=0x%" PRIx64, si, mask);
+        FAIL(buf);
+    }
+}
+
+/* ======================================================================== */
+/* TC2: cross-rule fusion (each rule has at most one IDB atom)                */
+/* ======================================================================== */
+
+static void
+test_cross_rule_fusion_marks_stratum(void)
+{
+    TEST("K-fusion: three rules with <=1 IDB atom each still fuse");
+
+    wl_plan_t *plan = build_plan(SRC_CROSS_RULE_FUSION, false);
+    if (!plan) {
+        FAIL("build_plan failed");
+        return;
+    }
+
+    uint32_t si = find_stratum_of(plan, "P");
+    if (si == UINT32_MAX) {
+        wl_plan_free(plan);
+        FAIL("no stratum produces P");
+        return;
+    }
+
+    if (relation_leading_op(plan, "P") != WL_PLAN_OP_K_FUSION) {
+        wl_plan_free(plan);
+        FAIL("premise: P was not rewritten to K_FUSION");
+        return;
+    }
+
+    bool ok = false;
+    uint64_t mask = strata_mask(plan, "E", &ok);
+    wl_plan_free(plan);
+    if (!ok) {
+        FAIL("wl_session_create failed");
+        return;
+    }
+
+    if ((mask & ((uint64_t)1 << si)) != 0) {
+        PASS;
+    } else {
+        char buf[96];
+        snprintf(buf, sizeof(buf), "E must mark stratum %u; mask=0x%" PRIx64,
+            si, mask);
+        FAIL(buf);
+    }
+}
+
+/* ======================================================================== */
+/* TC3: LFTJ star join, no optimizer passes                                  */
+/* ======================================================================== */
+
+static void
+test_lftj_star_join_marks_stratum(void)
+{
+    TEST("LFTJ: non-recursive star join without wirelog_optimize");
+
+    /* Pin the pass dependency: with SIP the chain becomes four ops --
+     * VARIABLE, JOIN, SEMIJOIN, JOIN -- which no longer matches
+     * lftj_chain_len()'s all-JOIN run, so nothing is hidden and this case
+     * only means anything on the un-optimized plan. */
+    wl_plan_t *opt = build_plan(SRC_STAR_JOIN, true);
+    if (!opt) {
+        FAIL("build_plan (optimized) failed");
+        return;
+    }
+    int opt_lead = relation_leading_op(opt, "R");
+    wl_plan_free(opt);
+    if (opt_lead == WL_PLAN_OP_LFTJ) {
+        FAIL("premise: optimized plan also uses LFTJ; case is mis-scoped");
+        return;
+    }
+
+    wl_plan_t *plan = build_plan(SRC_STAR_JOIN, false);
+    if (!plan) {
+        FAIL("build_plan failed");
+        return;
+    }
+
+    uint32_t si = find_stratum_of(plan, "R");
+    if (si == UINT32_MAX) {
+        wl_plan_free(plan);
+        FAIL("no stratum produces R");
+        return;
+    }
+
+    if (relation_leading_op(plan, "R") != WL_PLAN_OP_LFTJ) {
+        wl_plan_free(plan);
+        FAIL("premise: R was not rewritten to LFTJ");
+        return;
+    }
+
+    const char *edbs[] = { "A", "B", "C" };
+    for (uint32_t i = 0; i < 3; i++) {
+        bool ok = false;
+        uint64_t mask = strata_mask(plan, edbs[i], &ok);
+        if (!ok) {
+            wl_plan_free(plan);
+            FAIL("wl_session_create failed");
+            return;
+        }
+        if ((mask & ((uint64_t)1 << si)) == 0) {
+            char buf[96];
+            snprintf(buf, sizeof(buf),
+                "%s must mark stratum %u; mask=0x%" PRIx64, edbs[i], si, mask);
+            wl_plan_free(plan);
+            FAIL(buf);
+            return;
+        }
+    }
+
+    wl_plan_free(plan);
+    PASS;
+}
+
+/* ======================================================================== */
+/* TC4: unfused control -- the op scan alone already answers                 */
+/* ======================================================================== */
+
+/*
+ * This case is a control, not fault-detecting coverage: no mutation of the
+ * #1019 fix kills it, because the pre-#1019 operator scan already answered it
+ * correctly and the new refset arm answers it the same way.  It earns its
+ * place by asserting the INVERTED premise -- that the leading op is neither
+ * K_FUSION nor LFTJ -- so if a future rewrite starts collapsing this shape the
+ * case fails loudly instead of quietly turning into a duplicate of TC1/TC3.
+ */
+static void
+test_unfused_control(void)
+{
+    TEST("control: unfused recursion is marked and has no blinding op");
+
+    wl_plan_t *plan = build_plan(SRC_UNFUSED_TC, false);
+    if (!plan) {
+        FAIL("build_plan failed");
+        return;
+    }
+
+    uint32_t si = find_stratum_of(plan, "Path");
+    if (si == UINT32_MAX) {
+        wl_plan_free(plan);
+        FAIL("no stratum produces Path");
+        return;
+    }
+
+    /* Premise, inverted: this plan must NOT be rewritten, otherwise the case
+     * is not a control at all. */
+    int lead = relation_leading_op(plan, "Path");
+    if (lead == WL_PLAN_OP_K_FUSION || lead == WL_PLAN_OP_LFTJ) {
+        wl_plan_free(plan);
+        FAIL("premise: control plan was rewritten after all");
+        return;
+    }
+
+    bool ok = false;
+    uint64_t mask = strata_mask(plan, "Edge", &ok);
+    wl_plan_free(plan);
+    if (!ok) {
+        FAIL("wl_session_create failed");
+        return;
+    }
+
+    if ((mask & ((uint64_t)1 << si)) != 0) {
+        PASS;
+    } else {
+        char buf[96];
+        snprintf(buf, sizeof(buf),
+            "Edge must mark stratum %u; mask=0x%" PRIx64, si, mask);
+        FAIL(buf);
+    }
+}
+
+/* ======================================================================== */
+/* TC5: precision -- an independent stratum stays unmarked                   */
+/* ======================================================================== */
+
+static void
+test_independent_stratum_stays_clear(void)
+{
+    TEST("precision: independent stratum is not marked by a fused insert");
+
+    wl_plan_t *plan = build_plan(SRC_FUSED_PLUS_INDEPENDENT, false);
+    if (!plan) {
+        FAIL("build_plan failed");
+        return;
+    }
+
+    uint32_t si_path = find_stratum_of(plan, "Path");
+    uint32_t si_reach = find_stratum_of(plan, "Reach");
+    uint32_t si_ind = find_stratum_of(plan, "Ind");
+    if (si_path == UINT32_MAX || si_reach == UINT32_MAX
+        || si_ind == UINT32_MAX) {
+        wl_plan_free(plan);
+        FAIL("expected separate strata for Path, Reach and Ind");
+        return;
+    }
+    if (si_path == si_ind || si_reach == si_ind) {
+        wl_plan_free(plan);
+        FAIL("premise: Ind shares a stratum, so precision is untestable");
+        return;
+    }
+    if (relation_leading_op(plan, "Path") != WL_PLAN_OP_K_FUSION) {
+        wl_plan_free(plan);
+        FAIL("premise: Path was not rewritten to K_FUSION");
+        return;
+    }
+
+    bool ok = false;
+    uint64_t mask = strata_mask(plan, "Edge", &ok);
+    wl_plan_free(plan);
+    if (!ok) {
+        FAIL("wl_session_create failed");
+        return;
+    }
+
+    if ((mask & ((uint64_t)1 << si_path)) == 0) {
+        FAIL("Path stratum not marked");
+        return;
+    }
+    if ((mask & ((uint64_t)1 << si_reach)) == 0) {
+        FAIL("Reach stratum not marked");
+        return;
+    }
+    if ((mask & ((uint64_t)1 << si_ind)) != 0) {
+        char buf[96];
+        snprintf(buf, sizeof(buf),
+            "Ind stratum %u must stay clear; mask=0x%" PRIx64, si_ind, mask);
+        FAIL(buf);
+        return;
+    }
+    PASS;
+}
+
+/* ======================================================================== */
+/* TC6: transitive propagation through a fused stratum                       */
+/* ======================================================================== */
+
+static void
+test_transitive_propagation_through_fusion(void)
+{
+    TEST("transitive: Edge -> Path(fused) -> Reach -> Far");
+
+    wl_plan_t *plan = build_plan(SRC_FUSED_CHAIN, false);
+    if (!plan) {
+        FAIL("build_plan failed");
+        return;
+    }
+
+    if (relation_leading_op(plan, "Path") != WL_PLAN_OP_K_FUSION) {
+        wl_plan_free(plan);
+        FAIL("premise: Path was not rewritten to K_FUSION");
+        return;
+    }
+
+    const char *heads[] = { "Path", "Reach", "Far" };
+    uint32_t sidx[3];
+    for (uint32_t i = 0; i < 3; i++) {
+        sidx[i] = find_stratum_of(plan, heads[i]);
+        if (sidx[i] == UINT32_MAX) {
+            wl_plan_free(plan);
+            FAIL("missing stratum for a head relation");
+            return;
+        }
+    }
+
+    bool ok = false;
+    uint64_t mask = strata_mask(plan, "Edge", &ok);
+    wl_plan_free(plan);
+    if (!ok) {
+        FAIL("wl_session_create failed");
+        return;
+    }
+
+    for (uint32_t i = 0; i < 3; i++) {
+        if ((mask & ((uint64_t)1 << sidx[i])) == 0) {
+            char buf[96];
+            snprintf(buf, sizeof(buf),
+                "%s stratum %u not marked; mask=0x%" PRIx64, heads[i],
+                sidx[i], mask);
+            FAIL(buf);
+            return;
+        }
+    }
+    PASS;
+}
+
+/* ======================================================================== */
+/* TC7: rule-level mask                                                      */
+/* ======================================================================== */
+
+/*
+ * col_compute_affected_rules() reads the same per-rule reference sets and is
+ * blinded the same way.  It has no end-to-end observable of its own today
+ * (see #1030), so it is asserted directly.
+ */
+static void
+test_rule_level_mask_over_fusion(void)
+{
+    TEST("rule level: fused rule marked, independent rule left clear");
+
+    wl_plan_t *plan = build_plan(SRC_FUSED_PLUS_INDEPENDENT, false);
+    if (!plan) {
+        FAIL("build_plan failed");
+        return;
+    }
+
+    if (relation_leading_op(plan, "Path") != WL_PLAN_OP_K_FUSION) {
+        wl_plan_free(plan);
+        FAIL("premise: Path was not rewritten to K_FUSION");
+        return;
+    }
+
+    /* Rules are enumerated stratum-major, relation-minor. */
+    uint32_t idx = 0;
+    uint32_t rule_path = UINT32_MAX;
+    uint32_t rule_reach = UINT32_MAX;
+    uint32_t rule_ind = UINT32_MAX;
+    for (uint32_t si = 0; si < plan->stratum_count; si++) {
+        for (uint32_t ri = 0; ri < plan->strata[si].relation_count; ri++) {
+            const char *rn = plan->strata[si].relations[ri].name;
+            if (rn && strcmp(rn, "Path") == 0)
+                rule_path = idx;
+            else if (rn && strcmp(rn, "Reach") == 0)
+                rule_reach = idx;
+            else if (rn && strcmp(rn, "Ind") == 0)
+                rule_ind = idx;
+            idx++;
+        }
+    }
+    if (rule_path == UINT32_MAX || rule_reach == UINT32_MAX
+        || rule_ind == UINT32_MAX) {
+        wl_plan_free(plan);
+        FAIL("could not locate all rule indices");
+        return;
+    }
+
+    bool ok = false;
+    uint64_t mask = rules_mask(plan, "Edge", &ok);
+    wl_plan_free(plan);
+    if (!ok) {
+        FAIL("wl_session_create failed");
+        return;
+    }
+
+    if ((mask & ((uint64_t)1 << rule_path)) == 0) {
+        FAIL("fused rule Path not marked");
+        return;
+    }
+    if ((mask & ((uint64_t)1 << rule_reach)) == 0) {
+        FAIL("downstream rule Reach not marked");
+        return;
+    }
+    if ((mask & ((uint64_t)1 << rule_ind)) != 0) {
+        FAIL("independent rule Ind must stay clear");
+        return;
+    }
+    PASS;
+}
+
+/* ======================================================================== */
+/* END-TO-END HELPERS                                                        */
+/* ======================================================================== */
+
+#define MAX_TUPLES 256
+
+typedef struct {
+    int64_t x;
+    int64_t y;
+    int32_t mult;
+} tuple_ent_t;
+
+typedef struct {
+    tuple_ent_t ent[MAX_TUPLES];
+    uint32_t count;
+    uint32_t overflow;
+} tuple_set_t;
+
+static void
+tuple_set_bump(tuple_set_t *ts, int64_t x, int64_t y, int32_t diff)
+{
+    for (uint32_t i = 0; i < ts->count; i++) {
+        if (ts->ent[i].x == x && ts->ent[i].y == y) {
+            ts->ent[i].mult += diff;
+            return;
+        }
+    }
+    if (ts->count == MAX_TUPLES) {
+        ts->overflow++;
+        return;
+    }
+    ts->ent[ts->count].x = x;
+    ts->ent[ts->count].y = y;
+    ts->ent[ts->count].mult = diff;
+    ts->count++;
+}
+
+static bool
+tuple_set_live(const tuple_set_t *ts, int64_t x, int64_t y)
+{
+    for (uint32_t i = 0; i < ts->count; i++) {
+        if (ts->ent[i].x == x && ts->ent[i].y == y)
+            return ts->ent[i].mult > 0;
+    }
+    return false;
+}
+
+static uint32_t
+tuple_set_live_count(const tuple_set_t *ts)
+{
+    uint32_t n = 0;
+    for (uint32_t i = 0; i < ts->count; i++) {
+        if (ts->ent[i].mult > 0)
+            n++;
+    }
+    return n;
+}
+
+/* True when both sets have exactly the same live tuples. */
+static bool
+tuple_sets_equal(const tuple_set_t *a, const tuple_set_t *b)
+{
+    if (tuple_set_live_count(a) != tuple_set_live_count(b))
+        return false;
+    for (uint32_t i = 0; i < a->count; i++) {
+        if (a->ent[i].mult > 0 && !tuple_set_live(b, a->ent[i].x, a->ent[i].y))
+            return false;
+    }
+    return true;
+}
+
+static void
+path_delta_cb(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    if (!relation || strcmp(relation, "Path") != 0 || ncols != 2)
+        return;
+    tuple_set_bump((tuple_set_t *)user_data, row[0], row[1], diff);
+}
+
+static void
+path_tuple_cb(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    if (!relation || strcmp(relation, "Path") != 0 || ncols != 2)
+        return;
+    tuple_set_bump((tuple_set_t *)user_data, row[0], row[1], 1);
+}
+
+/* A 5-cycle plus two chords; the retraction below breaks the cycle. */
+static const int64_t SEED_EDGES[][2] = { { 1, 2 }, { 2, 3 } };
+static const int64_t INSERT_EDGES[][2]
+    = { { 3, 4 }, { 4, 5 }, { 5, 1 }, { 2, 5 }, { 6, 1 } };
+static const int64_t RETRACT_EDGE[2] = { 5, 1 };
+
+#define SEED_COUNT   (sizeof(SEED_EDGES) / sizeof(SEED_EDGES[0]))
+#define INSERT_COUNT (sizeof(INSERT_EDGES) / sizeof(INSERT_EDGES[0]))
+
+/*
+ * full_eval_paths - Path relation of a fresh session holding the final EDB,
+ * derived by a single non-incremental snapshot.
+ */
+static bool
+full_eval_paths(uint32_t workers, tuple_set_t *out)
+{
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
+    opts.num_workers = workers;
+    wirelog_easy_session_t *s = NULL;
+
+    memset(out, 0, sizeof(*out));
+    if (wirelog_easy_open_opts(SRC_FUSED_TC, &opts, &s) != WIRELOG_OK || !s)
+        return false;
+
+    for (size_t i = 0; i < SEED_COUNT; i++) {
+        if (wirelog_easy_insert(s, "Edge", SEED_EDGES[i], 2) != WIRELOG_OK) {
+            wirelog_easy_close(s);
+            return false;
+        }
+    }
+    for (size_t i = 0; i < INSERT_COUNT; i++) {
+        if (INSERT_EDGES[i][0] == RETRACT_EDGE[0]
+            && INSERT_EDGES[i][1] == RETRACT_EDGE[1])
+            continue;
+        if (wirelog_easy_insert(s, "Edge", INSERT_EDGES[i], 2) != WIRELOG_OK) {
+            wirelog_easy_close(s);
+            return false;
+        }
+    }
+
+    bool ok = wirelog_easy_snapshot(s, "Path", path_tuple_cb, out)
+        == WIRELOG_OK;
+    wirelog_easy_close(s);
+    return ok;
+}
+
+/*
+ * incremental_paths - Drive the same EDB through delta callback + step, one
+ * edge at a time, and fold the deltas back into a tuple set.  When
+ * @before_retraction is non-NULL it receives the state just before the
+ * retraction step.
+ */
+static bool
+incremental_paths(uint32_t workers, tuple_set_t *out,
+    tuple_set_t *before_retraction)
+{
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
+    opts.num_workers = workers;
+    wirelog_easy_session_t *s = NULL;
+
+    memset(out, 0, sizeof(*out));
+    if (wirelog_easy_open_opts(SRC_FUSED_TC, &opts, &s) != WIRELOG_OK || !s)
+        return false;
+    if (wirelog_easy_set_delta_cb(s, path_delta_cb, out) != WIRELOG_OK) {
+        wirelog_easy_close(s);
+        return false;
+    }
+
+    for (size_t i = 0; i < SEED_COUNT; i++) {
+        if (wirelog_easy_insert(s, "Edge", SEED_EDGES[i], 2) != WIRELOG_OK) {
+            wirelog_easy_close(s);
+            return false;
+        }
+    }
+    if (wirelog_easy_step(s) != WIRELOG_OK) {
+        wirelog_easy_close(s);
+        return false;
+    }
+
+    for (size_t i = 0; i < INSERT_COUNT; i++) {
+        if (wirelog_easy_insert(s, "Edge", INSERT_EDGES[i], 2) != WIRELOG_OK
+            || wirelog_easy_step(s) != WIRELOG_OK) {
+            wirelog_easy_close(s);
+            return false;
+        }
+    }
+
+    if (before_retraction)
+        *before_retraction = *out;
+
+    if (wirelog_easy_remove(s, "Edge", RETRACT_EDGE, 2) != WIRELOG_OK
+        || wirelog_easy_step(s) != WIRELOG_OK) {
+        wirelog_easy_close(s);
+        return false;
+    }
+
+    wirelog_easy_close(s);
+    return out->overflow == 0;
+}
+
+/* ======================================================================== */
+/* TC8: incremental result equals a from-scratch evaluation                  */
+/* ======================================================================== */
+
+static void
+test_incremental_matches_full_eval(void)
+{
+    const uint32_t worker_counts[] = { 1, 2, 4, 8 };
+    const uint32_t worker_count_n
+        = (uint32_t)(sizeof(worker_counts) / sizeof(worker_counts[0]));
+
+    for (uint32_t wi = 0; wi < worker_count_n; wi++) {
+        uint32_t w = worker_counts[wi];
+        char name[80];
+        snprintf(name, sizeof(name),
+            "end to end: incremental == full evaluation (W=%u)", w);
+        TEST(name);
+
+        tuple_set_t inc;
+        tuple_set_t full;
+        if (!incremental_paths(w, &inc, NULL)) {
+            FAIL("incremental run failed");
+            continue;
+        }
+        if (!full_eval_paths(w, &full)) {
+            FAIL("reference full evaluation failed");
+            continue;
+        }
+        if (tuple_set_live_count(&full) == 0) {
+            FAIL("premise: reference evaluation derived nothing");
+            continue;
+        }
+        if (!tuple_sets_equal(&inc, &full)) {
+            char buf[96];
+            snprintf(buf, sizeof(buf), "incremental %u tuples, full %u tuples",
+                tuple_set_live_count(&inc), tuple_set_live_count(&full));
+            FAIL(buf);
+            continue;
+        }
+        PASS;
+    }
+}
+
+/* ======================================================================== */
+/* TC9: retraction emits the exact negative deltas                           */
+/* ======================================================================== */
+
+/*
+ * col_session_step() starts from UINT64_MAX and *intersects* the removal
+ * mask, so a blinded 0 zeroes the whole mask and every retracted tuple is
+ * retained.  This is the only case that exercises that line.
+ */
+static void
+test_retraction_emits_exact_negative_deltas(void)
+{
+    TEST("retraction: exact -Path deltas and post-retraction state");
+
+    tuple_set_t before;
+    tuple_set_t after;
+    tuple_set_t full;
+
+    if (!incremental_paths(1, &after, &before)) {
+        FAIL("incremental run failed");
+        return;
+    }
+    if (!full_eval_paths(1, &full)) {
+        FAIL("reference full evaluation failed");
+        return;
+    }
+
+    if (tuple_set_live_count(&before) <= tuple_set_live_count(&full)) {
+        FAIL("premise: retraction did not have to remove anything");
+        return;
+    }
+
+    /* Every tuple live before and not live after must be exactly the set of
+     * tuples the reference evaluation no longer derives -- no more, no
+     * fewer. */
+    for (uint32_t i = 0; i < before.count; i++) {
+        if (before.ent[i].mult <= 0)
+            continue;
+        int64_t x = before.ent[i].x;
+        int64_t y = before.ent[i].y;
+        bool still_live = tuple_set_live(&after, x, y);
+        bool should_live = tuple_set_live(&full, x, y);
+        if (still_live != should_live) {
+            char buf[112];
+            snprintf(buf, sizeof(buf),
+                "Path(%" PRId64 ",%" PRId64 ") live=%d expected=%d after "
+                "retraction", x, y, (int)still_live, (int)should_live);
+            FAIL(buf);
+            return;
+        }
+    }
+
+    if (!tuple_sets_equal(&after, &full)) {
+        char buf[96];
+        snprintf(buf, sizeof(buf), "post-retraction %u tuples, expected %u",
+            tuple_set_live_count(&after), tuple_set_live_count(&full));
+        FAIL(buf);
+        return;
+    }
+    PASS;
+}
+
+/* ======================================================================== */
+/* TC10: --watch reproduction from the issue                                 */
+/* ======================================================================== */
+
+/*
+ * The original report: run the fused transitive closure under --watch, feed
+ * "Edge 3 4" on stdin, and observe that nothing is emitted.  wl_run_pipeline()
+ * always applies wirelog_optimize(), and the fusion rewrite is inside
+ * wl_plan_from_program(), so the shape is K_FUSION either way.
+ */
+static void
+test_watch_mode_emits_new_derivations(void)
+{
+    TEST("--watch: piped fact still derives new tuples");
+
+    char inpath[512];
+    char outpath[512];
+    test_tmppath(inpath, sizeof(inpath), "wirelog_test_1019_watch.in");
+    test_tmppath(outpath, sizeof(outpath), "wirelog_test_1019_watch.out");
+
+    FILE *in = fopen(inpath, "w");
+    if (!in) {
+        FAIL("cannot create watch input file");
+        return;
+    }
+    fprintf(in, "Edge 3 4\n");
+    fclose(in);
+
+    if (!freopen(inpath, "r", stdin)) {
+        remove(inpath);
+        FAIL("cannot redirect stdin");
+        return;
+    }
+
+    FILE *out = fopen(outpath, "w");
+    if (!out) {
+        remove(inpath);
+        FAIL("cannot create watch output file");
+        return;
+    }
+
+    const char *src = ".decl Edge(x: int64, y: int64)\n"
+        ".decl Path(x: int64, y: int64)\n"
+        ".output Path\n"
+        "Edge(1,2).\n"
+        "Edge(2,3).\n"
+        "Path(x,y) :- Edge(x,y).\n"
+        "Path(x,y) :- Path(x,z), Path(z,y).\n";
+
+    int rc = wl_run_pipeline(src, 1, false, true, 0, out);
+    fclose(out);
+    if (rc != 0) {
+        remove(inpath);
+        remove(outpath);
+        FAIL("wl_run_pipeline returned non-zero");
+        return;
+    }
+
+    char *output = wl_read_file(outpath);
+    remove(inpath);
+    remove(outpath);
+    if (!output) {
+        FAIL("cannot read watch output");
+        return;
+    }
+
+    /* Adding Edge(3,4) to Path(1,2),Path(2,3),Path(1,3) must derive the three
+     * new paths that end at 4. */
+    const char *expected[] = { "+Path(3, 4)", "+Path(2, 4)", "+Path(1, 4)" };
+    for (uint32_t i = 0; i < 3; i++) {
+        if (!strstr(output, expected[i])) {
+            char buf[96];
+            snprintf(buf, sizeof(buf), "missing %s in watch output",
+                expected[i]);
+            free(output);
+            FAIL(buf);
+            return;
+        }
+    }
+    free(output);
+    PASS;
+}
+
+/* ======================================================================== */
+/* MAIN                                                                      */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("=== Affected-strata detection across plan rewrites (#1019) ===\n");
+
+    test_fused_rule_marks_stratum();
+    test_cross_rule_fusion_marks_stratum();
+    test_lftj_star_join_marks_stratum();
+    test_unfused_control();
+    test_independent_stratum_stays_clear();
+    test_transitive_propagation_through_fusion();
+    test_rule_level_mask_over_fusion();
+    test_incremental_matches_full_eval();
+    test_retraction_emits_exact_negative_deltas();
+
+    /* Last: this one replaces the process stdin. */
+    test_watch_mode_emits_new_derivations();
+
+    printf("\n  passed: %d, failed: %d\n", tests_passed, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -319,6 +319,40 @@ retraction_rel_name(const char *rel, char *buf, size_t sz)
  *
  * Issue #158 extension: When retraction_seeded and iteration == 0, check
  * $r$<name> relations instead of $d$<name>.
+ *
+ * Issue #1019: this scan is blinded by the same plan rewrites that blinded
+ * col_compute_affected_strata(). On a fused relation rp->ops is
+ * [K_FUSION, EXCHANGE], both zero-initialised, so delta_mode is never
+ * WL_DELTA_FORCE_DELTA and this returns false unconditionally.
+ *
+ * FOUR of the eight call sites are blinded, not two.  All four pass a
+ * top-level wl_plan_stratum_t relation plan (&sp->relations[ri]), which is
+ * exactly what the rewrite replaced:
+ *   - col_eval_stratum(): the whole-stratum early exit (break the sub-pass
+ *     when EVERY rule answers true) and the per-rule pre-scan below it;
+ *   - tdd_worker_subpass_fn(): the same pair again on the TDD worker path
+ *     -- an all-rules early exit that sets ctx->all_empty_delta, and a
+ *     per-rule pre-scan in its relation loop.
+ * The other FOUR are not blinded, because they pass an inner operator list
+ * that still carries the FORCE_DELTA ops the rewrite hid:
+ *   - tdd_worker_eval_rule_slices() and tdd_coord_eval_fallback_rule_slices()
+ *     (this file) evaluate a wl_tdd_rule_slice_t; on a fused relation
+ *     tdd_build_rule_slices() takes those ops from
+ *     wl_plan_op_k_fusion_t.k_ops[], i.e. from inside the opaque_data;
+ *   - col_op_k_fusion_serial() and col_op_k_fusion() (columnar/ops.c)
+ *     evaluate meta->k_ops[d] directly.
+ * Call sites are named by function on purpose: line numbers drift.
+ *
+ * The blinding costs iterations, never correctness, so it is deliberately
+ * NOT fixed the way #1019 fixed the frontier: the answer depends on live
+ * per-iteration session state ($d$/$r$ relation contents, delta_seeded,
+ * retraction_seeded), which does not exist at plan-lowering time and so
+ * cannot be recorded on the plan. The two unblinded in-kernel checks are
+ * not a substitute either, and they differ from each other:
+ * col_op_k_fusion_serial() skips one fused branch with a continue, while
+ * col_op_k_fusion() builds a live_indices[] list and short-circuits the
+ * WHOLE K_FUSION op to an empty relation when live_count == 0. Neither can
+ * reproduce the whole-sub-pass break this function enables.
  */
 bool
 has_empty_forced_delta(const wl_plan_relation_t *rp, wl_col_session_t *sess,

--- a/wirelog/columnar/frontier.c
+++ b/wirelog/columnar/frontier.c
@@ -76,8 +76,8 @@ stratum_references_relation(const wl_plan_stratum_t *sp, const char *rel)
                 return true;
             }
             if ((pr->ops[oi].op == WL_PLAN_OP_JOIN
-                 || pr->ops[oi].op == WL_PLAN_OP_ANTIJOIN
-                 || pr->ops[oi].op == WL_PLAN_OP_SEMIJOIN)
+                || pr->ops[oi].op == WL_PLAN_OP_ANTIJOIN
+                || pr->ops[oi].op == WL_PLAN_OP_SEMIJOIN)
                 && pr->ops[oi].right_relation != NULL
                 && strcmp(pr->ops[oi].right_relation, rel) == 0) {
                 return true;
@@ -117,7 +117,7 @@ stratum_references_relation(const wl_plan_stratum_t *sp, const char *rel)
  */
 uint64_t
 col_compute_affected_strata(wl_session_t *session,
-                            const char *inserted_relation)
+    const char *inserted_relation)
 {
     if (!session || !inserted_relation)
         return 0;
@@ -180,7 +180,7 @@ col_compute_affected_strata(wl_session_t *session,
                     if (affected & ((uint64_t)1 << sj))
                         continue; /* already marked */
                     if (stratum_references_relation(&plan->strata[sj],
-                                                    produced)) {
+                        produced)) {
                         affected = bitmask_or_simd(affected, (uint64_t)1 << sj);
                     }
                 }
@@ -211,8 +211,8 @@ rule_references_relation(const wl_plan_relation_t *pr, const char *rel)
         }
         /* Check JOIN/ANTIJOIN/SEMIJOIN right_relation (right child of joins) */
         if ((pr->ops[oi].op == WL_PLAN_OP_JOIN
-             || pr->ops[oi].op == WL_PLAN_OP_ANTIJOIN
-             || pr->ops[oi].op == WL_PLAN_OP_SEMIJOIN)
+            || pr->ops[oi].op == WL_PLAN_OP_ANTIJOIN
+            || pr->ops[oi].op == WL_PLAN_OP_SEMIJOIN)
             && pr->ops[oi].right_relation != NULL
             && strcmp(pr->ops[oi].right_relation, rel) == 0) {
             return true;
@@ -262,7 +262,7 @@ col_compute_affected_rules(wl_session_t *session, const char *inserted_relation)
      */
     uint32_t nrules = 0;
     for (uint32_t si = 0; si < plan->stratum_count && nrules < MAX_RULES;
-         si++) {
+        si++) {
         uint32_t rc = plan->strata[si].relation_count;
         if (nrules + rc > MAX_RULES)
             rc = MAX_RULES - nrules;
@@ -281,10 +281,10 @@ col_compute_affected_rules(wl_session_t *session, const char *inserted_relation)
     {
         uint32_t idx = 0;
         for (uint32_t si = 0; si < plan->stratum_count && idx < MAX_RULES;
-             si++) {
+            si++) {
             for (uint32_t ri = 0;
-                 ri < plan->strata[si].relation_count && idx < MAX_RULES;
-                 ri++) {
+                ri < plan->strata[si].relation_count && idx < MAX_RULES;
+                ri++) {
                 rule_si[idx] = si;
                 rule_ri[idx] = ri;
                 idx++;

--- a/wirelog/columnar/frontier.c
+++ b/wirelog/columnar/frontier.c
@@ -60,29 +60,99 @@ bitmask_or_simd(uint64_t dst, uint64_t src)
 }
 
 /*
- * stratum_references_relation - Return true if any VARIABLE op in stratum sp
+ * refset_names_relation - Return true if the reference set recorded at plan
+ * lowering (Issue #1019) names `rel`.
+ */
+static bool
+refset_names_relation(const wl_plan_refset_t *rs, const char *rel)
+{
+    for (uint32_t i = 0; i < rs->count; i++) {
+        if (rs->names[i] != NULL && strcmp(rs->names[i], rel) == 0)
+            return true;
+    }
+    return false;
+}
+
+/*
+ * ops_reference_relation - Return true if any VARIABLE op in relation pr
  * references the relation named `rel`, or if any JOIN/ANTIJOIN/SEMIJOIN op
  * has right_relation matching `rel`.
+ *
+ * This sees only what survives in pr->ops, and two rewrites take the naming
+ * operators out of it by different means:
+ *   - rewrite_multiway_delta() moves them into wl_plan_op_k_fusion_t.k_ops[]
+ *     behind the K_FUSION op's opaque_data -- hidden, but still there;
+ *   - rewrite_lftj_chains() moves nothing.  build_lftj_op() copies only
+ *     rel_names[]/key_cols[] into wl_plan_op_lftj_t, and the caller then
+ *     free_op()s the original operators outright.
+ * Either way this returns false on a rewritten relation however many
+ * relations the rule really reads.
+ */
+static bool
+ops_reference_relation(const wl_plan_relation_t *pr, const char *rel)
+{
+    for (uint32_t oi = 0; oi < pr->op_count; oi++) {
+        if (pr->ops[oi].op == WL_PLAN_OP_VARIABLE
+            && pr->ops[oi].relation_name != NULL
+            && strcmp(pr->ops[oi].relation_name, rel) == 0) {
+            return true;
+        }
+        if ((pr->ops[oi].op == WL_PLAN_OP_JOIN
+            || pr->ops[oi].op == WL_PLAN_OP_ANTIJOIN
+            || pr->ops[oi].op == WL_PLAN_OP_SEMIJOIN)
+            && pr->ops[oi].right_relation != NULL
+            && strcmp(pr->ops[oi].right_relation, rel) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
+ * rule_references_relation - Return true if rule `ri` of stratum `sp` reads
+ * the relation named `rel`.
+ *
+ * Prefers the set recorded before any plan rewrite ran (Issue #1019), and
+ * falls back to the operator scan when that set does not answer yes.  The two
+ * arms are not equally load-bearing:
+ *
+ *   - The fallback IS load-bearing for hand-built plans.  Strata declared on
+ *     the stack in tests/test_affected_strata.c, tests/test_affected_rules.c
+ *     and tests/test_rule_level_frontier.c never run through
+ *     wl_plan_from_program(), so their rule_refs is NULL and the scan is the
+ *     only answer they have.  Those tests are the whole population: exec_plan.h
+ *     is not in wirelog_public_headers, so it is never installed, and
+ *     scripts/ci/check-advanced-header.sh allowlists what wirelog-advanced.h
+ *     may include -- exec_plan*.h is not on the list.  No installed header
+ *     exposes wl_plan_stratum_t, so a third-party embedder cannot fill one.
+ *
+ *   - The union is otherwise defensive only.  Instrumenting this function
+ *     over the full test suite measured ZERO cases where a recorded refset
+ *     said no and the operator scan said yes, so on today's repo the
+ *     exclusive form -- refset when present, scan otherwise -- would give
+ *     identical answers.  The scan arm is kept in case a future rewrite
+ *     introduces a name that lowering did not record; nothing exercises that
+ *     path today.
+ */
+static bool
+rule_references_relation(const wl_plan_stratum_t *sp, uint32_t ri,
+    const char *rel)
+{
+    if (sp->rule_refs != NULL && refset_names_relation(&sp->rule_refs[ri], rel))
+        return true;
+    return ops_reference_relation(&sp->relations[ri], rel);
+}
+
+/*
+ * stratum_references_relation - Return true if any rule of stratum sp reads
+ * the relation named `rel`.
  */
 static bool
 stratum_references_relation(const wl_plan_stratum_t *sp, const char *rel)
 {
     for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-        const wl_plan_relation_t *pr = &sp->relations[ri];
-        for (uint32_t oi = 0; oi < pr->op_count; oi++) {
-            if (pr->ops[oi].op == WL_PLAN_OP_VARIABLE
-                && pr->ops[oi].relation_name != NULL
-                && strcmp(pr->ops[oi].relation_name, rel) == 0) {
-                return true;
-            }
-            if ((pr->ops[oi].op == WL_PLAN_OP_JOIN
-                || pr->ops[oi].op == WL_PLAN_OP_ANTIJOIN
-                || pr->ops[oi].op == WL_PLAN_OP_SEMIJOIN)
-                && pr->ops[oi].right_relation != NULL
-                && strcmp(pr->ops[oi].right_relation, rel) == 0) {
-                return true;
-            }
-        }
+        if (rule_references_relation(sp, ri, rel))
+            return true;
     }
     return false;
 }
@@ -106,10 +176,18 @@ stratum_references_relation(const wl_plan_stratum_t *sp, const char *rel)
  * vorrq_u64 (NEON) or _mm_or_si128 (SSE2) instruction when those ISAs are
  * available. The scalar path is a plain | operator.
  *
- * Supports up to 64 strata (one uint64_t bitmask). Plans with more strata
- * will have bits beyond 63 silently ignored (conservative: returns 0 for
- * those strata, which causes them to be re-evaluated unconditionally by the
- * caller's fallback).
+ * Supports up to 64 strata (one uint64_t bitmask); strata 64 and above are
+ * clamped away below and never marked. There is no caller-side fallback that
+ * rescues them. The *evaluation* gates in col_session_step() and
+ * col_session_snapshot() test `affected_mask & ((uint64_t)1 << si)` with si
+ * bounded only by plan->stratum_count, so for si >= 64 the shift is undefined
+ * behaviour (C11 6.5.7p3), not a re-evaluation. The *frontier-reset* loops in
+ * col_session_snapshot() are the exception: they carry an explicit
+ * `&& si < MAX_STRATA` and so stop early rather than shifting out of range.
+ * Independently, MAX_STRATA (columnar/internal.h) caps the session's
+ * per-stratum frontier arrays at 32 while this mask is 64 wide, so strata
+ * 32..63 already run without per-stratum frontier tracking. Neither limit is
+ * enforced at plan construction; both need their own fix.
  *
  * @param session          Active session (must have a plan attached).
  * @param inserted_relation Name of the EDB relation receiving new facts.
@@ -196,32 +274,6 @@ col_compute_affected_strata(wl_session_t *session,
 /* ======================================================================== */
 
 /*
- * rule_references_relation - Return true if any VARIABLE op in relation pr
- * references the relation named `rel`.
- */
-static bool
-rule_references_relation(const wl_plan_relation_t *pr, const char *rel)
-{
-    for (uint32_t oi = 0; oi < pr->op_count; oi++) {
-        /* Check VARIABLE ops (left child of joins) */
-        if (pr->ops[oi].op == WL_PLAN_OP_VARIABLE
-            && pr->ops[oi].relation_name != NULL
-            && strcmp(pr->ops[oi].relation_name, rel) == 0) {
-            return true;
-        }
-        /* Check JOIN/ANTIJOIN/SEMIJOIN right_relation (right child of joins) */
-        if ((pr->ops[oi].op == WL_PLAN_OP_JOIN
-            || pr->ops[oi].op == WL_PLAN_OP_ANTIJOIN
-            || pr->ops[oi].op == WL_PLAN_OP_SEMIJOIN)
-            && pr->ops[oi].right_relation != NULL
-            && strcmp(pr->ops[oi].right_relation, rel) == 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/*
  * col_compute_affected_rules - Identify rules needing re-evaluation.
  *
  * Rules are enumerated globally across all strata in declaration order:
@@ -236,9 +288,11 @@ rule_references_relation(const wl_plan_relation_t *pr, const char *rel)
  *
  * SIMD: bitmask union uses bitmask_or_simd() (same helper as strata version).
  *
- * Supports up to 64 rules (one uint64_t bitmask). Plans with more rules will
- * have bits beyond 63 silently ignored (conservative: those rules are always
- * re-evaluated by the caller's fallback via UINT64_MAX mask).
+ * Supports up to 64 rules (one uint64_t bitmask, MAX_RULES). Rules past that
+ * are never enumerated and never marked. This is not conservative: the only
+ * caller (col_session_snapshot) uses the mask to decide which rule frontiers
+ * to reset, and an unmarked rule keeps the frontier it had, so an unreachable
+ * rule index is a skipped reset rather than a forced re-evaluation.
  *
  * @param session           Active session (must have a plan attached).
  * @param inserted_relation Name of the EDB relation receiving new facts.
@@ -296,9 +350,8 @@ col_compute_affected_rules(wl_session_t *session, const char *inserted_relation)
 
     /* --- Pass 1: seed rules that directly reference inserted_relation --- */
     for (uint32_t i = 0; i < nrules; i++) {
-        const wl_plan_relation_t *pr
-            = &plan->strata[rule_si[i]].relations[rule_ri[i]];
-        if (rule_references_relation(pr, inserted_relation)) {
+        if (rule_references_relation(&plan->strata[rule_si[i]], rule_ri[i],
+            inserted_relation)) {
             affected = bitmask_or_simd(affected, (uint64_t)1 << i);
         }
     }
@@ -329,9 +382,8 @@ col_compute_affected_rules(wl_session_t *session, const char *inserted_relation)
             for (uint32_t j = 0; j < nrules; j++) {
                 if (affected & ((uint64_t)1 << j))
                     continue; /* already marked */
-                const wl_plan_relation_t *pr
-                    = &plan->strata[rule_si[j]].relations[rule_ri[j]];
-                if (rule_references_relation(pr, head)) {
+                if (rule_references_relation(&plan->strata[rule_si[j]],
+                    rule_ri[j], head)) {
                     affected = bitmask_or_simd(affected, (uint64_t)1 << j);
                 }
             }

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -543,6 +543,21 @@ typedef struct {
 /* ======================================================================== */
 
 /**
+ * wl_plan_refset_t:
+ *
+ * De-duplicated set of relation names read by one relation's operator
+ * sequence (Issue #1019).
+ *
+ * @names: Owned array of @count owned, null-terminated names.  NULL when
+ *         @count is 0 and the relation had no operators.
+ * @count: Number of names.
+ */
+typedef struct {
+    char **names;
+    uint32_t count;
+} wl_plan_refset_t;
+
+/**
  * wl_plan_stratum_t:
  *
  * Execution plan for a single stratum.
@@ -554,6 +569,39 @@ typedef struct {
  *                  Used for DRedL-style deletion phase optimization.
  * @relations:      Array of per-relation plans (caller-owned).
  * @relation_count: Number of relations in this stratum.
+ * @rule_refs:      Issue #1019.  @relation_count entries, owned, parallel to
+ *                  @relations: the relations each rule reads, recorded at IR
+ *                  lowering before any plan rewrite runs.  Two rewrites erase
+ *                  those names from @relations[i].ops, by different means:
+ *                  rewrite_multiway_delta() really does move the naming
+ *                  operators out of reach, into
+ *                  wl_plan_op_k_fusion_t.k_ops[] behind
+ *                  wl_plan_op_t.opaque_data; rewrite_lftj_chains() moves no
+ *                  operators at all -- build_lftj_op() copies only
+ *                  rel_names[]/key_cols[] into wl_plan_op_lftj_t and then
+ *                  free_op()s the originals, so the operators are gone
+ *                  rather than hidden.  Either way a consumer scanning
+ *                  @relations[i].ops no longer sees the names.  NULL
+ *                  means "not recorded" -- consumers must fall back to scanning
+ *                  the operator list.  Held on the stratum rather than on
+ *                  wl_plan_relation_t because relation structs get rebuilt
+ *                  field by field in several places -- col_plan_split_at_exchange()
+ *                  and the two designated initialisers in columnar/eval.c that
+ *                  wrap a child op list -- so a new relation field is silently
+ *                  dropped rather than carried.
+ *
+ *                  Invariant to preserve when adding a construction site:
+ *                  every site must zero-initialise the stratum before
+ *                  filling it, so an unrecorded @rule_refs reads as NULL and
+ *                  consumers take the fallback path instead of dereferencing
+ *                  garbage.  wl_plan_from_program() gets that from calloc();
+ *                  the stack-declared wl_plan_stratum_t arrays in
+ *                  tests/test_affected_strata.c, tests/test_affected_rules.c
+ *                  and tests/test_rule_level_frontier.c (18 arrays at the
+ *                  time of writing) each memset() the struct first.  This
+ *                  type is deliberately NOT private to wl_plan_t: hand-built
+ *                  strata passed straight to the columnar frontier helpers
+ *                  are an established pattern in those three files.
  */
 typedef struct {
     uint32_t stratum_id;
@@ -561,6 +609,7 @@ typedef struct {
     bool is_monotone;
     const wl_plan_relation_t *relations;
     uint32_t relation_count;
+    wl_plan_refset_t *rule_refs;
 } wl_plan_stratum_t;
 
 /* ======================================================================== */

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -3160,6 +3160,113 @@ rewrite_lftj_chains(wl_plan_t *plan)
 }
 
 /* ======================================================================== */
+/* Referenced-relation sets (Issue #1019)                                   */
+/* ======================================================================== */
+
+/*
+ * plan_refsets_free - Release a wl_plan_stratum_t.rule_refs array of @count
+ * entries.  NULL-safe; entries with a NULL names array are skipped.
+ */
+static void
+plan_refsets_free(wl_plan_refset_t *refs, uint32_t count)
+{
+    if (!refs)
+        return;
+    for (uint32_t r = 0; r < count; r++) {
+        for (uint32_t i = 0; i < refs[r].count; i++)
+            free(refs[r].names[i]);
+        free(refs[r].names);
+    }
+    free(refs);
+}
+
+/*
+ * plan_op_referenced_relation - Name of the relation read by @op, using
+ * exactly the predicate the frontier scan in columnar/frontier.c applies:
+ * WL_PLAN_OP_VARIABLE contributes relation_name, JOIN/ANTIJOIN/SEMIJOIN
+ * contribute right_relation.  Every other operator contributes nothing.
+ * Returns NULL when the operator names no relation.
+ */
+static const char *
+plan_op_referenced_relation(const wl_plan_op_t *op)
+{
+    if (op->op == WL_PLAN_OP_VARIABLE)
+        return op->relation_name;
+    if (op->op == WL_PLAN_OP_JOIN || op->op == WL_PLAN_OP_ANTIJOIN
+        || op->op == WL_PLAN_OP_SEMIJOIN)
+        return op->right_relation;
+    return NULL;
+}
+
+/*
+ * plan_stratum_record_refs - Record, per relation of @st, the de-duplicated
+ * set of relation names its operators read (Issue #1019).
+ *
+ * Must be called while @st->relations still holds the operator list produced
+ * by IR lowering.  Two rewrites destroy that list, by different means:
+ * rewrite_multiway_delta() replaces it with a K_FUSION operator that holds the
+ * real operators in opaque_data (wl_plan_op_k_fusion_t.k_ops[]), whereas
+ * rewrite_lftj_chains() replaces the chain with an LFTJ operator whose
+ * opaque_data holds only wl_plan_op_lftj_t.rel_names[]/key_cols[] -- the
+ * original operators are free_op()d, not carried.  After either rewrite no
+ * scan of @st->relations[i].ops can recover the names, and
+ * col_compute_affected_strata() concludes that the stratum reads nothing.
+ *
+ * Returns 0 on success, -1 on allocation failure with @st->rule_refs left NULL
+ * (consumers then fall back to the operator scan).
+ */
+static int
+plan_stratum_record_refs(wl_plan_stratum_t *st)
+{
+    if (st->relation_count == 0 || !st->relations)
+        return 0;
+
+    wl_plan_refset_t *refs = (wl_plan_refset_t *)calloc(
+        st->relation_count, sizeof(wl_plan_refset_t));
+    if (!refs)
+        return -1;
+
+    for (uint32_t r = 0; r < st->relation_count; r++) {
+        const wl_plan_relation_t *rel = &st->relations[r];
+        if (rel->op_count == 0 || !rel->ops)
+            continue;
+
+        /* Each operator contributes at most one name, so op_count is a
+         * sufficient upper bound before de-duplication. */
+        char **names = (char **)calloc(rel->op_count, sizeof(char *));
+        if (!names) {
+            plan_refsets_free(refs, st->relation_count);
+            return -1;
+        }
+        refs[r].names = names;
+
+        for (uint32_t o = 0; o < rel->op_count; o++) {
+            const char *name = plan_op_referenced_relation(&rel->ops[o]);
+            if (!name)
+                continue;
+
+            bool seen = false;
+            for (uint32_t i = 0; i < refs[r].count && !seen; i++) {
+                if (strcmp(names[i], name) == 0)
+                    seen = true;
+            }
+            if (seen)
+                continue;
+
+            names[refs[r].count] = dup_str(name);
+            if (!names[refs[r].count]) {
+                plan_refsets_free(refs, st->relation_count);
+                return -1;
+            }
+            refs[r].count++;
+        }
+    }
+
+    st->rule_refs = refs;
+    return 0;
+}
+
+/* ======================================================================== */
 /* Public API                                                               */
 /* ======================================================================== */
 
@@ -3186,6 +3293,9 @@ wl_plan_free(wl_plan_t *plan)
                 }
                 free((void *)st->relations);
             }
+            /* Issue #1019: parallel to st->relations, so freed with the same
+             * count.  relation_count is 0 whenever relations is NULL. */
+            plan_refsets_free(st->rule_refs, st->relation_count);
         }
         free((void *)plan->strata);
     }
@@ -3518,6 +3628,17 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
         free((void *)unique_names);
         dst->relations = rels;
         dst->relation_count = unique_count;
+
+        /* Issue #1019: record what each relation reads while @ops is still the
+         * lowered operator list.  Deliberately placed after the ownership
+         * transfer above, not next to the rels[u].ops assignment: from here on
+         * wl_plan_free() reaches every allocation made so far, so the failure
+         * path does not have to unwind rels[] by hand.  Still ahead of all four
+         * rewrites below, which is what the record is for. */
+        if (plan_stratum_record_refs(dst) != 0) {
+            wl_plan_free(plan);
+            return -1;
+        }
     }
 
     /* Rewrite K-atom recursive rules for complete semi-naive evaluation.


### PR DESCRIPTION
Closes #1019. Two commits: a whitespace-only `uncrustify` reformat of `frontier.c` (which failed the hard gate on base and which the fix edits), then the fix.

Incremental evaluation decides which strata to re-run by asking, per rule, which relations its body reads — by walking the rule's plan operators. **Two rewrites leave nothing for that walk to find:**

| rewrite | what it does to the operands |
|---|---|
| `rewrite_multiway_delta` | moves them into `wl_plan_op_k_fusion_t.k_ops[]` behind `opaque_data` — hidden, present |
| `rewrite_lftj_chains` | copies only `rel_names[]`/`key_cols[]` and **`free_op()`s the originals** — gone |

`col_compute_affected_strata` then returns 0 and the caller concludes nothing changed.

## Severity, in order

**Retraction is the worst case**, because `session.c` *intersects*: `affected_mask &= col_compute_affected_strata(..., last_removed)` from `UINT64_MAX`, so one blinded 0 zeroes the whole mask. Removing `Edge(2,3)` leaves `Path(1,3)` and `Path(2,3)` in the snapshot — **retracted tuples retained**, worse than tuples merely missing.

**Insertion derives nothing.** `--watch` + `Edge 3 4` emits no deltas; the single-IDB-atom form emits three. Multi-stratum plans starve transitively.

## The issue was filed as a K-fusion defect. It isn't.

`rewrite_lftj_chains` blinds a plain **non-recursive** star join `R(x) :- A(x,y), B(x,z), C(x,w).` whenever the host doesn't call `wirelog_optimize` — which `wirelog-advanced.h` documents as supported — and via `wirelog_optimize` too, since `enable_semijoin` is public. That stratum is neither recursive nor fused, so **every fusion-shaped test misses it**.

Nor is "two IDB atoms in one rule" the trigger: `count_delta_positions` sums across *all* rules of a head, so two ordinary single-atom recursive rules fuse identically. That's the shape real programs have.

## Why the stratum, not the relation

`wl_plan_relation_t` is rebuilt or copied in three places that would each need to carry a new field — `col_plan_split_at_exchange` assigns members individually, and two designated initialisers in `eval.c` zero what they don't mention. **#975's relation-level `recursive_agg` is already silently dropped by two of them.**

`wl_plan_stratum_t` is never struct-copied in production. The three frontier unit tests build strata on the stack — 18 arrays — and every one `memset`s first, so `rule_refs == NULL` and they keep taking the scan path unchanged. Proved by rebuilding them with `-ftrivial-auto-var-init=pattern`, which would turn an unzeroed `rule_refs` into a fault.

## Under-marking is impossible

Recorded before the rewrites ⇒ superset of the post-rewrite scan, identical for non-fusing plans. Instrumented over the full suite, **470 frontier queries: 0 under-marks, 37 recoveries — all on `K_FUSION` or `LFTJ`, none on any other operator shape.** A second reviewer's independent harness over 210 plans × 7 optimizer configurations (130,032 rule pairs) agreed: 0 under-marks.

Perf is *better* — the refset short-circuits before touching the op array (mask microbench at 28 strata: 485–489 ns vs 566–568 ns).

## Safety

Fault injection at all three allocation sites, 120 plan builds under ASAN+UBSAN+LSAN: 105 built, 15 failed cleanly, no leak, no double free. `rule_refs` is written before the plan is published and never mutated; TSan clean at W=4 and W=8.

## Written down rather than asserted away

- `has_empty_forced_delta` is deliberately not hoisted (needs live per-iteration state). A fused shape blinds **four** of its call sites — both the sequential and TDD paths have a whole-stratum early exit and a per-rule pre-scan. An earlier revision of that comment said two. Correctness is unaffected; the loss is early-exit only.
- Two `frontier.c` comments claimed indices ≥ 64 are "re-evaluated unconditionally by the caller's fallback". **There is no such fallback** — `session.c` gates on `1ULL << si` with no clamp, which is UB. Both corrected; filed as #1033.

## Tests

`tests/test_affected_strata_rewrites.c`, **13 cases, 12 failing against the parent commit.** Every case builds a *real* plan via `wl_plan_from_program` — a hand-built plan takes the fallback and would be vacuous — and asserts its own premise first (that the specific blinding operator is present), so a change to when rewrites fire turns the file red rather than green. The LFTJ case additionally asserts the optimized build does *not* use LFTJ, so it can't quietly become a duplicate if SIP absorbs the shape.

Covers both rewrites, cross-rule fusion, precision (an independent stratum stays clear), transitive propagation, the rule-level mask, retraction (exact deltas + post-retraction snapshot), `--watch` end to end, and incremental-equals-full-evaluation at W ∈ {1,2,4,8}.

The unfused control is killed by no mutation and **says so in the file** — it earns its place by asserting the inverted premise, not by detecting faults.

## Validation

Suite **271 ok / 1 fail / 11 skipped** in release and ASAN+UBSAN+LSAN; the failure is the pre-existing `sbom_snapshot` pin drift. uncrustify clean on all five changed files. gcc + clang `-Wall -Wextra -Wconversion -Wshadow -Wpedantic` — no new diagnostics.

## Follow-ups filed, not fixed

#1030 (snapshot route stays stale — which is why the rule-level half has no end-to-end observable today and is pinned by a unit assertion), #1031 (mixed insert+remove step evaluates zero strata), #1032 (~20 TDD predicates blind to LFTJ), #1033 (≥64 index UB).