### PR TITLE
fix(columnar): unwind session_add_rel's pool promotion on OOM, and clear session.c's tidy backlog

### DIFF
--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -162,7 +162,8 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
         for (uint32_t c = 0; c < r->ncols; c++)
             memcpy(heap_cols[c], r->columns[c],
                 sizeof(int64_t) * r->capacity);
-        free(r->columns); /* free old columns array (arena owns buffers) */
+        /* free old columns array (arena owns buffers) */
+        free((void *)r->columns);
         r->columns = heap_cols;
         r->arena_owned = false;
     }
@@ -191,8 +192,8 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
 
     if (sess->nrels >= sess->rel_cap) {
         uint32_t nc = sess->rel_cap ? sess->rel_cap * 2 : 16;
-        col_rel_t **nr
-            = (col_rel_t **)realloc(sess->rels, sizeof(col_rel_t *) * nc);
+        col_rel_t **nr = (col_rel_t **)realloc(
+            (void *)sess->rels, sizeof(col_rel_t *) * nc);
         if (!nr)
             return ENOMEM;
         sess->rels = nr;
@@ -964,7 +965,8 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
                  * narrow-join workloads that dominate the v0.43 portfolio. */
                 sess->join_output_limit = (phys / 4) / 24ULL;
             } else {
-                sess->join_output_limit = COL_JOIN_OUTPUT_LIMIT_DEFAULT;
+                sess->join_output_limit
+                    = (uint64_t)COL_JOIN_OUTPUT_LIMIT_DEFAULT;
             }
         }
         /* Clamp to UINT32_MAX since nrows is uint32_t */
@@ -988,7 +990,7 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
      * Slab: 256 relations (cover ~20 rules x 5 ops + headroom)
      * Arena: 64MB initial (for row data buffers) */
     sess->delta_pool
-        = delta_pool_create(256, sizeof(col_rel_t), 64 * 1024 * 1024);
+        = delta_pool_create(256, sizeof(col_rel_t), 64UL * 1024 * 1024);
     if (!sess->delta_pool) {
         /* Non-fatal: pool allocation failed, fall back to malloc */
     }
@@ -998,7 +1000,7 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
      * (COL_REL_INIT_CAP * ncols * sizeof(int64_t) per operator).
      * Reset at each iteration boundary alongside delta_pool_reset.
      * NULL arena is handled gracefully: operators fall back to malloc. */
-    sess->eval_arena = wl_arena_create(64 * 1024 * 1024);
+    sess->eval_arena = wl_arena_create(64UL * 1024 * 1024);
     /* Non-fatal if NULL: col_rel_pool_new_auto falls back to malloc */
 
     /* Issue #224: Initialize memory accounting ledger.
@@ -1211,7 +1213,7 @@ oom:
         col_rel_free_contents(sess->rels[i]);
         free(sess->rels[i]);
     }
-    free(sess->rels);
+    free((void *)sess->rels);
     wl_workqueue_destroy(sess->wq);       /* NULL-safe */
     delta_pool_destroy(sess->delta_pool); /* NULL-safe */
     wl_compound_arena_free(sess->compound_arena); /* NULL-safe (Issue #559) */
@@ -1243,7 +1245,7 @@ col_session_destroy(wl_session_t *session)
         col_rel_free_contents(sess->rels[i]);
         free(sess->rels[i]);
     }
-    free(sess->rels);
+    free((void *)sess->rels);
     /* Free relation name hash table (Issue #281) */
     session_rel_free_hash(sess);
     col_mat_cache_clear(&sess->mat_cache);
@@ -1280,10 +1282,10 @@ col_session_destroy(wl_session_t *session)
             if (sess->exchange_bufs[src]) {
                 for (uint32_t dst = 0; dst < sess->exchange_num_workers; dst++)
                     col_rel_destroy(sess->exchange_bufs[src][dst]);
-                free(sess->exchange_bufs[src]);
+                free((void *)sess->exchange_bufs[src]);
             }
         }
-        free(sess->exchange_bufs);
+        free((void *)sess->exchange_bufs);
     }
     /* Issue #317: Free per-worker frontier progress tracker.
      * Worker sessions have progress.entries == NULL (set in col_worker_session_create)
@@ -1541,7 +1543,7 @@ col_worker_session_destroy(wl_col_session_t *worker)
             free(worker->rels[i]);
         }
     }
-    free(worker->rels);
+    free((void *)worker->rels);
 
     /* Free hash table (may have been lazily built) */
     session_rel_free_hash(worker);
@@ -2547,12 +2549,12 @@ col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
                 }
             }
             free(tdd_counts);
-            free(tdd_saved);
+            free((void *)tdd_saved);
         }
         if (pre_saved) {
             for (uint32_t ri = 0; ri < cnrels; ri++)
                 col_rel_destroy(pre_saved[ri]);
-            free(pre_saved);
+            free((void *)pre_saved);
         }
 
         if (rc != 0) {

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -142,6 +142,7 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
 {
     /* Pool-owned structs must be promoted to heap before storing in the
      * session, because col_session_destroy calls free() on each entry. */
+    col_rel_t *pool_src = NULL;
     if (r->pool_owned) {
         col_rel_t *heap = (col_rel_t *)calloc(1, sizeof(col_rel_t));
         if (!heap)
@@ -150,6 +151,7 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
         heap->pool_owned = false;
         /* Zero out source slot so pool_reset doesn't double-free contents */
         memset(r, 0, sizeof(*r));
+        pool_src = r;
         r = heap;
     }
     /* Arena-owned data must be promoted to heap before storing in the
@@ -158,7 +160,7 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
         /* Promote arena columns to heap: per-column malloc + memcpy */
         int64_t **heap_cols = col_columns_alloc(r->ncols, r->capacity);
         if (!heap_cols)
-            return ENOMEM;
+            goto oom;
         for (uint32_t c = 0; c < r->ncols; c++)
             memcpy(heap_cols[c], r->columns[c],
                 sizeof(int64_t) * r->capacity);
@@ -195,7 +197,7 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
         col_rel_t **nr = (col_rel_t **)realloc(
             (void *)sess->rels, sizeof(col_rel_t *) * nc);
         if (!nr)
-            return ENOMEM;
+            goto oom;
         sess->rels = nr;
         sess->rel_cap = nc;
     }
@@ -212,6 +214,24 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
      * session_find_rel. Continue adding relation. */
 
     return 0;
+
+oom:
+    /* Undo the pool-to-heap promotion.  A failed session_add_rel leaves the
+     * relation with the caller, which destroys it via col_rel_destroy(), so
+     * the promoted copy has to go back into the pool slot before returning.
+     * Without this the copy -- and the name, col_names[] and compound
+     * metadata it is now the only pointer to -- leaks, and the caller's
+     * col_rel_destroy() sees the zeroed slot with pool_owned cleared by the
+     * memset above and calls free() on an interior pointer into the
+     * delta_pool slab.  Both promotions run on relations from
+     * col_rel_pool_new_auto(), which sets pool_owned and arena_owned
+     * together. */
+    if (pool_src) {
+        *pool_src = *r;
+        pool_src->pool_owned = true;
+        free(r);
+    }
+    return ENOMEM;
 }
 
 void


### PR DESCRIPTION
Closes #1041. Unblocks #1031.

Two commits, deliberately separate — one behaviour-neutral, one a correctness fix.

## The defect: heap corruption, not a leak

`session_add_rel()` promotes a pool-owned `col_rel_t` to the heap so the session can outlive the delta pool. It copies the struct, clears `pool_owned` on the copy, **`memset`s the pool slot** — and then two allocation failures `return ENOMEM` with the promotion half-done.

The caller's contract is that it still owns the relation on failure, and every checking caller calls `col_rel_destroy(r)`. But the `memset` cleared `pool_owned`, so `col_rel_destroy` takes the heap branch and calls **`free()` on `pool->slab + n * slot_size`** — an interior pointer into the delta-pool slab.

The leak — the copy plus `name`, `col_names[]` and its strdups, and the compound metadata it is now the sole pointer to — is the *lesser* half.

**Not a cold-path curiosity in the sense that matters.** `col_rel_pool_new_auto()` sets `pool_owned` and `arena_owned` together and its results reach this function on the main evaluation path, so the promotion branch runs on **every sub-pass of semi-naive evaluation**. Only the failing allocation is cold.

Both returns now go to one `oom:` label that moves the copy back into the pool slot, restores `pool_owned`, and frees the copy.

## No regression test, and that is a gap rather than an omission

Both failing allocations are `calloc`/`realloc` inside libc, so a test needs malloc fault injection — and the tree has **no** `LD_PRELOAD` interposer, `__wrap_malloc` link trick, or allocator hook. Tracked separately. Several allocation-failure unwinds in recent work could only be checked by hand-patching a failure in and rebuilding, which is not a gate.

Audited instruction by instruction instead: per-function assembly comparison shows `session_add_rel` carrying exactly the intended additions — the saved pool pointer, the conditional copy-back of `sizeof(col_rel_t)`, the `pool_owned` store at its measured offset, and the free — plus register reallocation forced by the new live value. No other function changed except `__LINE__` immediates.

## How it was found

By clang-tidy, in a gate that was documented as hard but whose file regex matched nothing, so it had **never analysed a single file** (#1017). Repaired recently; this is the first real defect it has reported.

It sees only **half** the bug — it flags the `col_columns_alloc` failure and not the `realloc` failure a few lines later, which leaks identically. That is why the warning is *not* suppressed: every `NOLINT` in this codebase marks a false positive with an argument for infeasibility, and a suppression here would delete the only automated signal for a two-armed defect.

## Commit 1: the tidy backlog

`session.c` had **13** warnings, blocking #1031 whose own diff is nowhere near them.

| count | check | disposition |
|---|---|---|
| 9 | `bugprone-multi-level-implicit-pointer-conversion` | explicit `(void *)`, following `cb0eb32` |
| 3 | `bugprone-implicit-widening-of-multiplication-result` | all operands compile-time constants well inside their type (50e6, 64 MiB) — no `uint32_t` product can already have overflowed |
| 1 | `clang-analyzer-unix.Malloc` | the real defect — commit 2 |

Two of the widening fixes are spelled `64UL * 1024 * 1024`, matching the `8UL * 1024 * 1024` already in this file. The third multiplies inside `COL_JOIN_OUTPUT_LIMIT_DEFAULT` in `columnar/internal.h` and is cast at the use site to keep that commit inside one file; fixing the macro (`50ull`) is the better shape and is left for a change that already touches that header.

Commit 1 alone is **not** gate-clean — it deliberately leaves the true positive standing. CI evaluates the PR head tree, not intermediate commits, so this is green at head while keeping the two changes independently reviewable and revertable.

**Behaviour neutrality of commit 1 established by assembly diff**, not inspection: 12 differing lines, all `__LINE__` immediates shifted by two wrapped lines; per-function comparison shows only `col_session_create` and `col_session_destroy` differ, and `session_add_rel` is byte-identical to base.

## Validation

clang-tidy on `session.c`: **13 → 0**, verified across all 17 distinct (flags × include-path) configurations. `meson test` release and ASAN+UBSAN: 271 ok / 1 fail / 11 skipped, matching base — the failure is the pre-existing `sbom_snapshot` pin drift. gcc + clang `-Wall -Wextra -Wconversion -Wshadow -Wpedantic`: 34 warnings each on base and after, byte-identical after stripping line/column. uncrustify clean, base and after.

## Noted, not fixed

`session.c` calls `session_add_rel(sess, delta)` in one place and discards the return value, leaking `delta` on ENOMEM. That relation comes from `col_rel_new_auto`, so `pool_owned` is false and the corruption above does not apply — a plain leak. clang-tidy does not flag it.