### PR TITLE
obs(plan): make the LFTJ rewrite observable (#1032)

### DIFF
--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -3136,6 +3136,19 @@ rewrite_lftj_chains(wl_plan_t *plan)
                         ok = false;
                         break;
                     }
+                    /* Issue #1032: the only externally observable evidence
+                     * that an LFTJ was produced.  build_lftj_op() frees the
+                     * chain's operators and keeps only rel_names[], so any
+                     * consumer that does not descend into it sees a rule that
+                     * reads nothing -- and without this line "the rewrite fired
+                     * and the consumer coped" is indistinguishable from "the
+                     * rewrite never fired", which is what made the blindness
+                     * untestable.  TRACE, so release builds strip it. */
+                    WL_LOG(WL_LOG_SEC_ARRANGEMENT, WL_LOG_TRACE,
+                        "lftj rewrite relation=%s chain_at=%u k=%u "
+                        "left_key=%s right_key=%s",
+                        rel->name ? rel->name : "?", i, clen,
+                        lk0 ? lk0 : "-", rk0 ? rk0 : "-");
                     ni++;
                     i += clen;
                 } else {


### PR DESCRIPTION
Refs #1032. **Does not close it** -- this is the measurement step the issue's fix has to rest on, and it already changes the picture.

## The problem with #1032 as filed

`rewrite_lftj_chains()` replaces a join chain with one `WL_PLAN_OP_LFTJ`, and `build_lftj_op()` frees the chain's operators keeping only `rel_names[]`. **Nothing logged that**, anywhere.

That absence is why the issue could not be tested. Verifying "≈20 predicates don't descend into `rel_names[]`, so safety is decided on incomplete information" means telling apart *the rewrite fired and the consumer coped* from *the rewrite never fired*. Without a log line those are the same observation -- and I confirmed that the hard way, by first "verifying" agreement at W=1/2/4/8 on a program that, it turns out, never produced an LFTJ at all.

## What the line immediately shows

None of these produce an LFTJ on the default CLI path:

```
R(x)   :- A(x,y), B(x,z), C(x,w).            <- the issue's own example
R(x)   :- A(x,y), B(x,z), C(x,w), D(x,v).
R(x,w) :- A(x,y), B(y,z), C(z,w).
S(x)   :- P(x,a), P(x,b), P(x,c).            <- star over a same-stratum IDB
```

`lftj_chain_len()` needs every join in the chain to have `key_count == 1`, an empty `right_filter_expr`, an EDB `right_relation`, and -- the binding constraint -- **byte-identical `left_keys[0]` and `right_keys[0]` across the whole chain**. A star join does not survive that once the first join rewrites the left key.

So the blindness is real as code, but the wrong-answer severity attached to it rests on a reachability claim that does not hold for the shapes the issue names.

## Deliberately not fixing the predicates here

I found the fix and it is smaller than the issue assumes -- seven of the predicates route through one helper, `op_references_stratum_idb` (`eval.c:4402`), which has no LFTJ arm; teaching that one function to walk `rel_names[]` covers all seven. (K_FUSION is handled by eight separate open-coded guards, which is where the "twenty" comes from.)

But landing it now would mean fixing a consumer for operators I have not been able to produce, verified by a test that cannot fail -- the exact shape this log line exists to prevent. Someone should first find a program that genuinely produces LFTJ, then check whether any mode decision actually diverges. If none does, the change is defence-in-depth and should be labelled that way rather than as a wrong-answer fix.

## Validation

TRACE on the ARRANGEMENT section, so `-Dwirelog_log_max_level=error` strips it entirely; `log_abi_compile_erasure` still passes. Full suite **274 Ok / 11 Skipped**, abi **33/33**.

`sbom_snapshot` fails locally only -- that gate scans with `syft`, and this host's syft resolves a GitHub Action to a tag where the baseline holds a pinned SHA. It passes in CI.

## Note

Degraded sequential mode (subagent limit reached): design, critique and review all by the implementing agent.