### PR TITLE
fix(query): preserve results for unseeded bound .query

### DIFF
--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -411,14 +411,12 @@ free (to be computed). This enables the Magic Sets optimization pass to restrict
 evaluation to only the tuples reachable from the query, reducing intermediate
 result sizes for recursive programs.
 
-> **Status (Issue #989): a bound `.query` currently prunes nothing.**
-> The Magic Sets pass builds the magic demand relations and guards the rules
-> with them, but there is no syntax for supplying the bound *values* and
-> nothing seeds the demand relation. The demand relation therefore stays
-> empty, the guards match nothing, and the guarded rules are removed from the
-> result rather than restricted. Adding a bound `.query` to a working program
-> will make it derive fewer tuples, not the same tuples faster. Leave `.query`
-> off, or use all-free adornments, until seeding lands.
+> **Status (Issue #989): bound `.query` is accepted conservatively.**
+> The directive currently carries only an adornment (`b`/`f`), not the bound
+> values needed to seed a magic demand relation. The public optimizer therefore
+> leaves a bound query unoptimized instead of installing an empty guard. This
+> preserves the complete result until a query API with seed values is added;
+> all-free adornments remain a no-op as before.
 >
 > Seeding alone will not be enough. Issue #1027 tracks two further defects that
 > only become observable once the demand relation is populated: a rule can be
@@ -456,10 +454,10 @@ the magic demand relation `$m$Path_bf` and guards both `Path` rules with it,
 which is *intended* to restrict evaluation to only reachable tuples and avoid
 full materialization of the transitive closure.
 
-As written, this program prints nothing. There is no way to say *which* source
-node is bound, so `$m$Path_bf` is never populated and both guards reject every
-tuple. Deleting the `.query` line prints the full closure. See the status note
-above and Issue #989.
+As written, this program prints the full closure. There is no way to say
+*which* source node is bound, so the public optimizer conservatively leaves the
+query unoptimized. A future query API can seed `$m$Path_bf` and enable the
+intended restriction without changing this source syntax.
 
 Query with all arguments bound (point query):
 

--- a/tests/test_wirelog_public_api.c
+++ b/tests/test_wirelog_public_api.c
@@ -120,6 +120,58 @@ test_optimizer_config_disable_passes(void)
 }
 
 static int
+test_bound_query_without_seed_preserves_answers(void)
+{
+    const char *src =
+        ".decl edge(x:int32,y:int32)\n"
+        ".decl path(x:int32,y:int32)\n"
+        ".output path\n"
+        ".query path(b,f) .\n"
+        "edge(1,2).\n"
+        "edge(2,3).\n"
+        "edge(3,4).\n"
+        "path(x,y) :- edge(x,y).\n"
+        "path(x,y) :- edge(x,z), path(z,y).\n";
+    wirelog_error_t err = WIRELOG_ERR_UNKNOWN;
+    wirelog_program_t *program = wirelog_parse_string(src, &err);
+    if (!program || err != WIRELOG_OK) {
+        fprintf(stderr, "bound query parse failed err=%d\n", err);
+        return 1;
+    }
+
+    if (!wirelog_optimize(program, &err) || err != WIRELOG_OK) {
+        fprintf(stderr, "bound query optimize failed err=%d\n", err);
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    wirelog_executor_t *executor = wirelog_executor_create(program, &err);
+    if (!executor || err != WIRELOG_OK) {
+        fprintf(stderr, "bound query executor create failed err=%d\n", err);
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    wirelog_result_t *result = wirelog_evaluate(executor, &err);
+    uint64_t rows = result
+        ? wirelog_result_relation_cardinality(result, "path") : 0;
+    if (!result || err != WIRELOG_OK || rows != 6) {
+        fprintf(stderr,
+            "bound query changed unseeded result: rows=%" PRIu64 " err=%d\n",
+            rows, err);
+        wirelog_result_free(result);
+        wirelog_executor_free(executor);
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    wirelog_result_free(result);
+    wirelog_executor_free(executor);
+    wirelog_program_free(program);
+    return 0;
+}
+
+static int
 test_executor_result_api(void)
 {
     const char *src =
@@ -180,6 +232,7 @@ main(void)
     failures += test_utility_api();
     failures += test_optimizer_api();
     failures += test_optimizer_config_disable_passes();
+    failures += test_bound_query_without_seed_preserves_answers();
     failures += test_executor_result_api();
     if (failures == 0)
         printf("test_wirelog_public_api: OK\n");

--- a/wirelog/api_facade.c
+++ b/wirelog/api_facade.c
@@ -265,6 +265,27 @@ wirelog_optimizer_get_default_config(void)
     };
 }
 
+/*
+ * A parsed `.query` currently carries only an adornment (b/f), not the
+ * values that seed the corresponding magic relation.  Applying Magic Sets
+ * to such a demand creates an empty guard and silently drops every answer.
+ * Keep the public optimizer sound until the query API can provide those
+ * seed values.  Callers of wl_magic_sets_apply_with_demands() may still
+ * supply and seed explicit demands themselves.
+ */
+static bool
+has_unseeded_bound_query(const wirelog_program_t *program)
+{
+    if (!program)
+        return false;
+
+    for (uint32_t i = 0; i < program->demand_count; i++) {
+        if (program->demands[i].bound_mask != 0)
+            return true;
+    }
+    return false;
+}
+
 bool
 wirelog_optimize_with_config(wirelog_program_t *program,
     const wirelog_opt_config_t *config, wirelog_error_t *error)
@@ -312,15 +333,17 @@ wirelog_optimize_with_config(wirelog_program_t *program,
         &applied, &stats))
         return false;
 
-    rc = wl_magic_sets_apply_with_demands(
-        program, program->demands, program->demand_count, NULL);
-    if (rc != 0) {
-        set_error(error,
-            rc == -1 ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_INVALID_IR);
-        return false;
+    if (!has_unseeded_bound_query(program)) {
+        rc = wl_magic_sets_apply_with_demands(
+            program, program->demands, program->demand_count, NULL);
+        if (rc != 0) {
+            set_error(error,
+                rc == -1 ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_INVALID_IR);
+            return false;
+        }
+        if (!rebuild_after_magic_sets(program, error))
+            return false;
     }
-    if (!rebuild_after_magic_sets(program, error))
-        return false;
 
     stats.passes_applied = applied;
     stats.optimized_node_count = count_ir_nodes(program);

--- a/wirelog/passes/magic_sets.h
+++ b/wirelog/passes/magic_sets.h
@@ -145,8 +145,9 @@ typedef struct {
  *
  * With all-free adornment (the default), the all-free optimization
  * skips magic relation generation entirely, making this a no-op.
- * Magic Sets only activates when explicit .query directives specify
- * bound positions (future: parser support for .query).
+ * The public optimizer defers parsed bound `.query` directives until their
+ * seed values can be supplied.  Explicit callers may use this lower-level
+ * entry point and populate the generated demand relations themselves.
  *
  * Must be called AFTER: fusion, JPP, SIP.
  * Caller must call wl_ir_program_rebuild_relation_irs() and
@@ -170,7 +171,7 @@ wl_magic_sets_apply(struct wirelog_program *prog, wl_magic_sets_stats_t *stats);
  * Apply Magic Sets transformation with explicit demand specifications.
  * Demands with bound_mask == 0 are skipped (all-free optimization).
  *
- * Used for testing and for future .query directive support.
+ * Used for testing and for explicit callers that provide demand seeds.
  *
  * Returns:
  *    0: Success.


### PR DESCRIPTION
Closes #989

## Summary
- keep parsed bound `.query` directives out of Magic Sets until seed values are available
- prevent empty magic guards from silently dropping all answers
- add a public API regression test covering the documented transitive-closure shape
- document the conservative behavior and explicit seeded-demand API boundary

## Validation
- `meson test -C builddir wirelog_public_api --print-errorlogs`
- `meson test -C builddir magic_sets optimizer_equivalence --print-errorlogs`
- `meson test -C builddir --print-errorlogs` — 272 passed, 11 skipped, 1 unrelated SBOM baseline failure (`msys2/setup-msys2@7efe20...` vs `v2`)
- `uncrustify -c uncrustify.cfg --check wirelog/api_facade.c wirelog/passes/magic_sets.h tests/test_wirelog_public_api.c`
