### PR TITLE
build: bump version to 0.54.99

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.54.0',
+  version: '0.54.99',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
`v0.54.0` is tagged and released, so main moves to the post-release development version.

## The change

One line in `meson.build`: `0.54.0` → `0.54.99`.

`0.54.99` follows the convention the previous cycles used (`0.51.99` in `34572ca`) — the `.99` patch marks "after X.Y.0, before the next release" and keeps anything built from main distinguishable from the tagged release it followed.

**Nothing else needs editing.** `wirelog-version.h` is generated from `meson.build` through `wirelog/wirelog-version.h.in`, so the `MAJOR`/`MINOR`/`PATCH` defines and `WIRELOG_VERSION_STRING` follow automatically. `check-version-sync.py` (suite `abi`) exists to verify precisely that relationship, and the previous bump commit touched this same single line.

## Verification

- `wirelog_cli --version` reports `wirelog_cli 0.54.99`
- `abi` suite **33/33**, including `check-version-sync: OK` and the `version-1.1.0-fails` negative self-test
- full suite **274 Ok / 11 Skipped**

`sbom_snapshot` fails, and it is **pre-existing rather than caused by this change** — verified by stashing the diff and re-running on unmodified main, where it fails identically:

```
-msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff:NOASSERTION
+msys2/setup-msys2@v2:NOASSERTION
```

That gate scans the tree with `syft`, so the resolution depends on the local syft version. It passes in CI.

## Context

Follows the 0.54.0 release: https://github.com/semantic-reasoning/wirelog/releases/tag/v0.54.0

Release-process step 6 (attaching the at-tag workflow's tarball, checksums, SBOM, ABI manifest and provenance to that release) is still outstanding and is not part of this PR.