### PR TITLE
fix(plan): reconcile a head's aggregate operand domain instead of taking the last (#1024)

### DIFF
--- a/tests/test_recursive_agg_kfusion.c
+++ b/tests/test_recursive_agg_kfusion.c
@@ -672,27 +672,27 @@ test_mixed_min_max_not_canonicalized(void)
 /* ---------------------------------------------------------------------- */
 
 /*
- * Records current behaviour; it is not a statement that this behaviour is
- * right.
+ * Issue #1024: the operand's domain is reconciled across a head's rules, so
+ * rule order no longer decides how min() orders a symbol column.
  *
- * Where two rules of one head agree on the aggregate function and the number
- * of grouping columns but disagree on the operand's domain -- here a
+ * Two rules of one head can agree on the aggregate function and the number
+ * of grouping columns and still disagree on the operand's domain -- here a
  * declared `symbol` column against an undeclared relation, which has no
- * column types at all -- the relation is canonicalised under whichever
- * domain the *last* rule established.  The two programs below differ only in
- * the order of their last two rules and answer differently: with the
- * undeclared rule last the whole relation is reduced by intern id and
- * answers "zz", and with the declared rule last it is reduced
- * lexicographically and answers "aa".
+ * column types at all.  The domain used to be the one field agg_spec_observe
+ * did not compare, so whichever rule was written *last* established it: with
+ * the undeclared rule last the relation reduced by intern id and answered
+ * "zz", and with the declared rule last it reduced lexicographically and
+ * answered "aa".  Same data, same rules, different order, different answer.
  *
- * That is what the pre-fix scan did (it compared the aggregate function and
- * the group width across REDUCEs but never the operand domain, and kept the
- * last operator it saw), and it is reproduced deliberately so the fix does
- * not change any program's answer.  It is a latent variant of #965: plan
- * order, not the data, decides whether min() orders by string or by intern
- * id.  Fixing it means deciding what a relation whose rules genuinely
- * disagree should do, which is a separate question from where the
- * specification is stored.
+ * That was a latent variant of #965, whose point was that intern ids are
+ * assigned in first-appearance order, so ordering symbols by id makes the
+ * result depend on which unrelated facts were parsed first.
+ *
+ * UNKNOWN is not a third domain to negotiate with: it means no producer
+ * typed the operand, not that it is numeric.  So the rule that does know
+ * wins in either direction and both programs below must now answer "aa".
+ * The two orderings are the whole point -- one of them passed before the
+ * fix, so a test that ran only one would not have moved.
  */
 #define LASTWINS_FACTS                                                  \
         ".decl Edge(x: int64, y: int64)\n"                              \
@@ -704,32 +704,80 @@ test_mixed_min_max_not_canonicalized(void)
         "Label(x, min(v)) :- Label(y, v), Edge(y, x).\n"
 
 static void
-test_operand_type_last_rule_wins(void)
+test_operand_type_is_order_independent(void)
 {
-    TEST("operand domain: the last rule of the head decides (recorded)");
+    TEST("operand domain: rule order no longer decides the ordering");
 
-    /* Untyped rule last: the whole relation reduces by intern id. */
     static const char *untyped_last = LASTWINS_FACTS
         "Label(x, min(v)) :- Sym(x, v).\n"
         "Label(x, min(v)) :- M(x, v).\n";
-    /* Typed rule last: the whole relation reduces lexicographically. */
     static const char *typed_last = LASTWINS_FACTS
         "Label(x, min(v)) :- M(x, v).\n"
         "Label(x, min(v)) :- Sym(x, v).\n";
-    static const char *const want_untyped[] = { "1|zz", "2|zz", NULL };
-    static const char *const want_typed[] = { "1|aa", "2|aa", NULL };
+    /* Lexicographic in both orders.  Pre-fix, untyped_last answered zz. */
+    static const char *const want[] = { "1|aa", "2|aa", NULL };
 
     for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
         collect_t c;
         ASSERT(eval_relation_at(untyped_last, "Label",
             k_worker_counts[w], 1, &c) == 0, "evaluation failed");
-        ASSERT(saw_exactly(&c, want_untyped),
-            "untyped-last no longer reduces by intern id");
+        ASSERT(saw_exactly(&c, want),
+            "untyped-last must still order lexicographically");
 
         ASSERT(eval_relation_at(typed_last, "Label",
             k_worker_counts[w], 1, &c) == 0, "evaluation failed");
-        ASSERT(saw_exactly(&c, want_typed),
-            "typed-last no longer reduces lexicographically");
+        ASSERT(saw_exactly(&c, want),
+            "typed-last must still order lexicographically");
+    }
+    PASS();
+}
+
+/*
+ * The other half of #1024: a domain disagreement that is real.
+ *
+ * UNKNOWN against a known domain is not a conflict and is reconciled above.
+ * SCALAR against STRING is: one rule's `.decl` says the aggregated column
+ * holds numbers, another's says it holds symbols, and there is no widening
+ * that is right for both -- ordering the numeric rule's values
+ * lexicographically would reverse-intern values that are not intern ids.
+ * So the relation is vetoed and left un-canonicalised, exactly as it already
+ * is when the rules disagree on the aggregate function (TEST 8) or the
+ * grouping width.
+ *
+ * Group 1 keeping two rows is the whole assertion: it is what "not
+ * canonicalised" looks like.  Without this case the veto branch is dead
+ * code -- confirmed by mutation, deleting it left the other nine cases
+ * green.
+ *
+ * The mixed output itself is not pretty, and is not made prettier here: a
+ * column declared `symbol` shows a raw 5 because the numeric rule wrote one.
+ * That is the pre-existing consequence of a program whose rules disagree
+ * about what the column holds, and diagnosing it is #979's channel, not this
+ * change's business.
+ */
+static void
+test_operand_domain_conflict_is_vetoed(void)
+{
+    TEST("operand domain: a real SCALAR/STRING conflict is not reduced");
+
+    static const char *src =
+        ".decl Edge(x: int64, y: int64)\n"
+        ".decl Sym(x: int64, v: symbol)\n"
+        ".decl Num(x: int64, v: int64)\n"
+        ".decl Label(x: int64, l: symbol)\n"
+        "Sym(1,\"zz\"). Sym(1,\"aa\"). Num(1, 5). Num(1, 9).\n"
+        "Edge(1,2).\n"
+        "Label(x, min(v)) :- Sym(x, v).\n"
+        "Label(x, min(v)) :- Num(x, v).\n"
+        "Label(x, min(v)) :- Label(y, v), Edge(y, x).\n";
+    static const char *const want[] = { "1|5", "1|aa", "2|aa", NULL };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(src, "Label", k_worker_counts[w], 1, &c) == 0,
+            "evaluation failed");
+        ASSERT(saw_exactly(&c, want),
+            "a conflicting-domain relation must be left un-canonicalised");
     }
     PASS();
 }
@@ -749,7 +797,8 @@ main(void)
     test_group_by_two_columns();
     test_count_not_canonicalized();
     test_mixed_min_max_not_canonicalized();
-    test_operand_type_last_rule_wins();
+    test_operand_type_is_order_independent();
+    test_operand_domain_conflict_is_vetoed();
 
     printf("\n=== %d/%d passed, %d failed ===\n", pass_count, test_count,
         fail_count);

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -931,17 +931,33 @@ op_list_init(op_list_t *list)
  * direction -- it would start collapsing relations that are correctly left
  * alone today, under an order only one of their rules asked for.
  *
- * The operand's domain is the one field NOT compared: where several REDUCEs
- * agree on the aggregate and the group width, the last one's domain decides,
- * which is what the deleted scan did (it kept the last operator it saw and
- * never looked at agg_operand_type).  Reproduced deliberately so that no
- * program's answer moves with this change, but it is a latent variant of
- * #965: WL_PLAN_AGG_OPERAND_UNKNOWN and _STRING can coexist across two rules
- * of one head -- a declared `symbol` column in one and an undeclared
- * relation in the other -- and then rule order, not the data, decides whether
- * min() orders by string or by interned id.  Deciding what genuinely
- * disagreeing rules should do is a separate question from where the
- * specification is stored, and is not settled here.
+ * The operand's domain is reconciled rather than overwritten (Issue #1024).
+ * It used to be the one field not compared -- the last REDUCE's domain won,
+ * reproducing what the scan #975 deleted had done -- so for a head whose
+ * rules agreed on the aggregate and the group width but disagreed on the
+ * domain, *rule order* decided whether min() ordered a symbol column
+ * lexicographically or by interned id.  That is a latent variant of #965,
+ * whose whole point was that ordering symbols by id makes the answer depend
+ * on which unrelated facts were parsed first.
+ *
+ * Two disagreements are not the same thing and are not treated the same:
+ *
+ *   UNKNOWN against a known domain is not a conflict.  UNKNOWN means no
+ *   producer typed the operand -- an undeclared relation -- not that it is
+ *   numeric.  The rule that does know wins, in either direction, so the
+ *   answer no longer depends on which rule came last.
+ *
+ *   SCALAR against STRING is a real conflict: one rule's `.decl` says the
+ *   column holds numbers and another's says it holds symbols.  There is no
+ *   widening that is right for both -- ordering the numeric rule's values
+ *   lexicographically would reverse-intern values that are not ids -- so the
+ *   relation is vetoed, exactly as it already is when the rules disagree on
+ *   the aggregate function or the grouping width.  This is the issue's
+ *   option 1 for the case that genuinely needs it and its option 2 for the
+ *   case that does not; a blanket "any STRING wins" would silently reorder a
+ *   numeric column.
+ *
+ * The veto is sticky like the others.
  */
 static void
 agg_spec_observe(op_list_t *list, const wl_plan_op_t *reduce)
@@ -965,11 +981,25 @@ agg_spec_observe(op_list_t *list, const wl_plan_op_t *reduce)
         return;
     }
 
+    /* Issue #1024: reconcile the domain instead of letting the last rule win. */
+    if (list->agg.has_spec
+        && list->agg.operand_type != reduce->agg_operand_type
+        && list->agg.operand_type != WL_PLAN_AGG_OPERAND_UNKNOWN
+        && reduce->agg_operand_type != WL_PLAN_AGG_OPERAND_UNKNOWN) {
+        list->agg_vetoed = true;
+        memset(&list->agg, 0, sizeof(list->agg));
+        return;
+    }
+
+    wl_plan_agg_operand_t domain = reduce->agg_operand_type;
+    if (domain == WL_PLAN_AGG_OPERAND_UNKNOWN && list->agg.has_spec)
+        domain = list->agg.operand_type;
+
     list->agg.has_spec = true;
     list->agg.fn = reduce->agg_fn;
     list->agg.group_by_count = reduce->group_by_count;
     list->agg.aggregate_index = reduce->aggregate_index;
-    list->agg.operand_type = reduce->agg_operand_type;
+    list->agg.operand_type = domain;
 }
 
 static wl_plan_op_t *


### PR DESCRIPTION
Closes #1024.

The issue is filed as **a decision, not a bug report**, and offers three options. I picked one and implemented it rather than leaving it open; the reasoning is below and I am happy to be overruled on it.

## The defect

Two rules of one head agreeing on the aggregate and the group width but disagreeing on the operand's domain: whichever was written **last** decided the ordering.

```
Label(x, min(v)) :- Sym(x, v).   -- declared symbol column
Label(x, min(v)) :- M(x, v).     -- undeclared relation, no column types
    ->  Label(1, "zz")            reduced by intern id

Label(x, min(v)) :- M(x, v).
Label(x, min(v)) :- Sym(x, v).
    ->  Label(1, "aa")            reduced lexicographically
```

Same data, same rules, different order, different answer -- a latent variant of #965, whose point was that intern ids are assigned in first-appearance order, so ordering symbols by id makes the result depend on which unrelated facts were parsed first.

## The choice: option 1 for one case, option 2 for the other

The two disagreements are not the same thing:

| | |
|---|---|
| **UNKNOWN vs known** | Not a conflict. UNKNOWN means *no producer typed it* (an undeclared relation), not that it is numeric. The rule that knows wins, in either direction. Both programs above now answer `"aa"`. |
| **SCALAR vs STRING** | A real conflict -- one `.decl` says numbers, another says symbols. **Vetoed**, left un-canonicalised, exactly as when rules disagree on the aggregate function or grouping width. |

Option 2 as written ("if any rule says SYMBOL, order lexicographically") would silently reorder a genuinely numeric column, and ordering numbers lexicographically means reverse-interning values that are not intern ids. That is the one case worth not being clever about.

**Option 3 (keep last-wins, warn) was rejected because the warning cannot be seen**: `WL_LOG` defaults to `WL_LOG_NONE` and the gate is `LVL <= threshold`, so a WARN never reaches a user who has not already set it. That is #979 — and even after #979 lands, a diagnostic that leaves the answer order-dependent is worse than an answer that does not depend on order.

## Tests, including a gap I had to find by mutation

`test_operand_type_last_rule_wins` -- which recorded the old behaviour and was commented as documenting rather than endorsing it -- becomes `test_operand_type_is_order_independent` and asserts **both** orderings answer `"aa"`. Keeping both matters: one of them passed before this change, so a test running only one would not have moved.

The veto branch had **no** coverage. Deleting it left the other nine cases green -- the conflict shape simply never arose in them. `test_operand_domain_conflict_is_vetoed` builds one and asserts group 1 keeps two rows, which is what un-canonicalised looks like.

Both halves are now mutation-killed: reverting the reconciliation kills TEST 9, deleting the veto kills TEST 10.

That test's output is not pretty -- a column declared `symbol` shows a raw `5` because the numeric rule wrote one -- and is deliberately left that way. It is the pre-existing consequence of rules disagreeing about what a column holds; surfacing it is #979's channel, not this change's business.

## Validation

**10/10** in `test_recursive_agg_kfusion`, full suite **274 Ok / 11 Skipped**.

`sbom_snapshot` fails locally only -- that gate scans with `syft`, and this host's syft resolves a GitHub Action to a tag where the baseline holds a pinned SHA. It passes in CI.

## Note

Degraded sequential mode (subagent limit reached): design, critique and review all by the implementing agent. Given this PR resolves a question the issue explicitly left open, a second opinion on the SCALAR-vs-STRING veto in particular would be worth having.