### PR TITLE
fix(session): the .decl decides a relation's width, not its first producer (#1038)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,34 @@ All notable changes to wirelog are documented in this file.
   parties implement `read()` against these two accessors, so the change is
   called out separately from `wirelog_program_get_facts` above.
 
+- **A host insert must match the declared physical width** (#1038): the
+  `ncols` passed to `wirelog_easy_insert` is now checked against the
+  relation's `.decl` on the *first* insert as well as every later one, and a
+  mismatch returns an error instead of succeeding. Both the direct and the
+  incremental (delta-callback) insert paths enforce it. Removal is unchanged:
+  a remove against a relation with no established width is still the no-op it
+  always was, because there is nothing to remove.
+
+  This is the third embedder-visible consequence of #985 and the one that
+  was missing from the two entries above: for a relation declaring an
+  `inline` compound column, the width a host must insert at moved from the
+  logical count to the physical one. A host that inserted
+  `.decl p(id: int64, lbl: pair/2 inline)` at 2 and matched the old fact
+  path must now insert at 3.
+
+  Previously a relation's width was whatever its first producer happened to
+  supply -- the schema was set lazily from the caller's `ncols` and nothing
+  compared it against the declaration, so the check that already rejected
+  every *subsequent* mismatch was working from an accidental baseline. Both
+  directions were silent: too narrow fabricated a slot no source ever wrote
+  (`insert(p, {5, 55}, ncols=2)` derived `outr(5, 55, 0)`), and too wide
+  dropped the surplus without a word, which needed no compound at all --
+  a two-column `.decl` accepted a first insert of three.
+
+  Relations with no `.decl` are unaffected and stay caller-defined, as does
+  the degenerate zero-arity `.decl p()`, which carries no data for a width
+  check to protect.
+
   `wirelog_io_ctx_num_cols(ctx)` is now the physical row stride -- the
   `int64_t` slots one tuple occupies, which is what `docs/io-adapters.md` has
   always required `read()` to size its buffer by and the width wirelog

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4544,6 +4544,25 @@ test_wirelog_easy_inline_facts_exe = executable(
 
 test('wirelog_easy_inline_facts', test_wirelog_easy_inline_facts_exe)
 
+test_host_insert_width_exe = executable(
+  'test_host_insert_width',
+  files('test_host_insert_width.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  '../wirelog/wirelog-easy.c',
+  '../wirelog/api_facade.c',
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('host_insert_width', test_host_insert_width_exe)
+
 # Issue #717 / #703: behavioral-parity test for the advanced session API.
 test_wirelog_advanced_exe = executable(
   'test_wirelog_advanced',

--- a/tests/test_host_insert_width.c
+++ b/tests/test_host_insert_width.c
@@ -1,0 +1,391 @@
+/*
+ * test_host_insert_width.c - the .decl decides a relation's width (#1038)
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * A relation's column count used to be whatever its first producer happened
+ * to supply.  col_session_insert() lazily set the schema from the caller's
+ * ncols when r->ncols was still 0, and nothing at that moment compared it
+ * against the `.decl` -- the plan carried only relation names.  Every insert
+ * after the first was checked against that accidental width, so the gap was
+ * exactly one call wide, and it is the call that matters.
+ *
+ * The defect has two faces and both are silent:
+ *
+ *   too narrow.  `.decl p(id: int64, lbl: pair/2 inline)` occupies three
+ *   physical slots.  A host inserting at the *logical* width 2 established
+ *   the relation at 2, and a rule destructuring it then read a third slot
+ *   that was never written:
+ *
+ *       insert(p, {5, 55}, ncols=2)  ->  outr(5, 55, 0)
+ *
+ *   The 0 appears in no source data.  This is the shape #985 closed for the
+ *   fact and `.input` paths; wirelog_easy_insert() takes ncols from the
+ *   caller and kept it open.
+ *
+ *   too wide.  The same hole is not specific to compounds.  A relation
+ *   declared with two columns accepted a first insert of three and silently
+ *   dropped the third:
+ *
+ *       insert(q, {1, 2, 3}, ncols=3)  ->  o2(1, 2)
+ *
+ * So the assertions here are on *values*, not row counts or exit codes: in
+ * both directions the wrong answer has the same cardinality as the right one
+ * and a counting test passes on the defect.
+ *
+ * The positive controls are the point of the exercise.  Rejecting every
+ * first insert would satisfy every negative case above, so each is paired
+ * with a correctly-shaped insert that must still succeed and must still
+ * produce the real values -- including one relation with no compound at all,
+ * whose declared and physical widths already agreed and which must be
+ * byte-identical to before.
+ */
+
+#include "wirelog/wirelog-easy.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                            \
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
+
+#define PASS()                 \
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                         \
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
+
+/* An inline compound: two declared columns, three physical slots. */
+static const char *const SRC_INLINE =
+    ".decl p(id: int64, lbl: pair/2 inline)\n"
+    ".decl outr(id: int64, a: int64, b: int64)\n"
+    ".output outr\n"
+    "outr(i, a, b) :- p(i, a, b).\n";
+
+/* No compound anywhere: declared width == physical width == 2. */
+static const char *const SRC_PLAIN =
+    ".decl q(a: int64, b: int64)\n"
+    ".decl o2(a: int64, b: int64)\n"
+    ".output o2\n"
+    "o2(x, y) :- q(x, y).\n";
+
+/* Collected snapshot rows, flattened. */
+struct rows {
+    int64_t v[64];
+    uint32_t n;
+    uint32_t ncols;
+    uint32_t count;
+};
+
+static void
+collect(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    (void)relation;
+    struct rows *rs = (struct rows *)user_data;
+    rs->ncols = ncols;
+    rs->count++;
+    for (uint32_t i = 0; i < ncols && rs->n < 64; i++)
+        rs->v[rs->n++] = row[i];
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void
+test_narrow_first_insert_is_rejected(void)
+{
+    TEST("a first insert at the logical width is rejected, not accepted");
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(SRC_INLINE, &s) != WIRELOG_OK) {
+        FAIL("could not open the program");
+        return;
+    }
+
+    int64_t row[2] = { 5, 55 };
+    wirelog_error_t err = wirelog_easy_insert(s, "p", row, 2);
+
+    if (err == WIRELOG_OK) {
+        /* Show what it fabricated, so a failure here is self-explaining. */
+        struct rows rs = { { 0 }, 0, 0, 0 };
+        (void)wirelog_easy_step(s);
+        (void)wirelog_easy_snapshot(s, "outr", collect, &rs);
+        wirelog_easy_close(s);
+        if (rs.count > 0)
+            printf("\n      (accepted; outr = %lld %lld %lld)",
+                (long long)rs.v[0], (long long)rs.v[1],
+                (long long)rs.v[2]);
+        FAIL("ncols=2 was accepted for a relation occupying 3 slots");
+        return;
+    }
+
+    wirelog_easy_close(s);
+    PASS();
+}
+
+static void
+test_narrow_first_insert_fabricates_nothing(void)
+{
+    TEST("a rejected insert leaves no fabricated row behind");
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(SRC_INLINE, &s) != WIRELOG_OK) {
+        FAIL("could not open the program");
+        return;
+    }
+
+    int64_t row[2] = { 5, 55 };
+    (void)wirelog_easy_insert(s, "p", row, 2);
+    (void)wirelog_easy_step(s);
+
+    struct rows rs = { { 0 }, 0, 0, 0 };
+    (void)wirelog_easy_snapshot(s, "outr", collect, &rs);
+    wirelog_easy_close(s);
+
+    /* The count assertion is the weak half; the value assertion is why this
+     * test exists.  Pre-fix outr held exactly one row, (5, 55, 0), so a
+     * "no rows derived" check alone would not distinguish a rejected insert
+     * from one that fabricated a slot. */
+    if (rs.count != 0) {
+        if (rs.n >= 3 && rs.v[2] == 0)
+            FAIL("derived a row whose third slot was never written");
+        else
+            FAIL("derived a row from an insert that should have failed");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_correct_physical_width_still_works(void)
+{
+    TEST("control: an insert at the physical width succeeds and is exact");
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(SRC_INLINE, &s) != WIRELOG_OK) {
+        FAIL("could not open the program");
+        return;
+    }
+
+    int64_t row[3] = { 5, 55, 66 };
+    if (wirelog_easy_insert(s, "p", row, 3) != WIRELOG_OK) {
+        wirelog_easy_close(s);
+        FAIL("the correctly-shaped insert was rejected");
+        return;
+    }
+    (void)wirelog_easy_step(s);
+
+    struct rows rs = { { 0 }, 0, 0, 0 };
+    (void)wirelog_easy_snapshot(s, "outr", collect, &rs);
+    wirelog_easy_close(s);
+
+    if (rs.count != 1) {
+        FAIL("expected exactly one derived row");
+        return;
+    }
+    if (rs.n < 3 || rs.v[0] != 5 || rs.v[1] != 55 || rs.v[2] != 66) {
+        FAIL("the derived row does not carry the inserted values");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_wide_first_insert_is_rejected(void)
+{
+    TEST("a first insert wider than the .decl is rejected, not truncated");
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(SRC_PLAIN, &s) != WIRELOG_OK) {
+        FAIL("could not open the program");
+        return;
+    }
+
+    /* Three values into a two-column relation.  Pre-fix this was accepted
+     * and the 3 was dropped without a word -- the same defect as the
+     * inline case, in the other direction, and with no compound in sight. */
+    int64_t row[3] = { 1, 2, 3 };
+    wirelog_error_t err = wirelog_easy_insert(s, "q", row, 3);
+    wirelog_easy_close(s);
+
+    if (err == WIRELOG_OK) {
+        FAIL("ncols=3 was accepted for a relation declared with 2 columns");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_plain_relation_unchanged(void)
+{
+    TEST("control: a compound-free relation at its declared width is exact");
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(SRC_PLAIN, &s) != WIRELOG_OK) {
+        FAIL("could not open the program");
+        return;
+    }
+
+    int64_t row[2] = { 1, 2 };
+    if (wirelog_easy_insert(s, "q", row, 2) != WIRELOG_OK) {
+        wirelog_easy_close(s);
+        FAIL("the correctly-shaped insert was rejected");
+        return;
+    }
+    (void)wirelog_easy_step(s);
+
+    struct rows rs = { { 0 }, 0, 0, 0 };
+    (void)wirelog_easy_snapshot(s, "o2", collect, &rs);
+    wirelog_easy_close(s);
+
+    if (rs.count != 1 || rs.n < 2 || rs.v[0] != 1 || rs.v[1] != 2) {
+        FAIL("the ordinary path changed");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_established_width_still_enforced(void)
+{
+    TEST("control: a later mismatched insert is still rejected");
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(SRC_INLINE, &s) != WIRELOG_OK) {
+        FAIL("could not open the program");
+        return;
+    }
+
+    int64_t good[3] = { 5, 55, 66 };
+    if (wirelog_easy_insert(s, "p", good, 3) != WIRELOG_OK) {
+        wirelog_easy_close(s);
+        FAIL("the correctly-shaped insert was rejected");
+        return;
+    }
+
+    /* This was already rejected before the fix, by the r->ncols != num_cols
+     * arm.  It is here so that a change which replaced that arm with the new
+     * declared-width check, rather than adding to it, cannot pass. */
+    int64_t bad[2] = { 7, 77 };
+    wirelog_error_t err = wirelog_easy_insert(s, "p", bad, 2);
+    wirelog_easy_close(s);
+
+    if (err == WIRELOG_OK) {
+        FAIL("a mismatched insert after the width was set must still fail");
+        return;
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void
+noop_delta(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    (void)relation;
+    (void)row;
+    (void)ncols;
+    (void)diff;
+    (void)user_data;
+}
+
+/*
+ * col_session_insert() reroutes to col_session_insert_incremental() as soon
+ * as a delta callback is installed (issue #662), and that function carries
+ * its own copy of the lazy-schema block.  Every case above takes the
+ * non-incremental path, so a fix applied to only one of the two passes all
+ * of them -- confirmed by mutation: deleting the check from the incremental
+ * site alone left the other six cases green.  This case is what covers it.
+ */
+static void
+test_narrow_first_insert_rejected_in_delta_mode(void)
+{
+    TEST("the incremental insert path enforces the width too");
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(SRC_INLINE, &s) != WIRELOG_OK) {
+        FAIL("could not open the program");
+        return;
+    }
+    if (wirelog_easy_set_delta_cb(s, noop_delta, NULL) != WIRELOG_OK) {
+        wirelog_easy_close(s);
+        FAIL("could not install the delta callback");
+        return;
+    }
+
+    int64_t row[2] = { 5, 55 };
+    wirelog_error_t err = wirelog_easy_insert(s, "p", row, 2);
+    wirelog_easy_close(s);
+
+    if (err == WIRELOG_OK) {
+        FAIL("ncols=2 accepted on the incremental path");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_correct_width_still_works_in_delta_mode(void)
+{
+    TEST("control: the incremental path still accepts the right width");
+
+    wirelog_easy_session_t *s = NULL;
+    if (wirelog_easy_open(SRC_INLINE, &s) != WIRELOG_OK) {
+        FAIL("could not open the program");
+        return;
+    }
+    if (wirelog_easy_set_delta_cb(s, noop_delta, NULL) != WIRELOG_OK) {
+        wirelog_easy_close(s);
+        FAIL("could not install the delta callback");
+        return;
+    }
+
+    int64_t row[3] = { 5, 55, 66 };
+    wirelog_error_t err = wirelog_easy_insert(s, "p", row, 3);
+    wirelog_easy_close(s);
+
+    if (err != WIRELOG_OK) {
+        FAIL("the correctly-shaped incremental insert was rejected");
+        return;
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
+int
+main(void)
+{
+    printf("=== Host insert width follows the .decl (#1038) ===\n\n");
+
+    test_narrow_first_insert_is_rejected();
+    test_narrow_first_insert_fabricates_nothing();
+    test_correct_physical_width_still_works();
+    test_wide_first_insert_is_rejected();
+    test_plain_relation_unchanged();
+    test_established_width_still_enforced();
+    test_narrow_first_insert_rejected_in_delta_mode();
+    test_correct_width_still_works_in_delta_mode();
+
+    printf("\n=== Results: %d run, %d passed, %d failed ===\n",
+        tests_run, tests_passed, tests_failed);
+
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -340,6 +340,22 @@ typedef struct {
     uint32_t compound_count;
     uint32_t *compound_arity_map;
     uint32_t inline_physical_offset;
+
+    /* Issue #1038: the relation's declared *physical* width, propagated from
+     * the plan at session creation, or 0 when there is nothing to enforce.
+     *
+     * Without it a relation's width was whatever its first producer supplied
+     * -- col_session_insert() set the schema lazily from the caller's ncols
+     * and nothing compared that against the `.decl`.  A host inserting an
+     * inline-compound relation at its *logical* width established it too
+     * narrow, and a destructuring rule then read a slot nobody wrote.
+     *
+     * 0 covers two cases that are both correctly unenforced: a relation with
+     * no `.decl` (legitimate and caller-defined), and the degenerate
+     * zero-arity `.decl p()`, which carries no data for a width check to
+     * protect.  Using 0 rather than a sentinel keeps every calloc()
+     * allocation path correct by default, as the block above requires. */
+    uint32_t declared_ncols;
 } col_rel_t;
 
 /* ======================================================================== */

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1168,6 +1168,13 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
             r->has_graph_column = true;
             r->graph_col_idx = plan->edb_graph_col_index[i];
         }
+        /* Issue #1038: carry the declared physical width so the first insert
+         * is checked against the `.decl` rather than defining it.  Guarded on
+         * non-NULL for callers that build a plan by hand and never populate
+         * the array; they keep the old first-producer-wins behaviour. */
+        if (plan->edb_declared_width != NULL
+            && plan->edb_declared_width[i] != WL_PLAN_WIDTH_UNDECLARED)
+            r->declared_ncols = plan->edb_declared_width[i];
         rc = session_add_rel(sess, r);
         if (rc != 0) {
             col_rel_destroy(r);
@@ -1633,8 +1640,13 @@ col_session_insert(wl_session_t *session, const char *relation,
     if (!r)
         return ENOENT;
 
-    /* Lazy schema initialisation on first insert */
+    /* Lazy schema initialisation on first insert.  Issue #1038: the first
+     * insert used to *define* the width; it is now checked against the
+     * declared physical width when the program declared one, so a host
+     * cannot establish a relation at a shape its own `.decl` contradicts. */
     if (r->ncols == 0) {
+        if (r->declared_ncols != 0 && num_cols != r->declared_ncols)
+            return EINVAL;
         int rc = col_rel_set_schema(r, num_cols, NULL);
         if (rc != 0)
             return rc;
@@ -1779,8 +1791,13 @@ col_session_insert_incremental(wl_session_t *session, const char *relation,
     if (!r)
         return ENOENT;
 
-    /* Lazy schema initialisation on first insert */
+    /* Lazy schema initialisation on first insert.  Issue #1038: the first
+     * insert used to *define* the width; it is now checked against the
+     * declared physical width when the program declared one, so a host
+     * cannot establish a relation at a shape its own `.decl` contradicts. */
     if (r->ncols == 0) {
+        if (r->declared_ncols != 0 && num_cols != r->declared_ncols)
+            return EINVAL;
         int rc = col_rel_set_schema(r, num_cols, NULL);
         if (rc != 0)
             return rc;

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -637,7 +637,18 @@ typedef struct {
  * @edb_graph_col_index:   Parallel array (length edb_count); column index of
  *                         __graph_id (valid only when edb_has_graph_column[i]).
  *                         Issue #535: RDF named-graph support.
+ * @edb_declared_width:    Parallel array (length edb_count); the relation's
+ *                         declared *physical* width, or
+ *                         WL_PLAN_WIDTH_UNDECLARED when it has no `.decl`.
+ *                         Issue #1038: without this the first host insert
+ *                         defines the width and a later destructuring rule
+ *                         can read a slot nobody wrote.
  */
+/* Issue #1038: sentinel for edb_declared_width[i] when the relation carries
+ * no `.decl`.  Distinct from 0, which is the honest physical width of a
+ * zero-arity declaration such as `.decl p()`. */
+#define WL_PLAN_WIDTH_UNDECLARED UINT32_MAX
+
 typedef struct {
     const wl_plan_stratum_t *strata;
     uint32_t stratum_count;
@@ -649,6 +660,10 @@ typedef struct {
      * Allocated with edb_relations; freed in wl_plan_free. */
     const bool *edb_has_graph_column;
     const uint32_t *edb_graph_col_index;
+    /* Issue #1038: declared physical width per EDB relation, or
+     * WL_PLAN_WIDTH_UNDECLARED.  Allocated with edb_relations; freed in
+     * wl_plan_free. */
+    const uint32_t *edb_declared_width;
     struct wl_intern *intern; /* borrowed from program; lifetime >= plan */
 } wl_plan_t;
 

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -3315,6 +3315,7 @@ wl_plan_free(wl_plan_t *plan)
     /* Issue #535: free per-EDB graph-column metadata arrays. */
     free((void *)plan->edb_has_graph_column);
     free((void *)plan->edb_graph_col_index);
+    free((void *)plan->edb_declared_width);
 
     free(plan);
 }
@@ -3377,7 +3378,13 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
     /* Issue #535: parallel arrays for per-EDB graph-column metadata. */
     bool *edb_has_graph = (bool *)calloc(edb_cap, sizeof(bool));
     uint32_t *edb_graph_idx = (uint32_t *)calloc(edb_cap, sizeof(uint32_t));
-    if (!edb_has_graph || !edb_graph_idx) {
+    /* Issue #1038: the declared physical width, so the session can reject a
+     * first host insert that disagrees with the `.decl` instead of letting
+     * it define the relation.  WL_PLAN_WIDTH_UNDECLARED for a relation with
+     * no `.decl` -- those are legitimate and stay caller-defined. */
+    uint32_t *edb_decl_w = (uint32_t *)malloc(edb_cap * sizeof(uint32_t));
+    if (!edb_has_graph || !edb_graph_idx || !edb_decl_w) {
+        free(edb_decl_w);
         free(edb_graph_idx);
         free(edb_has_graph);
         free(edb_rels);
@@ -3415,6 +3422,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                     free((void *)edb_rels);
                     free(edb_has_graph);
                     free(edb_graph_idx);
+                    free(edb_decl_w);
                     free(plan);
                     return -1;
                 }
@@ -3427,6 +3435,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                     free((void *)edb_rels);
                     free(edb_has_graph);
                     free(edb_graph_idx);
+                    free(edb_decl_w);
                     free(plan);
                     return -1;
                 }
@@ -3439,10 +3448,24 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                     free((void *)edb_rels);
                     free(edb_has_graph);
                     free(edb_graph_idx);
+                    free(edb_decl_w);
                     free(plan);
                     return -1;
                 }
                 edb_graph_idx = itmp;
+                uint32_t *wtmp = (uint32_t *)realloc(edb_decl_w,
+                        edb_cap * sizeof(uint32_t));
+                if (!wtmp) {
+                    for (uint32_t j = 0; j < edb_count; j++)
+                        free(edb_rels[j]);
+                    free((void *)edb_rels);
+                    free(edb_has_graph);
+                    free(edb_graph_idx);
+                    free(edb_decl_w);
+                    free(plan);
+                    return -1;
+                }
+                edb_decl_w = wtmp;
             }
             edb_rels[edb_count] = dup_str(rel->name);
             if (!edb_rels[edb_count]) {
@@ -3451,12 +3474,19 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
                 free((void *)edb_rels);
                 free(edb_has_graph);
                 free(edb_graph_idx);
+                free(edb_decl_w);
                 free(plan);
                 return -1;
             }
             /* Issue #535: propagate graph-column metadata from IR. */
             edb_has_graph[edb_count] = rel->has_graph_column;
             edb_graph_idx[edb_count] = rel->graph_column_index;
+            /* Issue #1038: physical, not logical -- an inline compound
+             * column occupies compound_arity slots, and the physical count
+             * is what a host insert has to match. */
+            edb_decl_w[edb_count] = rel->has_decl
+                ? wl_ir_relation_physical_width(rel)
+                : WL_PLAN_WIDTH_UNDECLARED;
             edb_count++;
         }
     }
@@ -3465,6 +3495,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
     plan->edb_count = edb_count;
     plan->edb_has_graph_column = (const bool *)edb_has_graph;
     plan->edb_graph_col_index = (const uint32_t *)edb_graph_idx;
+    plan->edb_declared_width = (const uint32_t *)edb_decl_w;
 
     /* ----------------------------------------------------------------
      * Build strata


### PR DESCRIPTION
Closes #1038.

A relation's column count was whatever its first producer happened to supply. `col_session_insert()` set the schema lazily from the caller's `ncols` when `r->ncols` was still 0, and nothing at that moment compared it against the `.decl` -- the plan carried only relation names. Every insert *after* the first was checked, so the gap was exactly one call wide, and it is the call that establishes the shape everything else is then measured against.

## Both directions were silent

```
.decl p(id: int64, lbl: pair/2 inline)     -- 2 declared columns, 3 physical slots
insert(p, {5, 55}, ncols=2)   err=0        -- accepted at the LOGICAL width
outr(5, 55, 0)                             -- the 0 appears in no source data
```

```
.decl q(a: int64, b: int64)                -- no compound anywhere
insert(q, {1, 2, 3}, ncols=3) err=0        -- accepted, surplus dropped
o2(1, 2)
```

**The second case is not in the issue.** It confirms the general shape the issue predicted: "first producer wins" was never specific to compounds, and #985 was reachable *because* of it rather than the other way round.

## Approach

The declared physical width now rides on the plan beside the existing per-EDB graph-column metadata (#535) -- same parallel-array pattern, populated from `wl_ir_relation_physical_width()` where #535 populates `has_graph_column`, freed in the same place. `col_session_create()` copies it onto `col_rel_t`, and the two lazy-schema sites check before setting.

`WL_PLAN_WIDTH_UNDECLARED` (`UINT32_MAX`) marks a relation with no `.decl`; it has to be distinct from 0, which is the honest physical width of `.decl p()`. `col_rel_t` stores 0 for both instead, deliberately -- `internal.h` documents that every allocation path zero-initialises that block via `calloc()`, so a sentinel there would need each audited, and the two cases 0 conflates (undeclared, and a zero-arity declaration carrying no data) are both correctly unenforced.

## Coverage was thinner than it looked

`col_session_insert()` reroutes to `col_session_insert_incremental()` as soon as a delta callback is installed (#662), and that function carries **its own copy** of the lazy-schema block. Every case in my first draft took the non-incremental path: **deleting the check from the incremental site alone left all six green.** Two delta-mode cases now cover it and the mutation is killed.

## Tests

Assertions are on *values*, not row counts -- in both directions the wrong answer has the same cardinality as the right one, so a counting test passes on the defect.

Each negative is paired with a correctly-shaped insert that must still succeed and still carry the real values, including a compound-free relation that must be unchanged end to end; rejecting every first insert would otherwise satisfy all the negatives. One case pins that the pre-existing `r->ncols != num_cols` arm still fires, so a change that *replaced* it rather than adding to it cannot pass.

## Validation

8/8 new cases. Full suite **274 Ok / 11 Skipped** -- no existing test inserted at a width its `.decl` contradicts, so nothing else moves. The new test is also clean under ASan with `detect_leaks=1`, which exercises the realloc and unwind paths added to the plan builder.

`sbom_snapshot` fails, **pre-existing and unrelated**: it reports `msys2/setup-msys2@v2` against a pinned SHA in the baseline and reproduces on a clean `origin/main` with these changes stashed. No workflow file is touched here.

## Behaviour change

This tightens a public contract, and the CHANGELOG records it as the **third embedder-visible consequence of #985** -- the one the two entries added there did not cover. For a relation declaring an `inline` compound column, the width a host must insert at moved from the logical count to the physical one: a host inserting `.decl p(id: int64, lbl: pair/2 inline)` at 2 must now insert at 3. Such a host is currently getting fabricated data, so the error is the improvement, but it is a visible break and worth a reviewer's attention.

## Note

Independent Architect/Critic/Reviewer subagents were unavailable (session spawn limit reached), so this ran in the harness's degraded sequential mode -- design, critique and review were all performed by the implementing agent. Gates were not skipped, but their independence was weakened; the mutation testing and the ASan run stand in for a second pair of eyes.