### PR TITLE
feat(api): expose parsed input metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **Parsed `.input` metadata query** (#1070): applications can use
+  `wirelog_program_relation_has_input()` to inspect whether a relation has a
+  parsed `.input` directive without opening its source or invoking an I/O
+  adapter.
+
 ### Changed
 
 ### Deprecated

--- a/abi/libwirelog-1.0.abi.json
+++ b/abi/libwirelog-1.0.abi.json
@@ -64,6 +64,7 @@
     <elf-symbol name='wirelog_program_get_stratum' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_stratum_count' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_is_stratified' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_program_relation_has_input' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_result_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_result_get_relation' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_result_relation_cardinality' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>

--- a/abi/libwirelog-1.0.macos.symbols
+++ b/abi/libwirelog-1.0.macos.symbols
@@ -44,6 +44,7 @@ wirelog_program_get_schema
 wirelog_program_get_stratum
 wirelog_program_get_stratum_count
 wirelog_program_is_stratified
+wirelog_program_relation_has_input
 wirelog_session_create
 wirelog_session_destroy
 wirelog_session_insert

--- a/abi/libwirelog-1.0.symbols
+++ b/abi/libwirelog-1.0.symbols
@@ -62,6 +62,7 @@ wirelog_program_get_schema
 wirelog_program_get_stratum
 wirelog_program_get_stratum_count
 wirelog_program_is_stratified
+wirelog_program_relation_has_input
 wirelog_result_free
 wirelog_result_get_relation
 wirelog_result_relation_cardinality

--- a/abi/libwirelog-1.0.windows.symbols
+++ b/abi/libwirelog-1.0.windows.symbols
@@ -44,6 +44,7 @@ wirelog_program_get_schema
 wirelog_program_get_stratum
 wirelog_program_get_stratum_count
 wirelog_program_is_stratified
+wirelog_program_relation_has_input
 wirelog_session_create
 wirelog_session_destroy
 wirelog_session_insert

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,6 +7,17 @@ steps for each significant Wirelog release. Entries are ordered newest first.
 
 ---
 
+## 0.54 -> 0.60
+
+Version `0.60.0` adds a public parser-metadata query for hosts that need to
+make admission decisions before loading external sources:
+
+- `wirelog_program_relation_has_input()` reports whether a parsed relation has
+  an `.input` directive without opening a file or invoking an I/O adapter.
+  Matching is exact and case-sensitive; duplicate and undeclared-relation
+  directives are included.  Unknown relations and NULL arguments return
+  `false`.
+
 ## 0.53 -> 0.54
 
 Version `0.54.0` is a correctness-focused release. C source compatibility is

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -384,6 +384,14 @@ Load relation data from external files:
 .input Edge(IO="file", filename="edge.csv", delimiter=",")
 ```
 
+Hosts that need to inspect source-admission policy can call
+`wirelog_program_relation_has_input()` after parsing.  The query reads parser
+metadata only: it does not open the declared path, resolve the adapter, or
+perform custom I/O.  Relation names are matched exactly and
+case-sensitively; duplicate `.input` directives and `.input` directives for
+undeclared relations still report `true`, while unknown relations and NULL
+arguments report `false`.
+
 ### .output
 
 Write computed relation to stdout or a file:

--- a/tests/test_wirelog_public_api.c
+++ b/tests/test_wirelog_public_api.c
@@ -10,6 +10,21 @@
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+
+static int metadata_probe_reads;
+
+static int
+metadata_probe_read(wirelog_io_ctx_t *ctx, int64_t **out_data,
+    uint32_t *out_nrows, void *user_data)
+{
+    (void)ctx;
+    (void)out_data;
+    (void)out_nrows;
+    (void)user_data;
+    metadata_probe_reads++;
+    return -1;
+}
 
 static int
 test_utility_api(void)
@@ -30,6 +45,89 @@ test_utility_api(void)
     (void)wirelog_config_embedded();
     (void)wirelog_config_ipc();
     return 0;
+}
+
+static int
+test_program_input_metadata_api(void)
+{
+    static const char source[] =
+        "# .input Commented(filename=\"ignored.csv\")\n"
+        ".decl NoInput(x: int32)\n"
+        ".decl Text(s: string)\n"
+        "Text(\".input Fake(...)\").\n"
+        ".input Declared(IO=\"file\", filename=\"/definitely/missing/.input\")\n"
+        ".input Declared(IO=\"metadata_probe\", filename=\"relative.csv\")\n"
+        ".input Undeclared(IO=\"metadata_probe\", filename=\"/definitely/missing/undeclared.csv\")\n"
+        ".input session_state(IO=\"metadata_probe\", filename=\"/definitely/missing/session.csv\")\n"
+        ".input session_state(IO=\"metadata_probe\", filename=\"/definitely/missing/session2.csv\")\n"
+        ".input CamelCase(IO=\"metadata_probe\", filename=\"camel.csv\")\n"
+        ".input camelcase(IO=\"metadata_probe\", filename=\"lower.csv\")\n";
+    wirelog_io_adapter_t adapter = {
+        .abi_version = WIRELOG_IO_ABI_VERSION,
+        .scheme = "metadata_probe",
+        .read = metadata_probe_read,
+    };
+
+    if (wirelog_io_register_adapter(&adapter) != 0) {
+        fprintf(stderr, "metadata probe adapter registration failed: %s\n",
+            wirelog_io_last_error());
+        return 1;
+    }
+
+    wirelog_error_t err = WIRELOG_ERR_UNKNOWN;
+    wirelog_program_t *program = wirelog_parse_string(source, &err);
+    int failures = 0;
+    if (!program || err != WIRELOG_OK) {
+        fprintf(stderr, "input metadata parse failed err=%d\n", err);
+        failures = 1;
+        goto cleanup;
+    }
+
+    const struct {
+        const char *name;
+        bool expected;
+    } cases[] = {
+        { "Declared", true },
+        { "Undeclared", true },
+        { "session_state", true },
+        { "CamelCase", true },
+        { "camelcase", true },
+        { "CAMELCASE", false },
+        { "Commented", false },
+        { "literal .input", false },
+        { "Fake", false },
+        { "Unknown", false },
+        { "NoInput", false },
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        if (wirelog_program_relation_has_input(program, cases[i].name)
+            != cases[i].expected) {
+            fprintf(stderr, "unexpected .input metadata for '%s'\n",
+                cases[i].name);
+            failures = 1;
+        }
+    }
+    if (wirelog_program_relation_has_input(program, NULL)) {
+        fprintf(stderr, "NULL relation name should return false\n");
+        failures = 1;
+    }
+    if (wirelog_program_relation_has_input(NULL, "Declared")) {
+        fprintf(stderr, "NULL program should return false\n");
+        failures = 1;
+    }
+    if (metadata_probe_reads != 0) {
+        fprintf(stderr, "metadata query opened an adapter (%d reads)\n",
+            metadata_probe_reads);
+        failures = 1;
+    }
+
+cleanup:
+    wirelog_program_free(program);
+    if (wirelog_io_unregister_adapter("metadata_probe") != 0) {
+        fprintf(stderr, "metadata probe adapter unregister failed\n");
+        failures = 1;
+    }
+    return failures;
 }
 
 static int
@@ -230,6 +328,7 @@ main(void)
 {
     int failures = 0;
     failures += test_utility_api();
+    failures += test_program_input_metadata_api();
     failures += test_optimizer_api();
     failures += test_optimizer_config_disable_passes();
     failures += test_bound_query_without_seed_preserves_answers();

--- a/wirelog/ir/api.c
+++ b/wirelog/ir/api.c
@@ -221,6 +221,22 @@ wirelog_program_get_schema(const wirelog_program_t *program,
     return NULL;
 }
 
+bool
+wirelog_program_relation_has_input(const wirelog_program_t *program,
+    const char *relation_name)
+{
+    if (!program || !relation_name || !program->relations)
+        return false;
+
+    for (uint32_t i = 0; i < program->relation_count; i++) {
+        const wl_ir_relation_info_t *rel = &program->relations[i];
+        if (rel->name && strcmp(rel->name, relation_name) == 0)
+            return rel->has_input;
+    }
+
+    return false;
+}
+
 uint32_t
 wirelog_program_get_stratum_count(const wirelog_program_t *program)
 {

--- a/wirelog/wirelog-parser.h
+++ b/wirelog/wirelog-parser.h
@@ -127,6 +127,25 @@ wirelog_program_get_schema(const wirelog_program_t *program,
     const char *relation_name);
 
 /**
+ * wirelog_program_relation_has_input:
+ * @program: Parsed program
+ * @relation_name: Relation to query
+ *
+ * Check whether the parsed program contains an `.input` directive for a
+ * relation.  This queries parser metadata only; it does not open a file,
+ * resolve an adapter, or perform custom I/O.
+ *
+ * Relation names are compared exactly and case-sensitively.  An unknown
+ * relation, a NULL argument, or a relation without `.input` returns false.
+ * Duplicate directives and directives for undeclared relations return true.
+ *
+ * Returns: true if the relation has a parsed `.input` directive
+ */
+WIRELOG_API bool
+wirelog_program_relation_has_input(const wirelog_program_t *program,
+    const char *relation_name);
+
+/**
  * wirelog_program_is_stratified:
  * @program: Parsed program
  *


### PR DESCRIPTION
## Summary

- Add `wirelog_program_relation_has_input()` to query parsed `.input` metadata.
- Keep the query parser-only: it performs no file, adapter, or custom I/O.
- Add API, parser, ABI, documentation, and changelog coverage.

## Behavior

The API returns true for declared, undeclared, and duplicate `.input` directives, with exact case-sensitive matching. It returns false for unknown relations, NULL arguments, comments, and string literals that merely contain `.input`.

Closes #1070.

## Validation

- Focused `wirelog_public_api`, `program`, and `parser` tests: passed
- ABI suite: 33/33 passed
- Public API export and macro checks: passed
- Full suite: 275 passed, 11 skipped; one unrelated SBOM snapshot baseline-drift failure
