### PR TITLE
ci: skip full PR builds for documentation-only changes

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -30,6 +30,55 @@ env:
 
 jobs:
   # ==========================================================================
+  # Build scope gate
+  # Keep lint/policy checks active for every PR, but avoid the expensive build
+  # and sanitizer matrix when a PR only changes documentation or metadata.
+  # ==========================================================================
+  build-scope:
+    name: Detect build-triggering changes
+    runs-on: ubuntu-latest
+    outputs:
+      build-required: ${{ steps.scope.outputs.build-required }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect source and build-definition changes
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if ! changed_files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"; then
+            echo "Unable to determine the PR diff; running the full build as a safe fallback."
+            echo "build-required=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\n' "$changed_files"
+
+          build_required=false
+          while IFS= read -r path; do
+            case "$path" in
+              *.md|*.markdown|*.rst)
+                continue
+                ;;
+              *.c|*.h|*.in|wirelog/*|tests/*|examples/*|bench/*|fuzz/*|scripts/*|subprojects/*|cross/*|abi/*|sbom/*|.github/workflows/*|meson.build|meson_options.txt|uncrustify.cfg|.clang-tidy)
+                build_required=true
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          if [ "$build_required" = true ]; then
+            echo "build-required=true" >> "$GITHUB_OUTPUT"
+            echo "Build-triggering source or build-definition changes detected."
+          else
+            echo "build-required=false" >> "$GITHUB_OUTPUT"
+            echo "No source or build-definition changes detected; build matrix will be skipped."
+          fi
+
+  # ==========================================================================
   # Issue #747 B18: RC changelog freeze gate (stable always-emitting context)
   # Enforces only for PRs whose base branch is `1.0`; non-1.0 PRs SKIP/pass.
   # ==========================================================================
@@ -63,7 +112,8 @@ jobs:
   # ==========================================================================
   build-primary:
     name: Build / ubuntu-latest / gcc
-    needs: [lint]
+    needs: [lint, build-scope]
+    if: ${{ needs.build-scope.outputs.build-required == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -139,7 +189,8 @@ jobs:
   # ==========================================================================
   build-arm:
     name: Build / ubuntu-24.04-arm / gcc
-    needs: [build-primary]
+    needs: [build-primary, build-scope]
+    if: ${{ needs.build-scope.outputs.build-required == 'true' }}
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
@@ -173,7 +224,8 @@ jobs:
   # ==========================================================================
   build-matrix:
     name: Build / ${{ matrix.os }} / ${{ matrix.compiler }}
-    needs: [build-arm, build-mbedtls]
+    needs: [build-arm, build-mbedtls, build-scope]
+    if: ${{ needs.build-scope.outputs.build-required == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -306,7 +358,8 @@ jobs:
   # ==========================================================================
   build-mbedtls:
     name: mbedtls-enabled / ubuntu-latest / gcc
-    needs: [build-primary]
+    needs: [build-primary, build-scope]
+    if: ${{ needs.build-scope.outputs.build-required == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -345,7 +398,8 @@ jobs:
   # ==========================================================================
   sanitizer-matrix:
     name: Sanitizers / ${{ matrix.os }} / ${{ matrix.compiler }}
-    needs: [lint]
+    needs: [lint, build-scope]
+    if: ${{ needs.build-scope.outputs.build-required == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -415,7 +469,8 @@ jobs:
   # ==========================================================================
   tsan:
     name: TSan / ubuntu-latest / gcc
-    needs: [sanitizer-matrix]
+    needs: [sanitizer-matrix, build-scope]
+    if: ${{ needs.build-scope.outputs.build-required == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -477,7 +532,8 @@ jobs:
   # ==========================================================================
   tsan-native:
     name: TSan-native / ubuntu-latest / gcc
-    needs: [sanitizer-matrix]
+    needs: [sanitizer-matrix, build-scope]
+    if: ${{ needs.build-scope.outputs.build-required == 'true' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -129,6 +129,7 @@ jobs:
   # ==========================================================================
   clang-tidy-check:
     name: clang-tidy 22 check
+    if: ${{ false }}
     runs-on: ubuntu-latest
     needs: [uncrustify-check]
     timeout-minutes: 90

--- a/tests/test_lftj_integration.c
+++ b/tests/test_lftj_integration.c
@@ -13,6 +13,7 @@
  */
 
 #include "../wirelog/backend.h"
+#include "../wirelog/columnar/internal.h"
 #include "../wirelog/exec_plan.h"
 #include "../wirelog/exec_plan_gen.h"
 #include "../wirelog/passes/fusion.h"
@@ -39,29 +40,29 @@ static int pass_count = 0;
 static int fail_count = 0;
 
 #define TEST(name)                                      \
-    do {                                                \
-        test_count++;                                   \
-        printf("TEST %d: %s ... ", test_count, (name)); \
-    } while (0)
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
 
 #define PASS()            \
-    do {                  \
-        pass_count++;     \
-        printf("PASS\n"); \
-    } while (0)
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
 
 #define FAIL(msg)                    \
-    do {                             \
-        fail_count++;                \
-        printf("FAIL: %s\n", (msg)); \
-        return;                      \
-    } while (0)
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
 
 #define ASSERT(cond, msg) \
-    do {                  \
-        if (!(cond))      \
+        do {                  \
+            if (!(cond))      \
             FAIL(msg);    \
-    } while (0)
+        } while (0)
 
 /* ----------------------------------------------------------------
  * Tuple collector
@@ -132,7 +133,7 @@ make_plan(const char *src, wl_plan_t **out_plan, wirelog_program_t **out_prog)
  */
 static int
 make_plan_no_opt(const char *src, wl_plan_t **out_plan,
-                 wirelog_program_t **out_prog)
+    wirelog_program_t **out_prog)
 {
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
@@ -217,11 +218,11 @@ test_plan_has_lftj(void)
     TEST("Plan contains WL_PLAN_OP_LFTJ for 3-way EDB join");
 
     const char *src = ".decl r1(x: int32, a: int32)\n"
-                      ".decl r2(x: int32, b: int32)\n"
-                      ".decl r3(x: int32, c: int32)\n"
-                      ".decl out(x: int32, a: int32, b: int32, c: int32)\n"
-                      "r1(1, 10). r2(1, 100). r3(1, 1000).\n"
-                      "out(x, a, b, c) :- r1(x, a), r2(x, b), r3(x, c).\n";
+        ".decl r2(x: int32, b: int32)\n"
+        ".decl r3(x: int32, c: int32)\n"
+        ".decl out(x: int32, a: int32, b: int32, c: int32)\n"
+        "r1(1, 10). r2(1, 100). r3(1, 1000).\n"
+        "out(x, a, b, c) :- r1(x, a), r2(x, b), r3(x, c).\n";
 
     wirelog_program_t *prog = NULL;
     wl_plan_t *plan = NULL;
@@ -242,10 +243,10 @@ test_plan_no_lftj_for_binary(void)
     TEST("Plan does NOT contain WL_PLAN_OP_LFTJ for 2-way EDB join");
 
     const char *src = ".decl r1(x: int32, a: int32)\n"
-                      ".decl r2(x: int32, b: int32)\n"
-                      ".decl out(x: int32, a: int32, b: int32)\n"
-                      "r1(1, 10). r2(1, 100).\n"
-                      "out(x, a, b) :- r1(x, a), r2(x, b).\n";
+        ".decl r2(x: int32, b: int32)\n"
+        ".decl out(x: int32, a: int32, b: int32)\n"
+        "r1(1, 10). r2(1, 100).\n"
+        "out(x, a, b) :- r1(x, a), r2(x, b).\n";
 
     wirelog_program_t *prog = NULL;
     wl_plan_t *plan = NULL;
@@ -274,13 +275,13 @@ test_3way_join_result(void)
      * Only x=1 is in all three: out(1, 10, 100, 1000)
      */
     const char *src = ".decl r1(x: int32, a: int32)\n"
-                      ".decl r2(x: int32, b: int32)\n"
-                      ".decl r3(x: int32, c: int32)\n"
-                      ".decl out(x: int32, a: int32, b: int32, c: int32)\n"
-                      "r1(1, 10). r1(2, 20). r1(3, 30).\n"
-                      "r2(1, 100). r2(2, 200). r2(4, 400).\n"
-                      "r3(1, 1000). r3(3, 3000). r3(5, 5000).\n"
-                      "out(x, a, b, c) :- r1(x, a), r2(x, b), r3(x, c).\n";
+        ".decl r2(x: int32, b: int32)\n"
+        ".decl r3(x: int32, c: int32)\n"
+        ".decl out(x: int32, a: int32, b: int32, c: int32)\n"
+        "r1(1, 10). r1(2, 20). r1(3, 30).\n"
+        "r2(1, 100). r2(2, 200). r2(4, 400).\n"
+        "r3(1, 1000). r3(3, 3000). r3(5, 5000).\n"
+        "out(x, a, b, c) :- r1(x, a), r2(x, b), r3(x, c).\n";
 
     collect_t coll;
     ASSERT(run_session_no_opt(src, &coll) == 0, "run_session_no_opt failed");
@@ -320,15 +321,15 @@ test_4way_join_result(void)
      */
     const char *src
         = ".decl r1(x: int32, a: int32)\n"
-          ".decl r2(x: int32, b: int32)\n"
-          ".decl r3(x: int32, c: int32)\n"
-          ".decl r4(x: int32, d: int32)\n"
-          ".decl out(x: int32, a: int32, b: int32, c: int32, d: int32)\n"
-          "r1(1, 11). r1(2, 21). r1(3, 31).\n"
-          "r2(1, 12). r2(2, 22). r2(4, 42).\n"
-          "r3(1, 13). r3(3, 33). r3(5, 53).\n"
-          "r4(1, 14). r4(2, 24). r4(6, 64).\n"
-          "out(x, a, b, c, d) :- r1(x, a), r2(x, b), r3(x, c), r4(x, d).\n";
+        ".decl r2(x: int32, b: int32)\n"
+        ".decl r3(x: int32, c: int32)\n"
+        ".decl r4(x: int32, d: int32)\n"
+        ".decl out(x: int32, a: int32, b: int32, c: int32, d: int32)\n"
+        "r1(1, 11). r1(2, 21). r1(3, 31).\n"
+        "r2(1, 12). r2(2, 22). r2(4, 42).\n"
+        "r3(1, 13). r3(3, 33). r3(5, 53).\n"
+        "r4(1, 14). r4(2, 24). r4(6, 64).\n"
+        "out(x, a, b, c, d) :- r1(x, a), r2(x, b), r3(x, c), r4(x, d).\n";
 
     collect_t coll;
     ASSERT(run_session_no_opt(src, &coll) == 0, "run_session_no_opt failed");
@@ -362,15 +363,15 @@ test_idb_not_rewritten(void)
      * r1 ⋈ tc ⋈ r2 is NOT eligible for LFTJ.
      */
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      ".decl r1(x: int32, a: int32)\n"
-                      ".decl r2(x: int32, b: int32)\n"
-                      ".decl tc(x: int32, y: int32)\n"
-                      ".decl out(x: int32)\n"
-                      "edge(1, 2). edge(2, 3).\n"
-                      "r1(1, 10). r2(1, 100).\n"
-                      "tc(x, y) :- edge(x, y).\n"
-                      "tc(x, z) :- tc(x, y), edge(y, z).\n"
-                      "out(x) :- r1(x, a), tc(x, y), r2(x, b).\n";
+        ".decl r1(x: int32, a: int32)\n"
+        ".decl r2(x: int32, b: int32)\n"
+        ".decl tc(x: int32, y: int32)\n"
+        ".decl out(x: int32)\n"
+        "edge(1, 2). edge(2, 3).\n"
+        "r1(1, 10). r2(1, 100).\n"
+        "tc(x, y) :- edge(x, y).\n"
+        "tc(x, z) :- tc(x, y), edge(y, z).\n"
+        "out(x) :- r1(x, a), tc(x, y), r2(x, b).\n";
 
     wirelog_program_t *prog = NULL;
     wl_plan_t *plan = NULL;
@@ -382,6 +383,163 @@ test_idb_not_rewritten(void)
 
     /* The out-relation plan contains tc (IDB) -> no LFTJ rewrite for out */
     ASSERT(n == 0, "IDB-containing chain incorrectly rewritten as LFTJ");
+    PASS();
+}
+
+/* Test 6: TDD classifiers reject unsupported or malformed LFTJ metadata. */
+static void
+test_tdd_lftj_metadata_is_conservative(void)
+{
+    TEST("TDD rejects IDB and malformed LFTJ metadata conservatively");
+
+    const char *src = ".decl r1(x: int32, a: int32)\n"
+        ".decl r2(x: int32, b: int32)\n"
+        ".decl r3(x: int32, c: int32)\n"
+        ".decl out(x: int32, a: int32, b: int32, c: int32)\n"
+        "out(x, a, b, c) :- r1(x, a), r2(x, b), r3(x, c).\n";
+    wirelog_program_t *prog = NULL;
+    wl_plan_t *plan = NULL;
+    ASSERT(make_plan_no_opt(src, &plan, &prog) == 0,
+        "make_plan_no_opt failed");
+
+    const wl_plan_stratum_t *stratum = NULL;
+    const wl_plan_op_t *found_op = NULL;
+    for (uint32_t si = 0; si < plan->stratum_count && !found_op; si++) {
+        for (uint32_t ri = 0; ri < plan->strata[si].relation_count; ri++) {
+            const wl_plan_relation_t *rel = &plan->strata[si].relations[ri];
+            for (uint32_t oi = 0; oi < rel->op_count; oi++) {
+                if (rel->ops[oi].op == WL_PLAN_OP_LFTJ) {
+                    stratum = &plan->strata[si];
+                    found_op = &rel->ops[oi];
+                    break;
+                }
+            }
+        }
+    }
+    ASSERT(found_op && stratum, "real EDB-only LFTJ premise missing");
+    wl_plan_op_t *lftj_op = (wl_plan_op_t *)(uintptr_t)found_op;
+
+    wl_plan_op_lftj_t *original =
+        (wl_plan_op_lftj_t *)lftj_op->opaque_data;
+    ASSERT(original && original->k >= 3, "invalid generated LFTJ metadata");
+    ASSERT(!tdd_stratum_has_unsupported_lftj(stratum),
+        "valid EDB-only LFTJ incorrectly rejected");
+
+    wl_plan_op_lftj_t clone = *original;
+    clone.rel_names = calloc(clone.k, sizeof(*clone.rel_names));
+    clone.key_cols = calloc(clone.k, sizeof(*clone.key_cols));
+    ASSERT(clone.rel_names && clone.key_cols, "LFTJ metadata clone failed");
+    for (uint32_t i = 0; i < clone.k; i++) {
+        clone.rel_names[i] = original->rel_names[i];
+        clone.key_cols[i] = original->key_cols[i];
+    }
+
+    lftj_op->opaque_data = &clone;
+    clone.rel_names[0] = "out";
+    ASSERT(tdd_stratum_has_unsupported_lftj(stratum),
+        "IDB-bearing LFTJ was accepted");
+    ASSERT(stratum_max_idb_body_atoms(stratum) == 1,
+        "IDB operand count was not recorded");
+    ASSERT(!tdd_stratum_global_read_candidate(stratum),
+        "IDB-bearing LFTJ reached global-read candidate");
+    ASSERT(!tdd_stratum_mixed_slice_candidate(stratum),
+        "IDB-bearing LFTJ reached mixed-slice candidate");
+
+    clone.rel_names[1] = "out";
+    ASSERT(tdd_stratum_has_idb_self_join(stratum),
+        "two IDB LFTJ operands were not treated as self-join");
+
+    clone.rel_names[0] = NULL;
+    ASSERT(tdd_stratum_has_unsupported_lftj(stratum),
+        "NULL LFTJ relation name was accepted");
+    clone.rel_names[0] = original->rel_names[0];
+
+    free(clone.key_cols);
+    clone.key_cols = NULL;
+    ASSERT(tdd_stratum_has_unsupported_lftj(stratum),
+        "NULL LFTJ key array was accepted");
+    clone.key_cols = calloc(original->k, sizeof(*clone.key_cols));
+    ASSERT(clone.key_cols, "LFTJ key array restore failed");
+    for (uint32_t i = 0; i < clone.k; i++)
+        clone.key_cols[i] = original->key_cols[i];
+
+    clone.rel_names[0] = original->rel_names[0];
+    clone.rel_names[1] = original->rel_names[1];
+    free(clone.rel_names);
+    clone.rel_names = NULL;
+    ASSERT(tdd_stratum_has_unsupported_lftj(stratum),
+        "missing LFTJ relation array was accepted");
+
+    lftj_op->opaque_data = original;
+    free(clone.key_cols);
+    free(clone.rel_names);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+
+    const char *recursive_src =
+        ".decl edge(x: int32, y: int32)\n"
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n"
+        "path(x, z) :- path(x, y), path(y, z).\n";
+    prog = NULL;
+    plan = NULL;
+    ASSERT(make_plan(recursive_src, &plan, &prog) == 0,
+        "recursive plan build failed");
+    const wl_plan_op_t *fusion_found = NULL;
+    const wl_plan_stratum_t *fusion_stratum = NULL;
+    for (uint32_t si = 0; si < plan->stratum_count && !fusion_found; si++) {
+        for (uint32_t ri = 0; ri < plan->strata[si].relation_count; ri++) {
+            const wl_plan_relation_t *rel = &plan->strata[si].relations[ri];
+            for (uint32_t oi = 0; oi < rel->op_count; oi++) {
+                if (rel->ops[oi].op == WL_PLAN_OP_K_FUSION) {
+                    fusion_found = &rel->ops[oi];
+                    fusion_stratum = &plan->strata[si];
+                    break;
+                }
+            }
+        }
+    }
+    ASSERT(fusion_found && fusion_stratum, "real K_FUSION premise missing");
+    wl_plan_op_t *fusion_op = (wl_plan_op_t *)(uintptr_t)fusion_found;
+    wl_plan_op_k_fusion_t *fusion =
+        (wl_plan_op_k_fusion_t *)fusion_op->opaque_data;
+    ASSERT(fusion && fusion->k > 0 && fusion->k_ops && fusion->k_op_counts,
+        "invalid generated K_FUSION metadata");
+    wl_plan_op_k_fusion_t fusion_clone = *fusion;
+    fusion_clone.k_ops = calloc(fusion->k, sizeof(*fusion_clone.k_ops));
+    fusion_clone.k_op_counts = calloc(fusion->k,
+            sizeof(*fusion_clone.k_op_counts));
+    ASSERT(fusion_clone.k_ops && fusion_clone.k_op_counts,
+        "K_FUSION metadata clone failed");
+    for (uint32_t i = 0; i < fusion->k; i++) {
+        fusion_clone.k_ops[i] = fusion->k_ops[i];
+        fusion_clone.k_op_counts[i] = fusion->k_op_counts[i];
+    }
+    fusion_op->opaque_data = NULL;
+    ASSERT(tdd_stratum_has_unsupported_lftj(fusion_stratum),
+        "NULL K_FUSION metadata was accepted");
+    fusion_op->opaque_data = &fusion_clone;
+    fusion_clone.k = 0;
+    ASSERT(tdd_stratum_has_unsupported_lftj(fusion_stratum),
+        "zero-length K_FUSION metadata was accepted");
+    fusion_clone.k = fusion->k;
+    uint32_t bad_child = UINT32_MAX;
+    for (uint32_t i = 0; i < fusion->k; i++) {
+        if (fusion_clone.k_op_counts[i] > 0) {
+            bad_child = i;
+            break;
+        }
+    }
+    ASSERT(bad_child != UINT32_MAX, "K_FUSION has no non-empty child");
+    fusion_clone.k_ops[bad_child] = NULL;
+    fusion_op->opaque_data = &fusion_clone;
+    ASSERT(tdd_stratum_has_unsupported_lftj(fusion_stratum),
+        "NULL K_FUSION child was accepted");
+    fusion_op->opaque_data = fusion;
+    free(fusion_clone.k_ops);
+    free(fusion_clone.k_op_counts);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
     PASS();
 }
 
@@ -399,6 +557,7 @@ main(void)
     test_3way_join_result();
     test_4way_join_result();
     test_idb_not_rewritten();
+    test_tdd_lftj_metadata_is_conservative();
 
     printf("\nResults: %d/%d passed", pass_count, test_count);
     if (fail_count > 0)

--- a/tests/test_lftj_integration.c
+++ b/tests/test_lftj_integration.c
@@ -535,6 +535,8 @@ test_tdd_lftj_metadata_is_conservative(void)
     fusion_op->opaque_data = &fusion_clone;
     ASSERT(tdd_stratum_has_unsupported_lftj(fusion_stratum),
         "NULL K_FUSION child was accepted");
+    ASSERT(tdd_stratum_has_idb_self_join(fusion_stratum),
+        "NULL K_FUSION child broke self-join diagnostics");
     fusion_op->opaque_data = fusion;
     free(fusion_clone.k_ops);
     free(fusion_clone.k_op_counts);

--- a/tests/test_plan_gen.c
+++ b/tests/test_plan_gen.c
@@ -632,6 +632,26 @@ find_right_deep_candidate(wirelog_ir_node_t *node)
     return NULL;
 }
 
+static wirelog_ir_node_t *
+find_composite_left_joinlike(wirelog_ir_node_t *node,
+    wirelog_ir_node_type_t type)
+{
+    if (!node)
+        return NULL;
+    if (node->type == type && node->child_count == 2
+        && node->children[0]
+        && node->children[0]->type == WIRELOG_IR_JOIN
+        && node->children[1] && node->children[1]->relation_name)
+        return node;
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        wirelog_ir_node_t *hit
+            = find_composite_left_joinlike(node->children[i], type);
+        if (hit)
+            return hit;
+    }
+    return NULL;
+}
+
 static void
 test_join_with_composite_right_child_rejected(void)
 {
@@ -682,6 +702,100 @@ test_join_with_composite_right_child_rejected(void)
     }
     ASSERT(plan == NULL, "plan must not be returned on error");
 
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_antijoin_with_composite_right_child_rejected(void)
+{
+    TEST("ANTIJOIN with composite right child is rejected (#993)");
+
+    const char *src = ".decl a(x: int32, y: int32)\n"
+        ".decl b(y: int32, z: int32)\n"
+        ".decl blocked(z: int32)\n"
+        ".decl out(x: int32)\n"
+        "out(x) :- a(x, y), b(y, z), !blocked(z).\n";
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    ASSERT(prog != NULL, "parse failed");
+
+    wl_plan_t *control = NULL;
+    int rc = wl_plan_from_program(prog, &control);
+    ASSERT(rc == 0 && control != NULL,
+        "unmodified ANTIJOIN plan should be valid");
+    wl_plan_free(control);
+
+    wirelog_ir_node_t *anti = NULL;
+    for (uint32_t r = 0; r < prog->rule_count && !anti; r++) {
+        if (prog->rules[r].head_relation
+            && strcmp(prog->rules[r].head_relation, "out") == 0)
+            anti = find_composite_left_joinlike(prog->rules[r].ir_root,
+                    WIRELOG_IR_ANTIJOIN);
+    }
+    ASSERT(anti != NULL, "no composite-left ANTIJOIN candidate found");
+
+    uint32_t saved_child_count = anti->child_count;
+    anti->child_count = 1;
+    ASSERT(wl_ir_program_rebuild_relation_irs(prog) == 0,
+        "rebuild_relation_irs failed for missing child");
+    wl_plan_t *missing_plan = NULL;
+    rc = wl_plan_from_program(prog, &missing_plan);
+    ASSERT(rc != 0 && missing_plan == NULL,
+        "plan generation accepted a missing ANTIJOIN child");
+    anti->child_count = saved_child_count;
+
+    wirelog_ir_node_t *tmp = anti->children[0];
+    anti->children[0] = anti->children[1];
+    anti->children[1] = tmp;
+    ASSERT(wl_ir_program_rebuild_relation_irs(prog) == 0,
+        "rebuild_relation_irs failed");
+
+    wl_plan_t *plan = NULL;
+    rc = wl_plan_from_program(prog, &plan);
+    ASSERT(rc != 0 && plan == NULL,
+        "plan generation accepted an unrepresentable ANTIJOIN");
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
+test_semijoin_with_composite_right_child_rejected(void)
+{
+    TEST("SEMIJOIN with composite right child is rejected (#993)");
+
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(k_semijoin_chain_src, &err);
+    ASSERT(prog != NULL, "parse failed");
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *control = NULL;
+    int rc = wl_plan_from_program(prog, &control);
+    ASSERT(rc == 0 && control != NULL,
+        "unmodified SEMIJOIN plan should be valid");
+    wl_plan_free(control);
+
+    wirelog_ir_node_t *semi = NULL;
+    for (uint32_t r = 0; r < prog->rule_count && !semi; r++) {
+        if (prog->rules[r].head_relation
+            && strcmp(prog->rules[r].head_relation, "chain") == 0)
+            semi = find_composite_left_joinlike(prog->rules[r].ir_root,
+                    WIRELOG_IR_SEMIJOIN);
+    }
+    ASSERT(semi != NULL, "no composite-left SEMIJOIN candidate found");
+
+    wirelog_ir_node_t *tmp = semi->children[0];
+    semi->children[0] = semi->children[1];
+    semi->children[1] = tmp;
+    ASSERT(wl_ir_program_rebuild_relation_irs(prog) == 0,
+        "rebuild_relation_irs failed");
+
+    wl_plan_t *plan = NULL;
+    rc = wl_plan_from_program(prog, &plan);
+    ASSERT(rc != 0 && plan == NULL,
+        "plan generation accepted an unrepresentable SEMIJOIN");
     wirelog_program_free(prog);
     PASS();
 }
@@ -795,6 +909,8 @@ main(void)
     test_semijoin_chain_end_to_end();
     test_semijoin_head_projection_values();
     test_join_with_composite_right_child_rejected();
+    test_antijoin_with_composite_right_child_rejected();
+    test_semijoin_with_composite_right_child_rejected();
     test_side_compound_in_non_first_atom_rejected();
     test_plan_free_null();
     test_load_facts_null_safe();

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4300,6 +4300,83 @@ is_stratum_idb(const wl_plan_stratum_t *sp, const char *name)
 }
 
 /*
+ * LFTJ plans currently contain only EDB operands.  Keep that invariant
+ * explicit at the TDD boundary: a hand-built or future plan with an IDB
+ * operand must take the conservative path rather than being treated as an
+ * EDB-only operator by the linear TDD scans.
+ */
+static bool
+tdd_lftj_meta_valid(const wl_plan_op_lftj_t *meta)
+{
+    if (!meta || meta->k < 3 || !meta->rel_names || !meta->key_cols)
+        return false;
+    for (uint32_t i = 0; i < meta->k; i++) {
+        if (!meta->rel_names[i])
+            return false;
+    }
+    return true;
+}
+
+static uint32_t
+tdd_lftj_idb_count(const wl_plan_op_lftj_t *meta,
+    const wl_plan_stratum_t *sp)
+{
+    if (!tdd_lftj_meta_valid(meta))
+        return UINT32_MAX;
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < meta->k; i++) {
+        if (is_stratum_idb(sp, meta->rel_names[i]))
+            count++;
+    }
+    return count;
+}
+
+static bool
+tdd_ops_have_unsupported_lftj(const wl_plan_op_t *ops, uint32_t op_count,
+    const wl_plan_stratum_t *sp)
+{
+    if (!ops)
+        return false;
+    for (uint32_t i = 0; i < op_count; i++) {
+        const wl_plan_op_t *op = &ops[i];
+        if (op->op == WL_PLAN_OP_LFTJ) {
+            const wl_plan_op_lftj_t *meta =
+                (const wl_plan_op_lftj_t *)op->opaque_data;
+            if (tdd_lftj_idb_count(meta, sp) != 0)
+                return true;
+        } else if (op->op == WL_PLAN_OP_K_FUSION) {
+            if (!op->opaque_data)
+                return true;
+            const wl_plan_op_k_fusion_t *kf =
+                (const wl_plan_op_k_fusion_t *)op->opaque_data;
+            if (kf->k == 0 || !kf->k_ops || !kf->k_op_counts)
+                return true;
+            for (uint32_t k = 0; k < kf->k; k++) {
+                if (kf->k_op_counts[k] > 0 && !kf->k_ops[k])
+                    return true;
+                if (tdd_ops_have_unsupported_lftj(kf->k_ops[k],
+                    kf->k_op_counts[k], sp))
+                    return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool
+tdd_stratum_has_unsupported_lftj(const wl_plan_stratum_t *sp)
+{
+    if (!sp)
+        return true;
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        if (tdd_ops_have_unsupported_lftj(sp->relations[ri].ops,
+            sp->relations[ri].op_count, sp))
+            return true;
+    }
+    return false;
+}
+
+/*
  * ops_have_idb_idb_join:
  * Walk an op sequence tracking whether the eval stack top derives from IDB.
  * Returns true if any JOIN has BOTH IDB-derived left input AND IDB right.
@@ -4319,6 +4396,14 @@ ops_have_idb_idb_join(const wl_plan_op_t *ops, uint32_t op_count,
             if (right_idb && stack_has_idb)
                 return true;
             if (right_idb)
+                stack_has_idb = true;
+        } else if (op->op == WL_PLAN_OP_LFTJ) {
+            const wl_plan_op_lftj_t *meta =
+                (const wl_plan_op_lftj_t *)op->opaque_data;
+            uint32_t idb_count = tdd_lftj_idb_count(meta, sp);
+            if (idb_count == UINT32_MAX || idb_count >= 2)
+                return true;
+            if (idb_count == 1)
                 stack_has_idb = true;
         }
     }
@@ -4345,8 +4430,18 @@ ops_max_idb_segment_body_atoms(const wl_plan_op_t *ops, uint32_t op_count,
             segment_count = 0;
         }
 
-        if (op_references_stratum_idb(op, sp))
+        if (op->op == WL_PLAN_OP_LFTJ) {
+            const wl_plan_op_lftj_t *meta =
+                (const wl_plan_op_lftj_t *)op->opaque_data;
+            uint32_t idb_count = tdd_lftj_idb_count(meta, sp);
+            if (idb_count == UINT32_MAX
+                || UINT32_MAX - segment_count < idb_count)
+                segment_count = UINT32_MAX;
+            else
+                segment_count += idb_count;
+        } else if (op_references_stratum_idb(op, sp)) {
             segment_count++;
+        }
 
         if (op->op == WL_PLAN_OP_VARIABLE) {
             depth++;
@@ -4409,6 +4504,11 @@ op_references_stratum_idb(const wl_plan_op_t *op,
         || op->op == WL_PLAN_OP_ANTIJOIN)
         && op->right_relation)
         return is_stratum_idb(sp, op->right_relation);
+    if (op->op == WL_PLAN_OP_LFTJ) {
+        const wl_plan_op_lftj_t *meta =
+            (const wl_plan_op_lftj_t *)op->opaque_data;
+        return tdd_lftj_idb_count(meta, sp) != 0;
+    }
     return false;
 }
 
@@ -4440,6 +4540,16 @@ ops_max_idb_segment_join_like(const wl_plan_op_t *ops, uint32_t op_count,
         case WL_PLAN_OP_ANTIJOIN:
             segment_count++;
             break;
+        case WL_PLAN_OP_LFTJ: {
+            const wl_plan_op_lftj_t *meta =
+                (const wl_plan_op_lftj_t *)op->opaque_data;
+            uint32_t idb_count = tdd_lftj_idb_count(meta, sp);
+            if (idb_count == UINT32_MAX)
+                return UINT32_MAX;
+            if (idb_count > 0 && meta->k > 1)
+                segment_count += meta->k - 1;
+            break;
+        }
         default:
             break;
         }
@@ -4528,6 +4638,18 @@ tdd_record_segment_stats(const wl_plan_op_t *ops, uint32_t op_count,
             join_like++;
             has_antijoin = true;
             break;
+        case WL_PLAN_OP_LFTJ: {
+            const wl_plan_op_lftj_t *meta =
+                (const wl_plan_op_lftj_t *)op->opaque_data;
+            uint32_t idb_count = tdd_lftj_idb_count(meta, sp);
+            if (idb_count == UINT32_MAX) {
+                stats->unsafe_segments++;
+                return;
+            }
+            if (meta->k > 1)
+                join_like += meta->k - 1;
+            break;
+        }
         default:
             break;
         }
@@ -4599,6 +4721,9 @@ tdd_rule_slice_global_read_safe(const wl_plan_op_t *ops, uint32_t op_count,
     if (!relation_has_exchange || !ops || op_count == 0)
         return false;
 
+    if (tdd_ops_have_unsupported_lftj(ops, op_count, sp))
+        return false;
+
     for (uint32_t oi = 0; oi < op_count; oi++) {
         const wl_plan_op_t *op = &ops[oi];
         if (op->delta_mode == WL_DELTA_FORCE_EMPTY)
@@ -4619,6 +4744,13 @@ tdd_rule_slice_global_read_safe(const wl_plan_op_t *ops, uint32_t op_count,
             join_like++;
             has_antijoin = true;
             break;
+        case WL_PLAN_OP_LFTJ: {
+            const wl_plan_op_lftj_t *meta =
+                (const wl_plan_op_lftj_t *)op->opaque_data;
+            if (meta->k > 1)
+                join_like += meta->k - 1;
+            break;
+        }
         default:
             break;
         }
@@ -4636,6 +4768,9 @@ tdd_child_plan_global_read_safe(const wl_plan_op_t *ops, uint32_t op_count,
     const wl_plan_stratum_t *sp, bool relation_has_exchange)
 {
     if (!ops || op_count == 0)
+        return false;
+
+    if (tdd_ops_have_unsupported_lftj(ops, op_count, sp))
         return false;
 
     uint32_t idb_segments = 0;
@@ -4821,6 +4956,8 @@ tdd_stratum_global_read_candidate(const wl_plan_stratum_t *sp)
 {
     if (!sp)
         return false;
+    if (tdd_stratum_has_unsupported_lftj(sp))
+        return false;
     if (tdd_stratum_has_idb_self_join(sp))
         return false;
     uint32_t max_idb_atoms = tdd_stratum_global_read_max_idb_atoms(sp);
@@ -4924,6 +5061,13 @@ tdd_ops_single_idb_keys_exchange_aligned(const wl_plan_op_t *ops,
 
     for (uint32_t oi = 0; oi < op_count; oi++) {
         const wl_plan_op_t *op = &ops[oi];
+        if (op->op == WL_PLAN_OP_LFTJ) {
+            const wl_plan_op_lftj_t *meta =
+                (const wl_plan_op_lftj_t *)op->opaque_data;
+            if (tdd_lftj_idb_count(meta, sp) != 0)
+                return false;
+            continue;
+        }
         if (op->op == WL_PLAN_OP_VARIABLE) {
             if (is_stratum_idb(sp, op->relation_name)) {
                 stack_has_idb = true;
@@ -7571,6 +7715,9 @@ col_eval_stratum_tdd(const wl_plan_stratum_t *sp,
 {
     if (!sp || !coord)
         return EINVAL;
+
+    if (tdd_stratum_has_unsupported_lftj(sp))
+        return col_eval_stratum(sp, coord, stratum_idx);
 
     /* Single-worker fast path: zero overhead delegation */
     if (coord->num_workers <= 1)

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4386,6 +4386,9 @@ static bool
 ops_have_idb_idb_join(const wl_plan_op_t *ops, uint32_t op_count,
     const wl_plan_stratum_t *sp)
 {
+    if (!ops)
+        return op_count != 0;
+
     bool stack_has_idb = false;
     for (uint32_t oi = 0; oi < op_count; oi++) {
         const wl_plan_op_t *op = &ops[oi];

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4724,9 +4724,6 @@ tdd_rule_slice_global_read_safe(const wl_plan_op_t *ops, uint32_t op_count,
     if (!relation_has_exchange || !ops || op_count == 0)
         return false;
 
-    if (tdd_ops_have_unsupported_lftj(ops, op_count, sp))
-        return false;
-
     for (uint32_t oi = 0; oi < op_count; oi++) {
         const wl_plan_op_t *op = &ops[oi];
         if (op->delta_mode == WL_DELTA_FORCE_EMPTY)
@@ -4747,13 +4744,6 @@ tdd_rule_slice_global_read_safe(const wl_plan_op_t *ops, uint32_t op_count,
             join_like++;
             has_antijoin = true;
             break;
-        case WL_PLAN_OP_LFTJ: {
-            const wl_plan_op_lftj_t *meta =
-                (const wl_plan_op_lftj_t *)op->opaque_data;
-            if (meta->k > 1)
-                join_like += meta->k - 1;
-            break;
-        }
         default:
             break;
         }
@@ -4771,9 +4761,6 @@ tdd_child_plan_global_read_safe(const wl_plan_op_t *ops, uint32_t op_count,
     const wl_plan_stratum_t *sp, bool relation_has_exchange)
 {
     if (!ops || op_count == 0)
-        return false;
-
-    if (tdd_ops_have_unsupported_lftj(ops, op_count, sp))
         return false;
 
     uint32_t idb_segments = 0;
@@ -4911,6 +4898,8 @@ tdd_build_rule_slices(const wl_plan_stratum_t *sp,
 bool
 tdd_stratum_mixed_slice_candidate(const wl_plan_stratum_t *sp)
 {
+    if (tdd_stratum_has_unsupported_lftj(sp))
+        return false;
     wl_tdd_rule_slice_t *slices = NULL;
     uint32_t count = 0;
     uint32_t safe_count = 0;
@@ -5064,13 +5053,6 @@ tdd_ops_single_idb_keys_exchange_aligned(const wl_plan_op_t *ops,
 
     for (uint32_t oi = 0; oi < op_count; oi++) {
         const wl_plan_op_t *op = &ops[oi];
-        if (op->op == WL_PLAN_OP_LFTJ) {
-            const wl_plan_op_lftj_t *meta =
-                (const wl_plan_op_lftj_t *)op->opaque_data;
-            if (tdd_lftj_idb_count(meta, sp) != 0)
-                return false;
-            continue;
-        }
         if (op->op == WL_PLAN_OP_VARIABLE) {
             if (is_stratum_idb(sp, op->relation_name)) {
                 stack_has_idb = true;
@@ -5112,6 +5094,8 @@ bool
 tdd_stratum_single_idb_join_keys_exchange_aligned(
     const wl_plan_stratum_t *sp)
 {
+    if (tdd_stratum_has_unsupported_lftj(sp))
+        return false;
     if (tdd_stratum_has_idb_self_join(sp))
         return false;
 

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -333,12 +333,8 @@ retraction_rel_name(const char *rel, char *buf, size_t sz)
  *   - tdd_worker_subpass_fn(): the same pair again on the TDD worker path
  *     -- an all-rules early exit that sets ctx->all_empty_delta, and a
  *     per-rule pre-scan in its relation loop.
- * The other FOUR are not blinded, because they pass an inner operator list
+ * The other two are not blinded, because they pass an inner operator list
  * that still carries the FORCE_DELTA ops the rewrite hid:
- *   - tdd_worker_eval_rule_slices() and tdd_coord_eval_fallback_rule_slices()
- *     (this file) evaluate a wl_tdd_rule_slice_t; on a fused relation
- *     tdd_build_rule_slices() takes those ops from
- *     wl_plan_op_k_fusion_t.k_ops[], i.e. from inside the opaque_data;
  *   - col_op_k_fusion_serial() and col_op_k_fusion() (columnar/ops.c)
  *     evaluate meta->k_ops[d] directly.
  * Call sites are named by function on purpose: line numbers drift.
@@ -2734,257 +2730,6 @@ tdd_install_empty_delta_on_workers(wl_col_session_t *coord,
     return 0;
 }
 
-static int
-tdd_worker_eval_rule_slices(col_eval_tdd_worker_ctx_t *ctx,
-    wl_col_session_t *sess, uint32_t eff_iter, bool *out_any_new)
-{
-    const wl_plan_stratum_t *sp = ctx->sp;
-    uint32_t nrels = sp->relation_count;
-    col_rel_t **deltas = (col_rel_t **)calloc(nrels, sizeof(col_rel_t *));
-    if (!deltas)
-        return ENOMEM;
-
-    int rc = 0;
-    for (uint32_t si = 0; si < ctx->rule_slice_count; si++) {
-        const wl_tdd_rule_slice_t *slice = &ctx->rule_slices[si];
-        if (!slice->tdd_safe || slice->relation_index >= nrels)
-            continue;
-
-        const wl_plan_relation_t *target_plan =
-            &sp->relations[slice->relation_index];
-        wl_plan_relation_t tmp = {
-            .name = target_plan->name,
-            .delta_name = target_plan->delta_name,
-            .ops = slice->ops,
-            .op_count = slice->op_count,
-        };
-        if (has_empty_forced_delta(&tmp, sess, eff_iter))
-            continue;
-
-        eval_stack_t stack;
-        eval_stack_init(&stack);
-        rc = col_eval_relation_plan(&tmp, &stack, sess);
-        if (rc != 0) {
-            eval_stack_drain(&stack);
-            break;
-        }
-        if (stack.top == 0)
-            continue;
-
-        eval_entry_t result = eval_stack_pop(&stack);
-        eval_stack_drain(&stack);
-        if (!result.rel || result.rel->nrows == 0) {
-            if (result.owned)
-                col_rel_destroy(result.rel);
-            continue;
-        }
-
-        col_rel_t *target = session_find_rel(sess, target_plan->name);
-        if (target && target->ncols > 0 && result.rel->ncols != target->ncols) {
-            if (getenv("WIRELOG_TDD_GLOBAL_READ_DEBUG")) {
-                fprintf(stderr,
-                    "TDD worker slice schema mismatch rel=%s worker=%u "
-                    "slice=%u result_cols=%u target_cols=%u\n",
-                    target_plan->name, sess->worker_id, si,
-                    result.rel->ncols, target->ncols);
-            }
-            if (result.owned)
-                col_rel_destroy(result.rel);
-            rc = EINVAL;
-            break;
-        }
-
-        col_rel_t *delta = deltas[slice->relation_index];
-        if (delta && delta->ncols != result.rel->ncols) {
-            if (getenv("WIRELOG_TDD_GLOBAL_READ_DEBUG")) {
-                fprintf(stderr,
-                    "TDD worker slice delta schema mismatch rel=%s worker=%u "
-                    "slice=%u delta_cols=%u result_cols=%u\n",
-                    target_plan->name, sess->worker_id, si,
-                    delta->ncols, result.rel->ncols);
-            }
-            if (result.owned)
-                col_rel_destroy(result.rel);
-            rc = EINVAL;
-            break;
-        }
-        if (!delta) {
-            delta = col_rel_new_like(target_plan->delta_name, result.rel);
-            if (!delta) {
-                if (result.owned)
-                    col_rel_destroy(result.rel);
-                rc = ENOMEM;
-                break;
-            }
-            deltas[slice->relation_index] = delta;
-        }
-        rc = col_rel_append_all(delta, result.rel, sess->eval_arena);
-        if (result.owned)
-            col_rel_destroy(result.rel);
-        if (rc != 0)
-            break;
-    }
-
-    if (rc == 0) {
-        for (uint32_t ri = 0; ri < nrels; ri++) {
-            col_rel_t *delta = deltas[ri];
-            deltas[ri] = NULL;
-            if (!delta)
-                continue;
-
-            col_rel_t *target = session_find_rel(sess, sp->relations[ri].name);
-            if (target && target->nrows > 0) {
-                rc = bdx_hash_diff(delta, target);
-                if (rc != 0) {
-                    col_rel_destroy(delta);
-                    break;
-                }
-            }
-            if (sess->coordinator && delta->nrows > 0) {
-                col_rel_t *coord_target = session_find_rel(
-                    sess->coordinator, sp->relations[ri].name);
-                if (coord_target && coord_target->nrows > 0) {
-                    rc = tdd_hashset_diff(delta, coord_target);
-                    if (rc != 0) {
-                        col_rel_destroy(delta);
-                        break;
-                    }
-                }
-            }
-            if (delta->nrows > 1)
-                tdd_dedup_rel(delta);
-            bool produced = delta->nrows > 0;
-            rc = tdd_worker_publish_delta(ctx, sess, delta, ri, eff_iter);
-            if (rc != 0)
-                break;
-            if (produced && out_any_new)
-                *out_any_new = true;
-        }
-    }
-
-    for (uint32_t ri = 0; ri < nrels; ri++)
-        col_rel_destroy(deltas[ri]);
-    free(deltas);
-    return rc;
-}
-
-static int
-tdd_coord_append_delta(col_eval_tdd_worker_ctx_t *ctx, uint32_t rel_idx,
-    col_rel_t *delta)
-{
-    if (!delta || delta->nrows == 0) {
-        col_rel_destroy(delta);
-        return 0;
-    }
-    col_rel_t *existing = ctx->delta_rels[rel_idx];
-    if (!existing) {
-        ctx->delta_rels[rel_idx] = delta;
-        return 0;
-    }
-    if (existing->ncols != delta->ncols) {
-        col_rel_destroy(delta);
-        return EINVAL;
-    }
-    int rc = col_rel_append_all(existing, delta, NULL);
-    col_rel_destroy(delta);
-    return rc;
-}
-
-static int
-tdd_coord_eval_fallback_rule_slices(const wl_plan_stratum_t *sp,
-    wl_col_session_t *coord, col_eval_tdd_worker_ctx_t *ctx,
-    const wl_tdd_rule_slice_t *slices, uint32_t slice_count,
-    uint32_t eff_iter, bool *out_any_new)
-{
-    int rc = 0;
-    bool saved_diff = coord->diff_operators_active;
-    coord->diff_operators_active = coord->diff_enabled && eff_iter > 0;
-    coord->current_iteration = eff_iter;
-
-    for (uint32_t si = 0; si < slice_count; si++) {
-        const wl_tdd_rule_slice_t *slice = &slices[si];
-        if (slice->tdd_safe || slice->relation_index >= sp->relation_count)
-            continue;
-
-        const wl_plan_relation_t *target_plan =
-            &sp->relations[slice->relation_index];
-        wl_plan_relation_t tmp = {
-            .name = target_plan->name,
-            .delta_name = target_plan->delta_name,
-            .ops = slice->ops,
-            .op_count = slice->op_count,
-        };
-        if (has_empty_forced_delta(&tmp, coord, eff_iter))
-            continue;
-
-        eval_stack_t stack;
-        eval_stack_init(&stack);
-        rc = col_eval_relation_plan(&tmp, &stack, coord);
-        if (rc != 0) {
-            eval_stack_drain(&stack);
-            break;
-        }
-        if (stack.top == 0)
-            continue;
-
-        eval_entry_t result = eval_stack_pop(&stack);
-        eval_stack_drain(&stack);
-        if (!result.rel || result.rel->nrows == 0) {
-            if (result.owned)
-                col_rel_destroy(result.rel);
-            continue;
-        }
-
-        col_rel_t *target = session_find_rel(coord, target_plan->name);
-        if (target && target->ncols > 0 && result.rel->ncols != target->ncols) {
-            if (getenv("WIRELOG_TDD_GLOBAL_READ_DEBUG")) {
-                fprintf(stderr,
-                    "TDD fallback slice schema mismatch rel=%s slice=%u "
-                    "result_cols=%u target_cols=%u\n",
-                    target_plan->name, si, result.rel->ncols, target->ncols);
-            }
-            if (result.owned)
-                col_rel_destroy(result.rel);
-            rc = EINVAL;
-            break;
-        }
-
-        col_rel_t *delta = col_rel_new_like(target_plan->delta_name,
-                result.rel);
-        if (!delta) {
-            if (result.owned)
-                col_rel_destroy(result.rel);
-            rc = ENOMEM;
-            break;
-        }
-        rc = col_rel_append_all(delta, result.rel, coord->eval_arena);
-        if (result.owned)
-            col_rel_destroy(result.rel);
-        if (rc != 0) {
-            col_rel_destroy(delta);
-            break;
-        }
-
-        if (target && target->nrows > 0) {
-            rc = tdd_hashset_diff(delta, target);
-            if (rc != 0) {
-                col_rel_destroy(delta);
-                break;
-            }
-        }
-        if (delta->nrows > 1)
-            tdd_dedup_rel(delta);
-        if (delta->nrows > 0 && out_any_new)
-            *out_any_new = true;
-        rc = tdd_coord_append_delta(ctx, slice->relation_index, delta);
-        if (rc != 0)
-            break;
-    }
-
-    coord->diff_operators_active = saved_diff;
-    return rc;
-}
-
 static void
 tdd_worker_subpass_fn(void *arg)
 {
@@ -3061,33 +2806,6 @@ tdd_worker_subpass_fn(void *arg)
     }
 
     bool any_new = false;
-
-    if (ctx->rule_slices && ctx->rule_slice_count > 0) {
-        int slice_rc = tdd_worker_eval_rule_slices(ctx, sess, eff_iter,
-                &any_new);
-        free(snap);
-        if (slice_rc != 0) {
-            ctx->rc = slice_rc;
-            sess->tdd_subpass_active = saved_tdd_subpass;
-            sess->tdd_outbound_only_active = saved_outbound_only;
-            sess->diff_operators_active = saved_diff;
-            TDD_WORKER_RETURN();
-        }
-        delta_pool_reset(sess->delta_pool);
-        sess->rotation_ops->rotate_eval_arena(sess);
-        if (sess->cache_evict_threshold == 0) {
-            col_mat_cache_clear(&sess->mat_cache);
-        } else {
-            col_mat_cache_evict_until(&sess->mat_cache,
-                sess->cache_evict_threshold);
-        }
-        ctx->any_new = any_new;
-        sess->tdd_subpass_active = saved_tdd_subpass;
-        sess->tdd_outbound_only_active = saved_outbound_only;
-        sess->diff_operators_active = saved_diff;
-        ctx->runtime_ns = now_ns() - worker_t0;
-        TDD_WORKER_RETURN();
-    }
 
     /* Evaluate all relation plans (eval.c:505-604) */
     for (uint32_t ri = 0; ri < nrels; ri++) {
@@ -6606,8 +6324,7 @@ tdd_owner_exchange_deltas(const wl_plan_stratum_t *sp,
 static int
 tdd_global_read_exchange_deltas(const wl_plan_stratum_t *sp,
     wl_col_session_t *coord, col_eval_tdd_worker_ctx_t *ctxs, uint32_t W,
-    bool *out_any_accepted, uint32_t *out_accepted_rows,
-    bool install_coord_delta)
+    bool *out_any_accepted, uint32_t *out_accepted_rows)
 {
     uint32_t nrels = sp->relation_count;
     int rc = 0;
@@ -6620,8 +6337,6 @@ tdd_global_read_exchange_deltas(const wl_plan_stratum_t *sp,
         const char *dname = sp->relations[ri].delta_name;
         const char *rel_name = sp->relations[ri].name;
 
-        if (install_coord_delta)
-            session_remove_rel(coord, dname);
         for (uint32_t w = 0; w < W; w++)
             session_remove_rel(&coord->tdd_workers[w], dname);
 
@@ -6682,22 +6397,6 @@ tdd_global_read_exchange_deltas(const wl_plan_stratum_t *sp,
             *out_any_accepted = true;
         if (out_accepted_rows)
             *out_accepted_rows += combined->nrows;
-
-        if (install_coord_delta) {
-            col_rel_t *coord_delta = col_rel_new_like(dname, combined);
-            if (!coord_delta) {
-                col_rel_destroy(combined);
-                return ENOMEM;
-            }
-            rc = col_rel_append_all(coord_delta, combined, NULL);
-            if (rc == 0)
-                rc = session_add_rel(coord, coord_delta);
-            if (rc != 0) {
-                col_rel_destroy(coord_delta);
-                col_rel_destroy(combined);
-                return rc;
-            }
-        }
 
         if (coord_idb) {
             if (coord_idb->ncols == 0 && combined->ncols > 0) {
@@ -6900,32 +6599,11 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         && stratum_max_idb_body_atoms(sp) <= 1
         && tdd_stratum_single_idb_join_keys_exchange_aligned(sp);
     bool bdx_mode = has_idb_self_join && !self_join_mode;
-    wl_tdd_rule_slice_t *mixed_slices = NULL;
-    uint32_t mixed_slice_count = 0;
-    uint32_t mixed_safe_count = 0;
-    bool mixed_slice_mode = false;
-    const char *mixed_env = getenv("WIRELOG_TDD_MIXED_SLICES");
-    if (mixed_env && mixed_env[0] == '1') {
-        rc = tdd_build_rule_slices(sp, &mixed_slices, &mixed_slice_count,
-                &mixed_safe_count);
-        if (rc != 0) {
-            coord->tdd_total_ns += now_ns() - tdd_total_t0;
-            return rc;
-        }
-        mixed_slice_mode = mixed_safe_count > 0
-            && mixed_safe_count < mixed_slice_count;
-    }
     const char *global_read_env = getenv("WIRELOG_TDD_GLOBAL_READ");
     bool global_read_mode = !(global_read_env && global_read_env[0] == '0'
         && global_read_env[1] == '\0')
         && !owner_exchange_mode && !self_join_mode && !bdx_mode
         && tdd_stratum_global_read_candidate(sp);
-    if (mixed_slice_mode) {
-        owner_exchange_mode = false;
-        self_join_mode = false;
-        bdx_mode = false;
-        global_read_mode = true;
-    }
     bool replicate_mode = !owner_exchange_mode
         && !global_read_mode
         && ((coord->last_inserted_relation == NULL)
@@ -6957,7 +6635,6 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         int seq_rc = col_eval_stratum(sp, coord, stratum_idx);
         if (seq_rc == 0 && saved_total_iterations > 0)
             coord->total_iterations += saved_total_iterations;
-        free(mixed_slices);
         return seq_rc;
     }
 
@@ -6968,14 +6645,12 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         owner_fallback_saved = tdd_save_coord_idb(sp, coord);
         if (!owner_fallback_saved) {
             coord->tdd_total_ns += now_ns() - tdd_total_t0;
-            free(mixed_slices);
             return ENOMEM;
         }
     } else if (global_read_mode) {
         global_read_saved = tdd_save_coord_idb(sp, coord);
         if (!global_read_saved) {
             coord->tdd_total_ns += now_ns() - tdd_total_t0;
-            free(mixed_slices);
             return ENOMEM;
         }
     }
@@ -6990,7 +6665,6 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         tdd_free_saved_coord_idb(sp, owner_fallback_saved);
         tdd_free_saved_coord_idb(sp, global_read_saved);
         coord->tdd_total_ns += now_ns() - tdd_total_t0;
-        free(mixed_slices);
         return rc;
     }
 
@@ -7004,7 +6678,6 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                     tdd_free_saved_coord_idb(sp, owner_fallback_saved);
                     tdd_free_saved_coord_idb(sp, global_read_saved);
                     coord->tdd_total_ns += now_ns() - tdd_total_t0;
-                    free(mixed_slices);
                     return rc;
                 }
             }
@@ -7018,7 +6691,6 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         tdd_free_saved_coord_idb(sp, owner_fallback_saved);
         tdd_free_saved_coord_idb(sp, global_read_saved);
         coord->tdd_total_ns += now_ns() - tdd_total_t0;
-        free(mixed_slices);
         return rc;
     }
 
@@ -7048,7 +6720,6 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 tdd_free_saved_coord_idb(sp, owner_fallback_saved);
                 tdd_free_saved_coord_idb(sp, global_read_saved);
                 coord->tdd_total_ns += now_ns() - tdd_total_t0;
-                free(mixed_slices);
                 return ENOMEM;
             }
             rc = session_add_rel(&coord->tdd_workers[w], slot);
@@ -7058,7 +6729,6 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 tdd_free_saved_coord_idb(sp, owner_fallback_saved);
                 tdd_free_saved_coord_idb(sp, global_read_saved);
                 coord->tdd_total_ns += now_ns() - tdd_total_t0;
-                free(mixed_slices);
                 return rc;
             }
         }
@@ -7273,9 +6943,6 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 memset(ctxs[w].delta_rels, 0, nrels * sizeof(col_rel_t *));
                 ctxs[w].sp = sp;
                 ctxs[w].worker_sess = &coord->tdd_workers[w];
-                ctxs[w].rule_slices = mixed_slice_mode ? mixed_slices : NULL;
-                ctxs[w].rule_slice_count =
-                    mixed_slice_mode ? mixed_slice_count : 0;
                 ctxs[w].stratum_idx = stratum_idx;
                 ctxs[w].eff_iter = eff_iter;
                 ctxs[w].any_new = false;
@@ -7368,23 +7035,6 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 coord->tdd_queue_drain_ns += now_ns() - queue_t0;
             }
 
-            bool mixed_fallback_any_new = false;
-            if (mixed_slice_mode) {
-                rc = tdd_coord_eval_fallback_rule_slices(sp, coord,
-                        &ctxs[0], mixed_slices, mixed_slice_count,
-                        eff_iter, &mixed_fallback_any_new);
-                if (rc != 0) {
-                    for (uint32_t w = 0; w < W; w++)
-                        for (uint32_t ri = 0; ri < nrels; ri++) {
-                            col_rel_destroy(ctxs[w].delta_rels[ri]);
-                            ctxs[w].delta_rels[ri] = NULL;
-                        }
-                    goto done;
-                }
-                if (mixed_fallback_any_new)
-                    ctxs[0].any_new = true;
-            }
-
             uint64_t convergence_t0 = now_ns();
 
             /* Stratum-level early exit: all workers have all_empty_delta */
@@ -7395,7 +7045,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                     break;
                 }
             }
-            if (all_workers_empty && !mixed_slice_mode) {
+            if (all_workers_empty) {
                 coord->tdd_convergence_ns += now_ns() - convergence_t0;
                 for (uint32_t w = 0; w < W; w++)
                     for (uint32_t ri = 0; ri < nrels; ri++)
@@ -7444,8 +7094,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                             &owner_any_accepted, &owner_accepted_rows);
                 else if (global_read_mode)
                     brc = tdd_global_read_exchange_deltas(sp, coord, ctxs, W,
-                            &owner_any_accepted, &owner_accepted_rows,
-                            mixed_slice_mode);
+                            &owner_any_accepted, &owner_accepted_rows);
                 else if (bdx_mode)
                     brc = tdd_bdx_exchange_deltas(sp, coord, ctxs, W,
                             bdx_snap);
@@ -7461,10 +7110,9 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 if (getenv("WIRELOG_TDD_GLOBAL_READ_DEBUG"))
                     fprintf(stderr,
                         "TDD exchange error stratum=%u iter=%u rc=%d "
-                        "owner=%d global=%d bdx=%d mixed=%d replicate=%d\n",
+                        "owner=%d global=%d bdx=%d replicate=%d\n",
                         stratum_idx, eff_iter, brc, owner_exchange_mode,
-                        global_read_mode, bdx_mode, mixed_slice_mode,
-                        replicate_mode);
+                        global_read_mode, bdx_mode, replicate_mode);
                 rc = brc;
                 goto done;
             }
@@ -7516,7 +7164,6 @@ done:
         free(ctxs);
     }
     free(bdx_snap);
-    free(mixed_slices);
     coord->diff_operators_active = saved_diff;
 
     if (owner_adaptive_fallback && rc == 0) {

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1694,6 +1694,8 @@ wl_columnar_session_ensure_tdd_worker_slots(wl_col_session_t *sess,
     uint32_t active_workers);
 bool
 tdd_stratum_has_idb_self_join(const wl_plan_stratum_t *sp);
+bool
+tdd_stratum_has_unsupported_lftj(const wl_plan_stratum_t *sp);
 uint32_t
 stratum_max_idb_body_atoms(const wl_plan_stratum_t *sp);
 bool

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -302,6 +302,9 @@ static bool
 wl_columnar_session_tdd_stratum_is_safe(const wl_plan_stratum_t *sp,
     wl_col_session_t *sess)
 {
+    if (tdd_stratum_has_unsupported_lftj(sp))
+        return false;
+
     /* TDD is only beneficial for recursive strata when there is no
      * IDB self-join OR the IDB self-join is exchange-aligned.  A
      * non-aligned self-join forces replicate_mode (all W workers do
@@ -376,6 +379,13 @@ wl_columnar_session_tdd_plan_stratum(const wl_plan_stratum_t *sp,
     if (!sp->is_recursive) {
         decision.fallback_reason =
             WL_COLUMNAR_INTERNAL_TDD_FALLBACK_NON_RECURSIVE;
+        wl_columnar_session_tdd_debug_decision(sp, sess,
+            snapshot_tdd_eligible, decision);
+        return decision;
+    }
+    if (tdd_stratum_has_unsupported_lftj(sp)) {
+        decision.fallback_reason =
+            WL_COLUMNAR_INTERNAL_TDD_FALLBACK_UNSAFE_PLAN;
         wl_columnar_session_tdd_debug_decision(sp, sess,
             snapshot_tdd_eligible, decision);
         return decision;

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -413,14 +413,6 @@ wl_columnar_session_tdd_plan_stratum(const wl_plan_stratum_t *sp,
                 snapshot_tdd_eligible, decision);
             return decision;
         }
-        const char *mixed_env = getenv("WIRELOG_TDD_MIXED_SLICES");
-        if (mixed_env && mixed_env[0] == '1'
-            && tdd_stratum_mixed_slice_candidate(sp)) {
-            decision.use_tdd = true;
-            wl_columnar_session_tdd_debug_decision(sp, sess,
-                snapshot_tdd_eligible, decision);
-            return decision;
-        }
         decision.fallback_reason =
             WL_COLUMNAR_INTERNAL_TDD_FALLBACK_UNSAFE_PLAN;
         wl_columnar_session_tdd_debug_decision(sp, sess,

--- a/wirelog/exec_plan.h
+++ b/wirelog/exec_plan.h
@@ -464,7 +464,8 @@ typedef struct {
     /* A relation *name*, not a subplan.  The plan therefore cannot represent
      * a JOIN/ANTIJOIN/SEMIJOIN whose right child is itself composite: any
      * such tree must be built left-deep, with the composite side on the left.
-     * translate_ir_node() rejects a JOIN that violates this rather than
+     * translate_ir_node() rejects a JOIN/ANTIJOIN/SEMIJOIN that violates this
+     * rather than
      * emitting NULL here, which used to yield a plan that silently computed
      * nothing (#989). */
     const char *right_relation;

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -1515,7 +1515,7 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
              * child (JOIN/ANTIJOIN/SEMIJOIN/...) cannot be represented at
              * all.  Emitting NULL here yields an operator that matches
              * nothing and a silently empty result -- fail the plan instead
-             * (Issue #989). */
+             * (Issue #989/#993). */
             if (!rn || !rn->relation_name) {
                 WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_ERROR,
                     "JOIN right child (IR node type %d) carries no relation "
@@ -1550,7 +1550,20 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             const wirelog_ir_node_t *rn
                 = unwrap_filters_collect(node->children[1],
                     &op->right_filter_expr);
+            if (!rn || !rn->relation_name) {
+                WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_ERROR,
+                    "ANTIJOIN right child (IR node type %d) carries no "
+                    "relation name: the plan cannot represent a "
+                    "right-deep join",
+                    (int)(rn ? rn->type : node->children[1]->type));
+                return -1;
+            }
             op->right_relation = dup_str(rn ? rn->relation_name : NULL);
+        } else {
+            WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_ERROR,
+                "ANTIJOIN right child is missing: the plan cannot "
+                "represent a right-deep join");
+            return -1;
         }
         op->left_keys = (const char *const *)resolve_keys_to_colN(
             node->join_left_keys, node->join_key_count,
@@ -1576,7 +1589,20 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             const wirelog_ir_node_t *rn
                 = unwrap_filters_collect(node->children[1],
                     &op->right_filter_expr);
+            if (!rn || !rn->relation_name) {
+                WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_ERROR,
+                    "SEMIJOIN right child (IR node type %d) carries no "
+                    "relation name: the plan cannot represent a "
+                    "right-deep join",
+                    (int)(rn ? rn->type : node->children[1]->type));
+                return -1;
+            }
             op->right_relation = dup_str(rn ? rn->relation_name : NULL);
+        } else {
+            WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_ERROR,
+                "SEMIJOIN right child is missing: the plan cannot "
+                "represent a right-deep join");
+            return -1;
         }
         op->left_keys = (const char *const *)resolve_keys_to_colN(
             node->join_left_keys, node->join_key_count,


### PR DESCRIPTION
## Summary

- add a build-scope detection job to `ci-pr.yml`;
- keep `rc-changelog-freeze` and lint checks active for every PR;
- skip the compiler, platform, mbedTLS, sanitizer, and TSan jobs when changes are documentation-only or metadata-only;
- fail open to the full build when the PR diff cannot be determined.

## Build-triggering changes

The full pipeline remains enabled for C/H sources, generated-header templates, Meson definitions, cross-build settings, tests/examples/bench/fuzz/scripts, subprojects, ABI/SBOM inputs, and workflow configuration. Markdown, Markdown-like, and RST-only changes are excluded even when located below source directories.

## Validation

- Ruby YAML parse of `.github/workflows/ci-pr.yml`
- `git diff --check`
- changed-path classification fixtures for documentation, source, build definitions, cross files, ABI, and SBOM inputs
- independent Architect, Critic, and Reviewer validation

Related: #1075
