### PR TITLE
feat(decl): let an inline compound column name its slot types (#1037)

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4672,6 +4672,16 @@ if not is_android
     suite: 'cli',
   )
 
+  test('inline_slot_types',
+    baseline_py3,
+    args: [
+      files('test_inline_slot_types.py')[0],
+      wirelog_cli.full_path(),
+    ],
+    depends: wirelog_cli,
+    suite: 'cli',
+  )
+
   test('cli_version',
     baseline_py3,
     args: [

--- a/tests/test_inline_slot_types.py
+++ b/tests/test_inline_slot_types.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# test_inline_slot_types.py - per-slot types for inline compounds (#1037)
+#
+# Copyright (C) CleverPlant
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+# Usage: test_inline_slot_types.py <wirelog_cli_executable>
+#
+# The fact path has always round-tripped a symbol through an inline compound
+# slot: `p(1, "aa", "bb").` against `.decl p(id: int64, lbl: pair/2 inline)`
+# evaluates correctly.  The `.input` path could not express the same data,
+# because the `.decl` grammar records one type per *declared* column and
+# `type_name_to_column_type()` maps any `functor/arity` spelling to int64 --
+# so io_ctx.c typed every inline slot int64 and the integer reader refused
+# "aa".  The failure was loud rather than silent, which is the right failure,
+# but the data was unloadable.
+#
+# `f(t1, t2)` now names each slot's type.  `f/arity` is unchanged and still
+# means every slot is int64.
+#
+# The controls are the point.  A change that simply made the reader intern
+# anything non-numeric would satisfy the positive case while destroying the
+# declaration's authority, so:
+#
+#   * the old `pair/2` spelling must STILL refuse a symbol file -- that is
+#     what proves the new behaviour comes from the declaration rather than
+#     from the data,
+#   * an int64 slot declared explicitly must still reject a symbol,
+#   * and a compound-free relation must be untouched.
+
+import os
+import subprocess
+import sys
+import tempfile
+
+NEW = '''\
+.decl p(id: int64, lbl: pair(symbol, symbol) inline)
+.decl o(a: int64, b: symbol, c: symbol)
+.input p(filename="%s")
+.output o
+o(a,b,c) :- p(a, pair(b,c)).
+'''
+
+OLD = '''\
+.decl p(id: int64, lbl: pair/2 inline)
+.decl o(a: int64, b: symbol, c: symbol)
+.input p(filename="%s")
+.output o
+o(a,b,c) :- p(a, pair(b,c)).
+'''
+
+# Explicit int64 slots: a symbol file must still be refused.
+TYPED_INT = '''\
+.decl p(id: int64, lbl: pair(int64, int64) inline)
+.decl o(a: int64, b: int64, c: int64)
+.input p(filename="%s")
+.output o
+o(a,b,c) :- p(a, pair(b,c)).
+'''
+
+# Mixed slots, and the numeric one is second so a naive implementation that
+# applied slot 0's type to the whole compound would fail here.
+MIXED = '''\
+.decl p(id: int64, lbl: pair(symbol, int64) inline)
+.decl o(a: int64, b: symbol, c: int64)
+.input p(filename="%s")
+.output o
+o(a,b,c) :- p(a, pair(b,c)).
+'''
+
+PLAIN = '''\
+.decl q(a: int64, s: symbol)
+.decl r(a: int64, s: symbol)
+.input q(filename="%s")
+.output r
+r(a,s) :- q(a,s).
+'''
+
+
+def run(exe, program, tmpdir, name, rows):
+    csv = os.path.join(tmpdir, name + ".csv")
+    with open(csv, "w", encoding="utf-8") as fh:
+        fh.write(rows)
+    dl = os.path.join(tmpdir, name + ".dl")
+    with open(dl, "w", encoding="utf-8") as fh:
+        fh.write(program % csv)
+    env = dict(os.environ)
+    env.pop("WL_LOG", None)
+    return subprocess.run([exe, dl], capture_output=True, text=True,
+                          timeout=60, env=env)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: test_inline_slot_types.py <executable>\n")
+        return 1
+    exe = sys.argv[1]
+    ok = True
+
+    def fail(msg):
+        nonlocal ok
+        sys.stderr.write(msg.rstrip() + "\n")
+        ok = False
+
+    with tempfile.TemporaryDirectory() as td:
+        # The point of the issue.
+        r = run(exe, NEW, td, "new", "1\taa\tbb\n")
+        if 'o(1, "aa", "bb")' not in r.stdout:
+            fail("declared symbol slots: expected o(1, \"aa\", \"bb\"); "
+                 "stdout=%r stderr=%r" % (r.stdout.strip(), r.stderr.strip()))
+
+        # Control: the declaration decides, not the data.
+        r = run(exe, OLD, td, "old", "1\taa\tbb\n")
+        if r.returncode == 0:
+            fail("pair/2 must still refuse a symbol file -- otherwise the "
+                 "new behaviour is coming from the data, not the .decl")
+
+        # Control: explicit int64 slots reject symbols.
+        r = run(exe, TYPED_INT, td, "ti", "1\taa\tbb\n")
+        if r.returncode == 0:
+            fail("pair(int64, int64) must refuse a symbol file")
+
+        # Control: /arity still loads integers.
+        r = run(exe, OLD, td, "oldint", "1\t2\t3\n")
+        if r.returncode != 0:
+            fail("pair/2 must still load an all-integer file; stderr=%r"
+                 % r.stderr.strip())
+
+        # Per-slot, not per-compound.
+        r = run(exe, MIXED, td, "mix", "1\taa\t7\n")
+        if 'o(1, "aa", 7)' not in r.stdout:
+            fail("mixed slots: expected o(1, \"aa\", 7); stdout=%r stderr=%r"
+                 % (r.stdout.strip(), r.stderr.strip()))
+
+        # Control: no compound anywhere, unchanged.
+        r = run(exe, PLAIN, td, "plain", "1\tzz\n")
+        if 'r(1, "zz")' not in r.stdout:
+            fail("compound-free relation changed; stdout=%r" % r.stdout.strip())
+
+    if not ok:
+        return 1
+    print("test_inline_slot_types: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wirelog/io/io_ctx.c
+++ b/wirelog/io/io_ctx.c
@@ -86,8 +86,18 @@ wirelog_io_ctx_create_for_relation(const wl_ir_relation_info_t *rel,
         for (uint32_t i = 0; i < rel->column_count; i++) {
             if (rel->columns[i].compound_kind
                 == WIRELOG_COMPOUND_KIND_INLINE) {
-                for (uint32_t j = 0; j < rel->columns[i].compound_arity; j++)
-                    ctx->col_types[k++] = WIRELOG_TYPE_INT64;
+                /* Issue #1037: a `.decl` may name each slot's type as
+                 * `f(symbol, int64) inline`.  When it does, the side array
+                 * carries them at col*4+slot; a symbol slot reads as
+                 * WIRELOG_TYPE_STRING, which csv_reader.c already interns.
+                 * `f/arity` leaves slot_types NULL and keeps meaning
+                 * all-int64, so nothing that parses today moves. */
+                for (uint32_t j = 0; j < rel->columns[i].compound_arity; j++) {
+                    wirelog_column_type_t st = WIRELOG_TYPE_INT64;
+                    if (rel->slot_types && (i * 4 + j) < rel->slot_type_count)
+                        st = rel->slot_types[i * 4 + j];
+                    ctx->col_types[k++] = st;
+                }
             } else {
                 ctx->col_types[k++] = rel->columns[i].type;
             }

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -67,6 +67,10 @@ typedef struct {
     wirelog_compound_kind_t kind;
     uint32_t functor_id;
     uint32_t arity;
+    /* Issue #1037: set only for the f(t1, t2) spelling; false means f/arity,
+     * which continues to mean every slot is int64. */
+    bool has_slot_types;
+    wirelog_column_type_t slot_types[4];
 } compound_metadata_t;
 
 /**
@@ -114,8 +118,50 @@ parse_compound_metadata(const char *type_name, wl_intern_t *intern)
         return result; /* Invalid arity */
     }
 
-    /* Check for kind modifier (inline/side) after arity */
+    /* Issue #1037: decode an optional <t1,t2> between the arity and the
+     * modifier.  strtol above already stops at '<', so the arity is right
+     * either way; without this the modifier compare below sees "<...> inline"
+     * and fails, leaving compound_kind NONE. */
     char *kind_str = arity_end;
+    if (*kind_str == '<') {
+        char *q = kind_str + 1;
+        uint32_t n = 0;
+        while (*q && *q != '>') {
+            const char *tok = q;
+            while (*q && *q != ',' && *q != '>')
+                q++;
+            size_t tlen = (size_t)(q - tok);
+            wirelog_column_type_t ty;
+            /* `symbol` -> STRING exactly as type_name_to_column_type() does
+             * for a whole column; csv_reader.c already interns STRING
+             * columns, which is why no new public enum value is needed. */
+            if (tlen == 5 && strncmp(tok, "int32",
+                5) == 0) ty = WIRELOG_TYPE_INT32;
+            else if (tlen == 5 && strncmp(tok, "int64",
+                5) == 0) ty = WIRELOG_TYPE_INT64;
+            else if (tlen == 6 && strncmp(tok, "string",
+                6) == 0) ty = WIRELOG_TYPE_STRING;
+            else if (tlen == 6 && strncmp(tok, "symbol",
+                6) == 0) ty = WIRELOG_TYPE_STRING;
+            else {
+                free(functor_name); return result;
+            }
+            if (n >= 4) {
+                free(functor_name); return result;
+            }
+            result.slot_types[n++] = ty;
+            if (*q == ',') q++;
+        }
+        /* List length and arity validated equal rather than either being
+         * trusted: wl_ir_relation_physical_width() (#985) derives the
+         * physical width from compound_arity. */
+        if (*q != '>' || n == 0 || (uint32_t)arity_val != n) {
+            free(functor_name);
+            return result;
+        }
+        result.has_slot_types = true;
+        kind_str = q + 1;
+    }
     while (*kind_str && isspace((unsigned char)*kind_str))
         kind_str++;
 
@@ -212,6 +258,7 @@ relation_info_free(wl_ir_relation_info_t *info)
         }
         free(info->columns);
     }
+    free(info->slot_types); /* Issue #1037 */
     if (info->input_param_names) {
         for (uint32_t i = 0; i < info->input_param_count; i++) {
             free(info->input_param_names[i]);
@@ -462,6 +509,30 @@ collect_decl(struct wirelog_program *prog,
                 rel->columns[idx].compound_functor_id = meta.functor_id;
                 rel->columns[idx].compound_arity = meta.arity;
                 rel->columns[idx].compound_inline_col_offset = 0;
+
+                /* Issue #1037: fixed stride col*4+slot.  A physically packed
+                 * array would have to be built in column order and misaligns
+                 * if a scalar column precedes the compound.  Seeded INT64
+                 * rather than left at calloc's zero because
+                 * WIRELOG_TYPE_INT32 == 0, so a zero cell is otherwise
+                 * indistinguishable from an unwritten one. */
+                if (meta.has_slot_types
+                    && meta.kind == WIRELOG_COMPOUND_KIND_INLINE) {
+                    if (!rel->slot_types) {
+                        rel->slot_types = (wirelog_column_type_t *)calloc(
+                            (size_t)rel->column_count * 4,
+                            sizeof(wirelog_column_type_t));
+                        rel->slot_type_count = rel->slot_types
+                            ? rel->column_count * 4 : 0;
+                        for (uint32_t z = 0; z < rel->slot_type_count; z++)
+                            rel->slot_types[z] = WIRELOG_TYPE_INT64;
+                    }
+                    if (rel->slot_types
+                        && (idx * 4 + meta.arity) <= rel->slot_type_count) {
+                        for (uint32_t si = 0; si < meta.arity; si++)
+                            rel->slot_types[idx * 4 + si] = meta.slot_types[si];
+                    }
+                }
 
                 /* Issue #535: RDF named-graph support */
                 if (strcmp(param->name, "__graph_id") == 0) {

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -30,6 +30,16 @@ typedef struct wl_parser_ast_node wl_parser_ast_node_t;
 typedef struct {
     char *name;
     wirelog_column_t *columns;
+    /* Issue #1037: per-slot types for inline compound columns, stride
+     * col*4+slot, or NULL when no column names its slot types.
+     *
+     * Deliberately NOT a field on wirelog_column_t: that struct is public
+     * (wirelog-types.h) and travels by value inside wirelog_schema_t, which
+     * wirelog_program_get_schema() hands to embedders, so widening it is a
+     * layout break rather than a manifest update.  A side array keeps the
+     * ABI still, the same shape as plan->edb_declared_width (#1038). */
+    wirelog_column_type_t *slot_types;
+    uint32_t slot_type_count;
     uint32_t column_count;
     /* Issue #977: true once a `.decl` for this relation has been collected.
      * Distinguishes "declared with zero columns" (`.decl p()`, which parses

--- a/wirelog/parser/parser.c
+++ b/wirelog/parser/parser.c
@@ -174,18 +174,60 @@ parse_declaration_type(wl_parser_t *parser)
     if (!functor)
         return NULL;
 
-    if (!parser_consume(parser, WL_PARSER_LEXER_TOK_SLASH,
-        "expected '/' in compound type")) {
-        free(functor);
-        return NULL;
-    }
-    if (!parser_consume(parser, WL_PARSER_LEXER_TOK_INTEGER,
-        "expected compound arity after '/'")) {
-        free(functor);
-        return NULL;
-    }
+    /* Issue #1037: `f(t1, t2)` names each slot's type; `f/2` keeps meaning
+     * "every slot is int64".  No lexer change -- '(' ',' ')' are already
+     * tokens, and this function has always built the type string from
+     * separately lexed pieces rather than lexing one. */
+    char slot_types[4][8];
+    uint32_t slot_count = 0;
+    int64_t arity_value;
 
-    int64_t arity_value = parser->previous.int_value;
+    if (parser_match(parser, WL_PARSER_LEXER_TOK_LPAREN)) {
+        do {
+            const char *t = NULL;
+            if (parser_match(parser, WL_PARSER_LEXER_TOK_INT32)) t = "int32";
+            else if (parser_match(parser,
+                WL_PARSER_LEXER_TOK_INT64)) t = "int64";
+            else if (parser_match(parser,
+                WL_PARSER_LEXER_TOK_STRING_TYPE)) t = "string";
+            else if (parser_match(parser,
+                WL_PARSER_LEXER_TOK_SYMBOL_TYPE)) t = "symbol";
+            else {
+                parser_error(parser, "expected a slot type (int32, int64, "
+                    "string, symbol) in a compound type list");
+                free(functor);
+                return NULL;
+            }
+            /* Bounded before the write: the `/arity` spelling checks its
+            * bound after parsing an integer, which does not transfer. */
+            if (slot_count >= 4) {
+                parser_error(parser,
+                    "compound type list exceeds maximum arity 4");
+                free(functor);
+                return NULL;
+            }
+            snprintf(slot_types[slot_count], sizeof(slot_types[0]), "%s", t);
+            slot_count++;
+        } while (parser_match(parser, WL_PARSER_LEXER_TOK_COMMA));
+        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_RPAREN,
+            "expected ')' after compound type list")) {
+            free(functor);
+            return NULL;
+        }
+        arity_value = (int64_t)slot_count;
+    } else {
+        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_SLASH,
+            "expected '/' or '(' in compound type")) {
+            free(functor);
+            return NULL;
+        }
+        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_INTEGER,
+            "expected compound arity after '/'")) {
+            free(functor);
+            return NULL;
+        }
+        arity_value = parser->previous.int_value;
+    }
     if (arity_value <= 0 || arity_value > UINT32_MAX) {
         parser_error(parser, "compound arity must be a positive uint32");
         free(functor);
@@ -224,15 +266,28 @@ parse_declaration_type(wl_parser_t *parser)
     char arity_buf[32];
     snprintf(arity_buf, sizeof(arity_buf), "%u", (uint32_t)arity_value);
 
-    size_t len = strlen(functor) + 1 + strlen(arity_buf)
+    /* Slot types ride in the synthetic name as <t1,t2> so
+     * parse_compound_metadata() stays the single decoder. */
+    char slots_buf[96];
+    slots_buf[0] = '\0';
+    if (slot_count > 0) {
+        size_t off = (size_t)snprintf(slots_buf, sizeof(slots_buf), "<");
+        for (uint32_t i = 0; i < slot_count && off < sizeof(slots_buf); i++)
+            off += (size_t)snprintf(slots_buf + off, sizeof(slots_buf) - off,
+                    "%s%s", i ? "," : "", slot_types[i]);
+        if (off < sizeof(slots_buf))
+            snprintf(slots_buf + off, sizeof(slots_buf) - off, ">");
+    }
+
+    size_t len = strlen(functor) + 1 + strlen(arity_buf) + strlen(slots_buf)
         + (modifier ? 1 + strlen(modifier) : 0);
     char *type_name = (char *)malloc(len + 1);
     if (!type_name) {
         free(functor);
         return NULL;
     }
-    snprintf(type_name, len + 1, "%s/%s%s%s", functor, arity_buf,
-        modifier ? " " : "", modifier ? modifier : "");
+    snprintf(type_name, len + 1, "%s/%s%s%s%s", functor, arity_buf,
+        slots_buf, modifier ? " " : "", modifier ? modifier : "");
     free(functor);
     return type_name;
 }


### PR DESCRIPTION
Closes #1037.

`.decl p(id: int64, lbl: pair(symbol, symbol) inline)` now loads through `.input`:

```
tab.csv:  1<TAB>aa<TAB>bb
          ->  o(1, "aa", "bb")
```

`pair/2 inline` is unchanged and still means every slot is int64, so nothing that parses today moves.

## Design

**No lexer change.** `parse_declaration_type` never lexed `pair/2 inline` as one token — it lexes IDENT `/` NUMBER `[IDENT]` and *builds* the string. `(` `,` `)` are already tokens, so this is one more arm in a function that was already assembling a private encoding. Slot types ride in that encoding as `pair/2<symbol,symbol> inline`, keeping `parse_compound_metadata` the single decoder.

**Not a field on `wirelog_column_t`.** That struct is public and travels by value inside `wirelog_schema_t`, which `wirelog_program_get_schema()` hands to embedders — widening it is a layout break, not a manifest update. Slot types live on an internal side array on `wl_ir_relation_info_t`, the same shape as `plan->edb_has_graph_column` (#535) and `plan->edb_declared_width` (#1038). **The ABI does not move.**

**No new public enum value.** `symbol` already maps to `WIRELOG_TYPE_STRING` exactly as it does for a whole column, and `csv_reader.c:493` already interns STRING columns.

Two details that are load-bearing rather than stylistic:

- The side array is **fixed stride** `col*4+slot`, not packed. A packed array must be built in column order and misaligns if a scalar column precedes the compound — the declaration-order fragility this issue family keeps producing.
- It is **seeded `WIRELOG_TYPE_INT64`**, not left at `calloc`'s zero, because `WIRELOG_TYPE_INT32 == 0`. A zero cell would otherwise be indistinguishable from an unwritten one, and an explicit `int32` slot would read as unset.

The list length is validated **equal** to the arity rather than either being trusted — `wl_ir_relation_physical_width()` (#985) derives physical width from `compound_arity`, and a disagreement is exactly the declaration-versus-storage split that issue closed.

## Tests — the controls carry the weight

A change that simply made the reader intern anything non-numeric would satisfy the positive case while destroying the declaration's authority. So:

| case | asserts |
|---|---|
| `pair(symbol, symbol)` + symbol file | loads → `o(1, "aa", "bb")` |
| **`pair/2` + symbol file** | **still refused** — proves the behaviour comes from the `.decl`, not the data |
| `pair(int64, int64)` + symbol file | still refused |
| `pair/2` + integer file | still loads |
| `pair(symbol, int64)` + `1 aa 7` | numeric slot **second**, so applying slot 0's type to the whole compound fails |
| compound-free relation | untouched |

Mutation-tested: reverting `io_ctx.c` to unconditional `INT64` is **killed**.

## Why this took several attempts

My reproduction was wrong. The CSV adapter defaults to **tab**, not comma (`csv_adapter.c:74`), and I was writing comma-delimited probe files — so every `.input` test failed on the delimiter and I read that as the compound column being unloadable. I filed #1063 on that basis and have **closed it as invalid**. The real defect is exactly what #1037 described.

## Validation

Full suite **274 Ok / 11 Skipped**. `sbom_snapshot` fails locally only — that gate scans with `syft`, and this host's syft resolves a GitHub Action to a tag where the baseline holds a pinned SHA. It passes in CI.

## Note

Degraded sequential mode (subagent limit reached): design, critique and review all by the implementing agent.