### PR TITLE
fix: resolve issues 971, 980, and 1030

### DIFF
--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -651,10 +651,11 @@ frame-integrity validation example.
 
 ### UUID Functions
 
-`uuid4()`, `uuid5(namespace, name)`
+`uuid4()`, `uuid5(namespace, name)`, `uuid5_rfc(namespace_uuid, name)`
 
-The UUID built-ins require mbedTLS for non-zero runtime output and
-return the first 8 UUID bytes as an `int64`, not formatted text.
+The legacy `uuid4()` and `uuid5()` built-ins require mbedTLS for non-zero
+runtime output and return the first 8 UUID bytes as an `int64`, not formatted
+text. `uuid5_rfc()` returns a formatted symbol as described below.
 Disabled UUID calls follow the same fail-closed behavior described for
 crypto hash functions.
 
@@ -706,6 +707,13 @@ it so. RFC 4122 requires the namespace to *be* a 16-byte UUID and defines
 a 128-bit result; wirelog accepts whatever bytes the operand carries and
 returns only the first 8 of the 16 digest bytes. Treat the result as a
 namespaced fingerprint, not as a UUID.
+
+`uuid5_rfc(namespace_uuid, name)` is the standards-compliant string-returning
+variant. `namespace_uuid` must be a canonical 36-character UUID string; it is
+decoded to its 16 raw bytes before SHA-1 hashing. The name is arbitrary symbol
+text. The result is the full canonical lowercase UUID string with version 5 and
+the RFC variant bits set. A malformed namespace, or a call without mbedTLS,
+rejects the row.
 
 ### Comparison Operators
 

--- a/tests/test_ir.c
+++ b/tests/test_ir.c
@@ -258,6 +258,12 @@ test_create_aggregate_node(void)
         return;
     }
 
+    if (agg->aggregate_index != WL_IR_AGGREGATE_INDEX_UNSET) {
+        wl_ir_node_free(agg);
+        FAIL("unspecified aggregate position should retain legacy default");
+        return;
+    }
+
     if (!agg->agg_expr || agg->agg_expr->type != WL_IR_EXPR_VAR) {
         wl_ir_node_free(agg);
         FAIL("agg_expr mismatch");

--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -996,7 +996,8 @@ test_aggregation_multi_head_rejected(void)
     }
     if (ok->rules[0].ir_root->type != WIRELOG_IR_AGGREGATE
         || ok->rules[0].ir_root->agg_fn != WIRELOG_AGG_MIN
-        || ok->rules[0].ir_root->group_by_count != 1) {
+        || ok->rules[0].ir_root->group_by_count != 1
+        || ok->rules[0].ir_root->aggregate_index != 1) {
         wl_ir_program_free(ok);
         FAIL("control: expected AGGREGATE/MIN/group_by_count==1");
         return;

--- a/tests/test_string_eval.c
+++ b/tests/test_string_eval.c
@@ -138,6 +138,28 @@ run_string_program(const char *src, int64_t *out_values, int max_values)
     return n;
 }
 
+#ifdef WL_MBEDTLS_ENABLED
+static void
+test_eval_uuid5_rfc_known_vector(void)
+{
+    TEST("uuid5_rfc matches RFC 4122 known vector");
+
+    const char *src =
+        ".decl a(ns: symbol, name: symbol)\n"
+        "a(\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\", \"python.org\").\n"
+        ".decl r(ok: int64)\n"
+        "r(1) :- a(ns, name), uuid5_rfc(ns, name) = "
+        "\"886313e1-3b8a-5372-9b90-0c9aee199e5d\".\n";
+    int64_t values[2];
+    int n = run_string_program(src, values, 2);
+    if (n != 1 || values[0] != 1) {
+        FAIL("RFC 4122 UUID v5 known vector did not match");
+        return;
+    }
+    PASS();
+}
+#endif
+
 /* ======================================================================== */
 /* strlen tests                                                             */
 /* ======================================================================== */
@@ -725,6 +747,11 @@ main(void)
 
     printf("\n--- multiple input tuples ---\n");
     test_eval_strlen_multiple_inputs();
+
+#ifdef WL_MBEDTLS_ENABLED
+    printf("\n--- uuid5_rfc ---\n");
+    test_eval_uuid5_rfc_known_vector();
+#endif
 
     printf("\nResults: %d/%d passed, %d failed\n",
         tests_passed, tests_run, tests_failed);

--- a/tests/test_string_parser.c
+++ b/tests/test_string_parser.c
@@ -75,7 +75,7 @@ assert_parse_fails(const char *test_name, const char *src)
 }
 
 /* ======================================================================== */
-/* Valid Syntax: All 13 String Functions                                   */
+/* Valid Syntax: All 14 String Functions                                   */
 /* ======================================================================== */
 
 static void
@@ -209,6 +209,16 @@ test_parse_to_number(void)
     assert_parses("to_number(x) parses successfully", src);
 }
 
+static void
+test_parse_uuid5_rfc(void)
+{
+    const char *src =
+        ".decl a(ns: symbol, name: symbol)\n"
+        ".decl r(uuid: symbol)\n"
+        "r(uuid5_rfc(ns, name)) :- a(ns, name).\n";
+    assert_parses("uuid5_rfc(namespace, name) parses successfully", src);
+}
+
 /* ======================================================================== */
 /* Nested and Complex Expressions                                           */
 /* ======================================================================== */
@@ -320,6 +330,7 @@ main(void)
     test_parse_trim();
     test_parse_to_string();
     test_parse_to_number();
+    test_parse_uuid5_rfc();
 
     printf("\n--- Nested and Complex Expressions ---\n");
     test_parse_nested_cat_substr();

--- a/tests/test_symbol_aggregates.c
+++ b/tests/test_symbol_aggregates.c
@@ -608,6 +608,34 @@ test_mistyped_symbol_column_recursive(void)
 }
 
 static void
+test_aggregate_preserves_head_position(void)
+{
+    TEST("aggregate value stays at its declared head position");
+
+    static const char *src =
+        ".decl val(g: int64, v: int64)\n"
+        ".decl t(a: int64, g: int64)\n"
+        ".output t\n"
+        "val(7, 100). val(7, 50). val(4, 200).\n"
+        "t(min(v), g) :- val(g, v).\n";
+    collect_t c;
+    ASSERT(eval_relation(src, "t", &c) == 0, "aggregate evaluation failed");
+    bool saw_7 = false;
+    bool saw_4 = false;
+    for (uint32_t i = 0; i < c.count && i < MAX_SEEN; i++) {
+        if (c.ncols != 2)
+            continue;
+        if (c.raw[i][0] == 50 && c.raw[i][1] == 7)
+            saw_7 = true;
+        if (c.raw[i][0] == 200 && c.raw[i][1] == 4)
+            saw_4 = true;
+    }
+    ASSERT(saw_7 && saw_4,
+        "aggregate output was not restored to head order");
+    PASS();
+}
+
+static void
 test_mixed_interned_and_uninterned_group(void)
 {
     TEST("a group mixing interned and un-interned values prefers the strings");
@@ -826,6 +854,7 @@ main(void)
     test_join_chain_aggregate();
     test_min_of_to_upper();
     test_integer_aggregates_unchanged();
+    test_aggregate_preserves_head_position();
     test_mistyped_symbol_column_recursive();
     test_mixed_interned_and_uninterned_group();
     test_undeclared_relation();

--- a/tests/test_wirelog_easy.c
+++ b/tests/test_wirelog_easy.c
@@ -1847,6 +1847,7 @@ test_delta_cb_multi_round_recursive_insert(void)
     PASS();
 }
 
+/* PARITY: facade-only -- this regression uses the easy snapshot callback API. */
 static void
 test_delta_cb_snapshot_recomputes_fused_recursive_relation(void)
 {
@@ -1889,26 +1890,57 @@ test_delta_cb_snapshot_recomputes_fused_recursive_relation(void)
     tuple_collector_t tuples;
     memset(&tuples, 0, sizeof(tuples));
     if (wirelog_easy_snapshot(s, "path", collect_tuple, &tuples)
-        != WIRELOG_OK) {
-        FAIL("snapshot failed");
+        != WIRELOG_OK || tuples.count != 3) {
+        FAIL("snapshot after the second insert must contain the full closure");
         wirelog_easy_close(s);
         return;
     }
 
     bool found = false;
     for (int i = 0; i < tuples.count; i++) {
-        if (strcmp(tuples.relations[i], "path") == 0
-            && tuples.ncols[i] == 2 && tuples.rows[i][0] == 1
-            && tuples.rows[i][1] == 3) {
+        if (tuples.rows[i][0] == 1 && tuples.rows[i][1] == 3) {
             found = true;
             break;
         }
     }
-    wirelog_easy_close(s);
     if (!found) {
         FAIL("snapshot missed path(1,3) after the second insert");
+        wirelog_easy_close(s);
         return;
     }
+
+    /* A clean repeated snapshot must expose the same complete fused state,
+     * not a partially cached K-fusion result. */
+    memset(&tuples, 0, sizeof(tuples));
+    if (wirelog_easy_snapshot(s, "path", collect_tuple, &tuples)
+        != WIRELOG_OK || tuples.count != 3) {
+        FAIL("repeated snapshot must preserve the complete closure");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    int64_t third[] = { 3, 4 };
+    if (wirelog_easy_insert(s, "edge", third, 2) != WIRELOG_OK) {
+        FAIL("third insert failed");
+        wirelog_easy_close(s);
+        return;
+    }
+    memset(&tuples, 0, sizeof(tuples));
+    if (wirelog_easy_snapshot(s, "path", collect_tuple, &tuples)
+        != WIRELOG_OK || tuples.count != 6) {
+        FAIL("snapshot after a later insert must recompute the full closure");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    memset(&tuples, 0, sizeof(tuples));
+    if (wirelog_easy_snapshot(s, "path", collect_tuple, &tuples)
+        != WIRELOG_OK || tuples.count != 6) {
+        FAIL("repeated later snapshot must remain complete");
+        wirelog_easy_close(s);
+        return;
+    }
+    wirelog_easy_close(s);
     PASS();
 }
 

--- a/tests/test_wirelog_easy.c
+++ b/tests/test_wirelog_easy.c
@@ -1847,6 +1847,71 @@ test_delta_cb_multi_round_recursive_insert(void)
     PASS();
 }
 
+static void
+test_delta_cb_snapshot_recomputes_fused_recursive_relation(void)
+{
+    TEST("delta_cb snapshot recomputes a fused recursive relation");
+
+    static const char *src
+        = ".decl edge(a: int64, b: int64)\n"
+        ".decl path(a: int64, b: int64)\n"
+        "path(A, B) :- edge(A, B).\n"
+        "path(A, C) :- path(A, B), path(B, C).\n";
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(src, &s) != WIRELOG_OK || !s) {
+        FAIL("open failed");
+        return;
+    }
+
+    delta_collector_t deltas;
+    memset(&deltas, 0, sizeof(deltas));
+    if (wirelog_easy_set_delta_cb(s, collect_delta, &deltas) != WIRELOG_OK) {
+        FAIL("set_delta_cb failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    int64_t first[] = { 1, 2 };
+    if (wirelog_easy_insert(s, "edge", first, 2) != WIRELOG_OK
+        || wirelog_easy_step(s) != WIRELOG_OK) {
+        FAIL("initial insert/step failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    int64_t second[] = { 2, 3 };
+    if (wirelog_easy_insert(s, "edge", second, 2) != WIRELOG_OK) {
+        FAIL("second insert failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    tuple_collector_t tuples;
+    memset(&tuples, 0, sizeof(tuples));
+    if (wirelog_easy_snapshot(s, "path", collect_tuple, &tuples)
+        != WIRELOG_OK) {
+        FAIL("snapshot failed");
+        wirelog_easy_close(s);
+        return;
+    }
+
+    bool found = false;
+    for (int i = 0; i < tuples.count; i++) {
+        if (strcmp(tuples.relations[i], "path") == 0
+            && tuples.ncols[i] == 2 && tuples.rows[i][0] == 1
+            && tuples.rows[i][1] == 3) {
+            found = true;
+            break;
+        }
+    }
+    wirelog_easy_close(s);
+    if (!found) {
+        FAIL("snapshot missed path(1,3) after the second insert");
+        return;
+    }
+    PASS();
+}
+
 /* Issue #665: a 5-relation conjunctive rule was reported to surface
 * WIRELOG_ERR_EXEC from wirelog_easy_step when the EDB prerequisites were
 * inserted across separate epochs and only some were present at step time.
@@ -2153,6 +2218,7 @@ main(void)
     test_cleanup_order_no_use_after_free();
     test_intern_after_step_succeeds();
     test_delta_cb_multi_round_recursive_insert();
+    test_delta_cb_snapshot_recomputes_fused_recursive_relation();
     test_issue_665_partial_conjunction_default_workers();
     test_issue_665_partial_conjunction_multi_worker();
     test_snapshot_rebuilds_idb_after_query_mode_input_changes();

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -402,10 +402,12 @@ col_canonicalize_recursive_aggregates(const wl_plan_stratum_t *sp,
 
 static bool
 col_reduce_output_group_equal(const col_rel_t *rel, uint32_t a, uint32_t b,
-    uint32_t group_by_count)
+    uint32_t group_by_count, uint32_t aggregate_index)
 {
     for (uint32_t c = 0; c < group_by_count; c++) {
-        if (col_rel_get(rel, a, c) != col_rel_get(rel, b, c))
+        uint32_t out_col = c >= aggregate_index ? c + 1 : c;
+        if (col_rel_get(rel, a, out_col)
+            != col_rel_get(rel, b, out_col))
             return false;
     }
     return true;
@@ -417,11 +419,13 @@ typedef struct {
 } col_group_slot_t;
 
 static uint64_t
-col_group_hash(const col_rel_t *rel, uint32_t row, uint32_t group_by_count)
+col_group_hash(const col_rel_t *rel, uint32_t row, uint32_t group_by_count,
+    uint32_t aggregate_index)
 {
     uint64_t hash = UINT64_C(1469598103934665603);
     for (uint32_t c = 0; c < group_by_count; c++) {
-        hash ^= (uint64_t)col_rel_get(rel, row, c);
+        uint32_t out_col = c >= aggregate_index ? c + 1 : c;
+        hash ^= (uint64_t)col_rel_get(rel, row, out_col);
         hash *= UINT64_C(1099511628211);
     }
     return hash ? hash : 1;
@@ -435,6 +439,8 @@ col_canonicalize_recursive_aggregate_relation(col_rel_t *rel,
         return 0;
 
     uint32_t gc = spec->group_by_count;
+    uint32_t agg_index = spec->aggregate_index < rel->ncols
+        ? spec->aggregate_index : gc;
     if (rel->ncols <= gc)
         return EINVAL;
 
@@ -452,12 +458,13 @@ col_canonicalize_recursive_aggregate_relation(col_rel_t *rel,
     uint32_t map_mask = map_cap - 1;
     for (uint32_t row = 0; row < rel->nrows; row++) {
         uint32_t found = UINT32_MAX;
-        uint64_t hash = col_group_hash(rel, row, gc);
+        uint64_t hash = col_group_hash(rel, row, gc, agg_index);
         uint32_t slot = (uint32_t)hash & map_mask;
         while (groups[slot].hash != 0) {
             uint32_t keep = groups[slot].row;
             if (groups[slot].hash == hash
-                && col_reduce_output_group_equal(rel, keep, row, gc)) {
+                && col_reduce_output_group_equal(rel, keep, row, gc,
+                agg_index)) {
                 found = keep;
                 break;
             }
@@ -465,15 +472,15 @@ col_canonicalize_recursive_aggregate_relation(col_rel_t *rel,
         }
 
         if (found != UINT32_MAX) {
-            int64_t cur = col_rel_get(rel, found, gc);
-            int64_t val = col_rel_get(rel, row, gc);
+            int64_t cur = col_rel_get(rel, found, agg_index);
+            int64_t val = col_rel_get(rel, row, agg_index);
             /* Same comparator as col_op_reduce(): a fixpoint that ordered
              * lexicographically within an iteration and by intern id across
              * iterations would be worse than the original bug (#965). */
             bool better = col_agg_better(spec->fn, spec->operand_type,
                     intern, val, cur);
             if (better) {
-                col_rel_set(rel, found, gc, val);
+                col_rel_set(rel, found, agg_index, val);
                 if (rel->timestamps)
                     rel->timestamps[found] = rel->timestamps[row];
             }

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -6744,8 +6744,10 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
     col_rel_t *in = e.rel;
     uint32_t gc = op->group_by_count;
 
-    /* Output: group_by columns + 1 aggregate column */
+    /* Output: the group columns and aggregate retain the rule-head order. */
     uint32_t ocols = gc + 1;
+    uint32_t agg_index = op->aggregate_index < ocols
+        ? op->aggregate_index : gc;
     col_rel_t *out = col_rel_pool_new_auto(sess->delta_pool, sess->eval_arena,
             "$reduce", ocols);
     if (!out) {
@@ -6865,8 +6867,9 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
             for (uint32_t k = 0; k < gc && match; k++) {
                 uint32_t gi
                     = op->group_by_indices ? op->group_by_indices[k] : k;
+                uint32_t out_col = k >= agg_index ? k + 1 : k;
                 match = row[gi < in->ncols ? gi : 0]
-                    == col_rel_get(out, groups[slot].row, k);
+                    == col_rel_get(out, groups[slot].row, out_col);
             }
             if (match) {
                 found = true;
@@ -6877,10 +6880,10 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
         }
         if (found) {
             /* Update aggregate */
-            int64_t cur = col_rel_get(out, group_row, gc);
+            int64_t cur = col_rel_get(out, group_row, agg_index);
             switch (op->agg_fn) {
             case WIRELOG_AGG_COUNT:
-                col_rel_set(out, group_row, gc, cur + 1);
+                col_rel_set(out, group_row, agg_index, cur + 1);
                 break;
             case WIRELOG_AGG_SUM:
             {
@@ -6896,7 +6899,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                         col_rel_destroy(in);
                     return ERANGE;
                 }
-                col_rel_set(out, group_row, gc, next);
+                col_rel_set(out, group_row, agg_index, next);
             }
             break;
             case WIRELOG_AGG_MIN:
@@ -6906,7 +6909,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                  * intern id (Issue #965). */
                 if (col_agg_better(op->agg_fn, op->agg_operand_type,
                     sess->intern, agg_val, cur))
-                    col_rel_set(out, group_row, gc, agg_val);
+                    col_rel_set(out, group_row, agg_index, agg_val);
                 break;
             default:
                 break;
@@ -6916,9 +6919,10 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
             for (uint32_t k = 0; k < gc; k++) {
                 uint32_t gi
                     = op->group_by_indices ? op->group_by_indices[k] : k;
-                tmp[k] = row[gi < in->ncols ? gi : 0];
+                uint32_t out_col = k >= agg_index ? k + 1 : k;
+                tmp[out_col] = row[gi < in->ncols ? gi : 0];
             }
-            tmp[gc] = (op->agg_fn == WIRELOG_AGG_COUNT) ? 1 : agg_val;
+            tmp[agg_index] = (op->agg_fn == WIRELOG_AGG_COUNT) ? 1 : agg_val;
             int rc = col_rel_append_row(out, tmp);
             if (rc != 0) {
                 col_row_buf_release(&row_rb);

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -187,6 +187,58 @@ out:
     return ret;
 }
 
+#ifdef WL_MBEDTLS_ENABLED
+static int
+wl_columnar_ops_parse_uuid(const char *text, unsigned char uuid[16])
+{
+    static const unsigned char hyphen[4] = { 8, 13, 18, 23 };
+    size_t pos = 0;
+
+    if (!text || strlen(text) != 36)
+        return -1;
+    for (size_t i = 0; i < 36; i++) {
+        if (i == hyphen[0] || i == hyphen[1]
+            || i == hyphen[2] || i == hyphen[3]) {
+            if (text[i] != '-')
+                return -1;
+            continue;
+        }
+        unsigned char c = (unsigned char)text[i];
+        unsigned char nibble;
+        if (c >= '0' && c <= '9')
+            nibble = (unsigned char)(c - '0');
+        else if (c >= 'a' && c <= 'f')
+            nibble = (unsigned char)(c - 'a' + 10);
+        else if (c >= 'A' && c <= 'F')
+            nibble = (unsigned char)(c - 'A' + 10);
+        else
+            return -1;
+        if ((pos & 1u) == 0)
+            uuid[pos / 2] = (unsigned char)(nibble << 4);
+        else
+            uuid[pos / 2] |= nibble;
+        pos++;
+    }
+    return pos == 32 ? 0 : -1;
+}
+
+static int64_t
+wl_columnar_ops_format_uuid(const unsigned char uuid[16], wl_intern_t *intern)
+{
+    static const char hex[] = "0123456789abcdef";
+    char text[37];
+    size_t out = 0;
+    for (size_t i = 0; i < 16; i++) {
+        text[out++] = hex[uuid[i] >> 4];
+        text[out++] = hex[uuid[i] & 0x0f];
+        if (i == 3 || i == 5 || i == 7 || i == 9)
+            text[out++] = '-';
+    }
+    text[out] = '\0';
+    return wl_intern_put(intern, text);
+}
+#endif
+
 static int
 wl_columnar_ops_psa_hmac_sha256(const void *msg, size_t msg_len,
     const void *key, size_t key_len, unsigned char *digest, size_t digest_len)
@@ -912,6 +964,40 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
             if (!intern || wl_string_ops_to_number_checked(a, intern, &v) != 0)
                 goto bad;
             filt_push(&s, v);
+            break;
+        }
+        case WL_PLAN_EXPR_STR_FN_UUID5_RFC: {
+#ifdef WL_MBEDTLS_ENABLED
+            int64_t name_id = filt_pop(&s);
+            int64_t namespace_id = filt_pop(&s);
+            const char *namespace_text = intern
+                ? wl_intern_reverse(intern, namespace_id) : NULL;
+            const char *name = intern
+                ? wl_intern_reverse(intern, name_id) : NULL;
+            unsigned char namespace_uuid[16];
+            unsigned char digest[20];
+
+            /* RFC 4122 requires the namespace operand to be a canonical
+             * UUID string, but the name is an arbitrary string. */
+            if (!intern || !name
+                || wl_columnar_ops_parse_uuid(namespace_text,
+                namespace_uuid) != 0
+                || wl_columnar_ops_psa_hash_pair(PSA_ALG_SHA_1, false,
+                0, namespace_uuid, sizeof(namespace_uuid), 0,
+                name, strlen(name), digest, sizeof(digest)) != 0)
+                goto bad;
+            /* RFC 4122 v5: version 5 and the RFC variant. */
+            digest[6] = (digest[6] & 0x0F) | 0x50;
+            digest[8] = (digest[8] & 0x3F) | 0x80;
+            int64_t result = wl_columnar_ops_format_uuid(digest, intern);
+            if (result < 0)
+                goto bad;
+            filt_push(&s, result);
+#else
+            (void)filt_pop(&s);
+            (void)filt_pop(&s);
+            goto bad; /* uuid5_rfc requires mbedTLS */
+#endif
             break;
         }
 

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -2266,6 +2266,16 @@ col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
     wl_col_session_t *sess = COL_SESSION(session);
     const wl_plan_t *plan = sess->plan;
 
+    /* K-fusion's pre-seeded delta expansion is designed for step-style
+     * outbound evaluation.  On the snapshot route it can suppress the EDB
+     * base segment before the newly inserted delta reaches a fused recursive
+     * relation (#1030).  A delta callback makes inserts incremental, but a
+     * snapshot still promises the complete current model; fall back to the
+     * already-correct full evaluation path for that combination. */
+    if (sess->delta_cb != NULL && sess->last_inserted_relation != NULL
+        && sess->has_evaluated)
+        sess->pending_full_input_eval = true;
+
     /* Reset profiling counters for this evaluation pass */
     col_session_reset_snapshot_profile(sess);
 

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -157,6 +157,7 @@ typedef enum {
     WL_PLAN_EXPR_STR_FN_TRIM       = 0x4A, /* unary:   pop 1 push 1 */
     WL_PLAN_EXPR_STR_FN_TO_STRING  = 0x4B, /* unary:   pop 1 push 1 */
     WL_PLAN_EXPR_STR_FN_TO_NUMBER  = 0x4C, /* unary:   pop 1 push 1 */
+    WL_PLAN_EXPR_STR_FN_UUID5_RFC  = 0x4D, /* binary: pop 2 push 1 */
 
     /* String comparison operators (intern IDs → bool, via strcmp) */
     WL_PLAN_EXPR_CMP_STR_EQ  = 0x50, /* binary: pop 2 push bool */

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -335,14 +335,15 @@ typedef enum {
  *                  Only WIRELOG_AGG_MIN and WIRELOG_AGG_MAX are admitted.
  * @operand_type:   The aggregated operand's domain, which decides whether
  *                  the order is numeric or lexicographic (Issue #965).
- * @group_by_count: Number of leading grouping columns; the aggregated
- *                  value sits at column @group_by_count.
+ * @group_by_count: Number of grouping columns.
+ * @aggregate_index: Output column containing the aggregated value.
  */
 typedef struct {
     bool has_spec;
     wirelog_agg_fn_t fn;
     wl_plan_agg_operand_t operand_type;
     uint32_t group_by_count;
+    uint32_t aggregate_index;
 } wl_plan_agg_spec_t;
 
 /* ======================================================================== */
@@ -481,6 +482,7 @@ typedef struct {
     wl_plan_expr_buffer_t agg_expr;
     const uint32_t *group_by_indices;
     uint32_t group_by_count;
+    uint32_t aggregate_index;
 
     wl_plan_expr_buffer_t *map_exprs;
     uint32_t map_expr_count;

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -958,7 +958,8 @@ agg_spec_observe(op_list_t *list, const wl_plan_op_t *reduce)
 
     if (list->agg.has_spec
         && (list->agg.fn != reduce->agg_fn
-        || list->agg.group_by_count != reduce->group_by_count)) {
+        || list->agg.group_by_count != reduce->group_by_count
+        || list->agg.aggregate_index != reduce->aggregate_index)) {
         list->agg_vetoed = true;
         memset(&list->agg, 0, sizeof(list->agg));
         return;
@@ -967,6 +968,7 @@ agg_spec_observe(op_list_t *list, const wl_plan_op_t *reduce)
     list->agg.has_spec = true;
     list->agg.fn = reduce->agg_fn;
     list->agg.group_by_count = reduce->group_by_count;
+    list->agg.aggregate_index = reduce->aggregate_index;
     list->agg.operand_type = reduce->agg_operand_type;
 }
 
@@ -1616,6 +1618,7 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
         op->group_by_indices
             = dup_indices(node->group_by_indices, node->group_by_count);
         op->group_by_count = node->group_by_count;
+        op->aggregate_index = node->aggregate_index;
         if (node->agg_expr) {
             const wirelog_ir_node_t *child0
                 = (node->child_count > 0) ? node->children[0] : NULL;
@@ -2133,6 +2136,7 @@ clone_plan_op(const wl_plan_op_t *src, wl_plan_op_t *dst)
     dst->key_count = src->key_count;
     dst->project_count = src->project_count;
     dst->group_by_count = src->group_by_count;
+    dst->aggregate_index = src->aggregate_index;
     dst->map_expr_count = src->map_expr_count;
 
     if (src->relation_name) {

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -523,6 +523,7 @@ str_fn_to_tag(wirelog_str_fn_t fn)
     case WIRELOG_STR_FN_TRIM:        return WL_PLAN_EXPR_STR_FN_TRIM;
     case WIRELOG_STR_FN_TO_STRING:   return WL_PLAN_EXPR_STR_FN_TO_STRING;
     case WIRELOG_STR_FN_TO_NUMBER:   return WL_PLAN_EXPR_STR_FN_TO_NUMBER;
+    case WIRELOG_STR_FN_UUID5_RFC:   return WL_PLAN_EXPR_STR_FN_UUID5_RFC;
     }
     return WL_PLAN_EXPR_STR_FN_STRLEN; /* fallback */
 }
@@ -697,6 +698,7 @@ expr_result_type(const wl_ir_expr_t *expr, const col_ctx_t *ctx)
         case WIRELOG_STR_FN_STR_REPLACE:
         case WIRELOG_STR_FN_TRIM:
         case WIRELOG_STR_FN_TO_STRING:
+        case WIRELOG_STR_FN_UUID5_RFC:
             return WL_IR_COLTYPE_STRING;
         /* Produce a length, a code point, a boolean or a number. */
         case WIRELOG_STR_FN_STRLEN:

--- a/wirelog/ir/ir.c
+++ b/wirelog/ir/ir.c
@@ -163,6 +163,8 @@ wl_ir_node_create(wirelog_ir_node_type_t type)
     if (!node)
         return NULL;
     node->type = type;
+    if (type == WIRELOG_IR_AGGREGATE)
+        node->aggregate_index = WL_IR_AGGREGATE_INDEX_UNSET;
     return node;
 }
 

--- a/wirelog/ir/ir.h
+++ b/wirelog/ir/ir.h
@@ -19,6 +19,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* A zero aggregate_index is a valid head position.  Keep legacy/internal
+ * callers that do not specify one distinguishable from that position. */
+#define WL_IR_AGGREGATE_INDEX_UNSET UINT32_MAX
+
 /* ======================================================================== */
 /* Expression Representation                                                */
 /* ======================================================================== */
@@ -128,7 +132,7 @@ struct wirelog_ir_node {
     wl_ir_expr_t *agg_expr;     /* AGGREGATE: expression to aggregate */
     uint32_t *group_by_indices; /* AGGREGATE: grouping column indices */
     uint32_t group_by_count;    /* AGGREGATE: number of grouping columns */
-    uint32_t aggregate_index;   /* AGGREGATE: output position of aggregate */
+    uint32_t aggregate_index;   /* AGGREGATE: output position, or UNSET */
 
     /* Compound column IR (Issue #531) */
     struct {

--- a/wirelog/ir/ir.h
+++ b/wirelog/ir/ir.h
@@ -128,6 +128,7 @@ struct wirelog_ir_node {
     wl_ir_expr_t *agg_expr;     /* AGGREGATE: expression to aggregate */
     uint32_t *group_by_indices; /* AGGREGATE: grouping column indices */
     uint32_t group_by_count;    /* AGGREGATE: number of grouping columns */
+    uint32_t aggregate_index;   /* AGGREGATE: output position of aggregate */
 
     /* Compound column IR (Issue #531) */
     struct {

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -2335,6 +2335,12 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
         if (root) {
             wl_ir_node_set_relation(root, head->name);
             root->agg_fn = agg_node->agg_fn;
+            for (uint32_t i = 0; i < head->child_count; i++) {
+                if (head->children[i]->type == WL_PARSER_AST_NODE_AGGREGATE) {
+                    root->aggregate_index = i;
+                    break;
+                }
+            }
 
             if (agg_node->child_count >= 1) {
                 root->agg_expr = convert_expr(agg_node->children[0]);

--- a/wirelog/parser/lexer.c
+++ b/wirelog/parser/lexer.c
@@ -296,6 +296,8 @@ identifier_type(const char *start, uint32_t length)
         return WL_PARSER_LEXER_TOK_TO_STRING;
     if (IS_KW("to_number"))
         return WL_PARSER_LEXER_TOK_TO_NUMBER;
+    if (IS_KW("uuid5_rfc"))
+        return WL_PARSER_LEXER_TOK_UUID5_RFC;
 
     return WL_PARSER_LEXER_TOK_IDENT;
 }
@@ -601,6 +603,8 @@ wl_parser_lexer_token_type_str(wl_parser_lexer_token_type_t type)
         return "UUID4";
     case WL_PARSER_LEXER_TOK_UUID5:
         return "UUID5";
+    case WL_PARSER_LEXER_TOK_UUID5_RFC:
+        return "UUID5_RFC";
     case WL_PARSER_LEXER_TOK_CRC32_ETH:
         return "CRC32_ETHERNET";
     case WL_PARSER_LEXER_TOK_CRC32_CAST:

--- a/wirelog/parser/lexer.h
+++ b/wirelog/parser/lexer.h
@@ -98,6 +98,7 @@ typedef enum {
     /* UUID function keywords (mbedTLS) */
     WL_PARSER_LEXER_TOK_UUID4, /* uuid4 */
     WL_PARSER_LEXER_TOK_UUID5, /* uuid5 */
+    WL_PARSER_LEXER_TOK_UUID5_RFC, /* uuid5_rfc */
 
     /* CRC-32 function keywords (Issue #884) */
     WL_PARSER_LEXER_TOK_CRC32_ETH,  /* crc32_ethernet */

--- a/wirelog/parser/parser.c
+++ b/wirelog/parser/parser.c
@@ -265,6 +265,7 @@ token_to_str_fn(wl_parser_lexer_token_type_t type)
     case WL_PARSER_LEXER_TOK_TRIM:        return WIRELOG_STR_FN_TRIM;
     case WL_PARSER_LEXER_TOK_TO_STRING:   return WIRELOG_STR_FN_TO_STRING;
     case WL_PARSER_LEXER_TOK_TO_NUMBER:   return WIRELOG_STR_FN_TO_NUMBER;
+    case WL_PARSER_LEXER_TOK_UUID5_RFC:   return WIRELOG_STR_FN_UUID5_RFC;
     default:                               return WIRELOG_STR_FN_STRLEN;
     }
 }
@@ -284,7 +285,8 @@ is_string_fn_token(wl_parser_lexer_token_type_t type)
            || type == WL_PARSER_LEXER_TOK_STR_REPLACE
            || type == WL_PARSER_LEXER_TOK_TRIM
            || type == WL_PARSER_LEXER_TOK_TO_STRING
-           || type == WL_PARSER_LEXER_TOK_TO_NUMBER;
+           || type == WL_PARSER_LEXER_TOK_TO_NUMBER
+           || type == WL_PARSER_LEXER_TOK_UUID5_RFC;
 }
 
 /* Parse a string function call: fn(arg [, arg]*) */
@@ -327,6 +329,12 @@ parse_string_fn_expr(wl_parser_t *parser)
 
     if (!parser_consume(parser, WL_PARSER_LEXER_TOK_RPAREN,
         "expected ')' after string function arguments")) {
+        wl_parser_ast_node_free(node);
+        return NULL;
+    }
+
+    if (fn == WIRELOG_STR_FN_UUID5_RFC && node->child_count != 2) {
+        parser_error(parser, "uuid5_rfc expects namespace and name");
         wl_parser_ast_node_free(node);
         return NULL;
     }

--- a/wirelog/wirelog-types.h
+++ b/wirelog/wirelog-types.h
@@ -117,6 +117,7 @@ typedef enum {
     WIRELOG_STR_FN_TRIM,        /* trim(s) - strip leading/trailing whitespace */
     WIRELOG_STR_FN_TO_STRING,   /* to_string(x) - numeric to string */
     WIRELOG_STR_FN_TO_NUMBER,   /* to_number(s) - string to numeric */
+    WIRELOG_STR_FN_UUID5_RFC,   /* uuid5_rfc(namespace_uuid, name) */
 } wirelog_str_fn_t;
 
 /* ======================================================================== */


### PR DESCRIPTION
## Summary

- Add RFC 4122 UUID v5 string builtin `uuid5_rfc` while preserving legacy `uuid5`.
- Preserve aggregate expressions at their declared head positions with legacy IR defaults.
- Recompute fused relations before snapshots after delta-callback inserts.

## Validation

- Full build: passed
- Focused regression tests: 5/5 passed
- Full Meson suite: 272 passed, 11 skipped, 1 unrelated SBOM snapshot baseline mismatch (`msys2/setup-msys2` reference drift)
- Independent Reviewer, Architect, and Critic validation: approved

Closes #971
Closes #980
Closes #1030
