### PR TITLE
fix(ir): give a rejected program somewhere to say why (#979)

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4633,6 +4633,16 @@ if not is_android
   # Reuses baseline_py3 (already resolved above) to invoke the executable.
   # ============================================================================
 
+  test('cli_parse_diagnostics',
+    baseline_py3,
+    args: [
+      files('test_cli_parse_diagnostics.py')[0],
+      wirelog_cli.full_path(),
+    ],
+    depends: wirelog_cli,
+    suite: 'cli',
+  )
+
   test('cli_version',
     baseline_py3,
     args: [

--- a/tests/test_cli_parse_diagnostics.py
+++ b/tests/test_cli_parse_diagnostics.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# test_cli_parse_diagnostics.py - rejected programs explain themselves (#979)
+#
+# Copyright (C) CleverPlant
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# Usage: test_cli_parse_diagnostics.py <wirelog_cli_executable>
+#
+# Every load failure used to reach the user as the bare two words "Parse
+# error".  The rejection sites in wirelog/ir/program.c already compose good
+# messages naming the relation, the count and the line, but they emit through
+# WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR, ...) and wl_log_thresholds defaults
+# to WL_LOG_NONE (0).  The gate is (LVL) <= threshold and WL_LOG_ERROR is 1,
+# so 1 <= 0 is false and the text was discarded unless the user had already
+# set WL_LOG=PARSER:1 -- which requires knowing the answer to ask the
+# question.  wirelog_parse_string() separately filled a 512-byte errbuf with
+# the syntax error and let it go out of scope unread.
+#
+# So these cases assert on *stderr text with a scrubbed environment*.  WL_LOG
+# and WL_LOG_FILE are removed from the child environment explicitly: inherited
+# from a developer shell either would make every assertion below pass without
+# the fix, which is the exact failure mode the issue describes.
+#
+# Two properties are asserted together throughout, and the second is the one
+# that keeps the first honest:
+#
+#   1. the message names the thing that was rejected, and
+#   2. the program is *still rejected* -- non-zero exit, nothing evaluated.
+#
+# Without (2) a "fix" that made the checks permissive and printed a warning
+# would pass every text assertion here while silently reintroducing the
+# wrong-answer classes those checks exist to stop (#973, #977, #920).
+
+import os
+import subprocess
+import sys
+import tempfile
+
+# Rejections that must name their subject.  Each entry is
+#   (label, program text, [substrings that must all appear in stderr])
+# The substrings are deliberately the *identifiers from the program* rather
+# than fixed prose, so rewording a diagnostic does not break the test but
+# dropping the relation name does.
+#
+# Every identifier here is deliberately long and distinctive.  The first draft
+# of this test used the natural short names from the issue -- a relation `t`
+# and a variable `y` -- and the `t` case passed against the unfixed binary,
+# because the pre-existing stderr "Parse error\nerror: execution failed"
+# happens to contain a `t` (in "execution").  A one- or two-character needle
+# cannot distinguish a real diagnostic from an incidental substring, so the
+# assertion was vacuous in exactly the way this issue is about.  Keep these
+# names long enough that an accidental match is not possible.
+CASES = [
+    (
+        "fact arity",
+        '.decl edge(a: int64, b: int64)\n.output edge\nedge(1).\n',
+        ["edge"],
+    ),
+    (
+        "rule head width",
+        '.decl src(a: int64, b: int64)\n'
+        '.decl narrow(a: int64)\n'
+        '.output narrow\n'
+        'src(1, 2).\n'
+        'narrow(x, y) :- src(x, y).\n',
+        ["narrow"],
+    ),
+    (
+        "two aggregates in one head",
+        '.decl val(g: int64, v: int64)\n'
+        '.decl aggpair(g: int64, a: int64, b: int64)\n'
+        '.output aggpair\n'
+        'val(1, 5).  val(1, 9).\n'
+        'aggpair(g, min(v), max(v)) :- val(g, v).\n',
+        ["aggpair"],
+    ),
+    (
+        "unsafe variable under negation",
+        '.decl posrel(a: int64)\n'
+        '.decl negrel(a: int64, b: int64)\n'
+        '.decl outrel(a: int64)\n'
+        '.output outrel\n'
+        'posrel(1).\n'
+        'outrel(x) :- posrel(x), !negrel(x, unboundvar).\n',
+        ["unboundvar", "negrel"],
+    ),
+    (
+        "__graph_metadata arity",
+        '.decl __graph_metadata(a: int64, b: int64)\n'
+        '.decl z(a: int64)\n'
+        '.output z\n'
+        'z(1).\n',
+        ["__graph_metadata"],
+    ),
+]
+
+# A syntactically malformed program.  This is the errbuf that
+# wirelog_parse_string() filled and threw away, a different gap from the
+# lowering stages above, so it gets its own case.
+SYNTAX_CASE = '.decl e(a: int64, b: int64)\ne(1, 2)\n@@@ this is not datalog @@@\n'
+
+# Control.  A valid program must keep exiting 0 and must not gain any
+# diagnostic chatter on stderr.  Without this, a "fix" that unconditionally
+# printed an error string would satisfy every assertion above.
+VALID = (
+    '.decl e(a: int64, b: int64)\n'
+    '.decl reach(a: int64, b: int64)\n'
+    '.output reach\n'
+    'e(1, 2).  e(2, 3).\n'
+    'reach(x, y) :- e(x, y).\n'
+    'reach(x, z) :- reach(x, y), e(y, z).\n'
+)
+
+
+def _scrubbed_env():
+    """Child env with the logger opt-ins removed.
+
+    Inheriting WL_LOG=PARSER:1 (or a wildcard such as WL_LOG=*:5) from the
+    developer's shell would route the rejection text to stderr through the
+    logger and make these tests pass on an unfixed tree.
+    """
+    env = dict(os.environ)
+    env.pop("WL_LOG", None)
+    env.pop("WL_LOG_FILE", None)
+    # The legacy presence-flag shim (#277) enables TRACE on its section for
+    # any value, including "0", so it has to go too.
+    env.pop("WL_DEBUG_JOIN", None)
+    env.pop("WL_CONSOLIDATION_LOG", None)
+    return env
+
+
+def _run(exe, program_text, tmpdir, name):
+    path = os.path.join(tmpdir, name + ".dl")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(program_text)
+    return subprocess.run(
+        [exe, path], capture_output=True, text=True, timeout=60,
+        env=_scrubbed_env())
+
+
+def _fail(msg):
+    sys.stderr.write(msg if msg.endswith("\n") else msg + "\n")
+    return False
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: test_cli_parse_diagnostics.py <executable>\n")
+        return 1
+    exe = sys.argv[1]
+    ok = True
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for i, (label, text, needles) in enumerate(CASES):
+            r = _run(exe, text, tmpdir, "case%d" % i)
+
+            # (2) still rejected.
+            if r.returncode == 0:
+                ok = _fail(
+                    "%s: expected a non-zero exit (the program is invalid), "
+                    "got 0. Diagnostics must not come at the cost of "
+                    "accepting the program." % label)
+                continue
+
+            # (1) and it says what was wrong.
+            for needle in needles:
+                if needle not in r.stderr:
+                    ok = _fail(
+                        "%s: stderr does not name %r.\n"
+                        "  stderr was: %r\n"
+                        "  A rejected program must say which relation or "
+                        "variable was rejected without WL_LOG being set."
+                        % (label, needle, r.stderr.strip()))
+
+        # Syntax errors: the discarded errbuf.
+        #
+        # wl_parser_parse_string() composes "line %u, col %u: %s (got %s)"
+        # (parser.c:84) and wirelog_parse_string() drops it on the floor.
+        # Asserting the position keywords is what makes this bite: an earlier
+        # draft compared stderr for equality against the string "Parse error"
+        # and passed against the unfixed binary, because the real output is
+        # "Parse error\nerror: execution failed" -- not equal, so the
+        # assertion never fired.  Require the detail to be present rather
+        # than requiring the generic text to be absent.
+        r = _run(exe, SYNTAX_CASE, tmpdir, "syntax")
+        if r.returncode == 0:
+            ok = _fail("syntax: expected a non-zero exit, got 0")
+        else:
+            for needle in ("line ", "col "):
+                if needle not in r.stderr:
+                    ok = _fail(
+                        "syntax: stderr lacks %r, so the parser's error "
+                        "buffer is still being discarded.\n"
+                        "  stderr was: %r" % (needle, r.stderr.strip()))
+
+        # Control: a valid program is unaffected.
+        r = _run(exe, VALID, tmpdir, "valid")
+        if r.returncode != 0:
+            ok = _fail(
+                "control: a valid program must still exit 0, got %d\n"
+                "  stderr was: %r" % (r.returncode, r.stderr.strip()))
+        if "error" in r.stderr.lower():
+            ok = _fail(
+                "control: a valid program must not print an error; "
+                "stderr was %r" % r.stderr.strip())
+        if "reach(1, 3)" not in r.stdout.replace("  ", " "):
+            ok = _fail(
+                "control: the valid program must still evaluate "
+                "(reach(1, 3) missing); stdout was %r" % r.stdout.strip())
+
+    if not ok:
+        return 1
+    print("test_cli_parse_diagnostics: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wirelog/cli/driver.c
+++ b/wirelog/cli/driver.c
@@ -383,9 +383,19 @@ wl_run_pipeline(const char *source, uint32_t num_workers, bool delta_mode,
 
     /* 1. Parse */
     wirelog_error_t err;
-    wirelog_program_t *prog = wirelog_parse_string(source, &err);
+    /* Issue #979: the reason a program was rejected used to be composed and
+     * then dropped -- the parser's "line %u, col %u: ..." went out of scope
+     * unread, and the semantic stages could only reach a logger whose
+     * default threshold discards WL_LOG_ERROR.  A user got these two words
+     * and nothing else. */
+    char parse_err[512] = { 0 };
+    wirelog_program_t *prog
+        = wl_ir_parse_string_err(source, &err, parse_err, sizeof(parse_err));
     if (!prog) {
-        fprintf(stderr, "Parse error\n");
+        if (parse_err[0] != '\0')
+            fprintf(stderr, "Parse error: %s\n", parse_err);
+        else
+            fprintf(stderr, "Parse error\n");
         return -1;
     }
 

--- a/wirelog/ir/api.c
+++ b/wirelog/ir/api.c
@@ -24,6 +24,7 @@
 #include "../util/log.h"
 #include "../wirelog-parser.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -31,8 +32,26 @@
 /* Parsing                                                                  */
 /* ======================================================================== */
 
+/* Copy a rejection reason into the caller's buffer, if it wants one and
+ * there is one to give.  A NULL or zero-capacity buffer is the normal case
+ * -- it is what wirelog_parse_string() passes -- so this is not an error. */
+static void
+copy_err(char *errbuf, size_t errcap, const char *msg)
+{
+    if (!errbuf || errcap == 0 || !msg || msg[0] == '\0')
+        return;
+    snprintf(errbuf, errcap, "%s", msg);
+}
+
 wirelog_program_t *
 wirelog_parse_string(const char *program_text, wirelog_error_t *error)
+{
+    return wl_ir_parse_string_err(program_text, error, NULL, 0);
+}
+
+wirelog_program_t *
+wl_ir_parse_string_err(const char *program_text, wirelog_error_t *error,
+    char *errbuf, size_t errcap)
 {
     /* Issue #973: the post-parse stages below reject some programs and explain
      * why through WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR, ...) -- the
@@ -44,11 +63,14 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error)
      * so the process returned before the logger existed and no WL_LOG value
      * could help.  Initializing here makes WL_LOG=PARSER:1 actually work.
      *
-     * This does not change default output -- the gate is LVL <= threshold and
-     * the default WL_LOG_NONE (0) still suppresses WL_LOG_ERROR (1).  A user
-     * who sets nothing still sees only "Parse error" from cli/driver.c; giving
-     * them a message by default requires surfacing the errbuf below, which is
-     * issue #979.  This is the opt-in half of that.
+     * That did not change default output -- the gate is LVL <= threshold and
+     * the default WL_LOG_NONE (0) still suppresses WL_LOG_ERROR (1) -- so it
+     * was only the opt-in half.  The default-visible half is issue #979,
+     * which is now this function: the stages record their reason on the
+     * program via wl_ir_program_set_error() and it is copied into @errbuf
+     * below, independently of any threshold.  WL_LOG remains the way to see
+     * these when parsing through the public wirelog_parse_string(), which
+     * passes no buffer.
      *
      * Thread-safety caveat, and note this is a *new* exposure rather than
      * purely an inherited one.  wl_log_init() fcloses the old sink, NULLs it
@@ -63,6 +85,9 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error)
      * Cost: with WL_LOG_FILE set this reopens the sink on every call, so a
      * caller parsing many programs in a loop pays an fopen+fclose each time.
      * Unset -- the default -- it is just a threshold recompute. */
+    if (errbuf && errcap > 0)
+        errbuf[0] = '\0';
+
     if (!program_text) {
         if (error)
             *error = WIRELOG_ERR_PARSE;
@@ -71,10 +96,15 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error)
 
     wl_log_init();
 
-    char errbuf[512] = { 0 };
+    /* Named apart from the @errbuf parameter deliberately: this one is the
+     * parser's own scratch, sized by parser.c's error_msg[512]. */
+    char syntax_err[512] = { 0 };
     wl_parser_ast_node_t *ast
-        = wl_parser_parse_string(program_text, errbuf, sizeof(errbuf));
+        = wl_parser_parse_string(program_text, syntax_err, sizeof(syntax_err));
     if (!ast) {
+        /* Issue #979 gap 1: this text was composed and then discarded when
+         * the buffer went out of scope one line later. */
+        copy_err(errbuf, errcap, syntax_err);
         if (error)
             *error = WIRELOG_ERR_PARSE;
         return NULL;
@@ -90,7 +120,12 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error)
 
     prog->ast = ast;
 
+    /* Issue #979 gap 2: each stage records its reason on the program, which
+     * wl_ir_program_free() is about to destroy -- so copy it out first.  Doing
+     * the free first and the copy second reads identically and yields a
+     * use-after-free; the ordering here is load-bearing, not stylistic. */
     if (wl_ir_program_collect_metadata(prog, ast) != 0) {
+        copy_err(errbuf, errcap, prog->parse_error);
         wl_ir_program_free(prog);
         if (error)
             *error = WIRELOG_ERR_PARSE;
@@ -98,6 +133,7 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error)
     }
 
     if (wl_ir_program_convert_rules(prog, ast) != 0) {
+        copy_err(errbuf, errcap, prog->parse_error);
         wl_ir_program_free(prog);
         if (error)
             *error = WIRELOG_ERR_PARSE;
@@ -105,6 +141,7 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error)
     }
 
     if (wl_ir_program_merge_unions(prog) != 0) {
+        copy_err(errbuf, errcap, prog->parse_error);
         wl_ir_program_free(prog);
         if (error)
             *error = WIRELOG_ERR_MEMORY;

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -16,6 +16,7 @@
 #include "../util/log.h"
 
 #include <ctype.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -153,6 +154,34 @@ parse_compound_metadata(const char *type_name, wl_intern_t *intern)
 /* ======================================================================== */
 /* Program Create / Free                                                    */
 /* ======================================================================== */
+
+void
+wl_ir_program_set_error(struct wirelog_program *program, const char *fmt, ...)
+{
+    char buf[512];
+    va_list ap;
+
+    va_start(ap, fmt);
+    int n = vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+
+    if (n < 0)
+        return;
+
+    /* Log unconditionally, exactly as the open-coded WL_LOG at each site did,
+    * so WL_LOG=PARSER:1 keeps behaving as before for anyone relying on it. */
+    WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR, "%s", buf);
+
+    /* Defensive only -- all seven current call sites pass a live program.
+     * The log line above has already been emitted either way, so a future
+     * site that has a message but no program still gets WL_LOG behaviour
+     * identical to the open-coded call it replaced. */
+    if (!program)
+        return;
+    if (program->parse_error[0] != '\0')
+        return; /* first writer wins */
+    snprintf(program->parse_error, sizeof(program->parse_error), "%s", buf);
+}
 
 struct wirelog_program *
 wl_ir_program_create(void)
@@ -364,7 +393,7 @@ collect_decl(struct wirelog_program *prog,
                 typed_count++;
         }
         if (typed_count != 6) {
-            WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+            wl_ir_program_set_error(prog,
                 "'__graph_metadata' is reserved and must have exactly 6"
                 " columns (graph_id, tenant, timestamp, location, risk,"
                 " description); got %u",
@@ -759,7 +788,7 @@ atom_physical_column_count(const wl_parser_ast_node_t *atom,
  * is no value that could stand for "not written", and the rule-head
  * analogue is already rejected by validate_head_arities() below. */
 static int
-validate_fact_arities(const struct wirelog_program *program,
+validate_fact_arities(struct wirelog_program *program,
     const wl_parser_ast_node_t *ast)
 {
     for (uint32_t i = 0; i < ast->child_count; i++) {
@@ -781,14 +810,14 @@ validate_fact_arities(const struct wirelog_program *program,
         uint32_t declared = wl_ir_relation_physical_width(rel);
         if (node->child_count != declared) {
             if (declared != rel->column_count)
-                WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                wl_ir_program_set_error(program,
                     "fact for relation '%s' has %u argument(s) but '%s'"
                     " occupies %u column(s) (%u declared, inline compound"
                     " column(s) expanded to their slots) (line %u)",
                     rel->name, node->child_count, rel->name, declared,
                     rel->column_count, node->line);
             else
-                WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                wl_ir_program_set_error(program,
                     "fact for relation '%s' has %u argument(s) but '%s' is"
                     " declared with %u column(s) (line %u)",
                     rel->name, node->child_count, rel->name, declared,
@@ -876,7 +905,7 @@ validate_fact_arities(const struct wirelog_program *program,
  * Undeclared heads are skipped: they are widespread and legitimate
  * (bench/workloads/doop.dl has ~90). */
 static int
-validate_head_arities(const struct wirelog_program *program,
+validate_head_arities(struct wirelog_program *program,
     const wl_parser_ast_node_t *ast)
 {
     for (uint32_t i = 0; i < ast->child_count; i++) {
@@ -897,14 +926,14 @@ validate_head_arities(const struct wirelog_program *program,
         uint32_t declared = wl_ir_relation_physical_width(rel);
         if (emitted != declared) {
             if (declared != rel->column_count)
-                WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                wl_ir_program_set_error(program,
                     "rule head for relation '%s' emits %u column(s) but '%s'"
                     " occupies %u column(s) (%u declared, inline compound"
                     " column(s) expanded to their slots) (line %u)",
                     rel->name, emitted, rel->name, declared,
                     rel->column_count, head->line);
             else
-                WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                wl_ir_program_set_error(program,
                     "rule head for relation '%s' emits %u column(s) but '%s'"
                     " is declared with %u column(s) (line %u)",
                     rel->name, emitted, rel->name, declared, head->line);
@@ -2036,7 +2065,7 @@ wl_ir_program_push_constant_filters(const wl_parser_ast_node_t *rule_node,
 
 static wirelog_ir_node_t *
 convert_rule(const wl_parser_ast_node_t *rule_node,
-    const struct wirelog_program *prog)
+    struct wirelog_program *prog)
 {
     if (!rule_node || rule_node->child_count < 1)
         return NULL;
@@ -2090,7 +2119,7 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             head_agg_count++;
     }
     if (head_agg_count > 1) {
-        WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+        wl_ir_program_set_error(prog,
             "relation '%s' has %u aggregates in one rule head; at most one is "
             "supported. Derive each aggregate in its own rule and join the "
             "results (e.g. tmin(g, min(v)) :- val(g, v); "
@@ -2276,7 +2305,7 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                 if (bound)
                     continue;
 
-                WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR,
+                wl_ir_program_set_error(prog,
                     "unsafe variable '%s' appears only in negated atom '%s'; "
                     "bind it in a positive body atom (e.g. project the negated "
                     "relation first: key(...) :- %s(...); "

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -14,6 +14,8 @@
 
 #include "ir.h"
 #include "../intern.h"
+/* wirelog_error_t, for wl_ir_parse_string_err() below (#979). */
+#include "../wirelog.h"
 #include "../wirelog-types.h"
 #include "../passes/magic_sets.h"
 
@@ -175,6 +177,12 @@ struct wirelog_program {
     /* Source AST (retained for debugging, freed on program_free) */
     wl_parser_ast_node_t *ast;
 
+    /* Why the lowering stages rejected this program, if they did (#979).
+     * First writer wins -- see wl_ir_program_set_error().  Empty until a
+     * rejection, and read by wl_ir_parse_string_err() *before* it frees the
+     * program on the failure path, since this dies with the struct. */
+    char parse_error[512];
+
     /* Symbol intern table (string -> int64 mapping) */
     wl_intern_t *intern;
 
@@ -206,6 +214,40 @@ wl_ir_program_create(void);
 void
 wl_ir_program_free(struct wirelog_program *program);
 
+/**
+ * wl_ir_parse_string_err:
+ * @program_text: Datalog source
+ * @error: (out) (nullable): coarse error code, as wirelog_parse_string()
+ * @errbuf: (out) (nullable): buffer for the human-readable rejection reason
+ * @errcap: size of @errbuf in bytes
+ *
+ * wirelog_parse_string() with somewhere for the reason to go (issue #979).
+ *
+ * The public entry point's signature is ABI-frozen and has no message
+ * parameter, so it forwards here with (NULL, 0) and behaves exactly as
+ * before.  This variant is deliberately internal rather than a new
+ * `wirelog_parse_string_ex()` export: the only consumer that needs it is the
+ * CLI, which compiles wirelog_sources directly into its executable rather
+ * than linking libwirelog, so it reaches internal symbols without a new
+ * public one.  Adding a public symbol would mean updating three per-platform
+ * lists under abi/ plus the abidiff baseline, and committing to the surface
+ * forever -- a decision worth making on its own evidence rather than as a
+ * side effect of a diagnostics fix.  See #1024, which wants to know whether
+ * such rejections should be load-time errors at all.
+ *
+ * On failure @errbuf receives the reason when one is available: the parser's
+ * "line %u, col %u: ..." text for a syntax error, or the rejecting stage's
+ * message for a semantic one.  It is set to the empty string on entry, so an
+ * empty buffer after a NULL return means the failure had no message, not
+ * that the caller forgot to look.  @errbuf is caller-owned; nothing retains
+ * a pointer to it.
+ *
+ * Returns: the program, or NULL on failure.
+ */
+struct wirelog_program *
+wl_ir_parse_string_err(const char *program_text, wirelog_error_t *error,
+    char *errbuf, size_t errcap);
+
 int
 wl_ir_program_collect_metadata(struct wirelog_program *program,
     const wl_parser_ast_node_t *ast);
@@ -216,6 +258,33 @@ wl_ir_program_convert_rules(struct wirelog_program *program,
 
 int
 wl_ir_program_merge_unions(struct wirelog_program *program);
+
+/**
+ * wl_ir_program_set_error:
+ * @program: (nullable): the program being lowered
+ * @fmt: printf-style format for the rejection reason
+ *
+ * Record why lowering rejected @program, and log it (issue #979).
+ *
+ * Replaces the bare WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR, ...) that each
+ * rejection site used to call.  Those messages were already well composed --
+ * they name the relation, the counts and the source line -- but WL_LOG could
+ * not deliver them: wl_log_thresholds defaults to WL_LOG_NONE (0), the gate
+ * is (LVL) <= threshold, and WL_LOG_ERROR is 1.  Formatting once here and
+ * both storing and logging keeps a single format string per rejection, so
+ * the stored text and the logged text cannot drift apart.
+ *
+ * First writer wins.  Each stage returns non-zero as soon as it rejects, so
+ * in practice only one call fires per parse; keeping the first rather than
+ * the last means that if that ever stops holding, the user sees the root
+ * cause instead of whatever happened to run last.
+ */
+void
+wl_ir_program_set_error(struct wirelog_program *program, const char *fmt, ...)
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((format(printf, 2, 3)))
+#endif
+;
 
 void
 wl_ir_program_build_schemas(struct wirelog_program *program);


### PR DESCRIPTION
Closes #979.

Every load failure reached the user as the bare two words `Parse error` -- no line, no relation, no indication which of four stages rejected the program.

## Two gaps

`wirelog_parse_string()` filled a 512-byte errbuf with the parser's `line %u, col %u: ... (got %s)` and let it go out of scope one line later, unread.

The three lowering stages had no error parameter at all. They *do* explain themselves, through `WL_LOG(WL_LOG_SEC_PARSER, WL_LOG_ERROR, ...)`, and the messages are good -- they name the relation, the counts and the source line. But `wl_log_thresholds` is zero-init to `WL_LOG_NONE` (0), the gate is `(LVL) <= threshold`, and `WL_LOG_ERROR` is 1, so `1 <= 0` is false. The text was reachable only by a user who had already set `WL_LOG=PARSER:1` -- which requires knowing the answer to ask the question.

There are **seven** such rejection sites, not the two the issue lists: `__graph_metadata` arity, fact arity and rule-head width (two branches each, inline-compound-aware and plain), one-aggregate-per-head (#973), and unsafe variables under negation (#920). Five logical rejections across seven calls.

## Before / after

```
$ wirelog_cli bad.dl
Parse error

$ wirelog_cli bad.dl
Parse error: fact for relation 'edge' has 1 argument(s) but 'edge' is declared with 2 column(s) (line 3)
Parse error: unsafe variable 'unboundvar' appears only in negated atom 'negrel'; bind it in a positive body atom (e.g. project the negated relation first: key(...) :- negrel(...); head :- ..., !key(...))
Parse error: line 3, col 1: unexpected character (got ERROR)
```

No message was written for this PR -- these are the existing messages, finally delivered.

## Two design calls worth review

**No new public symbol.** The issue proposed `wirelog_parse_string_ex()` or a thread-local last-error. Both rejected: the only consumer that needs this is the CLI, and `meson.build` compiles `wirelog_sources` directly into `wirelog_cli` rather than linking libwirelog, so it reaches an internal entry point without a new export. A public symbol means three per-platform lists under `abi/` plus the abidiff baseline and a permanent surface commitment -- worth its own evidence, especially since #1024 is already asking whether these rejections should be load-time errors at all. A thread-local would also leave `wirelog_parse_error_t`'s `const char *message` pointing at storage the next parse on that thread overwrites, with no defensible owner. `wirelog_parse_string()` forwards with `(NULL, 0)` and is unchanged.

**The reason travels on the program struct, not through new parameters.** Threading `char *errbuf, size_t errcap` through the three stages is what the issue suggests, but they are called from ~25 places in `tests/test_program.c` and `tests/test_stratify.c`, all of which would have churned to pass `NULL`. All three already take the program as their first argument, so a `char parse_error[512]` field needs no signature change. `wl_ir_program_create()` calloc's, so it starts empty.

## The ordering is load-bearing

The copy-out precedes `wl_ir_program_free()` at all three sites, because the buffer lives in the struct being freed. Reversing the two lines reads identically and is a real `heap-use-after-free` -- confirmed under ASan (`READ of size 1` in `copy_err`). **The functional test does not catch that mutation**; freed memory still holds the old bytes. That ordering is protected by the sanitizer jobs, not by the new test.

## Tests

`tests/test_cli_parse_diagnostics.py` asserts what the issue actually asks for: a rejected program names the relation or variable with **no environment variable set**. It scrubs `WL_LOG`, `WL_LOG_FILE` and the two legacy presence flags from the child environment -- inheriting any of them would make every assertion pass on an unfixed tree, the precise failure mode this issue is about.

Every case also asserts the program is **still rejected**, so a change that made the checks permissive and merely printed a warning cannot pass. Those checks exist to stop wrong answers (#973, #977, #920); diagnostics must not be bought with them.

Two assertions in my first draft were vacuous and are recorded in the commit message: a relation named `t` matched the `t` in the pre-existing `error: execution failed`, and a syntax check compared stderr for equality against `Parse error` when the real output has a second line. Both passed against the unfixed binary. Fixed.

Mutation-tested: dropping the recorder's store kills 12 assertions; dropping the syntax copy kills 4.

## Validation

Full suite **273 Ok / 11 Skipped**; `abi` suite 33/33 including `abi_manifest` and `public_header_surface`.

The one failure, `sbom_snapshot`, is **pre-existing and unrelated** -- it reports `msys2/setup-msys2@v2` against a pinned SHA in the baseline, and reproduces identically on a clean `origin/main` tree with these changes stashed. No workflow file is touched here, so regenerating that baseline is left to whoever changed the pin.

## Note

Independent Architect/Critic/Reviewer subagents were unavailable (session spawn limit reached), so this ran in the harness's degraded sequential mode: the design, critique and review passes were all performed by the implementing agent. The gates were not skipped, but their independence was weakened. The mutation testing and the ASan check above are what stand in for a second pair of eyes -- an actual reviewer is still worth having here.