### PR TITLE
fix(magic_sets): do not guard a relation whose demand is never propagated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,78 @@ All notable changes to wirelog are documented in this file.
   physical today converts a warning plus correct output into silence plus
   zero rows. It is blocked on #989, not overlooked.
 
+- **Magic Sets no longer guards a relation it never generates a demand for**
+  (#1027): when an IDB body occurrence binds none of its columns, Phase 2 adds
+  no adorned predicate for that relation and Phase 4a generates no demand rule
+  -- but Phase 4b guarded its rules anyway. The relation was then restricted to
+  a demand relation nothing ever populates, while its own body needed it
+  unrestricted, so the recursion was cut. Left-recursive `p` under
+  `.query p(f, b)` over `e = {(1,2), (2,3), (3,4)}`, demand seeded at `y = 4`,
+  answered with one tuple against a six-tuple closure, losing two of the three
+  the query asked for. Measured identically with Logic Fusion on and off, and
+  with and without a filter on the rules, so this is not a #990 artifact.
+
+  A guard-viability closure now runs between Phase 2 and Phase 3. It is seeded
+  with every relation such an occurrence reads and closed under "R unguarded
+  implies every IDB R reads is unguarded" -- an unguarded relation is evaluated
+  in full, so a guarded child would cut its fixpoint one level down instead.
+  Every relation in the closure is dropped from the transformation entirely: no
+  magic relation, no demand rule (including demand rules that other, guarded
+  relations would otherwise key on it), no guard. Rules outside the closure are
+  guarded and pruned exactly as before. The correct fix is predicate splitting,
+  which this pass cannot do -- `insert_magic_guard` rewrites the rule root in
+  place, so one set of rules serves every adornment of a relation.
+
+  The Phase 2 event has its own statistic, `unrestrictable_relations`, instead
+  of sharing `skipped_all_free` with the unrelated Phase 1 event (a demand root
+  adorned all-free, which is a genuine no-op). Read it as "how much of the
+  program the pass declined to optimise in order to stay correct", not as "how
+  many answers were lost": it is seeded from a binding pattern, which does not
+  decide whether the occurrence contributes anything for the demand actually
+  seeded.
+
+  **The pruning this costs is not marginal.** Its dominant trigger is a rule
+  with a constant in the bound head position, `X(1, y) :- ...` under
+  `.query X(b, f)`: a constant yields no head variable, so Phase 2's bound set
+  starts empty, every IDB in that body binds nothing and seeds the closure, and
+  the transitive step unguards the subprogram below. Changing one character in
+  `X(a, b) :- p(a, b), q(a, b).` to `X(1, b) :- ...` takes the same program
+  from 4 adorned predicates and 4 guards to 2 and 1. Over a 342-program census
+  on which the pass is sound and query-complete both with and without the
+  closure, the unguarded oracle derives 1785 rows, the pass without the closure
+  820, and with it 1085; it derives more than before on 94 of the 342, roughly
+  one program in five. A separate sample found the constant-in-bound-head shape
+  in almost every program the closure made lossier -- that sample and the 342
+  census are different runs, so read the shape as the dominant trigger and the
+  94 as the rate, not as two views of one population.
+
+  Two shapes are out of the closure's reach and tracked separately: a relation
+  read under negation (#1047), which the walk never sees because it descends
+  only the positive child of an `ANTIJOIN`, and one defined by an aggregate
+  rule (#1048), which the walk now tests for and steps over -- Phase 2's
+  aggregate check guards only the seed site, and without the same check on the
+  transitive step the closure reached aggregate relations and everything below
+  them.
+
+  Neither is left unaffected, and for negation the change is a regression in
+  kind. The closure can leave `u` unguarded while a relation `u` reads under
+  negation stays guarded, and a guarded relation is a partial one. On
+  `u(x, y) :- u(x, z), e(z, y), !g(x, y).` with `g` guarded and seeded at
+  `x = 2` and `u` demanded free-bound, the pass without the closure guarded `u`
+  on an empty demand and derived 0 rows against a 3-row oracle -- lossy, but a
+  subset; with the closure `u` runs in full against a partially evaluated `g`
+  and derives 5 rows, two of which are not oracle answers at all. #1047's
+  defect was already present and already wrong there; it now presents as
+  unsound answers rather than as lost ones. Fixing it needs the walker #1047
+  tracks.
+
+  One new decline path: the closure walks rules of relations Phase 2 never
+  touched, so it is the first thing in the pass that can meet a rule with more
+  than `MS_MAX_ATOMS` body atoms in a subprogram the demand never reached.
+  Rather than fail -- which `api_facade.c` would report as
+  `WIRELOG_ERR_MEMORY`, failing `wirelog_optimize()` for a program that
+  optimized before -- the pass warns and leaves the program as written.
+
 - **Magic guards are built left-deep** (#989): `insert_magic_guard` produced
   `JOIN(magic_scan, body)`. When the body was itself composite -- a JOIN chain,
   an ANTIJOIN from a negated atom, a SIP-inserted SEMIJOIN -- that is a
@@ -204,13 +276,14 @@ All notable changes to wirelog are documented in this file.
   Two skip counters are added, kept apart because they mean different things.
   `skipped_constant_head` is a *policy* skip: the rule is well-formed and the
   pass declines. `skipped_unsupported_head` is a *capability* gap: the pass
-  reads head variables off a PROJECT root, and a rule fused to a FLATMAP root
-  -- Logic Fusion runs before Magic Sets in the shipping pipeline, and any rule
-  with a filter is a fusion candidate -- has no such root, so it was skipped in
-  total silence. That is the common way for a guard to go missing and the
-  headline shape of #990; teaching the pass to handle a fused head is separate
-  work, but the skip is now visible. Together these counters are the only
-  mechanism that can detect a guard silently not being inserted.
+  found no head variable names to key the guard on. The shape that used to
+  dominate it -- a rule fused to a `FLATMAP` root, which any rule with a filter
+  becomes, since Logic Fusion runs before Magic Sets -- no longer reaches it:
+  #990 made `get_head_vars` read the root's `project_exprs` rather than test
+  its node type, and fusion leaves `project_exprs` in place. What remains
+  reachable is a head wider than the 64-bit adornment mask. Together these
+  counters are the only mechanism that can detect a guard silently not being
+  inserted.
 - **`average()` is rejected instead of answering with an arbitrary row**
   (#978): `average()` was never implemented. `col_op_reduce` seeds each group
   with the group's first operand, and its update `switch` has arms for

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -420,11 +420,33 @@ result sizes for recursive programs.
 > will make it derive fewer tuples, not the same tuples faster. Leave `.query`
 > off, or use all-free adornments, until seeding lands.
 >
-> Seeding alone will not be enough. Issue #1027 tracks two further defects that
-> only become observable once the demand relation is populated: a rule can be
-> guarded on a demand no propagation rule ever generates, and two adornments of
-> one relation conjoin into a single rule body rather than forming separate
-> adorned predicates. Both lose answers.
+> **Not every relation is guarded.** Since Issue #1027 the pass excludes a
+> relation from the transformation altogether when some occurrence of it needs
+> to be read unrestricted -- when a rule body reads it without binding any of
+> its columns -- along with everything such a relation transitively reads. An
+> excluded relation is evaluated in full and yields its complete result, empty
+> demand relation or not. The same goes for a rule the pass declines to guard
+> for other reasons, such as a constant in the bound head position.
+>
+> So a bound `.query` splits the program in two: the part the pass left
+> unguarded still computes its full result, and the part it guarded computes
+> nothing. Only the second changes when seeding lands.
+>
+> **Do not read that as "the answer is either complete or empty."** Those two
+> parts interact, and where they do the output can be neither. If an unguarded
+> rule reads a *guarded* relation, it reads a partial relation and can derive
+> tuples the unoptimized program never derives -- under negation, because a
+> tuple missing from the guarded relation makes a `!` test pass that should
+> have failed (#1047); under aggregation, because the aggregate is computed
+> over a subset (#1048). A measured case derives 5 rows against a 3-row
+> oracle, 2 of which are not oracle answers. Until seeding lands, treat any
+> output from a program that mixes a bound `.query` with negation or
+> aggregation as unreliable rather than merely incomplete.
+>
+> Seeding alone will still not be enough. Issue #995 tracks a further defect
+> that becomes observable once the demand relation is populated: two
+> adornments of one relation conjoin into a single rule body rather than
+> forming separate adorned predicates, which loses answers.
 
 ### Syntax
 
@@ -460,6 +482,13 @@ As written, this program prints nothing. There is no way to say *which* source
 node is bound, so `$m$Path_bf` is never populated and both guards reject every
 tuple. Deleting the `.query` line prints the full closure. See the status note
 above and Issue #989.
+
+`Path` is guarded here because the recursive atom `Path(z, y)` binds `z`
+through `Edge(x, z)`. Written left-recursively instead --
+`Path(x, y) :- Path(x, z), Edge(z, y).` under `.query Path(f, b)` -- the
+recursive atom binds neither column, so the pass excludes `Path` from the
+transformation and that program prints the full closure rather than nothing.
+See the status note above and Issue #1027.
 
 Query with all arguments bound (point query):
 

--- a/tests/test_magic_sets.c
+++ b/tests/test_magic_sets.c
@@ -91,18 +91,33 @@ has_rule_for(const struct wirelog_program *prog, const char *head_name)
 /* Helper: parse a program with standard optimizer passes applied          */
 /* ======================================================================== */
 
+/*
+ * @fusion toggles Logic Fusion; the rest of the pipeline is fixed.
+ *
+ * Fusion is the one pass that rewrites a rule root in place, so it is also the
+ * one that has historically changed which shapes Magic Sets can read (#990).
+ * A case that runs both ways and agrees is evidence the behaviour under test
+ * is not a fusion artifact (#1027).
+ */
 static struct wirelog_program *
-parse_and_optimize(const char *src)
+parse_and_optimize_ex(const char *src, bool fusion)
 {
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
     if (!prog)
         return NULL;
     wl_subsumption_apply(prog, NULL);
-    wl_fusion_apply(prog, NULL);
+    if (fusion)
+        wl_fusion_apply(prog, NULL);
     wl_jpp_apply(prog, NULL);
     wl_sip_apply(prog, NULL);
     return prog;
+}
+
+static struct wirelog_program *
+parse_and_optimize(const char *src)
+{
+    return parse_and_optimize_ex(src, true);
 }
 
 /* ======================================================================== */
@@ -314,6 +329,144 @@ ms_evaluate(struct wirelog_program *prog, const char *out_rel,
         wl_session_destroy(session);
     wl_plan_free(plan);
     return rc == 0 && !out->overflow;
+}
+
+/* ======================================================================== */
+/* Helpers: oracle comparison (Issue #1027)                                */
+/* ======================================================================== */
+
+/* Whether the @ncols-wide @row appears in @set. */
+static bool
+ms_row_in_set(const ms_row_set_t *set, const int64_t *row, uint32_t ncols)
+{
+    if (set->ncols != ncols)
+        return false;
+    for (uint32_t i = 0; i < set->count; i++) {
+        bool same = true;
+        for (uint32_t c = 0; c < ncols; c++) {
+            if (set->rows[i][c] != row[c]) {
+                same = false;
+                break;
+            }
+        }
+        if (same)
+            return true;
+    }
+    return false;
+}
+
+/*
+ * Soundness: every tuple the transformed program derives is derived by the
+ * untransformed one too.
+ *
+ * A subset test, deliberately not an equality test.  Magic Sets exists to
+ * derive *fewer* tuples, so equality with the magic-off oracle would score
+ * correct pruning as a failure.
+ */
+static bool
+ms_rows_subset(const ms_row_set_t *sub, const ms_row_set_t *super)
+{
+    if (sub->overflow || super->overflow)
+        return false;
+    for (uint32_t i = 0; i < sub->count; i++) {
+        if (!ms_row_in_set(super, sub->rows[i], sub->ncols))
+            return false;
+    }
+    return true;
+}
+
+/*
+ * Query-completeness: every oracle tuple the query actually asked for
+ * survives.
+ *
+ * @bound_mask selects the demanded columns, low bit first; @seed holds one
+ * row of @seed_cols values per demanded binding, in the same order the magic
+ * relation stores them.  An oracle tuple whose bound columns match a seed row
+ * is in the answer to the query and must appear in @magic; everything else is
+ * what the demand is allowed to prune.
+ */
+static bool
+ms_query_complete(const ms_row_set_t *magic, const ms_row_set_t *oracle,
+    uint64_t bound_mask, const int64_t *seed, uint32_t seed_rows,
+    uint32_t seed_cols)
+{
+    if (magic->overflow || oracle->overflow)
+        return false;
+    for (uint32_t i = 0; i < oracle->count; i++) {
+        int64_t key[MS_MAX_COLS];
+        uint32_t nkey = 0;
+        for (uint32_t c = 0; c < oracle->ncols && nkey < MS_MAX_COLS; c++) {
+            if (bound_mask & (1ULL << c))
+                key[nkey++] = oracle->rows[i][c];
+        }
+        if (nkey != seed_cols)
+            return false;
+
+        bool demanded = false;
+        for (uint32_t s = 0; s < seed_rows && !demanded; s++) {
+            bool same = true;
+            for (uint32_t c = 0; c < seed_cols; c++) {
+                if (seed[(size_t)s * seed_cols + c] != key[c]) {
+                    same = false;
+                    break;
+                }
+            }
+            demanded = same;
+        }
+        if (demanded && !ms_row_in_set(magic, oracle->rows[i], oracle->ncols))
+            return false;
+    }
+    return true;
+}
+
+/*
+ * Parse, optimize, optionally apply @demands, and evaluate @out_rel.
+ *
+ * With @magic false this is the oracle: the same program with Magic Sets off.
+ *
+ * @magic_rel is seeded only when it exists.  A demand relation the
+ * guard-viability closure declined to create is not a setup failure -- it is
+ * the outcome under test (#1027), and the program is then evaluated
+ * unrestricted, which is what a relation in the closure requires.
+ *
+ * Rebuild and re-stratification are gated on magic_sets_applied, matching the
+ * shipping pipeline (api_facade.c rebuild_after_magic_sets()).
+ */
+static bool
+ms_run(const char *src, bool fusion, bool magic,
+    const wl_magic_demand_t *demands, uint32_t demand_count,
+    const char *magic_rel, const int64_t *seed, uint32_t seed_rows,
+    uint32_t seed_cols, const char *out_rel, ms_row_set_t *out,
+    wl_magic_sets_stats_t *stats)
+{
+    struct wirelog_program *prog = parse_and_optimize_ex(src, fusion);
+    if (!prog)
+        return false;
+
+    if (magic) {
+        if (wl_magic_sets_apply_with_demands(prog, demands, demand_count,
+            stats) != 0)
+            goto fail;
+        if (prog->magic_sets_applied) {
+            if (wl_ir_program_rebuild_relation_irs(prog) != 0)
+                goto fail;
+            wl_ir_program_free_strata(prog);
+            if (wl_ir_stratify_program(prog) != 0)
+                goto fail;
+        }
+        if (magic_rel && has_relation(prog, magic_rel)
+            && !seed_relation_facts(prog, magic_rel, seed, seed_rows,
+            seed_cols))
+            goto fail;
+    }
+
+    bool ok = ms_evaluate(prog, out_rel, 1, out);
+    wirelog_program_free(prog);
+    return ok;
+
+fail:
+    wirelog_program_free(prog);
+    return false;
 }
 
 /* ======================================================================== */
@@ -1440,6 +1593,24 @@ test_guard_over_semijoin_exact(void)
 /*
  * Test: a constant in the bound head position leaves the rule unguarded, so
  * it must not be counted as modified.
+ *
+ * Two programs, because the original one no longer reaches the counter.
+ *
+ * Part A is what this test used to assert on its own:
+ * `q(1, y) :- q(1, z), edge(z, y).` under `.query q(b, f)`.  The bound head
+ * position holds a constant, so the rule's bound set is empty and the
+ * recursive q(1, z) binds nothing.  q is therefore unrestrictable (#1027) and
+ * the guard-viability closure drops every adornment of it before Phase 4b runs
+ * -- so the rule is never reached, and skipped_constant_head is 0 where this
+ * test used to assert 1.  The old assertion pinned pre-fix behaviour: the
+ * counter only fired because Phase 4b was walking a relation it should not
+ * have been guarding at all.
+ *
+ * Part B keeps the counter itself pinned, on a rule that genuinely is a policy
+ * skip: the same constant head position, but no IDB body atom, so nothing
+ * makes the relation unrestrictable and Phase 4b really does decline the rule.
+ * Without Part B this test would pass against a pass that had simply stopped
+ * counting constant heads.
  */
 static void
 test_constant_head_position_not_counted(void)
@@ -1456,6 +1627,7 @@ test_constant_head_position_not_counted(void)
         "edge(3, 4).\n"
         "q(1, y) :- q(1, z), edge(z, y).\n";
 
+    /* Part A: unrestrictable, so the rule never reaches Phase 4b. */
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
         FAIL("parse failed");
@@ -1480,10 +1652,71 @@ test_constant_head_position_not_counted(void)
         FAIL("no guard was inserted, yet the rule was counted as modified");
         return;
     }
+    if (stats.unrestrictable_relations != 1) {
+        printf(" [unrestrictable_relations=%u]",
+            stats.unrestrictable_relations);
+        wirelog_program_free(prog);
+        FAIL("expected q to be the one unrestrictable relation");
+        return;
+    }
+    if (stats.skipped_constant_head != 0) {
+        printf(" [skipped_constant_head=%u]", stats.skipped_constant_head);
+        wirelog_program_free(prog);
+        FAIL("an unrestrictable relation must not reach the guard loop");
+        return;
+    }
+    if (has_relation(prog, "$m$q_bf")) {
+        wirelog_program_free(prog);
+        FAIL("an unrestrictable relation must not get a magic relation");
+        return;
+    }
+    if (prog->magic_sets_applied) {
+        wirelog_program_free(prog);
+        FAIL("nothing was adorned, so the program must be left untransformed");
+        return;
+    }
+    wirelog_program_free(prog);
+
+    /* Part B: a constant bound head position with no IDB body atom.  Nothing
+     * seeds the closure, the relation is adorned normally, and Phase 4b
+     * declines the rule -- the policy skip this counter names. */
+    static const char *policy_src = ".decl base(x: int32, y: int32)\n"
+        ".decl h(x: int32, y: int32)\n"
+        ".output h\n"
+        "base(1, 2).\n"
+        "base(2, 3).\n"
+        "h(1, y) :- base(x, y).\n";
+
+    prog = parse_and_optimize(policy_src);
+    if (!prog) {
+        FAIL("parse failed (policy program)");
+        return;
+    }
+
+    demands[0].relation_name = "h";
+    if (wl_magic_sets_apply_with_demands(prog, demands, 1, &stats) != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error (policy program)");
+        return;
+    }
+
+    if (stats.unrestrictable_relations != 0) {
+        printf(" [unrestrictable_relations=%u]",
+            stats.unrestrictable_relations);
+        wirelog_program_free(prog);
+        FAIL("no body atom binds nothing here; the closure must stay empty");
+        return;
+    }
     if (stats.skipped_constant_head != 1) {
         printf(" [skipped_constant_head=%u]", stats.skipped_constant_head);
         wirelog_program_free(prog);
         FAIL("expected skipped_constant_head == 1");
+        return;
+    }
+    if (stats.original_rules_modified != 0) {
+        printf(" [original_rules_modified=%u]", stats.original_rules_modified);
+        wirelog_program_free(prog);
+        FAIL("no guard was inserted, yet the rule was counted as modified");
         return;
     }
 
@@ -1941,6 +2174,610 @@ test_fused_constant_head_is_a_policy_skip(void)
     PASS();
 }
 
+/* ======================================================================== */
+/* Issue #1027: guard-viability closure                                    */
+/* ======================================================================== */
+
+/*
+ * Left-recursive p demanded p(f, b).  The recursive body atom p(x, z) binds
+ * neither of its columns -- the demand binds y, and y appears nowhere in it --
+ * so Phase 2 adds no adorned predicate for it and Phase 4a generates no demand
+ * rule.  Phase 4b used to guard p's rules regardless, restricting p to a
+ * demand relation nothing populates while p's own body needs it unrestricted.
+ *
+ * Over e = {(1,2), (2,3), (3,4)} the closure is six tuples.  Seeded at y = 4
+ * the answer used to be one, (3, 4): the base rule matched the seed directly
+ * and the recursive rule could then find nothing, losing (2, 4) and (1, 4).
+ */
+static const char *k_unrestrictable_filtered_src
+    = ".decl e(x: int32, y: int32)\n"
+    ".decl p(x: int32, y: int32)\n"
+    ".output p\n"
+    "e(1, 2).\n"
+    "e(2, 3).\n"
+    "e(3, 4).\n"
+    "p(x, y) :- e(x, y), y > 0.\n"
+    "p(x, y) :- p(x, z), e(z, y), y > 0.\n";
+
+/*
+ * The same program with no filter at all.
+ *
+ * The carrier of the claim that this is not a Logic Fusion artifact.  With no
+ * filter there is nothing for fusion to fold into a FLATMAP root, so both
+ * rules stay PROJECT-rooted whichever way the pipeline is run, and the answers
+ * were lost just the same.
+ */
+static const char *k_unrestrictable_plain_src
+    = ".decl e(x: int32, y: int32)\n"
+    ".decl p(x: int32, y: int32)\n"
+    ".output p\n"
+    "e(1, 2).\n"
+    "e(2, 3).\n"
+    "e(3, 4).\n"
+    "p(x, y) :- e(x, y).\n"
+    "p(x, y) :- p(x, z), e(z, y).\n";
+
+/*
+ * Mutual recursion: the relation that binds nothing is q, but the relation
+ * that gets guarded is p.
+ *
+ * This is what pins the *closure* rather than the direct case.  q(x, z) binds
+ * nothing under p(f, b), so q seeds the set; q's own body reads p, so p joins
+ * it.  A fix that only unguards the relation named at the seed site leaves p
+ * guarded, and p's fixpoint is still cut -- one row instead of six.
+ */
+static const char *k_unrestrictable_mutual_src
+    = ".decl e(x: int32, y: int32)\n"
+    ".decl p(x: int32, y: int32)\n"
+    ".decl q(x: int32, y: int32)\n"
+    ".output p\n"
+    "e(1, 2).\n"
+    "e(2, 3).\n"
+    "e(3, 4).\n"
+    "p(x, y) :- e(x, y), y > 0.\n"
+    "p(x, y) :- q(x, z), e(z, y), y > 0.\n"
+    "q(x, y) :- p(x, y), y > 0.\n";
+
+/*
+ * Test: a relation the pass cannot restrict keeps its answers.
+ *
+ * Asserted against the magic-off oracle as two set relations, not as equality:
+ *
+ *   soundness          -- magic is a subset of the oracle
+ *   query-completeness -- every oracle tuple whose bound columns are in the
+ *                         seed appears in magic
+ *
+ * Equality would be the wrong test: Magic Sets is meant to return fewer rows,
+ * and test_guarded_relation_still_prunes() below asserts that it does.  These
+ * two on their own are satisfied by a pass that inserts no guards anywhere,
+ * which is why that test is a required companion to this one.
+ *
+ * Every case runs with fusion on and off and the two must agree.
+ */
+static void
+test_unrestrictable_recursion_keeps_answers(void)
+{
+    TEST("test_unrestrictable_recursion_keeps_answers");
+
+    static const int64_t seed[] = { 4 };
+    const char *srcs[] = {
+        k_unrestrictable_filtered_src,
+        k_unrestrictable_plain_src,
+        k_unrestrictable_mutual_src,
+    };
+    const char *names[] = { "filtered", "unfiltered", "mutual" };
+
+    /* Every case is reported before the first failure aborts the test, so a
+     * red run says which of the six configurations lost answers rather than
+     * only the first. */
+    uint32_t failures = 0;
+
+    for (size_t si = 0; si < sizeof(srcs) / sizeof(srcs[0]); si++) {
+        ms_row_set_t reference;
+        bool have_reference = false;
+
+        for (uint32_t f = 0; f < 2; f++) {
+            bool fusion = f != 0;
+
+            wl_magic_demand_t demands[1];
+            demands[0].relation_name = "p";
+            demands[0].bound_mask = 0x2; /* p(f, b) */
+            demands[0].arity = 2;
+
+            ms_row_set_t oracle;
+            ms_row_set_t magic;
+            if (!ms_run(srcs[si], fusion, false, NULL, 0, NULL, NULL, 0, 0,
+                "p", &oracle, NULL)
+                || !ms_run(srcs[si], fusion, true, demands, 1, "$m$p_fb", seed,
+                1, 1, "p", &magic, NULL)) {
+                printf(" [%s fusion=%d: evaluation failed]", names[si],
+                    (int)fusion);
+                failures++;
+                continue;
+            }
+
+            if (!ms_rows_subset(&magic, &oracle)) {
+                printf(" [%s fusion=%d unsound magic=%u oracle=%u]", names[si],
+                    (int)fusion, magic.count, oracle.count);
+                failures++;
+            } else if (!ms_query_complete(&magic, &oracle,
+                demands[0].bound_mask, seed, 1, 1)) {
+                printf(" [%s fusion=%d lost magic=%u oracle=%u]", names[si],
+                    (int)fusion, magic.count, oracle.count);
+                failures++;
+            }
+
+            /* The two pipeline configurations must agree.  A difference here
+             * would mean the behaviour is a fusion artifact after all. */
+            if (!have_reference) {
+                reference = magic;
+                have_reference = true;
+            } else if (!ms_rows_subset(&magic, &reference)
+                || !ms_rows_subset(&reference, &magic)) {
+                printf(" [%s: fusion on and off disagree]", names[si]);
+                failures++;
+            }
+        }
+    }
+
+    if (failures > 0) {
+        FAIL("magic sets lost answers a demanded query needs");
+        return;
+    }
+    PASS();
+}
+
+/*
+ * Test: the Phase 2 signal has its own counter.
+ *
+ * skipped_all_free is incremented at two sites that mean different things: a
+ * demand root adorned all-free (Phase 1, a harmless optimisation skip) and an
+ * IDB body occurrence that binds nothing (Phase 2, the guard-viability
+ * signal).  Only the second one drives the closure, so it gets its own
+ * counter.  Asserting that skipped_all_free is 0 here is what makes this a
+ * split rather than a rename.
+ */
+static void
+test_unrestrictable_counter_is_split_from_all_free(void)
+{
+    TEST("test_unrestrictable_counter_is_split_from_all_free");
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "p";
+    demands[0].bound_mask = 0x2;
+    demands[0].arity = 2;
+
+    struct wirelog_program *prog
+        = parse_and_optimize(k_unrestrictable_filtered_src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_sets_stats_t stats;
+    if (wl_magic_sets_apply_with_demands(prog, demands, 1, &stats) != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    if (stats.unrestrictable_relations == 0) {
+        wirelog_program_free(prog);
+        FAIL("expected unrestrictable_relations > 0");
+        return;
+    }
+    if (stats.skipped_all_free != 0) {
+        printf(" [skipped_all_free=%u]", stats.skipped_all_free);
+        wirelog_program_free(prog);
+        FAIL("the Phase 2 site must no longer report as an all-free skip");
+        return;
+    }
+    if (stats.demand_roots != 1) {
+        printf(" [demand_roots=%u]", stats.demand_roots);
+        wirelog_program_free(prog);
+        FAIL("expected exactly one demand root");
+        return;
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+/*
+ * Negative control: a relation the closure does *not* reach must still be
+ * guarded, and the guard must still prune.
+ *
+ * Without this, "delete every guard insertion" satisfies every other test in
+ * this group.  Same shape as test_guard_recursive_eval_exact(): the demand is
+ * on the first column, the recursive atom Path(z, y) binds z, so nothing is
+ * unrestrictable and seed {2} must yield a strict subset of the six-tuple
+ * closure.  Run both ways round the fusion axis.
+ */
+static void
+test_guarded_relation_still_prunes(void)
+{
+    TEST("test_guarded_relation_still_prunes");
+
+    static const int64_t seed[] = { 2 };
+
+    for (uint32_t f = 0; f < 2; f++) {
+        bool fusion = f != 0;
+
+        wl_magic_demand_t demands[1];
+        demands[0].relation_name = "Path";
+        demands[0].bound_mask = 0x1; /* Path(b, f) */
+        demands[0].arity = 2;
+
+        ms_row_set_t oracle;
+        if (!ms_run(k_syntax_doc_src, fusion, false, NULL, 0, NULL, NULL, 0, 0,
+            "Path", &oracle, NULL)) {
+            printf(" [fusion=%d]", (int)fusion);
+            FAIL("oracle evaluation failed");
+            return;
+        }
+
+        wl_magic_sets_stats_t stats;
+        ms_row_set_t magic;
+        if (!ms_run(k_syntax_doc_src, fusion, true, demands, 1, "$m$Path_bf",
+            seed, 1, 1, "Path", &magic, &stats)) {
+            printf(" [fusion=%d]", (int)fusion);
+            FAIL("magic evaluation failed");
+            return;
+        }
+
+        if (stats.unrestrictable_relations != 0) {
+            printf(" [fusion=%d unrestrictable_relations=%u]", (int)fusion,
+                stats.unrestrictable_relations);
+            FAIL("nothing in this program binds nothing");
+            return;
+        }
+        if (stats.original_rules_modified != 2) {
+            printf(" [fusion=%d original_rules_modified=%u]", (int)fusion,
+                stats.original_rules_modified);
+            FAIL("both rules of Path must still be guarded");
+            return;
+        }
+        if (!ms_rows_subset(&magic, &oracle)) {
+            printf(" [fusion=%d]", (int)fusion);
+            FAIL("unsound: magic derived a tuple the oracle does not");
+            return;
+        }
+        if (magic.count != 3 || oracle.count != 6) {
+            printf(" [fusion=%d magic=%u oracle=%u]", (int)fusion, magic.count,
+                oracle.count);
+            FAIL("the guard must prune the closure to the tuples from seed 2");
+            return;
+        }
+    }
+
+    PASS();
+}
+
+/*
+ * Test: an unrestrictable relation does not drag its neighbours out of the
+ * transformation, and no demand rule is generated for it.
+ *
+ * q is unrestrictable: its bound head position is the constant 1, so the
+ * recursive q(1, z) binds nothing.  r is not -- r(z, y) binds z through
+ * edge(x, z) -- so r keeps its magic relation, its guards and its pruning.
+ *
+ * The demand rule is the part that is easy to get wrong.  Phase 4a walks the
+ * rules of r and finds the body atom q(x, y) adorned bf, which would key a
+ * demand rule on $m$q_bf -- a relation Phase 3 declined to create.  Such a
+ * rule is silently dropped later (wl_ir_program_rebuild_relation_irs()
+ * iterates relations, not rules), so nothing downstream complains; the
+ * assertion has to be made here.
+ */
+static void
+test_unrestrictable_neighbour_stays_guarded(void)
+{
+    TEST("test_unrestrictable_neighbour_stays_guarded");
+
+    static const char *src = ".decl edge(x: int32, y: int32)\n"
+        ".decl q(x: int32, y: int32)\n"
+        ".decl r(x: int32, y: int32)\n"
+        ".output q\n"
+        ".output r\n"
+        "q(1, 1).\n"
+        "q(1, 2).\n"
+        "edge(0, 1).\n"
+        "edge(1, 2).\n"
+        "edge(2, 3).\n"
+        "edge(3, 4).\n"
+        "q(1, y) :- q(1, z), edge(z, y).\n"
+        "r(x, y) :- q(x, y).\n"
+        "r(x, y) :- edge(x, z), r(z, y).\n";
+
+    static const int64_t seed[] = { 1 };
+
+    wl_magic_demand_t demands[2];
+    demands[0].relation_name = "q";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+    demands[1].relation_name = "r";
+    demands[1].bound_mask = 0x1;
+    demands[1].arity = 2;
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_magic_sets_stats_t stats;
+    if (wl_magic_sets_apply_with_demands(prog, demands, 2, &stats) != 0) {
+        wirelog_program_free(prog);
+        FAIL("magic sets returned error");
+        return;
+    }
+
+    if (has_relation(prog, "$m$q_bf")) {
+        wirelog_program_free(prog);
+        FAIL("q is unrestrictable: $m$q_bf must not be created");
+        return;
+    }
+    if (has_rule_for(prog, "$m$q_bf")) {
+        wirelog_program_free(prog);
+        FAIL("a demand rule was generated for a relation Phase 3 declined");
+        return;
+    }
+    if (!has_relation(prog, "$m$r_bf")) {
+        wirelog_program_free(prog);
+        FAIL("r is restrictable: $m$r_bf must still be created");
+        return;
+    }
+    if (stats.unrestrictable_relations != 1) {
+        printf(" [unrestrictable_relations=%u]",
+            stats.unrestrictable_relations);
+        wirelog_program_free(prog);
+        FAIL("expected q and only q to be unrestrictable");
+        return;
+    }
+    if (stats.adorned_predicates != 1) {
+        printf(" [adorned_predicates=%u]", stats.adorned_predicates);
+        wirelog_program_free(prog);
+        FAIL("expected r_bf to be the one surviving adorned predicate");
+        return;
+    }
+    if (stats.original_rules_modified != 2) {
+        printf(" [original_rules_modified=%u]", stats.original_rules_modified);
+        wirelog_program_free(prog);
+        FAIL("both rules of r must be guarded");
+        return;
+    }
+    if (stats.magic_rules_generated != 1) {
+        printf(" [magic_rules_generated=%u]", stats.magic_rules_generated);
+        wirelog_program_free(prog);
+        FAIL("expected exactly the $m$r_bf demand rule");
+        return;
+    }
+    wirelog_program_free(prog);
+
+    /* Answers: q is complete, r is pruned to the seed. */
+    ms_row_set_t oracle_q;
+    ms_row_set_t oracle_r;
+    ms_row_set_t magic_q;
+    ms_row_set_t magic_r;
+    if (!ms_run(src, true, false, NULL, 0, NULL, NULL, 0, 0, "q", &oracle_q,
+        NULL)
+        || !ms_run(src, true, false, NULL, 0, NULL, NULL, 0, 0, "r", &oracle_r,
+        NULL)
+        || !ms_run(src, true, true, demands, 2, "$m$r_bf", seed, 1, 1, "q",
+        &magic_q, NULL)
+        || !ms_run(src, true, true, demands, 2, "$m$r_bf", seed, 1, 1, "r",
+        &magic_r, NULL)) {
+        FAIL("evaluation failed");
+        return;
+    }
+
+    if (!ms_rows_subset(&magic_q, &oracle_q)
+        || !ms_rows_subset(&oracle_q, &magic_q)) {
+        printf(" [q magic=%u oracle=%u]", magic_q.count, oracle_q.count);
+        FAIL("q is unrestrictable, so it must be evaluated in full");
+        return;
+    }
+    if (!ms_rows_subset(&magic_r, &oracle_r)) {
+        FAIL("unsound: r derived a tuple the oracle does not");
+        return;
+    }
+    if (!ms_query_complete(&magic_r, &oracle_r, 0x1, seed, 1, 1)) {
+        FAIL("query-incomplete: r lost a demanded tuple");
+        return;
+    }
+    if (magic_r.count >= oracle_r.count) {
+        printf(" [r magic=%u oracle=%u]", magic_r.count, oracle_r.count);
+        FAIL("r's guard must still prune");
+        return;
+    }
+
+    PASS();
+}
+
+/*
+ * Test: the closure stops at an aggregate relation.
+ *
+ * Two programs differing in one character -- the body of G's aggregate rule
+ * reads the EDB e in one and the IDB S in the other.  Neither difference is
+ * reachable from the demand: X is unrestrictable (d reads it binding nothing),
+ * so the closure walks X's body, finds G, and would walk G's body next.
+ *
+ * relation_has_aggregate_rule() keeps aggregate relations out of Phase 2, but
+ * that guards the *seed* site only; the closure reaches G through X's body,
+ * where Phase 2 never looked.  Without the same test on the transitive step
+ * the second program pulled S out of the transformation and the pair measured
+ * differently -- adorned 2 vs 1, magic rules 2 vs 0 -- for a change that the
+ * pass is supposed not to see at all.  #1048 owns aggregates; this test is
+ * what keeps them out of #1027's closure.
+ */
+static void
+test_closure_stops_at_aggregate(void)
+{
+    TEST("test_closure_stops_at_aggregate");
+
+    static const char *agg_on_edb = ".decl e(x: int32, y: int32)\n"
+        ".decl S(x: int32, y: int32)\n"
+        ".decl G(g: int32, c: int32)\n"
+        ".decl X(a: int32, b: int32)\n"
+        ".decl d(p: int32, q: int32)\n"
+        ".output d\n"
+        "S(x, y) :- e(x, y).\n"
+        "S(x, y) :- e(x, z), S(z, y).\n"
+        "G(g, count(v)) :- e(g, v).\n"
+        "X(a, b) :- G(a, b).\n"
+        "d(p, q) :- S(p, q), X(u, v).\n";
+
+    static const char *agg_on_idb = ".decl e(x: int32, y: int32)\n"
+        ".decl S(x: int32, y: int32)\n"
+        ".decl G(g: int32, c: int32)\n"
+        ".decl X(a: int32, b: int32)\n"
+        ".decl d(p: int32, q: int32)\n"
+        ".output d\n"
+        "S(x, y) :- e(x, y).\n"
+        "S(x, y) :- e(x, z), S(z, y).\n"
+        "G(g, count(v)) :- S(g, v).\n"
+        "X(a, b) :- G(a, b).\n"
+        "d(p, q) :- S(p, q), X(u, v).\n";
+
+    const char *srcs[] = { agg_on_edb, agg_on_idb };
+    const char *names[] = { "aggregate over EDB", "aggregate over IDB" };
+    wl_magic_sets_stats_t seen[2];
+    uint32_t failures = 0;
+
+    for (size_t si = 0; si < 2; si++) {
+        for (uint32_t f = 0; f < 2; f++) {
+            struct wirelog_program *prog
+                = parse_and_optimize_ex(srcs[si], f != 0);
+            if (!prog) {
+                printf(" [%s fusion=%u: parse failed]", names[si], f);
+                failures++;
+                continue;
+            }
+
+            wl_magic_demand_t demands[1];
+            demands[0].relation_name = "d";
+            demands[0].bound_mask = 0x1; /* d(b, f) */
+            demands[0].arity = 2;
+
+            wl_magic_sets_stats_t stats;
+            if (wl_magic_sets_apply_with_demands(prog, demands, 1, &stats)
+                != 0) {
+                printf(" [%s fusion=%u: magic sets returned error]", names[si],
+                    f);
+                wirelog_program_free(prog);
+                failures++;
+                continue;
+            }
+
+            /* S is reachable only through the aggregate.  It must keep its
+             * magic relation whichever way G's rule is written. */
+            if (!has_relation(prog, "$m$S_bf")) {
+                printf(" [%s fusion=%u: S lost its magic relation]", names[si],
+                    f);
+                failures++;
+            }
+            if (stats.unrestrictable_relations != 1) {
+                printf(" [%s fusion=%u: unrestrictable_relations=%u]",
+                    names[si], f, stats.unrestrictable_relations);
+                failures++;
+            }
+            if (f == 0)
+                seen[si] = stats;
+            else if (memcmp(&seen[si], &stats, sizeof(stats)) != 0) {
+                printf(" [%s: fusion changed the outcome]", names[si]);
+                failures++;
+            }
+            wirelog_program_free(prog);
+        }
+    }
+
+    if (failures == 0 && memcmp(&seen[0], &seen[1], sizeof(seen[0])) != 0) {
+        printf(" [adorned %u vs %u, magic rules %u vs %u]",
+            seen[0].adorned_predicates, seen[1].adorned_predicates,
+            seen[0].magic_rules_generated, seen[1].magic_rules_generated);
+        failures++;
+    }
+
+    if (failures > 0) {
+        FAIL("the closure crossed into an aggregate relation");
+        return;
+    }
+    PASS();
+}
+
+/*
+ * Test: an over-long rule the closure reaches makes the pass decline, not
+ * fail.
+ *
+ * r is unrestrictable, and r's second rule has more than MS_MAX_ATOMS body
+ * atoms.  Phase 2 never walks r's rules -- no adorned predicate is ever
+ * created for r -- so the closure is the only thing that gets there.  Before
+ * the closure existed this program optimized; a -1 here would reach the caller
+ * through api_facade.c as WIRELOG_ERR_MEMORY and fail wirelog_optimize()
+ * outright, blaming allocation for a body-atom limit.
+ *
+ * The contract is rc == 0 with the program left exactly as written.
+ */
+static void
+test_over_long_rule_under_unrestrictable_declines(void)
+{
+    TEST("test_over_long_rule_under_unrestrictable_declines");
+
+    char src[65536];
+    size_t used = 0;
+    used += (size_t)snprintf(src + used, sizeof(src) - used,
+            ".decl e(x: int32, y: int32)\n"
+            ".decl r(x: int32, y: int32)\n"
+            ".decl s(x: int32, y: int32)\n"
+            ".decl d(p: int32, q: int32)\n"
+            ".output d\n"
+            "s(x, y) :- e(x, y).\n"
+            "r(x, y) :- e(x, y).\n"
+            "r(x, y) :- ");
+    for (uint32_t i = 0; i < 70; i++) {
+        used += (size_t)snprintf(src + used, sizeof(src) - used,
+                "e(v%u, v%u), ", i, i + 1);
+    }
+    snprintf(src + used, sizeof(src) - used,
+        "e(x, y).\n"
+        "d(p, q) :- s(p, q), r(u, v).\n");
+
+    struct wirelog_program *prog = parse_and_optimize(src);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    uint32_t rules_before = prog->rule_count;
+    uint32_t relations_before = prog->relation_count;
+
+    wl_magic_demand_t demands[1];
+    demands[0].relation_name = "d";
+    demands[0].bound_mask = 0x1;
+    demands[0].arity = 2;
+
+    wl_magic_sets_stats_t stats;
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, &stats);
+
+    bool declined = rc == 0 && !prog->magic_sets_applied
+        && prog->rule_count == rules_before
+        && prog->relation_count == relations_before
+        && stats.adorned_predicates == 0
+        && stats.unrestrictable_relations == 0
+        && stats.original_rules_modified == 0;
+
+    if (!declined)
+        printf(" [rc=%d applied=%d rules %u->%u relations %u->%u]", rc,
+            (int)prog->magic_sets_applied, rules_before, prog->rule_count,
+            relations_before, prog->relation_count);
+    wirelog_program_free(prog);
+
+    if (!declined) {
+        FAIL("an over-long rule under the closure must decline, not fail");
+        return;
+    }
+    PASS();
+}
+
 static void
 test_body_atom_limit_is_reported(void)
 {
@@ -2018,6 +2855,14 @@ main(void)
     test_wide_head_is_an_unsupported_head();
     test_fused_constant_head_is_a_policy_skip();
     test_body_atom_limit_is_reported();
+
+    printf("\nGuard Viability Tests (Issue #1027):\n");
+    test_unrestrictable_recursion_keeps_answers();
+    test_unrestrictable_counter_is_split_from_all_free();
+    test_guarded_relation_still_prunes();
+    test_unrestrictable_neighbour_stays_guarded();
+    test_closure_stops_at_aggregate();
+    test_over_long_rule_under_unrestrictable_declines();
 
     printf("\n=== Results ===\n");
     printf("Tests run:    %d\n", tests_run);

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -10,6 +10,8 @@
  * Algorithm overview:
  *  Phase 1: Identify demand roots (from explicit demands or .output relations).
  *  Phase 2: BFS to compute adorned program (which relations need magic guards).
+ *  Phase 2b: Guard-viability closure -- drop the relations that must stay
+ *            unguarded, and everything they read (#1027).
  *  Phase 3: Create magic relations ($m$<name>_<adornment>).
  *  Phase 4: Generate demand propagation rules and insert magic guards.
  *
@@ -155,6 +157,87 @@ adorned_add(ms_adorned_set_t *s, const char *name, uint64_t mask,
 }
 
 /* ======================================================================== */
+/* Unrestrictable Relation Set (Issue #1027)                                */
+/* ======================================================================== */
+
+/*
+ * Relations this pass must leave entirely unguarded.
+ *
+ * Textbook Magic Sets answers "one occurrence needs all of R, another needs
+ * only the demanded part" by splitting R into separate adorned predicates.
+ * This pass does not split: insert_magic_guard() mutates the rule root in
+ * place, so one set of rules serves every adornment of R.  Under that
+ * architecture the requirement collapses to all-or-nothing -- if any
+ * occurrence needs R unrestricted, R must not be guarded at all.
+ *
+ * Membership is by name.  Both sites that add to the set do so only under
+ * is_idb(), so every member is the head relation of some rule, and the set can
+ * therefore never hold more distinct names than the program has rules.  That
+ * bound is an invariant of this file -- it holds because of the two is_idb()
+ * guards a few lines away -- which is why the capacity is sized from
+ * prog->rule_count rather than from prog->relation_count.  Sizing it from the
+ * relation table would instead rest on what the parser chooses to put there,
+ * which is not this pass's to promise.
+ */
+typedef struct {
+    const char **names; /* borrowed from the program IR */
+    uint32_t count;
+    uint32_t capacity;
+} ms_relset_t;
+
+static bool
+relset_init(ms_relset_t *s, uint32_t capacity)
+{
+    memset(s, 0, sizeof(*s));
+    s->capacity = (capacity > 0) ? capacity : 1;
+    s->names = (const char **)calloc(s->capacity, sizeof(*s->names));
+    return s->names != NULL;
+}
+
+static void
+relset_free(ms_relset_t *s)
+{
+    /* Explicit cast: the array holds `const char *` elements, and an implicit
+     * `const char ** -> void *` conversion is a clang-tidy finding
+     * (bugprone-multi-level-implicit-pointer-conversion).  Same convention as
+     * exec_plan_gen.c's free() calls on borrowed-name arrays. */
+    free((void *)s->names);
+    s->names = NULL;
+    s->count = 0;
+    s->capacity = 0;
+}
+
+static bool
+relset_contains(const ms_relset_t *s, const char *name)
+{
+    if (!name)
+        return false;
+    for (uint32_t i = 0; i < s->count; i++) {
+        if (s->names[i] && strcmp(s->names[i], name) == 0)
+            return true;
+    }
+    return false;
+}
+
+/*
+ * Returns false only if the set is full, which the capacity bound above makes
+ * unreachable: the caller sizes it at prog->rule_count + 1 and every name
+ * added is a rule head.  The branch is kept rather than asserted because the
+ * consequence of a silent drop would be a relation guarded that must not be,
+ * i.e. lost answers; callers turn a false return into a declined pass.
+ */
+static bool
+relset_add(ms_relset_t *s, const char *name)
+{
+    if (!name || relset_contains(s, name))
+        return true;
+    if (s->count >= s->capacity)
+        return false;
+    s->names[s->count++] = name;
+    return true;
+}
+
+/* ======================================================================== */
 /* Magic Relation Name                                                      */
 /* ======================================================================== */
 
@@ -296,6 +379,102 @@ collect_body_atoms(const wirelog_ir_node_t *ir_root, ms_atom_t *atoms,
     uint32_t count = 0;
     collect_scans_r(ir_root->children[0], atoms, &count, overflow);
     return count;
+}
+
+/*
+ * Close @u under "R unguarded implies every IDB R reads is unguarded".
+ *
+ * @u arrives seeded with every relation whose IDB body occurrence bound
+ * nothing at the Phase 2 site.  Such an occurrence needs the whole relation,
+ * and the pass cannot give it an unguarded copy, so the relation must be left
+ * unguarded outright (see ms_relset_t).
+ *
+ * Being unguarded is contagious.  An unguarded R is evaluated in full, so
+ * every IDB in R's rule bodies must be evaluated in full too -- otherwise R's
+ * own fixpoint is cut through the guarded child and the answers are lost one
+ * level down instead of at R.  Hence the closure.
+ *
+ * The walk uses collect_body_atoms(), the same one Phase 2 uses, so it shares
+ * Phase 2's blind spot for negation, and it needs its own aggregate test:
+ *
+ *   - collect_scans_r() descends only into children[0] of an ANTIJOIN, so an
+ *     IDB read under negation is never an atom this loop sees (#1047).
+ *   - relation_has_aggregate_rule() keeps aggregate relations out of Phase 2
+ *     before the seed site can fire, but that covers the seed only.  This loop
+ *     reaches a relation through *another* relation's body, where Phase 2
+ *     never looked, so without the explicit test below an aggregate relation
+ *     -- and every relation it reads -- would enter @u after all.  Measured
+ *     on two programs differing in one character: without the test, both
+ *     `G(g, count(v)) :- e(g, v).` and `G(g, count(v)) :- S(g, v).` put G in
+ *     @u, and the second then walked G's body and unguarded S as well, giving
+ *     the pair different results -- 2 adorned predicates and 2 demand rules
+ *     against 1 and 0 -- for a difference the pass is supposed not to see.
+ *     The test is therefore repeated here and #1048 stays out of scope.
+ *
+ * Neither shape can be handled from inside this closure; both need a different
+ * walker and are tracked separately.  They are not, however, untouched by it.
+ * For negation specifically the change is real and measured, and it is not an
+ * improvement: the closure can leave R unguarded while a relation R reads
+ * under negation stays guarded, and a guarded relation is a partial relation.
+ * On
+ *
+ *     u(x, y) :- e(x, y).
+ *     u(x, y) :- u(x, z), e(z, y), !g(x, y).
+ *
+ * with e = {(1,2), (2,3), (3,4)}, g guarded and its demand seeded at x = 2,
+ * and u demanded free-bound: before this closure u was guarded on a demand
+ * nothing fills and derived 0 rows against a 3-row oracle -- lossy, but a
+ * subset.  After it u is unrestrictable, runs in full against a partially
+ * evaluated g, and derives 5 rows, of which (1,3) and (1,4) are not oracle
+ * answers at all.  Both fusion settings.  So #1047's defect, which was already
+ * present and already wrong here, changes register: it presented as lost
+ * answers and now presents as unsound ones.  Fixing that needs the walker
+ * #1047 tracks.
+ *
+ * Terminates: the bound is re-read each iteration but relset_add() appends a
+ * name at most once, so each relation is dequeued exactly once.
+ *
+ * Returns false if the closure could not be completed -- a rule with more than
+ * MS_MAX_ATOMS body atoms, or a full @u -- in which case the caller must not
+ * rely on @u and declines the transformation.
+ */
+static bool
+close_unrestrictable(const struct wirelog_program *prog, ms_relset_t *u)
+{
+    for (uint32_t ui = 0; ui < u->count; ui++) {
+        const char *rel = u->names[ui];
+
+        for (uint32_t ri = 0; ri < prog->rule_count; ri++) {
+            if (!prog->rules[ri].head_relation
+                || strcmp(prog->rules[ri].head_relation, rel) != 0)
+                continue;
+
+            const wirelog_ir_node_t *ir_root = prog->rules[ri].ir_root;
+            if (!ir_root)
+                continue;
+
+            ms_atom_t atoms[MS_MAX_ATOMS];
+            bool atom_overflow = false;
+            uint32_t atom_count = collect_body_atoms(ir_root, atoms,
+                    &atom_overflow);
+            if (atom_overflow) {
+                fprintf(stderr,
+                    "warning: magic sets declined: a rule with more than %u "
+                    "body atoms is reachable from an unguardable relation\n",
+                    MS_MAX_ATOMS);
+                return false;
+            }
+
+            for (uint32_t ai = 0; ai < atom_count; ai++) {
+                if (!atoms[ai].rel_name || !is_idb(prog, atoms[ai].rel_name)
+                    || relation_has_aggregate_rule(prog, atoms[ai].rel_name))
+                    continue;
+                if (!relset_add(u, atoms[ai].rel_name))
+                    return false;
+            }
+        }
+    }
+    return true;
 }
 
 /*
@@ -739,6 +918,7 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
         stats->skipped_aggregate = 0;
         stats->skipped_constant_head = 0;
         stats->skipped_unsupported_head = 0;
+        stats->unrestrictable_relations = 0;
     }
 
     /* === Phase 1: Seed the worklist from explicit demands === */
@@ -746,6 +926,18 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
     ms_adorned_set_t processed;
     if (!adorned_set_init(&processed))
         return -1;
+
+    /* Relations that must not be guarded at all (#1027).  Seeded in Phase 2,
+     * closed before Phase 3.  Every member is an IDB, so the distinct names
+     * cannot outnumber the program's rules; +1 keeps the allocation non-zero
+     * for a program with none.  See ms_relset_t for why the bound is taken
+     * from the rule table and not the relation table. */
+    ms_relset_t unrestrictable;
+    if (!relset_init(&unrestrictable, prog->rule_count + 1)) {
+        adorned_set_free(&processed);
+        return -1;
+    }
+    bool closure_incomplete = false;
 
     /* Simple queue over processed items (indices 0..count-1) */
     uint32_t wl_head = 0; /* index of next item to process */
@@ -792,6 +984,7 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
                 "warning: magic sets skipped program with more than %u "
                 "adorned predicates\n", MS_MAX_ADORNED);
             adorned_set_free(&processed);
+            relset_free(&unrestrictable);
             return -1;
         }
     }
@@ -836,6 +1029,7 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
                     "warning: magic sets skipped rule with more than %u "
                     "body atoms\n", MS_MAX_ATOMS);
                 adorned_set_free(&processed);
+                relset_free(&unrestrictable);
                 return -1;
             }
 
@@ -869,11 +1063,25 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
                                 "more than %u adorned predicates\n",
                                 MS_MAX_ADORNED);
                             adorned_set_free(&processed);
+                            relset_free(&unrestrictable);
                             return -1;
                         }
                     } else {
-                        if (stats)
-                            stats->skipped_all_free++;
+                        /* This occurrence binds nothing, so it needs every
+                         * tuple of the relation.  No adorned predicate is
+                         * added, so Phase 3 creates no demand relation and
+                         * Phase 4a generates no rule to fill one -- and a
+                         * guard over a demand nothing populates does not
+                         * prune, it cuts the recursion (#1027).  Seed the
+                         * guard-viability closure with the relation instead;
+                         * it will be excluded from guarding altogether.
+                         *
+                         * Not counted as skipped_all_free.  That counter names
+                         * the Phase 1 event -- a demand root adorned all-free,
+                         * a genuine optimisation skip -- and this is a
+                         * different thing entirely. */
+                        if (!relset_add(&unrestrictable, atom->rel_name))
+                            closure_incomplete = true;
                     }
                 }
 
@@ -888,10 +1096,68 @@ next_atom:
                         "warning: magic sets skipped rule with more than "
                         "%u variables\n", MS_MAX_VARS);
                     adorned_set_free(&processed);
+                    relset_free(&unrestrictable);
                     return -1;
                 }
             }
         }
+    }
+
+    /*
+     * === Guard-viability closure (Issue #1027) ===
+     *
+     * Between the BFS and any mutation.  Phase 2 seeded `unrestrictable` with
+     * the relations some occurrence needs whole; close it so that everything
+     * they read is unguarded too, then drop every adornment of every member.
+     *
+     * Dropping them here is the single point that skips all three of the
+     * things the pass would otherwise do with an adorned predicate: Phase 3
+     * creates no magic relation for it, Phase 4a generates no demand rule
+     * keyed on it, and Phase 4b inserts no guard into its rules.  All three
+     * iterate `processed`.  The one site that does not is the Phase 4a
+     * *target*, which keys off the body atom it is looking at rather than off
+     * `processed`; that one is skipped explicitly below.
+     *
+     * If the closure cannot be completed the pass declines rather than
+     * failing.  This walk reaches rules of relations Phase 2 never touched, so
+     * it is the first thing in the pass that can trip over a rule with more
+     * than MS_MAX_ATOMS body atoms in a subprogram the demand never reached.
+     * Returning -1 there would surface through api_facade.c as
+     * WIRELOG_ERR_MEMORY and fail wirelog_optimize() outright for a program
+     * that optimized before, naming a cause that is not the real one.  An
+     * incomplete closure is not an error, it just means no assignment of
+     * guards can be shown consistent -- so leave the program as written.
+     * Nothing has been mutated at this point: Phase 3 is the first writer.
+     */
+
+    if (!close_unrestrictable(prog, &unrestrictable))
+        closure_incomplete = true;
+
+    if (closure_incomplete) {
+        /*
+         * Declined: `magic_sets_applied` stays false and the IR is untouched.
+         * Both closure-derived counters are zeroed because neither describes
+         * anything that happened -- `unrestrictable` is a partial set here.
+         */
+        if (stats) {
+            stats->adorned_predicates = 0;
+            stats->unrestrictable_relations = 0;
+        }
+        adorned_set_free(&processed);
+        relset_free(&unrestrictable);
+        return 0;
+    }
+    if (stats)
+        stats->unrestrictable_relations = unrestrictable.count;
+
+    if (unrestrictable.count > 0) {
+        uint32_t kept = 0;
+        for (uint32_t i = 0; i < processed.count; i++) {
+            if (relset_contains(&unrestrictable, processed.items[i].rel_name))
+                continue;
+            processed.items[kept++] = processed.items[i];
+        }
+        processed.count = kept;
     }
 
     if (stats)
@@ -899,6 +1165,7 @@ next_atom:
 
     if (processed.count == 0){
         adorned_set_free(&processed);
+        relset_free(&unrestrictable);
         return 0; /* Nothing to do */
     }
 
@@ -911,6 +1178,7 @@ next_atom:
         char *mname = make_magic_name(ap->rel_name, ap->bound_mask, ap->arity);
         if (!mname) {
             adorned_set_free(&processed);
+            relset_free(&unrestrictable);
             return -1;
         }
 
@@ -918,6 +1186,7 @@ next_atom:
         if (rc != 0) {
             free(mname);
             adorned_set_free(&processed);
+            relset_free(&unrestrictable);
             return -1;
         }
         free(mname);
@@ -942,6 +1211,7 @@ next_atom:
             = make_magic_name(ap->rel_name, ap->bound_mask, ap->arity);
         if (!guard_magic) {
             adorned_set_free(&processed);
+            relset_free(&unrestrictable);
             return -1;
         }
 
@@ -976,6 +1246,7 @@ next_atom:
                     "body atoms\n", MS_MAX_ATOMS);
                 free(guard_magic);
                 adorned_set_free(&processed);
+                relset_free(&unrestrictable);
                 return -1;
             }
 
@@ -991,7 +1262,32 @@ next_atom:
                 if (!atom->rel_name)
                     goto next_4a_atom;
 
-                if (is_idb(prog, atom->rel_name)) {
+                /*
+                 * The guard-viability skip has to be applied here as well as
+                 * on `ap` (Issue #1027).  This loop is keyed on the *body
+                 * atom's* relation while `ap` names the *head's*, so an
+                 * unrestrictable body atom under a perfectly restrictable head
+                 * would otherwise still get a demand rule -- one whose head
+                 * names a magic relation Phase 3 declined to create.  Nothing
+                 * downstream reports that: wl_ir_program_rebuild_relation_irs()
+                 * iterates relations, so a rule with no declared head relation
+                 * is silently dropped.
+                 *
+                 * There is no demand to propagate to an unguarded relation in
+                 * any case; it is evaluated in full.
+                 *
+                 * This is not the last site with that hazard.  An *aggregate*
+                 * body atom reaches the same branch: Phase 2 skips it, so
+                 * Phase 3 creates no magic relation, but this condition does
+                 * not test for it and a `$m$` demand rule is built anyway.
+                 * Measured byte-identical before and after the closure, with
+                 * magic_rules_generated counting a rule that is then dropped.
+                 * That belongs to #1048 and is a one-line addition to this
+                 * same condition; it is left out here so the closure change
+                 * stays scoped.
+                 */
+                if (is_idb(prog, atom->rel_name)
+                    && !relset_contains(&unrestrictable, atom->rel_name)) {
                     uint64_t atom_mask = 0;
                     for (uint32_t ci = 0; ci < atom->col_count && ci < 64;
                         ci++) {
@@ -1006,6 +1302,7 @@ next_atom:
                         if (!body_magic) {
                             free(guard_magic);
                             adorned_set_free(&processed);
+                            relset_free(&unrestrictable);
                             return -1;
                         }
 
@@ -1021,6 +1318,7 @@ next_atom:
                                 free(guard_magic);
                                 wl_ir_node_free(demand_ir);
                                 adorned_set_free(&processed);
+                                relset_free(&unrestrictable);
                                 return -1;
                             }
                             if (stats)
@@ -1041,6 +1339,7 @@ next_4a_atom:
                         "%u variables\n", MS_MAX_VARS);
                     free(guard_magic);
                     adorned_set_free(&processed);
+                    relset_free(&unrestrictable);
                     return -1;
                 }
             }
@@ -1057,6 +1356,14 @@ next_4a_atom:
      * by splicing in JOIN(body, SCAN($m$rel)).  The guard SCAN is the right
      * child and the body stays on the left; see insert_magic_guard() for why
      * the other order does not survive plan translation (#989).
+     *
+     * Every adornment left in `processed` is one Phase 3 created a relation
+     * for and Phase 4a can propagate a demand into -- except the demand roots
+     * themselves, which by construction no propagation rule fills, because
+     * nothing above them demands anything.  Seeding those is #989.  For every
+     * other member the guard-viability closure removed the ones whose demand
+     * could not be filled before Phase 3 ran, so this loop no longer guards a
+     * rule on a demand nothing fills (#1027).
      */
 
     for (uint32_t pi = 0; pi < processed.count; pi++) {
@@ -1066,6 +1373,7 @@ next_4a_atom:
             = make_magic_name(ap->rel_name, ap->bound_mask, ap->arity);
         if (!guard_magic) {
             adorned_set_free(&processed);
+            relset_free(&unrestrictable);
             return -1;
         }
 
@@ -1082,8 +1390,8 @@ next_4a_atom:
             uint32_t head_arity = get_head_vars(ir_root, head_vars, 64);
             if (head_arity == 0) {
                 /* No head variable names the guard could be keyed on, so the
-                 * rule runs unrestricted -- sound but unoptimized.  A
-                 * capability gap, not a policy decision.
+                 * rule runs unrestricted.  A capability gap, not a policy
+                 * decision.
                  *
                  * Reachable.  get_head_vars() also returns 0 for a head wider
                  * than the 64-bit adornment mask, and that path needs only a
@@ -1095,12 +1403,15 @@ next_4a_atom:
                  * relation_has_aggregate_rule() excludes those relations
                  * before they can enter `processed`.
                  *
-                 * Guarding a rule is not on its own enough to make the demand
-                 * correct: the guard prunes only what the demand relation was
-                 * actually populated with, so a rule guarded on a demand that
-                 * no propagation rule ever fills loses answers rather than
-                 * saving work.  See #1027; nothing seeds $m$ today, so it is
-                 * not a shipping regression. */
+                 * Leaving one rule of a guarded relation unrestricted is not
+                 * automatically sound.  The rule still reads whatever its body
+                 * names, and a body atom on a *guarded* relation reads a
+                 * partial relation -- which is unsound under negation (#1047)
+                 * and wrong-valued under aggregation (#1048).  The
+                 * guard-viability closure (#1027) is what keeps the assignment
+                 * of guards consistent for the shapes it can see; this skip is
+                 * outside it, and the head arity that lands here is the one
+                 * shape where the pass has no guard to offer either way. */
                 if (stats)
                     stats->skipped_unsupported_head++;
                 WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_WARN,
@@ -1122,6 +1433,7 @@ next_4a_atom:
             if (gr == MS_GUARD_ERROR) {
                 free(guard_magic);
                 adorned_set_free(&processed);
+                relset_free(&unrestrictable);
                 return -1;
             }
             if (stats) {
@@ -1140,6 +1452,7 @@ next_4a_atom:
 
     prog->magic_sets_applied = true;
     adorned_set_free(&processed);
+    relset_free(&unrestrictable);
     return 0;
 }
 

--- a/wirelog/passes/magic_sets.h
+++ b/wirelog/passes/magic_sets.h
@@ -41,10 +41,23 @@ struct wirelog_program;
  * Statistics from a single Magic Sets pass invocation.
  *
  * @demand_roots:           Relations identified as demand roots.
- * @adorned_predicates:     Unique (relation, adornment) pairs with bound_mask != 0.
+ * @adorned_predicates:     Unique (relation, adornment) pairs with bound_mask
+ *                         != 0 that survived the guard-viability closure --
+ *                         that is, the ones a magic relation was created for.
+ *                         A pair the closure dropped is counted only by
+ *                         @unrestrictable_relations (#1027).
  * @magic_rules_generated:  Magic demand propagation rules added.
  * @original_rules_modified: Original rules with magic guards inserted.
- * @skipped_all_free:       Adorned predicates skipped (all-free adornment).
+ * @skipped_all_free:       Demand *roots* skipped because the demand itself is
+ *                         all-free (bound_mask == 0), the default for a
+ *                         .output relation with no bound .query.  A Phase 1
+ *                         event and a genuine optimisation skip: there is no
+ *                         restriction to propagate, so the pass declines and
+ *                         the program is left as written.  Nothing is lost.
+ *                         An all-free IDB *body occurrence* is a different
+ *                         event and is counted by @unrestrictable_relations
+ *                         below; it used to share this counter, which
+ *                         conflated a no-op with a correctness constraint.
  * @arity_mismatch_skipped: Demands skipped due to adornment count/arity mismatch.
  * @skipped_aggregate:     Aggregate rules skipped because Magic Sets cannot
  *                         safely insert magic guards into them yet.
@@ -81,23 +94,106 @@ struct wirelog_program;
  *                         2 BFS, so they never enter `processed` and the guard
  *                         loop never sees them.  The wide head is what remains
  *                         reachable in practice.
+ * @unrestrictable_relations: Relations excluded from the transformation
+ *                         entirely by the guard-viability closure (#1027).
+ *                         Seeded by an IDB body occurrence that binds nothing
+ *                         -- such an occurrence needs every tuple of the
+ *                         relation, and this pass cannot hand one occurrence
+ *                         an unguarded copy, because insert_magic_guard()
+ *                         rewrites the rule root in place and one set of rules
+ *                         serves every adornment.  Closed under "R unguarded
+ *                         implies every IDB R reads is unguarded", since an
+ *                         unguarded R evaluated against a guarded child has
+ *                         its own fixpoint cut.  Every member gets no magic
+ *                         relation, no demand rule and no guard.
+ *                         This is an over-approximation, not a lost-answers
+ *                         count.  It is seeded from an occurrence's binding
+ *                         pattern alone, and a binding pattern does not decide
+ *                         whether the occurrence contributes anything for the
+ *                         seeded demand -- a rule whose body is empty for that
+ *                         demand is guarded soundly and completely despite
+ *                         reading its relation all-free.  The closure has no
+ *                         way to tell those apart, so it excludes both.  What
+ *                         the counter reports is how much of the program the
+ *                         pass declined to optimise in order to stay correct.
  *
- * Both skip counters describe a rule that is evaluated unrestricted, which is
- * sound but unoptimized.  They are the only signal that a demand did not reach
- * it -- but only for a caller that supplies a stats struct.  The library's own
- * pipeline passes NULL (api_facade.c), so in a shipping build nothing reads
- * them; they are observability for tests and embedders, not a runtime warning.
- * A rule missing from both counters is guarded, which is not the same as
- * correctly restricted: a guard prunes only what its demand relation was
- * populated with, so a rule guarded on a demand no propagation rule ever fills
- * loses answers instead of saving work (#1027).  Guarding is complete only
- * when the demand actually propagates; these counters measure the first half.
- * They are kept apart because they are reported at different points, not
- * because the split is clean: as noted above, one capability gap is currently
- * counted on the policy side.
+ *                         That cost is not small, and its dominant trigger has
+ *                         a name: a rule with a constant in the bound head
+ *                         position, `X(1, y) :- ...` under `.query X(b, f)`.
+ *                         get_head_vars() yields no variable for a constant
+ *                         position, so Phase 2's `bound` set starts empty,
+ *                         so *every* IDB in that rule's body binds nothing and
+ *                         seeds the closure, and the transitive step unguards
+ *                         the whole subprogram reachable from there.  One
+ *                         character does it: changing `X(a, b) :- p(a, b),
+ *                         q(a, b).` to `X(1, b) :- p(a, b), q(a, b).` takes
+ *                         the same program from 4 adorned predicates and 4
+ *                         guards to 2 and 1.
+ *
+ *                         Measured over a 342-program census on which the pass
+ *                         with and without this closure are both sound and
+ *                         query-complete: the unguarded oracle derives 1785
+ *                         rows, the pass without the closure 820, and with it
+ *                         1085 -- so about a third of the pruning is given
+ *                         back.  It derives more than the pass without it on
+ *                         94 of the 342, roughly one program in five, which is
+ *                         not a corner case.  A separate sample found the
+ *                         constant-in-bound-head shape in almost every program
+ *                         the closure made lossier; that sample and the 342
+ *                         census are different runs and their counts do not
+ *                         combine, so take the shape as the dominant trigger
+ *                         and the 94 as the rate.
+ *
+ *                         Does not reach a relation read under negation
+ *                         (#1047), which is invisible to the walk this closure
+ *                         uses, or one defined by an aggregate rule (#1048),
+ *                         which the walk tests for and steps over.  Neither is
+ *                         left unaffected, though.  Under negation the closure
+ *                         can leave R unguarded while a relation R reads
+ *                         negatively stays guarded, i.e. partial -- measured,
+ *                         that turns #1047's pre-existing defect from lost
+ *                         answers into unsound ones.  See close_unrestrictable()
+ *                         in magic_sets.c for the program and the row counts.
+ *
+ * The two skip counters describe a rule the pass declined to guard.  That is
+ * sound *in isolation* but is not a "sound but unoptimized" outcome in
+ * general: an unrestricted rule that reads a relation the pass did guard is
+ * reading a partial relation, which is unsound under negation (#1047) and
+ * wrong-valued under aggregation (#1048).  Correctness comes from the whole
+ * assignment of guards being consistent, not from any one rule's skip; the
+ * guard-viability closure above is what enforces that for the shapes it can
+ * see, and the two issues named are the shapes it cannot.
+ *
+ * They are the only signal that a demand did not reach a rule -- but only for
+ * a caller that supplies a stats struct.  The library's own pipeline passes
+ * NULL (api_facade.c), so in a shipping build nothing reads them; they are
+ * observability for tests and embedders, not a runtime warning.  A rule
+ * missing from both counters is not necessarily guarded either: a rule of a
+ * relation in @unrestrictable_relations is unguarded and is counted by none of
+ * the three, because Phase 4b never walks it.  Being guarded is in turn not
+ * the same as being correctly restricted: a guard prunes only what its demand
+ * relation was populated with, so a rule guarded on a demand no propagation
+ * rule ever fills loses answers instead of saving work.  That is exactly the
+ * failure #1027 fixed, and the closure now removes the relation from the
+ * transformation rather than guarding it on a demand that stays empty.  The
+ * two skip counters are kept apart because they are reported at different
+ * points, not because the split is clean: as noted above, one capability gap
+ * is currently counted on the policy side.
  *
  * @original_rules_modified counts guards actually inserted.  A rule counted in
- * either skip counter is not counted there.
+ * either skip counter is not counted there, and neither is a rule of a
+ * relation in @unrestrictable_relations -- Phase 4b never reaches it.
+ *
+ * The pass can also decline outright, leaving the program exactly as written:
+ * that happens when the guard-viability closure cannot be completed, which
+ * today means a rule with more than MS_MAX_ATOMS body atoms somewhere under an
+ * unguardable relation.  It returns 0 with `magic_sets_applied` still false and
+ * both @adorned_predicates and @unrestrictable_relations at 0, and warns on
+ * stderr.  Declining is deliberate: the closure walks rules Phase 2 never
+ * reached, so it is the first thing in the pass able to trip over such a rule
+ * in a subprogram the demand never touched, and returning an error there would
+ * surface through api_facade.c as WIRELOG_ERR_MEMORY and fail
+ * wirelog_optimize() for a program that optimized before.
  */
 typedef struct {
     uint32_t demand_roots;
@@ -109,6 +205,7 @@ typedef struct {
     uint32_t skipped_aggregate;
     uint32_t skipped_constant_head;
     uint32_t skipped_unsupported_head;
+    uint32_t unrestrictable_relations;
 } wl_magic_sets_stats_t;
 
 /* ======================================================================== */


### PR DESCRIPTION
Closes #1027.

Magic sets adorns a relation, then guards its rules with the demand relation for that adornment. When a recursive body occurrence **binds nothing**, no adorned predicate is created and no demand rule is generated — but the rules were guarded anyway. The relation ends up globally restricted to a demand nothing fills while its own body needs it unrestricted, and the recursion is cut.

```
p(x, y) :- e(x, y).
p(x, y) :- p(x, z), e(z, y).
```
demanded free-bound, seeded at `y = 4`, over `e = {(1,2),(2,3),(3,4)}`: **1 row where the oracle has 6**, and two of the three the query asked for are missing. Identical with fusion on and off, filtered and unfiltered — the issue's original framing of this as a Logic Fusion interaction was wrong.

## The construction

An all-free demand relation isn't available — it would be nullary and `insert_magic_guard` refuses a zero-arity demand. Textbook magic sets splits the predicate, giving `p^ff` its own unguarded rules; this pass rewrites rule roots **in place**, so one set of rules serves every adornment. Under that constraint the requirement collapses to: **if any occurrence needs a relation unrestricted, it must not be guarded at all** — and that is contagious, since an unguarded relation is fully evaluated, so every IDB its rules read must be too.

Hence a guard-viability closure between the adornment BFS and magic-relation creation. Compacting the adorned-predicate list covers three of the four skip sites at once (they all iterate it); the demand-rule **target** keys off a body atom and carries its own check.

## Cost, stated rather than buried

Over a 342-program census where the pass is sound and query-complete both with and without the closure: oracle 1785 rows, without 820, with **1085**. It gives pruning back on **94 of 342, roughly one in five**. The dominant trigger is a constant in the bound head position — that yields no head variable, so the bound set starts empty, every IDB in that rule's body seeds the closure, and the transitive step unguards the reachable subprogram.

*(A separate sample found that shape in almost every program the closure made lossier. That sample and the 342 census are different runs and their counts do not combine — the shape is the trigger, the 94 is the rate.)*

## The negation interaction is not neutral, and the first version of this change claimed it was

Where the closure leaves a relation unguarded next to a negated read of a relation that **stays** guarded, that guarded relation is partial, so a `!` test passes that should have failed:

```
u(x,y) :- e(x,y).
u(x,y) :- u(x,z), e(z,y), !g(x,y).      /* g guarded, seeded x=2 */

before:  oracle=3  magic=0   <- lossy, but a subset
after:   oracle=3  magic=5   <- (1,3) and (1,4) are not oracle answers
```

#1047 was already wrong there; this changes how it **presents**, from lost answers to unsound ones. Recorded on that issue rather than papered over. `docs/SYNTAX.md` loses its "either the full result or nothing" dichotomy for the same reason — the output can be neither, and not even a subset.

## Out of scope, deliberately

- **#1047** negation — invisible to the walk, which descends only the positive child of an `ANTIJOIN`. Needs a different walker.
- **#1048** aggregates — the closure now **explicitly** steps over them, using the same test the seed site uses. The first version did not, and reached them transitively (`X → G → S`), which incidentally and inconsistently mitigated #1048. Caught in review; the guard is one line and the two programs that differ by one character now measure identically.
- **#1046**, **#995** — seed additions on this closure once it exists.

`skipped_constant_head` / `skipped_unsupported_head` were **not** added as seeds: measured, they turn magic sets fully off for the canonical `start`-constant shape.

## Also

`skipped_all_free` was counting two different events; it now counts only a demand root adorned all-free, with `unrestrictable_relations` for the body occurrence. Documented as an **over-approximation** — seeded from a binding pattern, which cannot tell whether the occurrence contributes anything for the demand actually seeded.

A rule of an unrestrictable relation can exceed the body-atom limit, which the closure reaches where the BFS never did. Rather than failing `wirelog_optimize()` with a memory error naming the wrong cause, the pass **declines**: applies nothing, leaves the IR untouched, warns.

## Testing

Three recursive shapes × both fusion settings, asserting **soundness and query-completeness** against the unguarded oracle rather than equality — magic sets is meant to return fewer rows, so equality scores correct pruning as failure. Those two alone are satisfied by a pass that inserts no guards, so a positive anchor asserts a neighbouring relation is still guarded and still prunes.

`test_constant_head_position_not_counted` pinned pre-fix behaviour and is now two parts: the original program pinning what is true now, and a new constant-head program with no IDB body atom where the counter still fires.

**Review evidence:** 1070 fuzzed programs, **0 regressions** — no program correct before and defective after. All suggested mutations killed, each by its intended test. Memory clean on all 17 exit paths under LSAN.

## Validation

271 ok / 1 fail / 11 skipped, release and ASAN+UBSAN+LSAN, **per-test status identical to base** — the failure is the pre-existing `sbom_snapshot` pin drift. `abi` 33/33 including the live `changelog_format` gate. clang-tidy 0 on changed files; uncrustify clean, base and after. `test_magic_sets` 28 → 30.