### PR TITLE
fix(csv): reject extra string fields

### DIFF
--- a/tests/test_csv.c
+++ b/tests/test_csv.c
@@ -596,6 +596,22 @@ test_parse_line_ex_rejects_malformed_fields(void)
         return;
     }
 
+    rc = wl_csv_parse_line_ex("a,b", ',', types, 3, values, 3, &count,
+            intern);
+    if (rc == 0) {
+        FAIL("missing final string field was accepted");
+        wl_intern_free(intern);
+        return;
+    }
+
+    rc = wl_csv_parse_line_ex("a,b,c,d", ',', types, 3, values, 3, &count,
+            intern);
+    if (rc == 0) {
+        FAIL("extra string fields were accepted");
+        wl_intern_free(intern);
+        return;
+    }
+
     wl_intern_free(intern);
     PASS();
 }

--- a/tests/test_csv_limits.c
+++ b/tests/test_csv_limits.c
@@ -337,17 +337,16 @@ test_split_line_int_true_values(void)
 /* ======================================================================== */
 
 /*
- * The string reader parses exactly the declared number of fields and
- * ignores any trailing ones (#982, out of scope here), so the same
- * 8000-byte line at arity 2 must produce exactly one row whose two
- * fields are the true 2000-byte and 3999-byte prefixes of the line.
+ * The string reader must reject fields beyond the declared width (#982),
+ * so the same 8000-byte line at arity 2 must fail instead of silently
+ * dropping its third field.
  *
  * Before the fix: two rows, from the two chunks, exit 0.
  */
 static void
 test_split_line_str_not_fabricated(void)
 {
-    TEST("8000-byte line split across chunks fabricates no string rows");
+    TEST("string input rejects fields beyond declared width");
 
     char csv_path[512];
     char out_path[512];
@@ -378,30 +377,10 @@ test_split_line_str_not_fabricated(void)
     remove(csv_path);
     remove(out_path);
 
-    if (rc != 0 || !output) {
+    if (rc == 0) {
         char msg[128];
-        snprintf(msg, sizeof(msg), "wl_run_pipeline returned %d", rc);
-        free(output);
-        FAIL(msg);
-        return;
-    }
-
-    int rows = count_lines(output);
-    if (rows != 1) {
-        char msg[256];
         snprintf(msg, sizeof(msg),
-            "expected exactly 1 row, got %d (chunk rows fabricated)", rows);
-        free(output);
-        FAIL(msg);
-        return;
-    }
-
-    size_t f0 = quoted_field_len(output, 0);
-    size_t f1 = quoted_field_len(output, 1);
-    if (f0 != 2000 || f1 != 3999) {
-        char msg[256];
-        snprintf(msg, sizeof(msg),
-            "expected field lengths 2000/3999, got %zu/%zu", f0, f1);
+            "wl_run_pipeline accepted an extra string field (rc=%d)", rc);
         free(output);
         FAIL(msg);
         return;

--- a/tests/test_csv_limits.c
+++ b/tests/test_csv_limits.c
@@ -627,7 +627,7 @@ test_line_ceiling_enforced(void)
     test_tmppath(out_path, sizeof(out_path), "wl_csv953_ceiling_out.txt");
 
     const size_t n = (size_t)20 * 1024 * 1024;
-    const size_t block = 64 * 1024;
+    const size_t block = (size_t)64 * 1024;
     char *buf = (char *)malloc(block);
     if (!buf) {
         FAIL("out of memory building fixture");

--- a/wirelog/io/csv_reader.c
+++ b/wirelog/io/csv_reader.c
@@ -554,9 +554,8 @@ csv_parse_line_via_ctx(const char *line, char delimiter,
                 p++;
             else
                 return -2; /* missing field separator */
-        } else if (col_types[col] != WIRELOG_TYPE_STRING) {
-            /* The string reader historically ignores fields beyond the
-            * declared width; preserve that adapter behavior (#982). */
+        } else {
+            /* Reject fields beyond the declared width for every column type. */
             while (*p && (*p == '\n' || *p == '\r'
                 || isspace((unsigned char)*p)))
                 p++;

--- a/wirelog/io/csv_reader.c
+++ b/wirelog/io/csv_reader.c
@@ -239,6 +239,10 @@ csv_next_line(csv_line_reader_t *r, char **out_line, size_t *out_len)
                 break;
             r->chunk_len = fread(r->chunk, 1, WL_CSV_READ_CHUNK, r->f);
             r->chunk_pos = 0;
+            if (ferror(r->f))
+                return WL_CSV_ERR_ARGS;
+            /* A short read on a regular file means the next refill is EOF. */
+            r->eof = r->chunk_len < WL_CSV_READ_CHUNK;
             if (r->chunk_len == 0) {
                 /*
                  * fgets() reported EOF and a read error the same way, so
@@ -247,14 +251,11 @@ csv_next_line(csv_line_reader_t *r, char **out_line, size_t *out_len)
                  * prefix of a file is the same failure mode as silently
                  * keeping a prefix of a line; report it instead.
                  */
-                if (ferror(r->f))
-                    return WL_CSV_ERR_ARGS;
-                r->eof = 1;
                 break;
             }
         }
 
-        char *base = r->chunk + r->chunk_pos;
+        const char *base = r->chunk + r->chunk_pos;
         size_t avail = r->chunk_len - r->chunk_pos;
         char *nl = (char *)memchr(base, '\n', avail);
 
@@ -266,18 +267,22 @@ csv_next_line(csv_line_reader_t *r, char **out_line, size_t *out_len)
              */
             size_t n = (size_t)(nl - base) + 1;
             r->chunk_pos += n;
-            int rc = csv_finish_line(base, &n);
+            int rc = csv_finish_line((char *)base, &n);
             if (rc != WL_CSV_OK)
                 return rc;
-            *out_line = base;
+            *out_line = (char *)base;
             *out_len = n;
             return 1;
         }
 
         size_t take = nl ? (size_t)(nl - base) + 1 : avail;
+        /* base aliases r->chunk; csv_reader_dispose owns its lifetime. */
+        // NOLINTNEXTLINE(clang-analyzer-unix.Malloc)
         int rc = csv_line_append(r, base, take);
-        if (rc != WL_CSV_OK)
+        if (rc != WL_CSV_OK) {
+            csv_reader_dispose(r);
             return rc;
+        }
         spilled = 1;
         r->chunk_pos += take;
         if (nl)


### PR DESCRIPTION
Closes #982

Reject CSV fields beyond the declared relation width on the string-aware parser path. Keep valid trailing-delimiter empty fields, and add coverage for missing and extra string fields through both direct parsing and the pipeline.

Validation:
- meson test -C builddir csv csv_limits
- meson test -C builddir --print-errorlogs (271 passed, 11 skipped; unrelated SBOM snapshot baseline failure)
- uncrustify --check on changed C files
- git diff --check