### PR TITLE
ci: re-enable clang-tidy PR gate

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -131,7 +131,7 @@ jobs:
     name: clang-tidy 22 check
     runs-on: ubuntu-latest
     needs: [uncrustify-check]
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -123,15 +123,12 @@ jobs:
           fi
 
   # ==========================================================================
-  # Phase 1c: clang-tidy 22 check (temporarily disabled)
-  # Temporary release unblock: restore the job condition before re-enabling
-  # this advisory check.
+  # Phase 1c: clang-tidy 22 check (hard gate)
   # Excludes: subprojects/**, build/**
   # Runs only after uncrustify passes.
   # ==========================================================================
   clang-tidy-check:
-    name: clang-tidy 22 check (temporarily disabled)
-    if: ${{ false }}
+    name: clang-tidy 22 check
     runs-on: ubuntu-latest
     needs: [uncrustify-check]
     timeout-minutes: 30


### PR DESCRIPTION
Re-enable the clang-tidy 22 check in the PR lint workflow as a hard gate.

- remove the temporary `if: false` condition
- restore the normal check name and hard-gate documentation
- retain changed C/H file filtering

Validation: `actionlint .github/workflows/lint-pr.yml`