### PR TITLE
fix(ir): make the physical width authoritative for storage, logical for declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,52 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+- **`wirelog_program_get_facts` reports the physical row stride** (#985): its
+  `num_cols` output is the number of `int64_t` slots each returned tuple
+  occupies -- which is what an embedder must index the buffer by -- and it is
+  no longer necessarily equal to the `column_count` of
+  `wirelog_program_get_schema`. The two agree for every relation that
+  declares no `inline` compound column; where one is declared they can
+  differ, as in `.decl pred(id: int64, payload: f/2 inline)`, which reports
+  `column_count` 2 and `num_cols` 3. (They still agree at `inline` arity 1 --
+  one declared column, one slot -- so an inline compound column is a
+  necessary but not a sufficient condition.) Logical width stays
+  authoritative for every declaration question (`wirelog_schema_t`,
+  `wirelog_program_get_schema`); physical width is authoritative for every
+  storage question.
+
+  The signature is unchanged and there is no ABI break, but this is a
+  semantic change for embedders. It affects no relation without an inline
+  compound column, which is every relation this API could previously return
+  facts for at all -- the fact syntax for an inline-compound relation did not
+  work before this release (see the `Fixed` entry below).
+
+- **`wirelog_io_ctx_num_cols` and `wirelog_io_ctx_col_type` are physical**
+  (#985): the same width change, on the installed I/O adapter contract. Third
+  parties implement `read()` against these two accessors, so the change is
+  called out separately from `wirelog_program_get_facts` above.
+
+  `wirelog_io_ctx_num_cols(ctx)` is now the physical row stride -- the
+  `int64_t` slots one tuple occupies, which is what `docs/io-adapters.md` has
+  always required `read()` to size its buffer by and the width wirelog
+  inserts that buffer at. It previously reported the declared column count,
+  which for a relation with an `inline` compound column names a stride the
+  storage does not use. `wirelog_io_ctx_col_type(ctx, i)` is indexed by the
+  same physical position, and each slot of an inline compound now reports
+  `WIRELOG_TYPE_INT64` rather than the compound column's declared type: the
+  slots carry raw `int64` payload. For
+  `.decl inp(id: int64, p: pair/2 inline, s: symbol)` an adapter is now told
+  4 columns of `INT64, INT64, INT64, STRING`, against 3 of
+  `INT64, <p's declared type>, STRING` before.
+
+  `WIRELOG_IO_ABI_VERSION` is unchanged and no signature moved; only the
+  values differ, and only for a relation declaring an `inline` compound
+  column. An adapter that already sizes its output from `num_cols` needs no
+  change -- the built-in CSV adapter did and does. One that reconstructs the
+  stride from a schema of its own will now disagree with wirelog for those
+  relations. See the accessor block in `wirelog/io/io_adapter.h` and
+  [docs/io-adapters.md](docs/io-adapters.md).
+
 - **Warning-clean library build** (#940): the last three `-Wunused-function`
   warnings in library code are gone. `expand_multiway_delta` is now compiled only under
   `#if !ENABLE_K_FUSION`, the configuration that actually calls it (used by
@@ -41,6 +87,73 @@ All notable changes to wirelog are documented in this file.
   callers anywhere and is removed.
 
 ### Fixed
+
+- **A relation with an `inline` compound column has a working fact and
+  `.input` syntax** (#985): such a relation has a *logical* width (its
+  declared columns) and a *physical* width (inline slots expanded), and no
+  component agreed which was authoritative. The fact path, the `.input`
+  path, and `wirelog_program_get_facts` strided by the logical width while
+  the storage was laid out physically, so:
+
+  ```
+  .decl src(a: int64, b: int64, c: int64)
+  .decl pred(id: int64, payload: f/2 inline)
+  src(1,10,20).  pred(7,99).  pred(x,y,z) :- src(x,y,z).
+  ```
+
+  emitted `pred(7, 99)` and `pred(1, 10)`, dropping the 20: the two-argument
+  fact fixed the relation's runtime width at 2 and the rule's third column
+  was truncated away by `col_rel_append_all` (`columnar/relation.c`), which
+  copies `dst->ncols` columns with no clamp against `src->ncols`. In the
+  other direction a body pattern that destructured the column read the
+  inline slot the fact never wrote --
+  `outr(id, p, q) :- pred(id, f(p, q)).` produced `outr(1, 99, 0)`, exit 0,
+  AddressSanitizer silent -- the `0` coming from
+  `tmp[c] = (src < e.rel->ncols) ? row[src] : 0;` in `columnar/ops.c`. An
+  `.input` file was mis-read the same way: a four-field file for
+  `.decl inp(id: int64, p: pair/2 inline, s: symbol)` loaded three fields
+  under the wrong types and evaluated to `outr(1, 7, 1, "pair")`, four
+  values of which none were the file's.
+
+  Physical width is now authoritative for every storage question -- the
+  inline-fact insert stride, the `.input` insert stride,
+  `wirelog_io_ctx_num_cols` and its `col_types` (an inline compound's slots
+  are raw `int64` payload), the CSV stride in
+  `wirelog_load_facts_from_csv`, and `wirelog_program_get_facts`. It is
+  derived from `columns[]` on demand by `wl_ir_relation_physical_width()`
+  rather than stored, because `column_count` has more than one writer and a
+  cached copy could go stale. Logical width remains authoritative for every
+  declaration question.
+
+  **Compatibility:** a fact whose argument count is not the relation's
+  physical width is now rejected at load with `WIRELOG_ERR_PARSE`, reported
+  through `WL_LOG=PARSER:1`. For an inline-compound relation the diagnostic
+  names both widths, since "2 arguments but 2 columns" would otherwise read
+  as a contradiction. Nothing expressible is taken away: `pred(1,99).` was
+  the only spelling that parsed, and it was the broken one, while the
+  correct flat spelling `pred(1,10,20).` was *rejected*. There is no
+  compound fact notation to redirect to either -- `pred(1, f(10,20)).` and
+  `pred(1, [10,20]).` are parse errors, as is `pred(x, f(y,z))` in a rule
+  head. Filling the unwritten slot instead of rejecting is not available:
+  `0` is a valid `int64` and a valid intern id alike. The rule-head analogue
+  was already rejected under #977; this makes facts agree with it. No
+  benchmark, example or `.dl` workload in the tree declares an inline
+  compound column at all. Around a dozen test files do -- `test_program`,
+  `test_parser`, `test_wirelog_easy`, `test_wirelog_advanced`,
+  `test_symbol_ordering`, `test_symbol_aggregates`, `test_symbol_digests`
+  and more; the set moves with the suite, so read that as a sample and not
+  as a closed list -- and each of them seeds such a relation through the API
+  at the physical width rather than through an inline fact, so none changes
+  behaviour. The passing suite is the evidence for that, not the
+  enumeration.
+
+  **A bound `.query` on such a relation is still not fixed.** `.query`
+  arity flows through `passes/magic_sets.c`, which is deliberately left
+  logical here: with #989 open the demand relation is never seeded, so the
+  arity-mismatch warning is currently what routes the inline-compound case
+  onto the skip path and lets it produce rows at all. Making that arity
+  physical today converts a warning plus correct output into silence plus
+  zero rows. It is blocked on #989, not overlooked.
 
 - **Magic guards are built left-deep** (#989): `insert_magic_guard` produced
   `JOIN(magic_scan, body)`. When the body was itself composite -- a JOIN chain,
@@ -150,8 +263,11 @@ All notable changes to wirelog are documented in this file.
   (#977): `collect_fact` packed `fact_data` using each fact's *own*
   argument count as the row stride, while both readers of that buffer --
   `wl_session_load_facts` and the public `wirelog_program_get_facts`, the
-  latter reachable by an embedder with no session at all -- strided by the
-  *declared* `column_count`. Nothing reconciled the two. Depending on which
+  latter reachable by an embedder with no session at all -- strided by a
+  single fixed width taken from the `.decl` (the *declared* `column_count`
+  at the time; #985 above moves both readers to the physical width, which is
+  the same number for every relation that declares no `inline` compound
+  column). Nothing reconciled the two. Depending on which
   side was wider this produced a heap over-read, an uninitialised read
   *inside* the allocation that AddressSanitizer cannot see (exit status 0,
   emitting heap bytes as query answers), or a fabricated tuple: `val(1,5,7).
@@ -170,12 +286,23 @@ All notable changes to wirelog are documented in this file.
 
   **Compatibility:** programs that previously loaded now fail to load. Every
   rejected shape was already producing a crash, uninitialised heap, or a
-  fabricated tuple, so nothing correct is lost. One shape worth naming:
-  flattened facts against an inline-compound column -- `p(1,2,3).` against
-  `.decl p(id: int64, lbl: pair/2 inline)` -- were accepted and silently
-  dropped the third value; they are now rejected. Verified across every
-  Datalog program in the tree, including those the benchmarks generate from
-  CSV at runtime: no in-tree program changes behaviour.
+  fabricated tuple, so nothing correct is lost. Verified across every Datalog
+  program in the tree, including those the benchmarks generate from CSV at
+  runtime: no in-tree program changes behaviour.
+
+  **One half of this check is superseded later in this same release.** As
+  landed, the comparison was against the *logical* `column_count`, which for
+  a relation with an `inline` compound column is not the width its storage
+  uses. That rejected the flattened spelling -- `p(1,2,3).` against
+  `.decl p(id: int64, lbl: pair/2 inline)`, previously accepted while
+  silently dropping the third value -- and went on accepting the
+  two-argument `p(1,2).`, which leaves the second inline slot never written.
+  #985 (see its `Fixed` entry above) moves the comparison to the physical
+  width, so in the released build `p(1,2,3).` is **accepted** and stored as
+  three slots, and `p(1,2).` is the rejected spelling. Read the two entries
+  together: the *existence* of a fact arity check is #977, the width it
+  compares against is #985. Nothing here changes for a relation without an
+  `inline` compound column, which is every relation in the tree.
 
   This covers the inline-fact half of #977. Rule bodies and facts on
   undeclared relations remain unvalidated; rule heads are covered by the
@@ -210,12 +337,14 @@ All notable changes to wirelog are documented in this file.
 
   Heads are compared against the declared **physical** width, where an
   `inline` compound column counts as its full arity and a `side` compound as
-  one handle column -- deliberately unlike the fact check above, which
-  compares logically. The head grammar has no compound-term production
+  one handle column. The head grammar has no compound-term production
   (`pred(x, f(y, z))` is a parse error), so the flattened spelling
   `pred(x, y, z) :- src(x, y, z).` is the only way to write an
   inline-compound relation from a rule, and a logical comparison would reject
-  it.
+  it. When this landed the fact check above compared logically instead, an
+  asymmetry documented here as deliberate; #985 removed it by moving the fact
+  check to the physical width too, so in the released build both compare
+  physically.
 
   **Compatibility:** programs that previously loaded now fail to load. Every
   rejected shape was already a crash or a wrong answer. One shape worth

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -226,17 +226,52 @@ query answers with exit status 0, or a tuple assembled from two different
 facts. Loading fails with `WIRELOG_ERR_PARSE`; run with `WL_LOG=PARSER:1` to
 see which relation and which arities.
 
-Facts are compared against the declared **logical** width — one argument per
-declared column. For a relation with an `inline` compound column that has an
-awkward consequence: `p(1,2,3).` against `.decl p(id: int64, lbl: pair/2
-inline)` is rejected as three arguments against two columns, while `p(1,2).`
-is accepted and writes only the first of the two inline slots.
+Facts are compared against the declared **physical** width (#985), exactly as
+rule heads are: an `inline` compound column counts as its full arity, a `side`
+compound as the one handle column it is stored in. A fact is a row of the
+relation's storage, and that is the stride the storage uses.
 
-There is no compound spelling to reach for instead — `p(1, pair(2,3)).` is a
-parse error, because facts admit only integer and string constants. So an
-inline-compound relation currently cannot be populated correctly by an inline
-fact at all: the accepted form leaves a slot unwritten and produces no output.
-Use `.input` or derive the relation from a rule. Tracked as #985.
+```
+.decl p(id: int64, lbl: pair/2 inline)
+p(1, 2, 3).         /* accepted: 3 physical columns, written flat */
+p(1, 2).            /* rejected: 2, and leaves the second slot unwritten */
+
+.decl q(a: int64, m: m/4 side)
+q(1, 2).            /* accepted: a side compound is one handle column */
+```
+
+The flat spelling is the only spelling. `p(1, pair(2,3)).` and `p(1, [2,3]).`
+are parse errors — facts admit integer and string constants only — and the
+head grammar has no compound-term production either, so `p(x, pair(y,z))` in a
+rule head is a parse error as well. Flat is what a rule writes
+(`p(x, y, z) :- src(x, y, z).`) and flat is what an `.input` file carries: one
+field per physical column, four fields for
+`.decl inp(id: int64, p: pair/2 inline, s: symbol)`.
+
+Until #985 this comparison was logical, which rejected `p(1, 2, 3).` and
+accepted `p(1, 2).` — that is, it rejected the working spelling and accepted
+the broken one, leaving such a relation with no usable fact syntax at all. The
+accepted form left the second inline slot never written, and a body pattern
+that destructures the column read it regardless:
+`outr(id, x, y) :- p(id, pair(x, y)).` produced a `0` present in no source
+data. Rejecting is forced rather than chosen — `0` is a valid `int64` and a
+valid intern id, so no filler value could mean "not written".
+
+One thing a fact can do that an `.input` file cannot: put a **symbol** in an
+inline compound slot. `p(1, "aa", "bb").` against
+`.decl p(id: int64, lbl: pair/2 inline)` works, and
+`o(a, b, c) :- p(a, pair(b, c)).` gives `o(1, "aa", "bb")`. The same three
+values in a CSV file fail the load, because the `.decl` grammar records one
+type per declared column and has no way to say that slot 1 of `lbl` is a
+symbol — so the loader types every inline slot as `int64` and the reader
+cannot parse `aa`. This is a gap in the `.input` path, not a property of the
+storage; the slots are ordinary `int64` cells and hold interned ids fine.
+
+The physical width is also the row stride reported by
+`wirelog_program_get_facts`. It agrees with the `column_count` of
+`wirelog_program_get_schema` for every relation that declares no `inline`
+compound column, and can exceed it where one is declared. See the note on
+that function in `wirelog/wirelog.h`.
 
 Facts on a relation with **no** `.decl` at all are unaffected by this check
 and continue to fail later, during loading, with a less specific message.
@@ -276,12 +311,12 @@ answer instead.
 Loading fails with `WIRELOG_ERR_PARSE`; run with `WL_LOG=PARSER:1` to see
 which relation and which arities.
 
-Unlike the fact check, heads are compared against the declared **physical**
-width — an `inline` compound column counts as its full arity, a `side`
-compound as the single handle column it is stored in. The reason is that the
-head grammar has no compound-term production (`pred(x, f(y, z))` is a parse
-error), so the flattened spelling is the only way to write an
-inline-compound relation from a rule:
+Heads are compared against the declared **physical** width — an `inline`
+compound column counts as its full arity, a `side` compound as the single
+handle column it is stored in. The reason is that the head grammar has no
+compound-term production (`pred(x, f(y, z))` is a parse error), so the
+flattened spelling is the only way to write an inline-compound relation from
+a rule:
 
 ```
 .decl src(a: int64, b: int64, c: int64)
@@ -301,11 +336,10 @@ that destructures the column reads it anyway — `outr(id, p, q) :- pred(id,
 f(p, q)).` produced `outr(1, 99, 0)`, a value present in no source data,
 where the three-argument spelling correctly produces `outr(1, 10, 20)`.
 
-The corresponding *fact* `pred(1, 99).` is accepted, because facts must be
-compared logically (see [Inline facts must match their declared
-arity](#inline-facts-must-match-their-declared-arity) above) and so cannot be
-held to the physical width. That asymmetry is real and is tracked as #985 —
-it is a limitation of the width model, not of this check.
+The corresponding *fact* `pred(1, 99).` is rejected for the same reason, and
+by the same physical comparison (see [Inline facts must match their declared
+arity](#inline-facts-must-match-their-declared-arity) above). It was accepted
+until #985, which is where the `outr(1, 99, 0)` above was observed.
 
 Rule **bodies** are still not validated against their `.decl`.
 

--- a/docs/io-adapters.md
+++ b/docs/io-adapters.md
@@ -59,8 +59,8 @@ internals:
 | Accessor | Description |
 |----------|-------------|
 | `wirelog_io_ctx_relation_name(ctx)` | Name of the target relation |
-| `wirelog_io_ctx_num_cols(ctx)` | Column count |
-| `wirelog_io_ctx_col_type(ctx, i)` | Column type (`WIRELOG_TYPE_INT64`, `WIRELOG_TYPE_STRING`, ...) |
+| `wirelog_io_ctx_num_cols(ctx)` | Physical row stride: `int64_t` slots per tuple (see below) |
+| `wirelog_io_ctx_col_type(ctx, i)` | Type of physical slot `i` (`WIRELOG_TYPE_INT64`, `WIRELOG_TYPE_STRING`, ...) |
 | `wirelog_io_ctx_param(ctx, key)` | `.input` parameter lookup (e.g. `"filename"`, `"delimiter"`) |
 | `wirelog_io_ctx_intern_string(ctx, utf8)` | Intern a string, returns `int64_t` id for `WIRELOG_TYPE_STRING` columns |
 | `wirelog_io_ctx_platform(ctx)` | Platform context pointer (e.g. `JavaVM *` on Android) |
@@ -69,6 +69,39 @@ internals:
 Adapters never see `wl_intern_t`, `wl_ir_relation_info_t`, or any other
 internal type. This is the ABI firewall -- the context struct is opaque and
 its layout is private.
+
+#### `num_cols` is physical, not declared (#985)
+
+`wirelog_io_ctx_num_cols(ctx)` is the **physical row stride**: the number of
+`int64_t` slots one tuple of the relation occupies. That is the number of
+fields your `read()` must produce per row, and the width wirelog inserts the
+returned buffer at. It is not the relation's declared column count.
+
+A column declared as an `inline` compound occupies its full arity of
+consecutive slots:
+
+```
+.decl inp(id: int64, p: pair/2 inline, s: symbol)
+```
+
+is three declared columns but `num_cols` 4, and its `.input` file carries
+four fields. A `side` compound is a single handle slot, and so is every
+scalar, so the two numbers agree for every relation that declares no inline
+compound column.
+
+`wirelog_io_ctx_col_type(ctx, i)` is indexed by the same physical position:
+`i` runs over slots, not over declared columns. Each slot of an inline
+compound reports `WIRELOG_TYPE_INT64`, because the slots carry raw `int64`
+payload and the declared type of the compound column does not describe them.
+For the relation above the types are `INT64, INT64, INT64, STRING`.
+
+Before #985 both accessors reported the *declared* column count and the
+declared per-column types, which named a stride the storage does not use. The
+signatures and `WIRELOG_IO_ABI_VERSION` are unchanged; what changed is the
+value for a relation with an inline compound column. An adapter that already
+sizes its output from `num_cols` -- which this contract has always required
+-- needs no change. One that reconstructs the stride from a schema of its own
+will now disagree with wirelog for those relations.
 
 ---
 

--- a/tests/test_input_arity.c
+++ b/tests/test_input_arity.c
@@ -1,5 +1,5 @@
 /*
- * test_input_arity.c - .input CSV arity validation tests (Issue #977)
+ * test_input_arity.c - .input CSV arity validation tests (#977, #985)
  *
  * Copyright (C) CleverPlant
  * Licensed under LGPL-3.0
@@ -12,12 +12,22 @@
  * another: a heap over-read when the file is narrower than the .decl,
  * silently re-strided tuples when it is wider.
  *
- * These tests drive the real pipeline (parse -> plan -> load .input ->
+ * Since #985 that stride is the relation's PHYSICAL width -- an `inline`
+ * compound column expands to its full arity of slots -- so the declared
+ * column count and the file's field count are no longer the same number for
+ * every relation.  Cases 6 through 9 cover that.
+ *
+ * Cases 1 through 8 drive the real pipeline (parse -> plan -> load .input ->
  * evaluate) through wl_run_pipeline so both the columnar insert path
- * and the printed results are exercised.
+ * and the printed results are exercised.  Case 9 is the other CSV entry an
+ * embedder has -- wirelog_load_facts_from_csv(), which computes its width
+ * and column types itself and never builds an io_ctx -- so it is driven
+ * through the public executor API instead.
  */
 
 #include "../wirelog/cli/driver.h"
+#include "../wirelog/intern.h"
+#include "../wirelog/wirelog.h"
 
 #include "test_tmpdir.h"
 
@@ -400,19 +410,384 @@ test_empty_csv_still_loads(void)
 }
 
 /* ======================================================================== */
+/* Case 6: inline-compound .decl is fed at its PHYSICAL width (#985)        */
+/* ======================================================================== */
+
+/*
+ * `.decl inp(id: int64, p: pair/2 inline, s: symbol)` is three declared
+ * columns and four physical ones, so its `.input` file has four fields.
+ *
+ * Pre-fix wirelog_io_ctx_create_for_relation() published num_cols == 3 and
+ * a three-entry col_types, so the reader consumed the first three fields
+ * with the *third* declared type -- symbol -- applied to the compound's
+ * second slot.  The 4-field file loaded with rc 0 and evaluated to
+ * `outr(1, 7, 1, "pair")`: the 8 dropped, "aa" never read, `1` the intern
+ * id minted for the string "8", and `"pair"` the reverse-intern of the
+ * unwritten fourth slot's 0, which happened to be the functor name.  Four
+ * columns, none of them the file's.
+ *
+ * This is therefore a wrong-answer test, not an error-message test, and it
+ * asserts the values.  A three-field file for the same .decl (the shape a
+ * logical reading of the header would suggest) is Case 7.
+ */
+static void
+test_inline_compound_input_uses_physical_width(void)
+{
+    TEST("inline-compound .decl loads its .input at the physical width");
+
+    char csv_path[512];
+    char out_path[512];
+    test_tmppath(csv_path, sizeof(csv_path), "wl_arity_inline.csv");
+    test_tmppath(out_path, sizeof(out_path), "wl_arity_inline_out.txt");
+
+    if (write_text_file(csv_path, "1,7,8,aa\n") != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    char src[1024];
+    snprintf(src, sizeof(src),
+        ".decl inp(id: int64, p: pair/2 inline, s: symbol)\n"
+        ".input inp(filename=\"%s\", delimiter=\",\")\n"
+        ".decl outr(a: int64, b: int64, c: int64, d: symbol)\n"
+        ".output outr\n"
+        "outr(A, B, C, D) :- inp(A, B, C, D).\n",
+        csv_path);
+
+    char *output = NULL;
+    int rc = run_pipeline_capture(src, out_path, &output);
+
+    remove(csv_path);
+    remove(out_path);
+
+    if (rc != 0 || !output) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "wl_run_pipeline returned %d", rc);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    if (count_substr(output, "outr(") != 1
+        || count_substr(output, "outr(1, 7, 8, \"aa\")") != 1) {
+        char msg[512];
+        snprintf(msg, sizeof(msg),
+            "expected exactly outr(1, 7, 8, \"aa\"); got:\n%s", output);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    free(output);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Case 7: under-width .input against an inline-compound .decl             */
+/* ======================================================================== */
+
+/*
+ * The same relation fed a three-field file -- one field per *declared*
+ * column, which is exactly the mistake the old num_cols invited.  Pre-fix
+ * this loaded with rc 0 and printed the same fabricated
+ * `outr(1, 7, 1, "pair")` as the 4-field file did.
+ *
+ * The absence of any output line is asserted alongside the non-zero rc: a
+ * change that keeps the load rejected but prints a partially-loaded row
+ * first would otherwise pass on the rc alone.
+ */
+static void
+test_inline_compound_under_width_input_rejected(void)
+{
+    TEST("under-width .input vs an inline-compound .decl is rejected");
+
+    char csv_path[512];
+    char out_path[512];
+    test_tmppath(csv_path, sizeof(csv_path), "wl_arity_inline_narrow.csv");
+    test_tmppath(out_path, sizeof(out_path),
+        "wl_arity_inline_narrow_out.txt");
+
+    if (write_text_file(csv_path, "1,7,8\n") != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    char src[1024];
+    snprintf(src, sizeof(src),
+        ".decl inp(id: int64, p: pair/2 inline, s: symbol)\n"
+        ".input inp(filename=\"%s\", delimiter=\",\")\n"
+        ".decl outr(a: int64, b: int64, c: int64, d: symbol)\n"
+        ".output outr\n"
+        "outr(A, B, C, D) :- inp(A, B, C, D).\n",
+        csv_path);
+
+    char *output = NULL;
+    int rc = run_pipeline_capture(src, out_path, &output);
+
+    remove(csv_path);
+    remove(out_path);
+
+    if (rc == 0) {
+        char msg[512];
+        snprintf(msg, sizeof(msg),
+            "expected non-zero rc for a 3-field CSV vs a 4-column-physical "
+            ".decl; got 0 with output:\n%s", output ? output : "(null)");
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    if (output && count_substr(output, "outr(") != 0) {
+        char msg[512];
+        snprintf(msg, sizeof(msg),
+            "a rejected load must print nothing; got:\n%s", output);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    free(output);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Case 8: regression - a plain relation's num_cols stays logical           */
+/* ======================================================================== */
+
+/*
+ * No compound column anywhere, so the physical width must equal the
+ * declared one and a two-field file must still load.
+ *
+ * This case kills no mutant that the rest of the file does not already
+ * kill.  Measured, mutating the per-column sum in
+ * wl_ir_relation_physical_width() three ways:
+ *
+ *   phys += col->compound_arity                    Cases 3,4,5,6,8,9 fail
+ *   phys += (kind == INLINE) ? 1 : compound_arity  Cases 3,4,5,6,8,9 fail
+ *   phys += (kind != NONE) ? compound_arity : 1    all 9 pass
+ *
+ * The first two collapse every plain column to 0 -- compound_arity is 0
+ * when there is no compound -- so they take this case down in company
+ * rather than alone.  The third miscounts only `side` compounds, which no
+ * case in this file declares; it is caught in tests/test_program.c by
+ * test_fact_arity_side_compound_is_one_column() and
+ * test_head_arity_compound_handle_form_rejected().  So nothing in the
+ * "over-counting helper" class is uniquely caught here.
+ *
+ * What it is, and why it stays: a no-op pin on the path 99% of relations
+ * take.  wl_ir_relation_physical_width() is the identity on a
+ * compound-free relation, and this asserts that end to end -- through the
+ * io_ctx, the adapter, and the columnar insert -- rather than by reading
+ * the helper.  It is the tested form of the "no in-tree program changes
+ * behaviour" claim in the CHANGELOG, it costs one CSV file and one join,
+ * and it fails loudly if the physical width ever stops being derived from
+ * columns[] and starts being stored or guessed.
+ */
+static void
+test_plain_relation_width_unchanged(void)
+{
+    TEST("plain 2-column relation still loads a 2-field .input");
+
+    char csv_path[512];
+    char out_path[512];
+    test_tmppath(csv_path, sizeof(csv_path), "wl_arity_plain.csv");
+    test_tmppath(out_path, sizeof(out_path), "wl_arity_plain_out.txt");
+
+    if (write_text_file(csv_path, "1,2\n2,3\n") != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    char src[1024];
+    snprintf(src, sizeof(src),
+        ".decl edge(x: int64, y: int64)\n"
+        ".input edge(filename=\"%s\", delimiter=\",\")\n"
+        ".decl reach(x: int64, y: int64)\n"
+        ".output reach\n"
+        "reach(X, Y) :- edge(X, Y).\n",
+        csv_path);
+
+    char *output = NULL;
+    int rc = run_pipeline_capture(src, out_path, &output);
+
+    remove(csv_path);
+    remove(out_path);
+
+    if (rc != 0 || !output) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "wl_run_pipeline returned %d", rc);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    if (count_substr(output, "reach(") != 2
+        || count_substr(output, "reach(1, 2)") != 1
+        || count_substr(output, "reach(2, 3)") != 1) {
+        char msg[512];
+        snprintf(msg, sizeof(msg),
+            "expected exactly reach(1, 2) and reach(2, 3); got:\n%s", output);
+        free(output);
+        FAIL(msg);
+        return;
+    }
+
+    free(output);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Case 9: the public embedder entry -- wirelog_load_facts_from_csv (#985)  */
+/* ======================================================================== */
+
+/*
+ * `wirelog_load_facts_from_csv()` (api_facade.c) is the CSV entry an
+ * embedder reaches with no `.input` directive and no adapter registry
+ * involved, and it builds its own width and its own col_types array rather
+ * than going through wirelog_io_ctx_create_for_relation().  Both of those
+ * are separate code from anything Cases 6-8 touch.
+ *
+ * The relation carries a trailing `symbol` column *after* the inline
+ * compound, which is what makes the type array observable: the expansion
+ * has to shift `s`'s STRING type from logical position 2 to physical
+ * position 3.  Two independent reverts are killed here:
+ *
+ *   - the width.  Back at rel->column_count the reader is asked for 3
+ *     columns, the 4-field file trips the per-line width check in
+ *     wl_csv_read_file_via_ctx(), and the load returns false.
+ *   - the type expansion.  Without the shift, physical slot 2 is typed
+ *     STRING and slot 3 int64, so "8" is interned as a string and "aa" is
+ *     handed to the integer parser.
+ *
+ * The relation is declared without `.input` so the load under test is the
+ * explicit public call, not the executor's eager seeding.
+ */
+static void
+test_public_api_csv_inline_compound(void)
+{
+    TEST("wirelog_load_facts_from_csv: inline compound + trailing symbol");
+
+    char csv_path[512];
+    test_tmppath(csv_path, sizeof(csv_path), "wl_arity_api_inline.csv");
+
+    if (write_text_file(csv_path, "1,7,8,aa\n2,70,80,bb\n") != 0) {
+        FAIL("cannot write CSV fixture");
+        return;
+    }
+
+    static const char *src
+        = ".decl inp(id: int64, p: pair/2 inline, s: symbol)\n"
+        ".decl outr(a: int64, b: int64, c: int64, d: symbol)\n"
+        ".output outr\n"
+        "outr(A, B, C, D) :- inp(A, B, C, D).\n";
+
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog) {
+        remove(csv_path);
+        FAIL("wirelog_parse_string failed");
+        return;
+    }
+
+    wirelog_executor_t *exec = wirelog_executor_create(prog, &err);
+    if (!exec) {
+        wirelog_program_free(prog);
+        remove(csv_path);
+        FAIL("wirelog_executor_create failed");
+        return;
+    }
+
+    bool ok = wirelog_load_facts_from_csv(exec, "inp", csv_path, &err);
+    remove(csv_path);
+    if (!ok) {
+        char msg[160];
+        snprintf(msg, sizeof(msg),
+            "load of a 4-field CSV into a 4-column-physical relation "
+            "returned false (err=%d)", (int)err);
+        wirelog_executor_free(exec);
+        wirelog_program_free(prog);
+        FAIL(msg);
+        return;
+    }
+
+    wirelog_result_t *res = wirelog_evaluate(exec, &err);
+    if (!res) {
+        wirelog_executor_free(exec);
+        wirelog_program_free(prog);
+        FAIL("wirelog_evaluate returned NULL");
+        return;
+    }
+
+    const wirelog_intern_t *in = wirelog_program_get_intern(prog);
+    int64_t aa = in ? wl_intern_get(in, "aa") : -1;
+    int64_t bb = in ? wl_intern_get(in, "bb") : -1;
+    uint64_t rows = wirelog_result_relation_cardinality(res, "outr");
+    const int64_t *data
+        = (const int64_t *)wirelog_result_get_relation(res, "outr");
+
+    int bad = 0;
+    char msg[256];
+    msg[0] = '\0';
+
+    if (aa < 0 || bb < 0) {
+        snprintf(msg, sizeof(msg),
+            "the symbol column was not interned: aa=%lld bb=%lld",
+            (long long)aa, (long long)bb);
+        bad = 1;
+    } else if (rows != 2 || !data) {
+        snprintf(msg, sizeof(msg), "expected 2 outr rows, got %llu",
+            (unsigned long long)rows);
+        bad = 1;
+    } else {
+        /* Row order is not part of the contract; match either way. */
+        const int64_t *r0 = &data[0];
+        const int64_t *r1 = &data[4];
+        if (r0[0] == 2) {
+            const int64_t *t = r0;
+            r0 = r1;
+            r1 = t;
+        }
+        if (r0[0] != 1 || r0[1] != 7 || r0[2] != 8 || r0[3] != aa
+            || r1[0] != 2 || r1[1] != 70 || r1[2] != 80 || r1[3] != bb) {
+            snprintf(msg, sizeof(msg),
+                "expected outr(1,7,8,\"aa\") and outr(2,70,80,\"bb\"); got "
+                "(%lld,%lld,%lld,%lld) and (%lld,%lld,%lld,%lld)",
+                (long long)r0[0], (long long)r0[1], (long long)r0[2],
+                (long long)r0[3], (long long)r1[0], (long long)r1[1],
+                (long long)r1[2], (long long)r1[3]);
+            bad = 1;
+        }
+    }
+
+    wirelog_result_free(res);
+    wirelog_executor_free(exec);
+    wirelog_program_free(prog);
+
+    if (bad) {
+        FAIL(msg);
+        return;
+    }
+    PASS();
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
 int
 main(void)
 {
-    printf("=== test_input_arity (Issue #977) ===\n");
+    printf("=== test_input_arity (Issues #977, #985) ===\n");
 
     test_narrow_csv_rejected();
     test_wide_csv_rejected();
     test_matching_width_evaluates();
     test_symbol_relation_unaffected();
     test_empty_csv_still_loads();
+    test_inline_compound_input_uses_physical_width();
+    test_inline_compound_under_width_input_rejected();
+    test_plain_relation_width_unchanged();
+    test_public_api_csv_inline_compound();
 
     printf("\n=== Results: %d run, %d passed, %d failed ===\n",
         tests_run, tests_passed, tests_failed);

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -2957,26 +2957,113 @@ test_fact_arity_wider_than_decl_rejected(void)
 
     /* Inline-compound columns.  `.decl p(id, lbl: pair/2 inline)` has a
      * *logical* width of 2 and a *physical* width of 3, and this fact is
-     * written flat.  It is rejected, because facts are compared logically:
-     * collect_fact packs one slot per written argument and both readers
-     * stride by rel->column_count, which is the logical width.
+     * written flat.  It is ACCEPTED (#985): facts are compared against the
+     * physical width, because a fact is a row of the relation's storage and
+     * an inline compound occupies its full arity of slots there.
      *
-     * Pre-fix this was accepted and silently dropped the third value.
-     * Note this is the one place where the fact rule and the rule-head rule
-     * diverge: validate_head_arities() (#977 unit 3) compares *physical*
-     * width via atom_physical_column_count(), so the head spelling of this
-     * same shape -- pred(x,y,z) against .decl pred(id, payload: f/2 inline)
-     * -- is accepted, and is pinned by
-     * test_head_arity_inline_compound_accepted().  The divergence is not an
-     * oversight: the head grammar has no compound-term production, so the
-     * flattened spelling is the only one available to a rule, while facts
-     * are packed and read back at the logical width.  If compound terms ever
-     * become expressible in facts, this comparison has to move with it. */
-    bad = make_program(".decl p(id: int64, lbl: pair/2 inline)\n"
+     * This half used to assert the opposite, under a logical comparison.
+     * That was the defect: it rejected the only spelling that works and
+     * accepted `p(1, 2).`, which left the second inline slot never written
+     * for a body pattern to read back as a fabricated 0.
+     *
+     * The contents are asserted, not merely non-NULL: a check deleted rather
+     * than corrected would still leave fact_data non-NULL, so only the
+     * values distinguish "accepted" from "accepted and stored correctly". */
+    struct wirelog_program *ok
+        = make_program(".decl p(id: int64, lbl: pair/2 inline)\n"
             "p(1, 2, 3).\n");
+    if (!ok) {
+        FAIL("flat p(1,2,3). against inline-compound .decl p/2 accepted");
+        return;
+    }
+    if (ok->relation_count != 1 || ok->relations[0].fact_count != 1
+        || !ok->relations[0].fact_data) {
+        wl_ir_program_free(ok);
+        FAIL("p(1,2,3). should store exactly one fact row");
+        return;
+    }
+    if (ok->relations[0].fact_data[0] != 1
+        || ok->relations[0].fact_data[1] != 2
+        || ok->relations[0].fact_data[2] != 3) {
+        wl_ir_program_free(ok);
+        FAIL("p(1,2,3). should store the slots 1,2,3");
+        return;
+    }
+    wl_ir_program_free(ok);
+
+    PASS();
+}
+
+static void
+test_fact_arity_compound_handle_form_rejected(void)
+{
+    TEST("Fact arity: handle-form fact into a compound relation is rejected");
+
+    /* The mutation-resistant half of #985, and the whole of its defect B.
+     * `.decl p(id, lbl: pair/2 inline)` is two logical columns and three
+     * physical ones, so the two-argument fact writes one slot fewer than the
+     * relation occupies.
+     *
+     * Pre-fix this was accepted -- 2 == column_count -- and left the second
+     * inline slot never written; a body pattern that destructures the column
+     * read it anyway and produced a fabricated 0
+     * (`outr(id, x, y) :- p(id, pair(x, y)).` -> outr(1, 99, 0), exit 0,
+     * ASAN silent).  There is no honest default to fill the slot with: 0 is
+     * a valid int64 and a valid intern id alike.
+     *
+     * If anyone "simplifies" the fact comparison back to the logical
+     * rel->column_count, this is the test that fails.  The accepting half in
+     * test_fact_arity_wider_than_decl_rejected() alone would not catch it --
+     * a blanket accept passes that one. */
+    struct wirelog_program *bad
+        = make_program(".decl p(id: int64, lbl: pair/2 inline)\n"
+            "p(1, 2).\n");
     if (bad) {
         wl_ir_program_free(bad);
-        FAIL("flat p(1,2,3). against inline-compound .decl p/2 rejected");
+        FAIL("handle-form p(1,2). against inline-compound .decl p/2 rejected");
+        return;
+    }
+
+    PASS();
+}
+
+static void
+test_fact_arity_side_compound_is_one_column(void)
+{
+    TEST("Fact arity: a side compound occupies exactly one column");
+
+    /* A `side` compound is stored as a single handle slot, not
+     * compound_arity of them, so the handle form is the *only* form and
+     * `q(1, 2).` must be accepted against `.decl q(a: int64, m: m/4 side)`.
+     * Without this the physical-width sum could be written as a blanket
+     * `+= compound_arity` and every other test in the file would still
+     * pass.  It is the fact-side twin of the SIDE half of
+     * test_head_arity_compound_handle_form_rejected(). */
+    struct wirelog_program *ok
+        = make_program(".decl q(a: int64, m: m/4 side)\n"
+            "q(1, 2).\n");
+    if (!ok) {
+        FAIL("q(1,2). against side-compound .decl q/2 should be accepted");
+        return;
+    }
+    if (ok->relation_count != 1 || ok->relations[0].fact_count != 1
+        || !ok->relations[0].fact_data
+        || ok->relations[0].fact_data[0] != 1
+        || ok->relations[0].fact_data[1] != 2) {
+        wl_ir_program_free(ok);
+        FAIL("q(1,2). should store the slots 1,2");
+        return;
+    }
+    wl_ir_program_free(ok);
+
+    /* Widening to the side compound's arity is a mismatch, not an
+     * alternative spelling. */
+    struct wirelog_program *bad
+        = make_program(".decl q(a: int64, m: m/4 side)\n"
+            "q(1, 2, 3).\n");
+    if (bad) {
+        wl_ir_program_free(bad);
+        FAIL("q(1,2,3). against side-compound .decl q/2 should be rejected");
         return;
     }
 
@@ -3345,12 +3432,13 @@ test_head_arity_compound_handle_form_rejected(void)
 {
     TEST("Head arity: handle-form head into a compound relation is rejected");
 
-    /* The open question this unit had to settle.  `pred(1, 99).` is a legal
-     * *fact* -- unit 2 compares facts logically, and 2 == 2 -- so it is not
-     * obvious that the head analogue `pred(x, y) :- src(x, y).` should be
-     * illegal.  It is, and the reason is not symmetry but a fabricated
-     * value: the head leaves the second inline slot never written, and a
-     * body pattern that destructures the column reads it anyway.
+    /* The open question this unit had to settle.  `pred(1, 99).` used to be
+     * a legal *fact* -- unit 2 compared facts logically, and 2 == 2 -- so it
+     * was not obvious that the head analogue `pred(x, y) :- src(x, y).`
+     * should be illegal.  It is, and the reason is not symmetry but a
+     * fabricated value: the head leaves the second inline slot never
+     * written, and a body pattern that destructures the column reads it
+     * anyway.
      *
      *   .decl src(a: int64, b: int64)
      *   .decl pred(id: int64, payload: f/2 inline)
@@ -3366,12 +3454,12 @@ test_head_arity_compound_handle_form_rejected(void)
      * one the relation must be written at, and this shape is rejected.
      *
      * (The identical defect via the *fact* form -- `pred(1, 99).` plus the
-     * same destructuring rule, also outr(1, 99, 0) -- is still accepted,
-     * because unit 2 must compare facts logically: wl_session_load_facts()
-     * and wirelog_program_get_facts() both stride by column_count.  That
-     * asymmetry is real and is not resolved here -- issue #985 tracks it,
-     * along with the fact that an inline-compound relation cannot be
-     * populated correctly by an inline fact at all.) */
+     * same destructuring rule, also outr(1, 99, 0) -- was accepted when this
+     * unit landed, because unit 2 then compared facts logically.  #985
+     * closed that: wl_session_load_facts() and wirelog_program_get_facts()
+     * now stride physically and the fact pass compares physically, so
+     * `pred(1, 99).` is rejected too.  See
+     * test_fact_arity_compound_handle_form_rejected().) */
     struct wirelog_program *bad
         = make_program(".decl src(a: int64, b: int64)\n"
             ".decl pred(id: int64, payload: f/2 inline)\n"
@@ -3580,6 +3668,84 @@ test_api_get_facts(void)
         free(data);
         wirelog_program_free(prog);
         FAIL("fact data mismatch");
+        return;
+    }
+
+    free(data);
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * The same public reader against a relation with an `inline` compound
+ * column -- the case the other three get_facts tests cannot reach, because
+ * every one of them declares a plain relation where the logical and
+ * physical widths are the same number.
+ *
+ * `.decl pred(id: int64, payload: f/2 inline)` is two declared columns and
+ * three physical slots.  *num_cols is the caller's row stride into *data,
+ * so it must be 3; wirelog.h documents exactly that as the public contract
+ * and the CHANGELOG leads its `Changed` section with it.  Reverting
+ * ir/api.c to `rel->column_count` returns 2 here, and an embedder indexing
+ * the buffer by it reads pred(1, 98) followed by whatever tuple 99 begins.
+ *
+ * The slot values are asserted, not just the count: rel->fact_data already
+ * holds three slots (collect_fact packs one per written argument), so a
+ * stride of 2 still yields a non-NULL buffer of plausible-looking numbers.
+ * Only the contents distinguish "the whole row" from "the row's prefix".
+ */
+static void
+test_api_get_facts_inline_compound_physical_width(void)
+{
+    TEST("wirelog_program_get_facts reports the physical stride");
+
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl pred(id: int64, payload: f/2 inline)\n"
+            "pred(1, 98, 99).\n",
+            NULL);
+    if (!prog) {
+        FAIL("program is NULL");
+        return;
+    }
+
+    /* The declaration side stays logical: 2 columns, not 3. */
+    const wirelog_schema_t *schema = wirelog_program_get_schema(prog, "pred");
+    if (!schema || schema->column_count != 2) {
+        char buf[80];
+        snprintf(buf, sizeof(buf), "expected schema column_count 2, got %u",
+            schema ? schema->column_count : 0u);
+        wirelog_program_free(prog);
+        FAIL(buf);
+        return;
+    }
+
+    int64_t *data = NULL;
+    uint32_t num_rows = 0, num_cols = 0;
+    int rc
+        = wirelog_program_get_facts(prog, "pred", &data, &num_rows, &num_cols);
+    if (rc != 0) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "get_facts should return 0, got %d", rc);
+        free(data);
+        wirelog_program_free(prog);
+        FAIL(buf);
+        return;
+    }
+
+    if (num_rows != 1 || num_cols != 3) {
+        char buf[80];
+        snprintf(buf, sizeof(buf),
+            "expected 1x3 (physical), got %ux%u", num_rows, num_cols);
+        free(data);
+        wirelog_program_free(prog);
+        FAIL(buf);
+        return;
+    }
+
+    if (!data || data[0] != 1 || data[1] != 98 || data[2] != 99) {
+        free(data);
+        wirelog_program_free(prog);
+        FAIL("expected the slots {1,98,99}");
         return;
     }
 
@@ -3978,6 +4144,8 @@ main(void)
     test_fact_arity_narrower_than_decl_rejected();
     test_fact_arity_decl_after_facts_rejected();
     test_fact_arity_wider_than_decl_rejected();
+    test_fact_arity_compound_handle_form_rejected();
+    test_fact_arity_side_compound_is_one_column();
     test_fact_arity_mixed_across_facts_rejected();
     test_fact_arity_zero_param_decl_rejected();
     test_fact_arity_matching_accepted();
@@ -3996,6 +4164,7 @@ main(void)
 
     /* Fact extraction API */
     test_api_get_facts();
+    test_api_get_facts_inline_compound_physical_width();
     test_api_get_facts_no_facts();
     test_api_get_facts_unknown_relation();
 

--- a/tests/test_wirelog_easy_inline_facts.c
+++ b/tests/test_wirelog_easy_inline_facts.c
@@ -260,6 +260,143 @@ test_inline_compound_head_evaluates_exactly(void)
     return rc;
 }
 
+static int
+has_triple(const struct triple_state *st, int64_t a, int64_t b, int64_t c)
+{
+    for (uint32_t i = 0; i < st->rows; i++) {
+        if (st->seen[i][0] == a && st->seen[i][1] == b
+            && st->seen[i][2] == c)
+            return 1;
+    }
+    return 0;
+}
+
+/* T5 (issue #985): a flat inline-compound *fact* must be accepted and must
+ *     coexist with the flattened rule-head spelling at the same width.
+ *
+ *     Pre-fix `pred(7, 98, 99).` was rejected outright (three arguments
+ *     against a two-column .decl, compared logically) while the broken
+ *     two-argument `pred(7, 99).` was accepted -- so the relation had no
+ *     working fact syntax at all.  Worse, the accepted form fixed the
+ *     relation's runtime width at 2, so the rule's three columns were then
+ *     truncated: the issue's own reproducer emitted pred(7, 99) and
+ *     pred(1, 10), dropping the 20.
+ *
+ *     ncols is asserted inside the callback, which is where the truncation
+ *     is visible; collect_triples() poisons st->rows if it is not 3.  Both
+ *     rows are asserted by value and order-insensitively, because the row
+ *     *count* is 2 either way -- a count-only assertion passes on the bug. */
+static int
+test_inline_compound_flat_fact_evaluates_exactly(void)
+{
+    static const char *src = ".decl src(a: int64, b: int64, c: int64)\n"
+        ".decl pred(id: int64, payload: f/2 inline)\n"
+        "src(1, 10, 20).\n"
+        "pred(7, 98, 99).\n"
+        "pred(x, y, z) :- src(x, y, z).\n";
+
+    wirelog_easy_session_t *s = NULL;
+    wirelog_error_t err = wirelog_easy_open(src, &s);
+    if (err != WIRELOG_OK || !s) {
+        fprintf(stderr, "T5 open err=%d (flat inline-compound fact must be "
+            "accepted; a logical arity check rejects it)\n", err);
+        return 1;
+    }
+
+    struct triple_state st = { 0, { { 0, 0, 0 } } };
+    err = wirelog_easy_snapshot(s, "pred", collect_triples, &st);
+    int rc = 0;
+    if (err != WIRELOG_OK) {
+        fprintf(stderr, "T5 snapshot err=%d\n", err);
+        rc = 1;
+    } else if (st.rows != 2) {
+        fprintf(stderr, "T5: expected 2 pred rows at ncols 3, got %u\n",
+            st.rows);
+        rc = 1;
+    } else if (!has_triple(&st, 7, 98, 99) || !has_triple(&st, 1, 10, 20)) {
+        fprintf(stderr, "T5: expected pred(7,98,99) and pred(1,10,20), got "
+            "pred(%lld,%lld,%lld) and pred(%lld,%lld,%lld)\n",
+            (long long)st.seen[0][0], (long long)st.seen[0][1],
+            (long long)st.seen[0][2], (long long)st.seen[1][0],
+            (long long)st.seen[1][1], (long long)st.seen[1][2]);
+        rc = 1;
+    }
+    wirelog_easy_close(s);
+    return rc;
+}
+
+/* T6 (issue #985): the handle-form fact must fail to open.
+ *
+ *     `pred(1, 99).` leaves the second inline slot never written, and
+ *     `outr(id, p, q) :- pred(id, f(p, q)).` destructures the column and
+ *     reads it regardless -- outr(1, 99, 0) pre-fix, exit 0, ASAN silent.
+ *     The 0 is present in no source data and there is no honest default to
+ *     put there, so the program is rejected at load.
+ *
+ *     T7 is this test's positive control and is not optional: without it a
+ *     change that rejected *everything* would leave T6 green. */
+static int
+test_inline_compound_handle_fact_rejected(void)
+{
+    static const char *src = ".decl pred(id: int64, payload: f/2 inline)\n"
+        ".decl outr(id: int64, p: int64, q: int64)\n"
+        "pred(1, 99).\n"
+        "outr(id, p, q) :- pred(id, f(p, q)).\n";
+
+    wirelog_easy_session_t *s = NULL;
+    wirelog_error_t err = wirelog_easy_open(src, &s);
+    if (err == WIRELOG_OK) {
+        fprintf(stderr, "T6: pred(1,99). against an f/2 inline .decl must "
+            "not open (it fabricates outr(1,99,0))\n");
+        wirelog_easy_close(s);
+        return 1;
+    }
+    return 0;
+}
+
+/* T7 (issue #985): positive control for T6, and the assertion that the
+ *     fabricated 0 is gone.
+ *
+ *     Same destructuring rule, the fact written flat.  The second inline
+ *     slot is now written, so the body pattern reads real data and outr
+ *     carries the source values instead of a slot nobody filled in. */
+static int
+test_inline_compound_flat_fact_destructures_exactly(void)
+{
+    static const char *src = ".decl pred(id: int64, payload: f/2 inline)\n"
+        ".decl outr(id: int64, p: int64, q: int64)\n"
+        "pred(1, 98, 99).\n"
+        "outr(id, p, q) :- pred(id, f(p, q)).\n";
+
+    wirelog_easy_session_t *s = NULL;
+    wirelog_error_t err = wirelog_easy_open(src, &s);
+    if (err != WIRELOG_OK || !s) {
+        fprintf(stderr, "T7 open err=%d\n", err);
+        return 1;
+    }
+
+    struct triple_state st = { 0, { { 0, 0, 0 } } };
+    err = wirelog_easy_snapshot(s, "outr", collect_triples, &st);
+    int rc = 0;
+    if (err != WIRELOG_OK) {
+        fprintf(stderr, "T7 snapshot err=%d\n", err);
+        rc = 1;
+    } else if (st.rows != 1) {
+        fprintf(stderr, "T7: expected 1 outr row at ncols 3, got %u\n",
+            st.rows);
+        rc = 1;
+    } else if (st.seen[0][0] != 1 || st.seen[0][1] != 98
+        || st.seen[0][2] != 99) {
+        fprintf(stderr,
+            "T7: expected outr(1,98,99), got outr(%lld,%lld,%lld)\n",
+            (long long)st.seen[0][0], (long long)st.seen[0][1],
+            (long long)st.seen[0][2]);
+        rc = 1;
+    }
+    wirelog_easy_close(s);
+    return rc;
+}
+
 int
 main(void)
 {
@@ -268,6 +405,9 @@ main(void)
     failures += test_static_fact_joins_with_host_insert();
     failures += test_matching_arity_facts_evaluate_exactly();
     failures += test_inline_compound_head_evaluates_exactly();
+    failures += test_inline_compound_flat_fact_evaluates_exactly();
+    failures += test_inline_compound_handle_fact_rejected();
+    failures += test_inline_compound_flat_fact_destructures_exactly();
     if (failures == 0)
         printf("test_wl_easy_inline_facts: OK\n");
     else

--- a/wirelog/api_facade.c
+++ b/wirelog/api_facade.c
@@ -494,18 +494,32 @@ wirelog_load_facts_from_csv(wirelog_executor_t *executor,
     uint32_t nrows = 0;
     uint32_t ncols = 0;
     wirelog_column_type_t *types = NULL;
-    if (rel->column_count > 0) {
+    /* Physical width (#985), and physical-indexed types to match: this is
+     * the CSV row stride and the stride the rows are inserted at, so an
+     * inline compound column contributes compound_arity int64 slots rather
+     * than one column of its declared type.  Same expansion as
+     * wirelog_io_ctx_create_for_relation() (io/io_ctx.c). */
+    uint32_t phys = wl_ir_relation_physical_width(rel);
+    if (phys > 0 && rel->columns) {
         types = (wirelog_column_type_t *)malloc(
-            rel->column_count * sizeof(wirelog_column_type_t));
+            phys * sizeof(wirelog_column_type_t));
         if (!types) {
             set_error(error, WIRELOG_ERR_MEMORY);
             return false;
         }
-        for (uint32_t i = 0; i < rel->column_count; i++)
-            types[i] = rel->columns[i].type;
+        uint32_t k = 0;
+        for (uint32_t i = 0; i < rel->column_count; i++) {
+            if (rel->columns[i].compound_kind
+                == WIRELOG_COMPOUND_KIND_INLINE) {
+                for (uint32_t j = 0; j < rel->columns[i].compound_arity; j++)
+                    types[k++] = WIRELOG_TYPE_INT64;
+            } else {
+                types[k++] = rel->columns[i].type;
+            }
+        }
     }
 
-    int rc = wl_csv_read_file_ex(csv_file, ',', types, rel->column_count,
+    int rc = wl_csv_read_file_ex(csv_file, ',', types, phys,
             &data, &nrows, &ncols, executor->program->intern);
     free(types);
     if (rc != 0) {

--- a/wirelog/io/csv_adapter.c
+++ b/wirelog/io/csv_adapter.c
@@ -142,9 +142,17 @@ csv_read(wirelog_io_ctx_t *ctx, int64_t **out_data,
      * The invariant being restored is the adapter contract itself:
      * docs/io-adapters.md requires read() to produce a buffer of
      * *out_nrows * wirelog_io_ctx_num_cols(ctx) elements, and
-     * wirelog_io_ctx_num_cols() is set from rel->column_count
+     * wirelog_io_ctx_num_cols() is the relation's PHYSICAL width
      * (io/io_ctx.c) -- the very stride wl_session_load_input_files()
      * inserts at.  This branch was violating the contract it publishes.
+     *
+     * Physical, not the declared rel->column_count: an `inline` compound
+     * column occupies compound_arity slots, so a file for
+     * `.decl inp(id: int64, p: pair/2 inline, s: symbol)` carries four
+     * fields against three declared columns (#985).  This branch needs no
+     * special case for that -- it compares the detected width against
+     * num_cols and never sees column_count -- but the number it is
+     * comparing against is no longer the declared one.
      *
      * -2 is the code wl_csv_read_file_via_ctx() uses for a width
      * mismatch, reused for consistency of the return value only.  Note

--- a/wirelog/io/io_adapter.h
+++ b/wirelog/io/io_adapter.h
@@ -67,6 +67,34 @@ typedef struct wirelog_io_ctx wirelog_io_ctx_t;
 /* Context Accessors (implemented in #453)                                  */
 /* ======================================================================== */
 
+/*
+ * wirelog_io_ctx_num_cols() is the PHYSICAL row stride of the relation --
+ * the number of int64_t slots one tuple occupies, which is the number of
+ * fields read() must produce per row and the width wirelog inserts the
+ * returned buffer at.  It is NOT the relation's declared column count.
+ *
+ * A column declared as an `inline` compound occupies its full arity of
+ * consecutive slots: `.decl inp(id: int64, p: pair/2 inline, s: symbol)` is
+ * three declared columns but num_cols 4, and its `.input` file carries four
+ * fields.  A `side` compound is one handle slot, and so is every scalar, so
+ * the two numbers agree for every relation that declares no inline compound
+ * column.
+ *
+ * wirelog_io_ctx_col_type(ctx, i) is indexed by the same physical position,
+ * so `i` runs over slots and not over declared columns.  Each slot of an
+ * inline compound reports WIRELOG_TYPE_INT64 -- the slots carry raw int64
+ * payload, and the declared type of a compound column does not describe
+ * them.  In the example above the types are INT64, INT64, INT64, STRING.
+ *
+ * Before #985 both accessors reported the declared column count and the
+ * declared per-column types, which named a stride the storage does not use;
+ * an adapter for such a relation was handed the wrong width and the wrong
+ * types.  The signatures are unchanged and WIRELOG_IO_ABI_VERSION is
+ * unchanged, but an adapter that reconstructed the stride from a schema of
+ * its own -- rather than from num_cols, as the contract in
+ * docs/io-adapters.md requires -- will now disagree with wirelog for a
+ * relation with an inline compound column.  Index by num_cols.
+ */
 WIRELOG_API const char *
 wirelog_io_ctx_relation_name(const wirelog_io_ctx_t *ctx);
 WIRELOG_API uint32_t

--- a/wirelog/io/io_ctx.c
+++ b/wirelog/io/io_ctx.c
@@ -32,22 +32,66 @@ wirelog_io_ctx_create_for_relation(const wl_ir_relation_info_t *rel,
         return NULL;
 
     ctx->relation_name = rel->name;                          /* borrowed */
-    ctx->num_cols = rel->column_count;
+    /* Physical width (#985).  num_cols is the adapter contract's row stride:
+     * docs/io-adapters.md requires read() to produce
+     * *out_nrows * wirelog_io_ctx_num_cols(ctx) elements, and
+     * wl_session_load_input_files() inserts at exactly that stride.  An
+     * inline compound column occupies compound_arity slots, so the logical
+     * rel->column_count named a stride the storage does not use. */
+    ctx->num_cols = wl_ir_relation_physical_width(rel);
     ctx->param_keys = (const char **)rel->input_param_names;      /* borrowed */
     ctx->param_values = (const char **)rel->input_param_values;   /* borrowed */
     ctx->num_params = rel->input_param_count;
     ctx->intern = intern;                                    /* borrowed */
     ctx->platform_ctx = NULL;
 
-    if (rel->column_count > 0 && rel->columns) {
+    if (ctx->num_cols > 0 && rel->columns) {
         ctx->col_types = (wirelog_column_type_t *)malloc(
-            rel->column_count * sizeof(wirelog_column_type_t));
+            ctx->num_cols * sizeof(wirelog_column_type_t));
         if (!ctx->col_types) {
             free(ctx);
             return NULL;
         }
-        for (uint32_t i = 0; i < rel->column_count; i++)
-            ctx->col_types[i] = rel->columns[i].type;
+        /* col_types is physical-indexed too, so it stays parallel to
+         * num_cols.  The load-bearing part of this loop is the *shift*: a
+         * scalar column after an inline compound must report its declared
+         * type at the compound's physical position, not at its logical one,
+         * or a trailing `symbol` lands on an inline slot and the file is
+         * read under the wrong types.
+         *
+         * Each inline slot is pinned to WIRELOG_TYPE_INT64, which is a
+         * CHOICE about this path and not a fact about the storage.  The
+         * slots are ordinary int64 cells and hold interned string ids
+         * perfectly well: `p(1, "aa", "bb").` against
+         * `.decl p(id: int64, lbl: pair/2 inline)` with
+         * `o(a,b,c) :- p(a, pair(b,c)).` evaluates to o(1, "aa", "bb") in
+         * this same release, through the fact path.  The `.input` path
+         * cannot do that, and the reason is a missing input, not a property
+         * of the layout: the grammar records one type per *declared* column
+         * (`rel->columns[i].type`, which for any `functor/arity` spelling is
+         * just WIRELOG_TYPE_INT64 -- see type_name_to_column_type() in
+         * ir/program.c), so there is nowhere to say that slot 1 of `lbl` is
+         * a symbol and slot 2 an integer.  Absent per-slot types, int64 is
+         * the only defensible default.
+         *
+         * Consequence, stated as the limitation it is: a symbol cannot be
+         * loaded into an inline compound slot from an `.input` file.  The
+         * 3-field CSV matching the fact above fails the load outright --
+         * "adapter 'csv' failed to read data" -- because the integer-only
+         * reader cannot parse "aa".  It fails loudly rather than
+         * fabricating, which is the right failure, but it is still a gap.
+         * Lifting it needs per-slot compound types in the `.decl` grammar;
+         * a follow-up issue tracks that. */
+        uint32_t k = 0;
+        for (uint32_t i = 0; i < rel->column_count; i++) {
+            if (rel->columns[i].compound_kind
+                == WIRELOG_COMPOUND_KIND_INLINE) {
+                for (uint32_t j = 0; j < rel->columns[i].compound_arity; j++)
+                    ctx->col_types[k++] = WIRELOG_TYPE_INT64;
+            } else {
+                ctx->col_types[k++] = rel->columns[i].type;
+            }
+        }
     }
 
     return ctx;

--- a/wirelog/ir/api.c
+++ b/wirelog/ir/api.c
@@ -251,7 +251,12 @@ wirelog_program_get_facts(const wirelog_program_t *prog, const char *relation,
             if (rel->fact_count == 0)
                 return 1;
 
-            uint32_t ncols = rel->column_count;
+            /* Physical width (#985).  *num_cols is the caller's row stride
+             * into *data, not a declaration; an inline compound column
+             * occupies compound_arity slots there.  It can therefore exceed
+             * wirelog_program_get_schema()'s column_count -- see the note on
+             * this function in wirelog.h. */
+            uint32_t ncols = wl_ir_relation_physical_width(rel);
             uint32_t total = rel->fact_count * ncols;
             int64_t *copy = (int64_t *)malloc(total * sizeof(int64_t));
             if (!copy)

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -710,7 +710,7 @@ atom_physical_column_count(const wl_parser_ast_node_t *atom,
  * row stride, but both readers of that buffer -- wl_session_load_facts()
  * (session_facts.c) and the public wirelog_program_get_facts() (ir/api.c),
  * the latter reachable by an embedder with no session at all -- stride by
- * the *declared* rel->column_count.  (exec_plan_gen.c only tests
+ * the relation's PHYSICAL width.  (exec_plan_gen.c only tests
  * fact_data != NULL; it never reads the contents.)  Nothing reconciled the
  * two, so a mismatch produced, depending on direction:
  *
@@ -734,7 +734,30 @@ atom_physical_column_count(const wl_parser_ast_node_t *atom,
  * because column_count is 0; that is a separate defect and is deliberately
  * left unchanged here.  The guard keys off has_decl rather than
  * `column_count > 0` because `.decl p()` parses and leaves column_count
- * == 0, and those relations must be checked, not skipped. */
+ * == 0, and those relations must be checked, not skipped.
+ *
+ * PHYSICAL width, not logical (#985).  A fact is a row of the relation's
+ * storage, so its argument count is a stride, and the stride an `inline`
+ * compound column contributes is its full arity.  This used to compare
+ * against the logical rel->column_count, on the reasoning that the readers
+ * strided by column_count too -- but that was the defect, not a constraint:
+ * both readers now stride physically, and while they did not, the accepted
+ * `pred(1, 99).` against `.decl pred(id: int64, payload: f/2 inline)` left
+ * the second inline slot never written, and a body pattern that
+ * destructures the column read it regardless.
+ * `outr(id, p, q) :- pred(id, f(p, q)).` evaluated to outr(1, 99, 0) with
+ * exit 0 and ASAN silent -- a fabricated value in no source data.
+ *
+ * Nothing is taken away by tightening.  The flat spelling `pred(1,10,20).`
+ * is the redirect, and it is the *only* spelling that ever worked: the fact
+ * grammar admits integer and string constants only, so `pred(1, f(10,20)).`
+ * and `pred(1, [10,20]).` are parse errors, and the head grammar likewise
+ * has no compound-term production.  Before this change the flat spelling was
+ * rejected and the broken one accepted, which is to say the relation had no
+ * working fact syntax at all.  Rejecting a wrong-width fact rather than
+ * zero-filling is forced: 0 is a valid int64 and a valid intern id, so there
+ * is no value that could stand for "not written", and the rule-head
+ * analogue is already rejected by validate_head_arities() below. */
 static int
 validate_fact_arities(const struct wirelog_program *program,
     const wl_parser_ast_node_t *ast)
@@ -755,58 +778,26 @@ validate_fact_arities(const struct wirelog_program *program,
         if (!rel || !rel->has_decl)
             continue;
 
-        if (node->child_count != rel->column_count) {
-            WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
-                "fact for relation '%s' has %u argument(s) but '%s' is"
-                " declared with %u column(s) (line %u)",
-                rel->name, node->child_count, rel->name, rel->column_count,
-                node->line);
+        uint32_t declared = wl_ir_relation_physical_width(rel);
+        if (node->child_count != declared) {
+            if (declared != rel->column_count)
+                WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                    "fact for relation '%s' has %u argument(s) but '%s'"
+                    " occupies %u column(s) (%u declared, inline compound"
+                    " column(s) expanded to their slots) (line %u)",
+                    rel->name, node->child_count, rel->name, declared,
+                    rel->column_count, node->line);
+            else
+                WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                    "fact for relation '%s' has %u argument(s) but '%s' is"
+                    " declared with %u column(s) (line %u)",
+                    rel->name, node->child_count, rel->name, declared,
+                    node->line);
             return -1;
         }
     }
 
     return 0;
-}
-
-/* The number of PHYSICAL columns a relation's `.decl` describes.
- *
- * An `inline` compound column is stored as `compound_arity` contiguous
- * physical slots; a `side` compound is a single handle slot, and so is every
- * scalar.  This is the same walk collect_decl() runs to assign
- * compound_inline_col_offset -- for every declaration the parser can
- * produce, the prefix sum there ends at exactly this value -- and the same
- * layout col_rel_t records in compound_arity_map.
- *
- * The INLINE arm deliberately adds compound_arity unguarded, mirroring
- * collect_decl() exactly rather than defending against a zero arity.  A
- * guard such as `compound_arity > 0 ? compound_arity : 1` would look safer
- * but is the opposite: it is the only construct that could make the two
- * walks disagree (1 here against 0 there), turning an invariant violation
- * into a silent width mismatch instead of an obvious one.
- *
- * The invariant holds regardless: parse_compound_metadata() resets the whole
- * metadata struct -- kind included -- on every failure path, returning
- * kind = NONE for a non-positive arity and for an inline arity above
- * WL_IR_COMPOUND_INLINE_MAX_ARITY, and program.c's collect_decl() is the
- * only writer of columns[].compound_kind.  So INLINE implies
- * 1 <= compound_arity <= WL_IR_COMPOUND_INLINE_MAX_ARITY. */
-static uint32_t
-declared_physical_column_count(const wl_ir_relation_info_t *rel)
-{
-    uint32_t phys = 0;
-
-    if (!rel)
-        return 0;
-    if (!rel->columns)
-        return rel->column_count;
-
-    for (uint32_t i = 0; i < rel->column_count; i++) {
-        const wirelog_column_t *col = &rel->columns[i];
-        phys += (col->compound_kind == WIRELOG_COMPOUND_KIND_INLINE)
-            ? col->compound_arity
-            : 1u;
-    }
-    return phys;
 }
 
 /* Issue #977: validate every rule head against its relation's declared
@@ -839,14 +830,14 @@ declared_physical_column_count(const wl_ir_relation_info_t *rel)
  * against `.decl t/2`.
  *
  * PHYSICAL width, not logical -- this is the one thing that must not be
- * "simplified".  Unit 2 compares facts LOGICALLY, and deliberately so:
- * collect_fact() packs one slot per written argument and both readers
- * (wl_session_load_facts, wirelog_program_get_facts) stride by the logical
- * rel->column_count.  A rule head is the opposite.  The head grammar has no
- * compound-term production at all -- parse_head_arg() (parser/parser.c)
- * dispatches only to aggregate and arithmetic expressions, so
- * `pred(x, f(y, z))` is a parse error -- which leaves the flattened spelling
- * as the only way to write an inline-compound relation from a rule:
+ * "simplified".  Since #985 the fact pass above measures physically too, so
+ * the two agree; before it the fact pass compared logically and this comment
+ * had to argue the divergence was intentional.  It was not a divergence
+ * worth keeping: the head grammar has no compound-term production at all --
+ * parse_head_arg() (parser/parser.c) dispatches only to aggregate and
+ * arithmetic expressions, so `pred(x, f(y, z))` is a parse error -- which
+ * leaves the flattened spelling as the only way to write an inline-compound
+ * relation from a rule:
  *
  *   .decl pred(id: int64, payload: f/2 inline)
  *   pred(x, y, z) :- src(x, y, z).              -> pred(1, 10, 20)
@@ -864,14 +855,13 @@ declared_physical_column_count(const wl_ir_relation_info_t *rel)
  * compound support, instead of two that can drift apart.
  *
  * The two-argument handle form -- `pred(x, y)` against the same .decl -- is
- * rejected, even though the corresponding *fact* `pred(1, 99).` is accepted
- * by the logical fact rule.  The asymmetry is deliberate: the head leaves
- * the second inline slot never written, and a body pattern that destructures
- * the column reads it regardless, so
- * `outr(id, p, q) :- pred(id, f(p, q)).` evaluated to outr(1, 99, 0) with
- * exit 0 and ASAN silent -- a fabricated value, the failure mode this issue
- * exists to remove.  The three-argument spelling of the same program yields
- * outr(1, 10, 20), which is correct.
+ * rejected, and since #985 so is the corresponding *fact* `pred(1, 99).`.
+ * The reason is the same for both: the handle form leaves the second inline
+ * slot never written, and a body pattern that destructures the column reads
+ * it regardless, so `outr(id, p, q) :- pred(id, f(p, q)).` evaluated to
+ * outr(1, 99, 0) with exit 0 and ASAN silent -- a fabricated value, the
+ * failure mode this issue exists to remove.  The three-argument spelling of
+ * the same program yields outr(1, 10, 20), which is correct.
  *
  * Aggregate heads need no special case.  parse_aggregate_expr() has exactly
  * one caller, parse_head_arg(), so an AGGREGATE node is always a direct
@@ -904,12 +894,20 @@ validate_head_arities(const struct wirelog_program *program,
             continue;
 
         uint32_t emitted = atom_physical_column_count(head, rel, program);
-        uint32_t declared = declared_physical_column_count(rel);
+        uint32_t declared = wl_ir_relation_physical_width(rel);
         if (emitted != declared) {
-            WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
-                "rule head for relation '%s' emits %u column(s) but '%s' is"
-                " declared with %u column(s) (line %u)",
-                rel->name, emitted, rel->name, declared, head->line);
+            if (declared != rel->column_count)
+                WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                    "rule head for relation '%s' emits %u column(s) but '%s'"
+                    " occupies %u column(s) (%u declared, inline compound"
+                    " column(s) expanded to their slots) (line %u)",
+                    rel->name, emitted, rel->name, declared,
+                    rel->column_count, head->line);
+            else
+                WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                    "rule head for relation '%s' emits %u column(s) but '%s'"
+                    " is declared with %u column(s) (line %u)",
+                    rel->name, emitted, rel->name, declared, head->line);
             return -1;
         }
     }

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -64,6 +64,77 @@ typedef struct {
     uint32_t graph_column_index;  /* valid only when has_graph_column == true */
 } wl_ir_relation_info_t;
 
+/* The number of PHYSICAL columns a relation's `.decl` describes -- the row
+ * stride of every buffer that stores or transports its tuples.
+ *
+ * An `inline` compound column is stored as `compound_arity` contiguous
+ * physical slots; a `side` compound is a single handle slot, and so is every
+ * scalar.  This is the same walk collect_decl() (ir/program.c) runs to assign
+ * compound_inline_col_offset -- for every declaration the parser can
+ * produce, the prefix sum there ends at exactly this value -- and the same
+ * layout col_rel_t records in compound_arity_map.
+ *
+ * Physical width is authoritative for every storage question: fact-buffer
+ * and `.input` row strides, the `num_cols` a reader is handed, the width a
+ * relation is materialised at.  The *logical* column_count stays
+ * authoritative for every declaration question: columns[], wirelog_schema_t,
+ * wirelog_program_get_schema().  Issue #985 is what happened while the two
+ * were confused for each other.
+ *
+ * Derived on demand rather than stored, because column_count has more than
+ * one writer -- collect_decl(), which is re-entrant for a repeated `.decl`
+ * (#724), and wl_ir_program_add_magic_relation(), which calloc()s columns[]
+ * and never runs the offset loop at all.  A cached field would have to be
+ * refreshed by both; a derivation cannot go stale.  The calloc'd case is
+ * exact rather than merely safe: WIRELOG_COMPOUND_KIND_NONE is 0, so every
+ * zeroed column contributes 1 and the sum is column_count.
+ *
+ * The `!rel->columns` early return is unreachable for a nonzero
+ * column_count and is not covered by a test on purpose -- there is no
+ * observable behaviour to pin.  Both writers named above allocate
+ * columns[] before assigning column_count and bail out on allocation
+ * failure without assigning it, so `column_count > 0 && columns == NULL`
+ * cannot be constructed; the branch exists so that the zero case reads as
+ * a deliberate 0 rather than as a loop that happens not to run.  A mutant
+ * that changes it to `return 0` is an equivalent mutant, not a coverage
+ * gap.
+ *
+ * The INLINE arm deliberately adds compound_arity unguarded, mirroring
+ * collect_decl() exactly rather than defending against a zero arity.  A
+ * guard such as `compound_arity > 0 ? compound_arity : 1` would look safer
+ * but is the opposite: it is the only construct that could make the two
+ * walks disagree (1 here against 0 there), turning an invariant violation
+ * into a silent width mismatch instead of an obvious one.
+ *
+ * The invariant holds regardless: parse_compound_metadata() resets the whole
+ * metadata struct -- kind included -- on every failure path, returning
+ * kind = NONE for a non-positive arity and for an inline arity above
+ * WL_IR_COMPOUND_INLINE_MAX_ARITY, and program.c's collect_decl() is the
+ * only writer of columns[].compound_kind.  So INLINE implies
+ * 1 <= compound_arity <= WL_IR_COMPOUND_INLINE_MAX_ARITY.
+ *
+ * static inline in the header rather than a function in program.c because
+ * tests/test_io_ctx links only io/io_ctx.c plus intern, and
+ * io/io_ctx_internal.h already includes this header. */
+static inline uint32_t
+wl_ir_relation_physical_width(const wl_ir_relation_info_t *rel)
+{
+    uint32_t phys = 0;
+
+    if (!rel)
+        return 0;
+    if (!rel->columns)
+        return rel->column_count;
+
+    for (uint32_t i = 0; i < rel->column_count; i++) {
+        const wirelog_column_t *col = &rel->columns[i];
+        phys += (col->compound_kind == WIRELOG_COMPOUND_KIND_INLINE)
+            ? col->compound_arity
+            : 1u;
+    }
+    return phys;
+}
+
 /* ======================================================================== */
 /* Rule IR                                                                  */
 /* ======================================================================== */

--- a/wirelog/session_facts.c
+++ b/wirelog/session_facts.c
@@ -34,8 +34,13 @@ wl_session_load_facts(wl_session_t *sess, const struct wirelog_program *prog)
         if (!rel->name || rel->fact_count == 0 || !rel->fact_data)
             continue;
 
+        /* Physical width, not rel->column_count (#985): fact_data is packed
+         * one slot per written argument, and validate_fact_arities() has
+         * already required that count to be the physical width.  An inline
+         * compound column occupies compound_arity slots, so the logical
+         * count would insert at a shorter stride than the buffer holds. */
         int rc = wl_session_insert(sess, rel->name, rel->fact_data,
-                rel->fact_count, rel->column_count);
+                rel->fact_count, wl_ir_relation_physical_width(rel));
         if (rc != 0) {
             fprintf(stderr, "error: failed to load facts for '%s'\n",
                 rel->name);
@@ -111,8 +116,12 @@ wl_session_load_input_files(wl_session_t *sess,
         }
 
         if (nrows > 0 && data) {
+            /* Physical width, matching wirelog_io_ctx_num_cols() (#985):
+             * the adapter contract sizes this buffer at
+             * nrows * wirelog_io_ctx_num_cols(ctx), and io_ctx.c sets that
+             * from the physical width. */
             rc = wl_session_insert(sess, rel->name, data, nrows,
-                    rel->column_count);
+                    wl_ir_relation_physical_width(rel));
             free(data);
             if (rc != 0) {
                 fprintf(stderr,

--- a/wirelog/wirelog-easy.c
+++ b/wirelog/wirelog-easy.c
@@ -377,7 +377,23 @@ wirelog_easy_print_delta(const char *relation, const int64_t *row,
      * warrant to treat an integer id as a pointer into the intern table.
      * In the schema-unavailable branch, default to integer rendering so a
      * synthetic delta call (or a schema-less relation) does not trip the
-     * abort. */
+     * abort.
+     *
+     * The ncols equality is a *logical* schema against a *physical* row
+     * width.  The two agree for every relation that declares no `inline`
+     * compound column; where one is declared they can differ, and then the
+     * equality fails: `.decl pred(id: int64, payload: f/2 inline)` reports
+     * column_count 2 while the row carries 3 slots (#985).  (An `inline`
+     * compound of arity 1 is one declared column and one slot, so the
+     * equality still holds there -- an inline compound column is necessary
+     * for the mismatch, not sufficient.)  A relation whose widths do differ
+     * therefore always renders as raw integers here, including any genuine
+     * `symbol` column beside the compound.  That is the safe direction of
+     * the degradation -- no abort, no id misread as a pointer -- and it is
+     * left deliberate rather than accidental: rendering per column would
+     * need the logical-to-physical slot map, which this printer does not
+     * have.  Not to be "fixed" by comparing against a physical width; that
+     * would index schema->columns[] physically, which is wrong. */
     const wirelog_schema_t *schema
         = wirelog_program_get_schema(s->prog, relation);
     bool have_schema = (schema != NULL && schema->columns != NULL

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -186,11 +186,22 @@ wirelog_program_get_intern(const wirelog_program_t *prog);
  * Returns a flat row-major int64_t array of all facts declared for
  * the given relation.  Caller must free the returned array.
  *
+ * @p num_cols is the PHYSICAL row stride of @p data -- the number of
+ * int64_t slots each tuple occupies -- and it is what you must index by.
+ * It is not necessarily the declared column count reported by
+ * wirelog_program_get_schema(): a column declared as an `inline` compound
+ * (`.decl pred(id: int64, payload: f/2 inline)`) is one schema column but
+ * occupies its full arity of consecutive slots here, so that relation
+ * reports column_count 2 and num_cols 3.  The two agree for every relation
+ * that declares no inline compound column.  The signature is unchanged and
+ * no ABI break is involved, but this is a semantic change for an embedder
+ * that had treated the two as interchangeable: index by @p num_cols (#985).
+ *
  * @param prog       Compiled program
  * @param relation   Relation name (e.g., "edge")
  * @param data       Output: allocated array of int64_t values (caller frees)
  * @param num_rows   Output: number of fact tuples
- * @param num_cols   Output: number of columns per tuple
+ * @param num_cols   Output: physical slots per tuple (the row stride)
  * @return 0 on success, -1 on error (unknown relation), 1 if no facts
  */
 WIRELOG_API int


### PR DESCRIPTION
Closes #985.

An `inline` compound column gives a relation **two widths**. `.decl pred(id: int64, payload: f/2 inline)` declares 2 columns and occupies 3 int64 slots. Nothing agreed which was authoritative, so the answer depended on which producer materialised the relation first:

```
src(1,10,20). pred(7,99). pred(x,y,z) :- src(x,y,z).
    -> pred(7, 99), pred(1, 10)      the 20 is gone

pred(1,99).  outr(id,p,q) :- pred(id, f(p,q)).
    -> outr(1, 99, 0)                the 0 is in no source data
```

Both exit 0, no diagnostic.

## Why tightening is safe: there was no working fact syntax at all

| spelling | before |
|---|---|
| `pred(1,99).` | accepted, then fabricates |
| `pred(1,10,20).` | **rejected** |
| `pred(1, f(10,20)).` | parse error |
| `pred(x, f(y,z)) :- ...` | parse error, in heads too |

The only spelling the checker accepted was the broken one. So this **removes no expressiveness** — it redirects to a spelling that already parses and already evaluates correctly once the width agrees. Same for `.input`: a correctly-shaped CSV was refused, an under-shaped one loaded and fabricated.

## The fix

Physical width authoritative for storage/stride; logical stays authoritative for declaration — `columns[]`, `wirelog_schema_t`, `wirelog_program_get_schema` unchanged.

`wl_ir_relation_physical_width()` is **derived, not stored**: `column_count` has more than one writer, including `wl_ir_program_add_magic_relation` (which `calloc`s columns and never runs `collect_decl`'s offset walk), and `collect_decl` is re-entrant. A derivation can't go stale. `static inline` in the header because `test_io_ctx` links `io_ctx.c` without `ir/program.c`.

Review found the unguarded `+= compound_arity` is safe for a **stronger** reason than its comment gave: `INLINE` with arity outside 1..4 is a *parse error*, so it never reaches `collect_decl`.

## Deliberately NOT done: `passes/magic_sets.c`

Making `get_arity()` physical looks like the same fix and is a **live regression**. While #989 leaves bound `.query` pruning everything, the arity-mismatch warning is what currently *rescues* an inline-compound relation onto the skip path:

| | base | with that change |
|---|---|---|
| inline `.decl` + `.query pred(b,f,f)` | warning + `pred(1, 10, 20)` | **silence, zero rows** |

Confirmed by experiment on a clean tree, twice, independently. The `.query` door stays open, blocked on #989.

## Evidence

- **Differential fuzz vs an independent oracle, 57,691 declaration shapes** (multiple inline compounds, inline-then-symbol, arities at and past the bounds, side/inline mixed, magic relations, re-entrant `.decl`, zero-arity): **0 mismatches here, 15,122 on base.**
- **All 32 `.dl` files in the tree: byte-identical output.** This is a no-op wherever no inline compound is declared.
- ASAN+UBSAN+LSAN clean; no measurable cost (every call site is per-relation, none per-row).

## Coverage was thinner than it looked

Reverting `wirelog_program_get_facts`, `wirelog_load_facts_from_csv`, and its type expansion each left the **whole suite green** — including the change this PR leads with. Each now fails a named test.

Tests assert **values, not row counts**: the truncating answer has the same cardinality as the correct one, so a count assertion passes on the bug. The `.input` case is a wrong-answer test rather than an error-message test — at logical 3 / physical 4 with a trailing `symbol`, base *accepts* the file and prints the interned functor name as the symbol.

Two cases cannot fail on base and are kept deliberately as anti-mutation pins (a `side` compound stays one column; a compound-free relation's width is unchanged end to end).

## Public contracts

Two change meaning without changing signature, both documented in the header, CHANGELOG `### Changed`, and `docs/io-adapters.md`: `wirelog_program_get_facts`'s `num_cols`, and the adapter pair `wirelog_io_ctx_num_cols` / `wirelog_io_ctx_col_type`.

Also corrects the **#977 CHANGELOG entry**, which said the flat spelling is rejected — true of #977, superseded here. The *existence* of a fact arity check is #977; the width it compares against is this.

## Validation

271 ok / 1 fail / 11 skipped, release and ASAN+UBSAN — the failure is the pre-existing `sbom_snapshot` pin drift. `abi` 33/33 including the live `changelog_format` gate. uncrustify clean on all 16 changed files, on base and after. gcc + clang `-Wall -Wextra -Wconversion -Wshadow -Wpedantic`: warning counts byte-identical to base.