### PR TITLE
perf(columnar): put string comparison back on the compiled path (#966)

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4662,6 +4662,16 @@ if not is_android
     suite: 'cli',
   )
 
+  test('string_compare_ops',
+    baseline_py3,
+    args: [
+      files('test_string_compare_ops.py')[0],
+      wirelog_cli.full_path(),
+    ],
+    depends: wirelog_cli,
+    suite: 'cli',
+  )
+
   test('cli_version',
     baseline_py3,
     args: [

--- a/tests/test_string_compare_ops.py
+++ b/tests/test_string_compare_ops.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# test_string_compare_ops.py - symbol ordering on the compiled path (#966)
+#
+# Copyright (C) CleverPlant
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# Usage: test_string_compare_ops.py <wirelog_cli_executable>
+#
+# #962 made ordering comparisons on symbols lexicographic by emitting
+# WL_PLAN_EXPR_CMP_STR_LT..GTE.  Those opcodes were absent from
+# col_expr_compile's accepted set, so any predicate containing one hit
+# `default: return NULL` and the whole expression fell back to the
+# interpreter.  #966 adds them to the compiled evaluator.
+#
+# This is a performance change, so there is no failing-before assertion to
+# make: the interpreter was already correct and the compiled path must agree
+# with it exactly.  What this test guards is that agreement -- it pins the
+# observable semantics of all six operators so a divergence between the two
+# implementations cannot land silently.  That matters more than usual here:
+# the sweep during #962 found no program anywhere in this tree that compares
+# symbols, so before this file nothing at all would have caught one.
+#
+# Two cases are chosen specifically because a plausible wrong implementation
+# gets them wrong:
+#
+#   "Zebra" < "apple"     byte order, not case-insensitive collation
+#                         ('Z' is 0x5A, 'a' is 0x61)
+#   "apple10" < "apple9"  lexicographic, not numeric
+#
+# and one because it is the pre-#962 behaviour:
+#
+#   comparing by intern id would order by *insertion*, so with the facts
+#   below in this order an id comparison makes "apple" < "banana" true and
+#   "Zebra" < "apple" false.  The expected set here says otherwise.
+
+import os
+import subprocess
+import sys
+import tempfile
+
+PROGRAM = '''\
+.decl W(s: symbol, t: symbol)
+.decl LT(s: symbol, t: symbol)
+.decl GT(s: symbol, t: symbol)
+.decl LTE(s: symbol, t: symbol)
+.decl GTE(s: symbol, t: symbol)
+.decl EQ(s: symbol, t: symbol)
+.decl NEQ(s: symbol, t: symbol)
+.output LT
+.output GT
+.output LTE
+.output GTE
+.output EQ
+.output NEQ
+W("apple","banana"). W("banana","apple"). W("apple","apple").
+W("Zebra","apple"). W("apple10","apple9").
+LT(s,t)  :- W(s,t), s < t.
+GT(s,t)  :- W(s,t), s > t.
+LTE(s,t) :- W(s,t), s <= t.
+GTE(s,t) :- W(s,t), s >= t.
+EQ(s,t)  :- W(s,t), s = t.
+NEQ(s,t) :- W(s,t), s != t.
+'''
+
+EXPECTED = sorted([
+    'EQ("apple", "apple")',
+    'GT("banana", "apple")',
+    'GTE("apple", "apple")',
+    'GTE("banana", "apple")',
+    'LT("apple10", "apple9")',
+    'LT("apple", "banana")',
+    'LT("Zebra", "apple")',
+    'LTE("apple10", "apple9")',
+    'LTE("apple", "apple")',
+    'LTE("apple", "banana")',
+    'LTE("Zebra", "apple")',
+    'NEQ("apple10", "apple9")',
+    'NEQ("apple", "banana")',
+    'NEQ("banana", "apple")',
+    'NEQ("Zebra", "apple")',
+])
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: test_string_compare_ops.py <executable>\n")
+        return 1
+    exe = sys.argv[1]
+
+    env = dict(os.environ)
+    for k in ("WL_LOG", "WL_LOG_FILE"):
+        env.pop(k, None)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "str6.dl")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(PROGRAM)
+        r = subprocess.run([exe, path], capture_output=True, text=True,
+                           timeout=60, env=env)
+
+    if r.returncode != 0:
+        sys.stderr.write("exit %d; stderr=%r\n" % (r.returncode, r.stderr))
+        return 1
+
+    got = sorted(l.strip() for l in r.stdout.replace("\r\n", "\n").split("\n")
+                 if l.strip())
+
+    if got != EXPECTED:
+        missing = [x for x in EXPECTED if x not in got]
+        extra = [x for x in got if x not in EXPECTED]
+        if missing:
+            sys.stderr.write("missing rows: %r\n" % missing)
+        if extra:
+            sys.stderr.write("unexpected rows: %r\n" % extra)
+        return 1
+
+    print("test_string_compare_ops: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -1112,6 +1112,12 @@ typedef struct {
 typedef struct {
     col_expr_instr_t *instrs;
     uint32_t ninstr;
+    /* Issue #966: fixed for the whole expression, so it is resolved once here
+     * rather than passed to the per-row evaluator.  Borrowed -- wl_plan_t
+     * documents its intern as outliving the plan, which outlives any compiled
+     * expression.  NULL is legal and matches the interpreter's own NULL-intern
+     * fallbacks. */
+    const wl_intern_t *intern;
 } col_expr_compiled_t;
 
 static void
@@ -1134,7 +1140,7 @@ col_expr_compiled_free(col_expr_compiled_t *c)
  * col_eval_expr_run in that case.
  */
 static col_expr_compiled_t *
-col_expr_compile(const uint8_t *buf, uint32_t size)
+col_expr_compile(const uint8_t *buf, uint32_t size, const wl_intern_t *intern)
 {
     if (!buf || size == 0)
         return NULL;
@@ -1186,6 +1192,18 @@ col_expr_compile(const uint8_t *buf, uint32_t size)
         case WL_PLAN_EXPR_CMP_GT:
         case WL_PLAN_EXPR_CMP_LTE:
         case WL_PLAN_EXPR_CMP_GTE:
+        /* Issue #966: string-ordering comparisons (no payload).  #962 made
+         * these correct by emitting them; they were absent here, so any
+         * predicate containing one fell to `default: return NULL` and the
+         * whole expression was demoted to the interpreter.  Measured at
+         * ~66 ns/cmp of the ~77 ns regression -- the demotion, not the
+         * strcmp. */
+        case WL_PLAN_EXPR_CMP_STR_EQ:
+        case WL_PLAN_EXPR_CMP_STR_NEQ:
+        case WL_PLAN_EXPR_CMP_STR_LT:
+        case WL_PLAN_EXPR_CMP_STR_GT:
+        case WL_PLAN_EXPR_CMP_STR_LTE:
+        case WL_PLAN_EXPR_CMP_STR_GTE:
         /* Aggregate operators (no payload) */
         case WL_PLAN_EXPR_AGG_COUNT:
         case WL_PLAN_EXPR_AGG_SUM:
@@ -1213,6 +1231,7 @@ col_expr_compile(const uint8_t *buf, uint32_t size)
         return NULL;
     }
     c->ninstr = ninstr;
+    c->intern = intern;
 
     /* Pass 2: fill instruction array. */
     uint32_t j = 0;
@@ -1252,10 +1271,22 @@ col_expr_compile(const uint8_t *buf, uint32_t size)
  * VAR instructions use pre-parsed column indices — no strtol per row.
  * Returns 0 on success with result in *out_val, non-zero on error.
  */
+/*
+ * Issue #966: string comparison on the compiled path.
+ *
+ * The six CMP_STR arms below are transcribed from the interpreter's block in
+ * col_eval_expr rather than paraphrased, because their fallbacks are NOT
+ * symmetric and the asymmetry is load-bearing: when either reverse lookup
+ * fails, EQ/NEQ fall back to comparing the raw ids, while LT/GT/LTE/GTE
+ * yield false.  Collapsing the two families into one shape would be a silent
+ * wrong-answer change, and #962's sweep found no program in this tree that
+ * compares symbols -- nothing existing would catch it.
+ */
 static int
 col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
     uint32_t ncols, int64_t *out_val)
 {
+    const wl_intern_t *intern = c->intern;
     filt_stack_t s;
     s.top = 0;
     for (uint32_t k = 0; k < c->ninstr; k++) {
@@ -1264,6 +1295,50 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_VAR:
             filt_push(&s, (in->iarg < ncols) ? row[in->iarg] : 0);
             break;
+        case WL_PLAN_EXPR_CMP_STR_EQ: {
+            int64_t b = filt_pop(&s), a = filt_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            filt_push(&s,
+                (sa && sb) ? (strcmp(sa, sb) == 0 ? 1 : 0) : (a == b ? 1 : 0));
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_STR_NEQ: {
+            int64_t b = filt_pop(&s), a = filt_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            filt_push(&s,
+                (sa && sb) ? (strcmp(sa, sb) != 0 ? 1 : 0) : (a != b ? 1 : 0));
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_STR_LT: {
+            int64_t b = filt_pop(&s), a = filt_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            filt_push(&s, (sa && sb) ? (strcmp(sa, sb) < 0 ? 1 : 0) : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_STR_GT: {
+            int64_t b = filt_pop(&s), a = filt_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            filt_push(&s, (sa && sb) ? (strcmp(sa, sb) > 0 ? 1 : 0) : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_STR_LTE: {
+            int64_t b = filt_pop(&s), a = filt_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            filt_push(&s, (sa && sb) ? (strcmp(sa, sb) <= 0 ? 1 : 0) : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_STR_GTE: {
+            int64_t b = filt_pop(&s), a = filt_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            filt_push(&s, (sa && sb) ? (strcmp(sa, sb) >= 0 ? 1 : 0) : 0);
+            break;
+        }
         case WL_PLAN_EXPR_CONST_INT:
         case WL_PLAN_EXPR_BOOL:
             filt_push(&s, in->larg);
@@ -1625,7 +1700,8 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
             for (uint32_t c = 0; c < ce_map_count; c++) {
                 if (op->map_exprs[c].data && op->map_exprs[c].size > 0)
                     ce_map[c] = col_expr_compile(op->map_exprs[c].data,
-                            op->map_exprs[c].size);
+                            op->map_exprs[c].size,
+                            sess ? sess->intern : NULL);
             }
         }
     }
@@ -2463,7 +2539,9 @@ col_op_filter(const wl_plan_op_t *op, eval_stack_t *stack,
 
     /* Slow path: pre-compile expression once, then evaluate per row. */
     col_expr_compiled_t *ce =
-        (buf && bsz > 0) ? col_expr_compile(buf, bsz) : NULL;
+        (buf && bsz > 0)
+        ? col_expr_compile(buf, bsz, sess ? sess->intern : NULL)
+        : NULL;
 
     /* Row scratch, hoisted out of the loop (#1000). */
     col_row_buf_t row_rb;
@@ -2567,7 +2645,7 @@ fill_filtered_rel(const uint8_t *buf, uint32_t bsz, col_rel_t *rel,
     }
 
     /* Slow path: compile once, evaluate per row */
-    col_expr_compiled_t *ce = col_expr_compile(buf, bsz);
+    col_expr_compiled_t *ce = col_expr_compile(buf, bsz, intern);
     for (uint32_t r = 0; r < rel->nrows; r++) {
         col_rel_row_copy_out(rel, r, row_buf);
         int pass;
@@ -6772,7 +6850,8 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
 
     col_expr_compiled_t *agg_ce = NULL;
     if (op->agg_expr.data && op->agg_expr.size > 0)
-        agg_ce = col_expr_compile(op->agg_expr.data, op->agg_expr.size);
+        agg_ce = col_expr_compile(op->agg_expr.data, op->agg_expr.size,
+                sess ? sess->intern : NULL);
 
     /* Row scratch, hoisted out of the loop (#1000). */
     col_row_buf_t row_rb;


### PR DESCRIPTION
Closes #966.

#962 made symbol ordering lexicographically correct by emitting `WL_PLAN_EXPR_CMP_STR_LT..GTE`. Those opcodes were never added to `col_expr_compile`'s accepted set, so a predicate containing one hit `default: return NULL` and the **entire** expression was demoted to the bytecode interpreter.

## One correction to the issue

The issue proposes adding an `intern` parameter to `col_eval_expr_compiled` as step one. That is the wrong end: the evaluator runs **per row** and `intern` is fixed for the whole expression. Resolving it once in `col_expr_compile` and storing it on `col_expr_compiled_t` means the evaluator reads `c->intern` and **its four call sites are untouched**.

All four *compile* call sites already had intern within reach -- `col_op_map`, `col_op_filter` and `col_op_reduce` take `wl_col_session_t`, and `fill_filtered_rel` received it as a parameter.

## Measured

1M comparisons (1000x1000 join with a symbol comparison in the body), best of five, with an integer control of identical shape:

| | before | after |
|---|---|---|
| string | 261 ms | 220 ms |
| integer (control) | 187 ms | 189 ms |
| **attributable** | **74 ms** | **31 ms** |

**58% of the string-comparison overhead recovered.** Less than the ~86% the issue projects, and deliberately so -- see below.

## `filter_is_simple_cmp` deliberately untouched

The column-native SIMD filter scan still rejects these opcodes. The issue flags that as the part worth deciding separately and I agree: a left-packing scan over `strcmp` results is not obviously vectorisable, and the id-comparison shortcut that would make it vectorisable is exactly the behaviour #962 removed. That is the gap between 58% and 86%.

## The fallbacks are not symmetric

The six evaluator arms are **transcribed** from the interpreter, not paraphrased. When either reverse lookup fails, `EQ`/`NEQ` fall back to comparing raw ids while `LT`/`GT`/`LTE`/`GTE` yield false. Collapsing the two families into one shape would be a silent wrong-answer change. Worth a reviewer diffing the two implementations rather than reading mine alone.

## Tests, and an honest limit

This is a performance change, so no failing-before assertion exists -- the interpreter was already correct and the compiled path must agree exactly. `tests/test_string_compare_ops.py` pins that agreement across all six operators. It matters more than usual: #962's sweep found no program anywhere in this tree that compares symbols, so before this file **nothing would have caught a divergence**.

Two cases are chosen because a plausible wrong implementation gets them wrong -- `"Zebra" < "apple"` is byte order, not case-insensitive collation, and `"apple10" < "apple9"` is lexicographic, not numeric. Both also separate string ordering from intern-id ordering (the pre-#962 behaviour).

**Mutation results as a pair:**

- compiled `LT` compares ids instead of strings → **KILLED**
- revert the whitelist so the opcodes demote again → **SURVIVES**

The second is correct and worth stating plainly: correctness is identical either way, so the test guards semantics and only the measurement guards the performance. A future change that quietly re-demotes these opcodes would not be caught by the suite.

## Validation

Full suite **274 Ok / 11 Skipped**. `sbom_snapshot` fails locally only -- that gate scans the tree with `syft`, and this host's syft resolves a GitHub Action to a tag where the baseline holds a pinned SHA. It passes in CI (confirmed on #1055).

## Note

Independent Architect/Critic/Reviewer subagents were unavailable (session spawn limit reached), so this ran in degraded sequential mode -- design, critique and review were all performed by the implementing agent.