### PR TITLE
fix(cli): render output columns by physical layout, not declared index

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4719,6 +4719,27 @@ test_input_arity_exe = executable(
 test('input_arity', test_input_arity_exe)
 
 # ============================================================================
+# CLI physical column rendering (#1036)
+# ============================================================================
+test_cli_physical_columns_exe = executable(
+  'test_cli_physical_columns',
+  files('test_cli_physical_columns.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  driver_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+  install: false,
+)
+test('cli_physical_columns', test_cli_physical_columns_exe)
+
+# ============================================================================
 # CSV Reader Line/Field Limit Tests (#953)
 # The reader used to pull lines through a fixed 4096-byte fgets buffer, so a
 # longer physical line was delivered in chunks and every chunk became its own

--- a/tests/test_cli_physical_columns.c
+++ b/tests/test_cli_physical_columns.c
@@ -1,0 +1,268 @@
+/*
+ * test_cli_physical_columns.c - CLI renders by physical layout (Issue #1036)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * The CLI used to pick a column's render type by indexing the relation's
+ * declared columns[] with the row's *physical* position.  Those two indexings
+ * agree only until the first `inline` compound column, which occupies
+ * compound_arity slots rather than one -- after it every type is shifted, and
+ * on the last column the index runs off the end of columns[] entirely.
+ *
+ * The visible result is not a crash but a plausible-looking wrong line.  For
+ *
+ *     .decl inp(id: int64, p: pair/2 inline, s: symbol)
+ *
+ * a row whose physical values are [1, 7, 0, intern("zz")] printed as
+ *
+ *     inp(1, 7, "pair", 1)
+ *
+ * -- the compound's second slot reverse-interned into the *functor name*,
+ * because slot 2 was rendered with `s`'s symbol type, and the genuine symbol
+ * printed as its raw intern id, because slot 3 had no declared column at all.
+ *
+ * So these tests assert the rendered text, not a row count or an exit status:
+ * both the buggy and the correct output are one well-formed line with four
+ * fields, and the wrong one is the more plausible-looking of the two.
+ *
+ * Each case pairs the compound relation with a compound-free control in the
+ * same program.  Without the control, a "fix" that stopped reverse-interning
+ * altogether -- printing every symbol as a raw id -- would pass every
+ * positive assertion here.
+ */
+
+#include "../wirelog/cli/driver.h"
+
+#include "test_tmpdir.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
+
+/*
+ * Run the full pipeline on @src, capturing printed tuples into @outpath.
+ * On success (*out_text != NULL) the caller must free(*out_text).
+ */
+static int
+run_capture(const char *src, const char *outpath, char **out_text)
+{
+    *out_text = NULL;
+
+    FILE *f = fopen(outpath, "w");
+    if (!f)
+        return -999;
+
+    int rc = wl_run_pipeline(src, 1, false, false, 0, f);
+    fclose(f);
+
+    *out_text = wl_read_file(outpath);
+    return rc;
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * An inline compound sits between an int64 and a symbol, so every physical
+ * slot after the compound is misaligned by one against columns[].
+ *
+ * The control relation `plain` carries the same symbol in the same trailing
+ * position with no compound before it; it rendered correctly before the fix
+ * and must still.
+ */
+static const char *const k_inline_then_symbol_src =
+    ".decl src(a: int64, b: int64, c: int64, d: symbol)\n"
+    ".decl inp(id: int64, p: pair/2 inline, s: symbol)\n"
+    ".decl plain(id: int64, s: symbol)\n"
+    ".output inp\n"
+    ".output plain\n"
+    "src(1, 7, 0, \"zz\").\n"
+    "inp(x, y, z, w) :- src(x, y, z, w).\n"
+    "plain(x, w) :- src(x, y, z, w).\n";
+
+static void
+test_inline_compound_render(void)
+{
+    TEST("stdout: a symbol after an inline compound renders as itself");
+
+    char path[512];
+    test_tmppath(path, sizeof(path), "wl_1036_stdout.txt");
+
+    char *text = NULL;
+    int rc = run_capture(k_inline_then_symbol_src, path, &text);
+    if (rc != 0 || !text) {
+        free(text);
+        remove(path);
+        FAIL("pipeline did not run");
+        return;
+    }
+
+    /*
+     * The compound's slots are raw payload and print as integers; the
+     * trailing symbol reverse-interns.  Pre-fix this was
+     * inp(1, 7, "pair", 1).
+     */
+    bool ok = strstr(text, "inp(1, 7, 0, \"zz\")") != NULL;
+    bool no_functor = strstr(text, "\"pair\"") == NULL;
+    /* Control: unaffected by the compound, correct before and after. */
+    bool control = strstr(text, "plain(1, \"zz\")") != NULL;
+
+    free(text);
+    remove(path);
+
+    if (!ok)
+        FAIL("expected inp(1, 7, 0, \"zz\")");
+    else if (!no_functor)
+        FAIL("a compound slot was reverse-interned to the functor name");
+    else if (!control)
+        FAIL("control relation lost its symbol rendering");
+    else
+        PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * The CSV writer behind .output(filename=...) had the identical indexing, and
+ * is a separate code path from the stdout printer -- a fix applied to only
+ * one of them passes the case above and fails here.
+ */
+static void
+test_inline_compound_csv(void)
+{
+    TEST("csv: .output(filename=) writes physical columns");
+
+    char csv[512], cap[512];
+    test_tmppath(csv, sizeof(csv), "wl_1036_out.csv");
+    test_tmppath(cap, sizeof(cap), "wl_1036_csvcap.txt");
+    remove(csv);
+
+    char src[1024];
+    snprintf(src, sizeof(src),
+        ".decl src(a: int64, b: int64, c: int64, d: symbol)\n"
+        ".decl inp(id: int64, p: pair/2 inline, s: symbol)\n"
+        ".output inp(filename=\"%s\")\n"
+        "src(1, 7, 0, \"zz\").\n"
+        "inp(x, y, z, w) :- src(x, y, z, w).\n",
+        csv);
+
+    char *ignored = NULL;
+    int rc = run_capture(src, cap, &ignored);
+    free(ignored);
+    remove(cap);
+
+    if (rc != 0) {
+        remove(csv);
+        FAIL("pipeline did not run");
+        return;
+    }
+
+    char *written = wl_read_file(csv);
+    remove(csv);
+    if (!written) {
+        FAIL("no CSV file was written");
+        return;
+    }
+
+    bool ok = strstr(written, "1,7,0,zz") != NULL;
+    bool no_functor = strstr(written, "pair") == NULL;
+    free(written);
+
+    if (!ok)
+        FAIL("expected the row 1,7,0,zz");
+    else if (!no_functor)
+        FAIL("a compound slot was reverse-interned to the functor name");
+    else
+        PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+/*
+ * A relation whose declared width already equals its physical width must be
+ * byte-identical to before.  This is the case that fails if the new helper
+ * miscounts a non-compound column, or treats a `side` compound -- which
+ * occupies one slot, not compound_arity -- as if it were inline.
+ */
+static void
+test_side_compound_and_plain_unchanged(void)
+{
+    TEST("control: side compound and plain relations are unchanged");
+
+    char path[512];
+    test_tmppath(path, sizeof(path), "wl_1036_side.txt");
+
+    /*
+     * sq's compound is `side`, which occupies one handle slot rather than
+     * compound_arity, so its declared and physical widths already agree and
+     * the trailing symbol must still reverse-intern.  A helper that treated
+     * every compound as inline would widen the handle to two slots, push the
+     * symbol to a physical index the walk types as raw payload, and print
+     * 99's neighbour as an integer.
+     */
+    static const char *const src =
+        ".decl e(a: int64, b: int64, c: symbol)\n"
+        ".decl sq(id: int64, h: pair/2 side, s: symbol)\n"
+        ".output sq\n"
+        "e(4, 99, \"qq\").\n"
+        "sq(x, y, z) :- e(x, y, z).\n";
+
+    char *text = NULL;
+    int rc = run_capture(src, path, &text);
+    if (rc != 0 || !text) {
+        free(text);
+        remove(path);
+        FAIL("pipeline did not run");
+        return;
+    }
+
+    bool ok = strstr(text, "sq(4, 99, \"qq\")") != NULL;
+    free(text);
+    remove(path);
+
+    if (!ok)
+        FAIL("expected sq(4, 99, \"qq\")");
+    else
+        PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+int
+main(void)
+{
+    printf("=== CLI physical column rendering (#1036) ===\n\n");
+
+    test_inline_compound_render();
+    test_inline_compound_csv();
+    test_side_compound_and_plain_unchanged();
+
+    printf("\n=== Results: %d run, %d passed, %d failed ===\n",
+        tests_run, tests_passed, tests_failed);
+
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/cli/driver.c
+++ b/wirelog/cli/driver.c
@@ -151,6 +151,43 @@ find_relation(const wirelog_program_t *prog, const char *name)
     return NULL;
 }
 
+/*
+ * Type of the physical column at index @phys, or INT64 when it cannot be
+ * named.
+ *
+ * A relation's columns[] is its *declared* list; a row is laid out
+ * physically, and an inline compound column occupies compound_arity slots
+ * rather than one.  Indexing columns[] with a physical position therefore
+ * shifts every type after the first inline compound and runs off the end on
+ * the last one -- the mistake build_atom_scan() in ir/program.c warns about
+ * by name, and that #962 fixed there.  Every renderer below goes through
+ * this instead (#1036).
+ *
+ * An inline compound's slots are raw int64 payload, not the declared type of
+ * the compound as a whole, which is the same expansion io_ctx.c applies to
+ * the .input column types.  A physical index past the declared width has no
+ * declared type at all; INT64 renders it verbatim rather than reverse-
+ * interning a value that is not an intern id.
+ */
+static wirelog_column_type_t
+physical_column_type(const wl_ir_relation_info_t *rel, uint32_t phys)
+{
+    if (!rel)
+        return WIRELOG_TYPE_INT64;
+
+    uint32_t at = 0;
+    for (uint32_t c = 0; c < rel->column_count; c++) {
+        bool inl = (rel->columns[c].compound_kind
+            == WIRELOG_COMPOUND_KIND_INLINE);
+        uint32_t width = inl ? rel->columns[c].compound_arity : 1;
+
+        if (phys < at + width)
+            return inl ? WIRELOG_TYPE_INT64 : rel->columns[c].type;
+        at += width;
+    }
+    return WIRELOG_TYPE_INT64;
+}
+
 /* Write a single tuple as a CSV row to the given file */
 static void
 write_tuple_csv(FILE *f, const wl_ir_relation_info_t *rel,
@@ -160,8 +197,7 @@ write_tuple_csv(FILE *f, const wl_ir_relation_info_t *rel,
         if (i > 0)
             fprintf(f, ",");
 
-        if (rel && i < rel->column_count
-            && rel->columns[i].type == WIRELOG_TYPE_STRING && intern) {
+        if (physical_column_type(rel, i) == WIRELOG_TYPE_STRING && intern) {
             const char *str = wl_intern_reverse(intern, row[i]);
             if (str)
                 fprintf(f, "%s", str);
@@ -209,8 +245,8 @@ print_tuple_cb(const char *relation, const int64_t *row, uint32_t ncols,
         if (i > 0)
             fprintf(ctx->out, ", ");
 
-        if (rel && i < rel->column_count
-            && rel->columns[i].type == WIRELOG_TYPE_STRING && ctx->intern) {
+        if (physical_column_type(rel, i) == WIRELOG_TYPE_STRING
+            && ctx->intern) {
             const char *str = wl_intern_reverse(ctx->intern, row[i]);
             if (str)
                 fprintf(ctx->out, "\"%s\"", str);
@@ -313,8 +349,7 @@ parse_watch_line(char *line, char *relation_out, size_t rel_buf_size,
 
         /* Type-aware parsing: intern strings when schema is known */
         bool is_string = false;
-        if (rel_info && col < rel_info->column_count
-            && rel_info->columns[col].type == WIRELOG_TYPE_STRING)
+        if (physical_column_type(rel_info, col) == WIRELOG_TYPE_STRING)
             is_string = true;
 
         if (is_string && intern) {
@@ -360,8 +395,8 @@ delta_tuple_cb(const char *relation, const int64_t *row, uint32_t ncols,
         if (i > 0)
             fprintf(ctx->out, ", ");
 
-        if (rel && i < rel->column_count
-            && rel->columns[i].type == WIRELOG_TYPE_STRING && ctx->intern) {
+        if (physical_column_type(rel, i) == WIRELOG_TYPE_STRING
+            && ctx->intern) {
             const char *str = wl_intern_reverse(ctx->intern, row[i]);
             if (str)
                 fprintf(ctx->out, "\"%s\"", str);


### PR DESCRIPTION
Closes #1036. Touches `wirelog/cli/driver.c` only — **disjoint from the 0.54.0 magic-sets work in flight.**

The CLI picked a column's render type by indexing the relation's declared `columns[]` with the row's **physical** position. Those agree only until the first `inline` compound column, which occupies `compound_arity` slots rather than one.

```
.decl inp(id: int64, p: pair/2 inline, s: symbol)
src(1, 7, 0, "zz").   inp(x, y, z, w) :- src(x, y, z, w).
```
printed **`inp(1, 7, "pair", 1)`** for a row holding `1, 7, 0, intern("zz")`.

Two things wrong in one line:
- physical slot 2 holds the compound's second value `0`, but was rendered with `s`'s symbol type and **reverse-interned into the functor name `"pair"`** — a string appearing nowhere in the program's data;
- physical slot 3 holds the real symbol, but there is no `columns[3]`, so it fell through to the integer path and printed a raw intern id.

Neither is a crash, and the result is a well-formed four-field line — which is why it survived. **The wrong output is the more plausible-looking of the two.**

## The fix

All four sites (`write_tuple_csv`, `print_tuple_cb`, `parse_watch_line`, `delta_tuple_cb`) now go through one helper that walks the declared columns accumulating physical width. Inline slots are typed raw `int64` — the same expansion `io_ctx.c` got in #985 — and a position past the declared width is too, rendering verbatim rather than reverse-interning a value that is not an intern id.

This is the mistake `build_atom_scan()` in `ir/program.c` **warns about by name** ("in particular by indexing `rel_info->columns[]` with a physical position") and that #962 fixed there. The printer was the remaining instance.

Pre-existing and reachable through the rule-head route — the output above is byte-identical before and after #985. What #985 changed is the *reach*, by opening the fact and `.input` doors onto the same relations.

## Tests

| case | base | fixed |
|---|---|---|
| stdout printer | **FAIL** | PASS |
| CSV writer (`.output(filename=)`) | **FAIL** | PASS |
| `side` compound control | PASS | PASS |

The stdout printer and the CSV writer are **separate code paths** — a fix applied to only one passes the first and fails the second.

Each case asserts the **rendered text**, not a row count or exit status, since both the buggy and correct outputs are one well-formed line. Each pairs the compound relation with a compound-free control in the same program, so a "fix" that simply stopped reverse-interning altogether would fail.

The third case is a `side` compound, which occupies one handle slot rather than `compound_arity` and must not move. **Mutation-verified**: flipping the helper's test from `== INLINE` to `!= NONE` fails it and only it.

## Stated gap

`parse_watch_line` carries the identical indexing and the identical change but is **not covered** — exercising it needs a watch-mode session on stdin. Deliberate rather than overlooked.

## Validation

273 ok / 1 fail / 11 skipped — the failure is the pre-existing `sbom_snapshot` pin drift. `abi` 33/33. clang-tidy **0** on `driver.c` before and after (checked first, since the now-live gate blocks on a file's pre-existing backlog). uncrustify clean on both changed files.

## Process note

Produced in **degraded mode** — the independent Architect / Critic / Reviewer passes this repo's workflow normally uses were unavailable (subagent quota). One author wrote the plan, the fix and the tests, so there is no independent review of any of them. The mutation results above are self-run. Worth a second pair of eyes on the helper's width walk in particular.