### PR TITLE
refactor(columnar): extract evaluation stack from ops.c

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -29,6 +29,7 @@ bench_backend_src = files(
   subdir_wirelog / 'columnar/relation.c',
   subdir_wirelog / 'columnar/cache.c',
   subdir_wirelog / 'columnar/ops.c',
+  subdir_wirelog / 'columnar/eval_stack.c',
   subdir_wirelog / 'columnar/eval.c',
   subdir_wirelog / 'columnar/arrangement.c',
   subdir_wirelog / 'columnar/frontier.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -815,6 +815,7 @@ backend_src = files(
   '../wirelog/columnar/relation.c',
   '../wirelog/columnar/cache.c',
   '../wirelog/columnar/ops.c',
+  '../wirelog/columnar/eval_stack.c',
   '../wirelog/columnar/eval.c',
   '../wirelog/columnar/arrangement.c',
   '../wirelog/columnar/frontier.c',

--- a/wirelog/columnar/eval_stack.c
+++ b/wirelog/columnar/eval_stack.c
@@ -1,0 +1,60 @@
+/*
+ * columnar/eval_stack.c - Columnar operator evaluation stack
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ */
+
+#include "columnar/internal.h"
+
+void
+eval_stack_init(eval_stack_t *s)
+{
+    memset(s, 0, sizeof(*s));
+}
+
+int
+eval_stack_push(eval_stack_t *s, col_rel_t *r, bool owned)
+{
+    if (s->top >= COL_STACK_MAX)
+        return ENOBUFS;
+    s->items[s->top].rel = r;
+    s->items[s->top].owned = owned;
+    s->items[s->top].is_delta = false;
+    s->items[s->top].seg_boundaries = NULL;
+    s->items[s->top].seg_count = 0;
+    s->top++;
+    return 0;
+}
+
+/* Push with explicit delta flag (used by VARIABLE and JOIN to tag delta results). */
+int
+eval_stack_push_delta(eval_stack_t *s, col_rel_t *r, bool owned, bool is_delta)
+{
+    int rc = eval_stack_push(s, r, owned);
+    if (rc == 0)
+        s->items[s->top - 1].is_delta = is_delta;
+    return rc;
+}
+
+eval_entry_t
+eval_stack_pop(eval_stack_t *s)
+{
+    eval_entry_t e = { NULL, false, false, NULL, 0 };
+    if (s->top > 0)
+        e = s->items[--s->top];
+    return e;
+}
+
+void
+eval_stack_drain(eval_stack_t *s)
+{
+    while (s->top > 0) {
+        eval_entry_t e = eval_stack_pop(s);
+        if (e.seg_boundaries)
+            free(e.seg_boundaries);
+        if (e.owned)
+            col_rel_destroy(e.rel);
+    }
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1597,7 +1597,7 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
     col_rel_t *out_delta);
 
 /* ======================================================================== */
-/* Eval Stack & Operators (columnar/ops.c)                                  */
+/* Eval Stack (columnar/eval_stack.c) and operators (columnar/ops.c)         */
 /* ======================================================================== */
 
 void

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -1478,61 +1478,6 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
 }
 
 /* ======================================================================== */
-/* Eval Stack                                                                */
-/* ======================================================================== */
-
-void
-eval_stack_init(eval_stack_t *s)
-{
-    memset(s, 0, sizeof(*s));
-}
-
-int
-eval_stack_push(eval_stack_t *s, col_rel_t *r, bool owned)
-{
-    if (s->top >= COL_STACK_MAX)
-        return ENOBUFS;
-    s->items[s->top].rel = r;
-    s->items[s->top].owned = owned;
-    s->items[s->top].is_delta = false;
-    s->items[s->top].seg_boundaries = NULL;
-    s->items[s->top].seg_count = 0;
-    s->top++;
-    return 0;
-}
-
-/* Push with explicit delta flag (used by VARIABLE and JOIN to tag delta results). */
-int
-eval_stack_push_delta(eval_stack_t *s, col_rel_t *r, bool owned, bool is_delta)
-{
-    int rc = eval_stack_push(s, r, owned);
-    if (rc == 0)
-        s->items[s->top - 1].is_delta = is_delta;
-    return rc;
-}
-
-eval_entry_t
-eval_stack_pop(eval_stack_t *s)
-{
-    eval_entry_t e = { NULL, false, false, NULL, 0 };
-    if (s->top > 0)
-        e = s->items[--s->top];
-    return e;
-}
-
-void
-eval_stack_drain(eval_stack_t *s)
-{
-    while (s->top > 0) {
-        eval_entry_t e = eval_stack_pop(s);
-        if (e.seg_boundaries)
-            free(e.seg_boundaries);
-        if (e.owned)
-            col_rel_destroy(e.rel);
-    }
-}
-
-/* ======================================================================== */
 /* Operator Implementations                                                  */
 /* ======================================================================== */
 

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -90,7 +90,7 @@ wirelog_lockfree_queue_src = files('util/lockfree_queue.c', )
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
 wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
-                           'columnar/ops.c', 'columnar/eval.c',
+                           'columnar/ops.c', 'columnar/eval_stack.c', 'columnar/eval.c',
                            'columnar/arrangement.c', 'columnar/frontier.c', 'columnar/frontier_epoch.c',
                            'columnar/mobius.c', 'columnar/session.c', 'columnar/session_hash.c',
                            'columnar/delta_pool.c', 'columnar/lftj.c',


### PR DESCRIPTION
## Summary

- extract the columnar operator evaluation stack from the oversized `ops.c` into `wirelog/columnar/eval_stack.c`;
- preserve the existing `eval_stack_*` internal linkage contract, ownership handling, delta markers, and segment-boundary cleanup;
- update production, test, and benchmark Meson source lists;
- keep the change behavior-preserving as the first atomic step for #1087.

Related: #1087
Related clang-tidy findings: #1077

## Validation

- `meson setup --reconfigure builddir -Dtests=true`
- `meson compile -C builddir`
- 12 focused expression/filter/join/consolidation tests via `meson test`
- `git diff --check`
- independent Reviewer, Architect, and Critic approval
- `.text` size remained within budget and decreased by 4,932 bytes in review
