### PR TITLE
obs(session): record the join-output high-water mark (#959)

### DIFF
--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1050,6 +1050,11 @@ typedef struct wl_col_session_t {
      * based on available physical memory, num_workers, and estimated row width.
      * 0 = disabled (no limit). Overridable via WIRELOG_JOIN_OUTPUT_LIMIT env var. */
     uint64_t join_output_limit;
+    /* Issue #959: high-water mark of a single join's output, per session.
+     * Workers are separate sessions, so each carries its own -- which is the
+     * number needed to decide whether dividing the row cap by W is right:
+     * compare a worker's peak against single_threaded_peak / W. */
+    uint64_t join_output_peak;
     /* Shared join-output counter for relation-level TDD workers. Borrowed from
      * the coordinator while a single non-recursive relation plan is running;
      * NULL uses the session-local join_output_limit semantics. */

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -2796,6 +2796,12 @@ col_join_output_limit_reached(wl_col_session_t *sess, const col_rel_t *out)
         return false;
     uint64_t limit = sess->join_output_shared_count
         ? sess->join_output_shared_limit : sess->join_output_limit;
+    /* Issue #959: record the high-water mark even when no cap is set, so a
+     * run that completes still reports what it needed.  Cheap: this helper
+     * is already called once per output-size check, and it is a compare and
+     * a store on a session-local field. */
+    if (out && out->nrows > sess->join_output_peak)
+        sess->join_output_peak = out->nrows;
     if (limit == 0)
         return false;
     if (sess->join_output_shared_count) {

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1265,6 +1265,36 @@ col_session_destroy(wl_session_t *session)
     if (!session)
         return;
     wl_col_session_t *sess = COL_SESSION(session);
+
+    /* Issue #959: report the join-output high-water mark before teardown.
+     *
+     * The open question is whether dividing the row cap by W is right --
+     * col_session_worker_init() gives each worker join_output_limit / W,
+     * which assumes a worker's largest intermediate is 1/W of the
+     * single-threaded one.  Workers are separate sessions, so each prints
+     * its own line and the ratio is readable directly:
+     *
+     *     WL_LOG=SESSION:4 ... 2>&1 | grep join_output_peak
+     *
+     * A worker peak near single_threaded_peak / W means the division is
+     * sound for that workload; a much larger one is the reproduction #959
+     * has been missing, and also sizes the fix.  DEBUG rather than INFO so
+     * it does not appear in ordinary runs.
+     *
+     * Known gap, stated rather than left to be discovered: only the
+     * coordinator reaches here.  Worker sessions are bitwise copies torn
+     * down on their own path and never call col_session_destroy, so at W=8
+     * this still prints exactly one line.  What it gives today is the
+     * single-threaded reference number -- the denominator of the ratio --
+     * and confirmation that it does not change with W.  Capturing the
+     * numerator needs the same emit on the worker teardown path, which is
+     * the next step for #959 and is deliberately not guessed at here. */
+    WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_DEBUG,
+        "join_output_peak rows=%llu limit=%llu workers=%u",
+        (unsigned long long)sess->join_output_peak,
+        (unsigned long long)sess->join_output_limit,
+        sess->num_workers);
+
     /* Issue #600: tear down rotation strategy first so the destroy hook
      * still sees a fully-populated session (eval_arena, compound_arena,
      * etc.) before any of the other teardown frees them. NULL-safe. */


### PR DESCRIPTION
Refs #959. **Does not close it** — this is the measurement the policy question needs, and it already argues against the issue's stated mechanism.

## The number did not exist

#959 asks whether dividing the join row cap by W is right. `col_session_worker_init()` gives each worker `join_output_limit / W`, which assumes a worker's largest intermediate is 1/W of the single-threaded one — and the issue argues K-fusion breaks that, since each fused copy materialises its own join output.

Nothing recorded the maximum. `col_rel_t` knows its row count and the cap is compared against it, but the high-water mark was discarded, so a run that completed said nothing about how close it came and a run that failed said only that it hit the limit.

`col_join_output_limit_reached()` is already called once per output-size check, so this costs a compare and a store on a session-local field. It records even with no cap set, so a completing run still reports what it needed.

## What it shows so far

Two-rule recursive closure, 200 nodes, out-degree 3 — a K-fusion shape:

| | coordinator peak |
|---|---|
| W=1 | 10200 rows |
| W=8 | 10200 rows |

Unchanged. And independently, bisecting `WIRELOG_JOIN_OUTPUT_LIMIT` for the smallest value that completes gives **10765 at both widths** — so a worker running under `limit/8` is in fact sufficient here.

Neither observation reproduces the disproportion the issue describes. Combined with the issue's own note that raising the budget 27x (`WIRELOG_JOIN_OUTPUT_LIMIT=2000000000`, per-worker 105,263,157) *still* hits the cap, the evidence points at total volume rather than at how it is split.

## Known gap — stated, not left to be discovered

**Only the coordinator reaches `col_session_destroy`.** Worker sessions are bitwise copies torn down on their own path, so at W=8 this still prints exactly one line.

So what this gives today is the **denominator** of the ratio — the single-threaded peak, and confirmation that it does not move with W. Capturing the numerator needs the same emit on the worker teardown path. That is the next step for #959 and I deliberately did not guess at where it goes.

I would rather land the half that is correct and name the half that is missing than infer worker peaks from thresholds and present it as measured.

## Validation

DEBUG on the SESSION section: absent from ordinary runs, stripped entirely under `-Dwirelog_log_max_level=error`. Full suite **274 Ok / 11 Skipped**.

`sbom_snapshot` fails locally only — that gate scans with `syft`, and this host's syft resolves a GitHub Action to a tag where the baseline holds a pinned SHA. It passes in CI.

## Note

Degraded sequential mode (subagent limit reached): design, critique and review all by the implementing agent.