### PR TITLE
refactor(columnar): extract checked arithmetic from ops.c

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -29,6 +29,7 @@ bench_backend_src = files(
   subdir_wirelog / 'columnar/relation.c',
   subdir_wirelog / 'columnar/cache.c',
   subdir_wirelog / 'columnar/ops.c',
+  subdir_wirelog / 'columnar/arithmetic.c',
   subdir_wirelog / 'columnar/eval_stack.c',
   subdir_wirelog / 'columnar/eval.c',
   subdir_wirelog / 'columnar/arrangement.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -815,6 +815,7 @@ backend_src = files(
   '../wirelog/columnar/relation.c',
   '../wirelog/columnar/cache.c',
   '../wirelog/columnar/ops.c',
+  '../wirelog/columnar/arithmetic.c',
   '../wirelog/columnar/eval_stack.c',
   '../wirelog/columnar/eval.c',
   '../wirelog/columnar/arrangement.c',

--- a/wirelog/columnar/arithmetic.c
+++ b/wirelog/columnar/arithmetic.c
@@ -1,0 +1,127 @@
+/*
+ * columnar/arithmetic.c - Checked integer arithmetic for columnar expressions
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#include "columnar/internal.h"
+
+#include <errno.h>
+#include <stdint.h>
+
+static inline uint64_t
+wl_columnar_arithmetic_abs_u64(int64_t v)
+{
+    return v < 0 ? (uint64_t)0 - (uint64_t)v : (uint64_t)v;
+}
+
+/* Use compiler builtins where available; otherwise use explicit range checks. */
+#if defined(__GNUC__) || defined(__clang__)
+#define WL_COLUMNAR_ARITHMETIC_HAVE_INT64_OVERFLOW_BUILTIN 1
+#elif defined(__has_builtin)
+#if __has_builtin(__builtin_add_overflow) \
+    && __has_builtin(__builtin_sub_overflow) \
+    && __has_builtin(__builtin_mul_overflow)
+#define WL_COLUMNAR_ARITHMETIC_HAVE_INT64_OVERFLOW_BUILTIN 1
+#endif
+#endif
+
+int
+wl_columnar_arithmetic_checked_add_int64(int64_t a, int64_t b, int64_t *out)
+{
+#if defined(WL_COLUMNAR_ARITHMETIC_HAVE_INT64_OVERFLOW_BUILTIN)
+    return __builtin_add_overflow(a, b, out) ? ERANGE : 0;
+#else
+    if (b > 0) {
+        if (a > INT64_MAX - b)
+            return ERANGE;
+    } else {
+        if (a < INT64_MIN - b)
+            return ERANGE;
+    }
+    *out = a + b;
+    return 0;
+#endif
+}
+
+int
+wl_columnar_arithmetic_checked_sub_int64(int64_t a, int64_t b, int64_t *out)
+{
+#if defined(WL_COLUMNAR_ARITHMETIC_HAVE_INT64_OVERFLOW_BUILTIN)
+    return __builtin_sub_overflow(a, b, out) ? ERANGE : 0;
+#else
+    if (b > 0) {
+        if (a < INT64_MIN + b)
+            return ERANGE;
+    } else {
+        if (a > INT64_MAX + b)
+            return ERANGE;
+    }
+    *out = a - b;
+    return 0;
+#endif
+}
+
+int
+wl_columnar_arithmetic_checked_mul_int64(int64_t a, int64_t b, int64_t *out)
+{
+#if defined(WL_COLUMNAR_ARITHMETIC_HAVE_INT64_OVERFLOW_BUILTIN)
+    return __builtin_mul_overflow(a, b, out) ? ERANGE : 0;
+#else
+    if (a == 0 || b == 0) {
+        *out = 0;
+        return 0;
+    }
+    if ((a == -1 && b == INT64_MIN) || (b == -1 && a == INT64_MIN))
+        return ERANGE;
+
+    uint64_t ua = wl_columnar_arithmetic_abs_u64(a);
+    uint64_t ub = wl_columnar_arithmetic_abs_u64(b);
+    if ((a < 0) == (b < 0)) {
+        if (ua > (uint64_t)INT64_MAX / ub)
+            return ERANGE;
+    } else {
+        if (ua > ((uint64_t)INT64_MAX + 1ULL) / ub)
+            return ERANGE;
+    }
+    *out = a * b;
+    return 0;
+#endif
+}
+
+int
+wl_columnar_arithmetic_checked_div_int64(int64_t a, int64_t b, int64_t *out)
+{
+    if (b == 0 || (a == INT64_MIN && b == -1))
+        return ERANGE;
+    *out = a / b;
+    return 0;
+}
+
+int
+wl_columnar_arithmetic_checked_mod_int64(int64_t a, int64_t b, int64_t *out)
+{
+    if (b == 0 || (a == INT64_MIN && b == -1))
+        return ERANGE;
+    *out = a % b;
+    return 0;
+}
+
+int
+wl_columnar_arithmetic_checked_shl_int64(int64_t a, int64_t b, int64_t *out)
+{
+    if (b < 0 || b >= 64)
+        return ERANGE;
+    *out = (int64_t)((uint64_t)a << (uint32_t)b);
+    return 0;
+}
+
+int
+wl_columnar_arithmetic_checked_shr_int64(int64_t a, int64_t b, int64_t *out)
+{
+    if (b < 0 || b >= 64)
+        return ERANGE;
+    *out = a >> (uint32_t)b;
+    return 0;
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1600,6 +1600,22 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
 /* Eval Stack (columnar/eval_stack.c) and operators (columnar/ops.c)         */
 /* ======================================================================== */
 
+/* Checked expression arithmetic (columnar/arithmetic.c). */
+int
+wl_columnar_arithmetic_checked_add_int64(int64_t a, int64_t b, int64_t *out);
+int
+wl_columnar_arithmetic_checked_sub_int64(int64_t a, int64_t b, int64_t *out);
+int
+wl_columnar_arithmetic_checked_mul_int64(int64_t a, int64_t b, int64_t *out);
+int
+wl_columnar_arithmetic_checked_div_int64(int64_t a, int64_t b, int64_t *out);
+int
+wl_columnar_arithmetic_checked_mod_int64(int64_t a, int64_t b, int64_t *out);
+int
+wl_columnar_arithmetic_checked_shl_int64(int64_t a, int64_t b, int64_t *out);
+int
+wl_columnar_arithmetic_checked_shr_int64(int64_t a, int64_t b, int64_t *out);
+
 void
 eval_stack_init(eval_stack_t *s);
 int

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -372,123 +372,6 @@ filt_pop(filt_stack_t *s)
     return s->top != 0 ? s->vals[--s->top] : 0;
 }
 
-static inline uint64_t
-wl_columnar_ops_abs_u64(int64_t v)
-{
-    return v < 0 ? (uint64_t)0 - (uint64_t)v : (uint64_t)v;
-}
-
-/* Use compiler builtins where available; otherwise use explicit range checks. */
-#if defined(__GNUC__) || defined(__clang__)
-#define WL_COLUMNAR_OPS_HAVE_INT64_OVERFLOW_BUILTIN 1
-#elif defined(__has_builtin)
-#if __has_builtin(__builtin_add_overflow) \
-    && __has_builtin(__builtin_sub_overflow) \
-    && __has_builtin(__builtin_mul_overflow)
-#define WL_COLUMNAR_OPS_HAVE_INT64_OVERFLOW_BUILTIN 1
-#endif
-#endif
-
-/* Checked int64 arithmetic helpers shared by both slow and compiled evaluators. */
-static int
-wl_columnar_ops_checked_add_int64(int64_t a, int64_t b, int64_t *out)
-{
-#if defined(WL_COLUMNAR_OPS_HAVE_INT64_OVERFLOW_BUILTIN)
-    return __builtin_add_overflow(a, b, out) ? ERANGE : 0;
-#else
-    if (b > 0) {
-        if (a > INT64_MAX - b)
-            return ERANGE;
-    } else {
-        if (a < INT64_MIN - b)
-            return ERANGE;
-    }
-    *out = a + b;
-    return 0;
-#endif
-}
-
-static int
-wl_columnar_ops_checked_sub_int64(int64_t a, int64_t b, int64_t *out)
-{
-#if defined(WL_COLUMNAR_OPS_HAVE_INT64_OVERFLOW_BUILTIN)
-    return __builtin_sub_overflow(a, b, out) ? ERANGE : 0;
-#else
-    if (b > 0) {
-        if (a < INT64_MIN + b)
-            return ERANGE;
-    } else {
-        if (a > INT64_MAX + b)
-            return ERANGE;
-    }
-    *out = a - b;
-    return 0;
-#endif
-}
-
-static int
-wl_columnar_ops_checked_mul_int64(int64_t a, int64_t b, int64_t *out)
-{
-#if defined(WL_COLUMNAR_OPS_HAVE_INT64_OVERFLOW_BUILTIN)
-    return __builtin_mul_overflow(a, b, out) ? ERANGE : 0;
-#else
-    if (a == 0 || b == 0) {
-        *out = 0;
-        return 0;
-    }
-    if ((a == -1 && b == INT64_MIN) || (b == -1 && a == INT64_MIN))
-        return ERANGE;
-
-    uint64_t ua = wl_columnar_ops_abs_u64(a);
-    uint64_t ub = wl_columnar_ops_abs_u64(b);
-    if ((a < 0) == (b < 0)) {
-        if (ua > (uint64_t)INT64_MAX / ub)
-            return ERANGE;
-    } else {
-        if (ua > ((uint64_t)INT64_MAX + 1ULL) / ub)
-            return ERANGE;
-    }
-    *out = a * b;
-    return 0;
-#endif
-}
-
-static int
-wl_columnar_ops_checked_div_int64(int64_t a, int64_t b, int64_t *out)
-{
-    if (b == 0 || (a == INT64_MIN && b == -1))
-        return ERANGE;
-    *out = a / b;
-    return 0;
-}
-
-static int
-wl_columnar_ops_checked_mod_int64(int64_t a, int64_t b, int64_t *out)
-{
-    if (b == 0 || (a == INT64_MIN && b == -1))
-        return ERANGE;
-    *out = a % b;
-    return 0;
-}
-
-static int
-wl_columnar_ops_checked_shl_int64(int64_t a, int64_t b, int64_t *out)
-{
-    if (b < 0 || b >= 64)
-        return ERANGE;
-    *out = (int64_t)((uint64_t)a << (uint32_t)b);
-    return 0;
-}
-
-static int
-wl_columnar_ops_checked_shr_int64(int64_t a, int64_t b, int64_t *out)
-{
-    if (b < 0 || b >= 64)
-        return ERANGE;
-    *out = a >> (uint32_t)b;
-    return 0;
-}
-
 /*
  * col_eval_expr_run:
  * Core postfix expression evaluator. Runs the bytecode against a row and
@@ -574,7 +457,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_ADD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_add_int64(a, b, &v) != 0)
+            if (wl_columnar_arithmetic_checked_add_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -582,7 +465,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SUB: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_sub_int64(a, b, &v) != 0)
+            if (wl_columnar_arithmetic_checked_sub_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -590,7 +473,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_MUL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_mul_int64(a, b, &v) != 0)
+            if (wl_columnar_arithmetic_checked_mul_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -598,7 +481,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_DIV: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_div_int64(a, b, &v) != 0)
+            if (wl_columnar_arithmetic_checked_div_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -606,7 +489,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_MOD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_mod_int64(a, b, &v) != 0)
+            if (wl_columnar_arithmetic_checked_mod_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -634,7 +517,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SHL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_shl_int64(a, b, &v) != 0)
+            if (wl_columnar_arithmetic_checked_shl_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -642,7 +525,7 @@ col_eval_expr_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SHR: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_shr_int64(a, b, &v) != 0)
+            if (wl_columnar_arithmetic_checked_shr_int64(a, b, &v) != 0)
                 goto bad;
             filt_push(&s, v);
             break;
@@ -1346,7 +1229,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_ADD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_add_int64(a, b, &v) != 0) {
+            if (wl_columnar_arithmetic_checked_add_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -1356,7 +1239,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SUB: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_sub_int64(a, b, &v) != 0) {
+            if (wl_columnar_arithmetic_checked_sub_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -1366,7 +1249,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_MUL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_mul_int64(a, b, &v) != 0) {
+            if (wl_columnar_arithmetic_checked_mul_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -1376,7 +1259,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_DIV: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_div_int64(a, b, &v) != 0) {
+            if (wl_columnar_arithmetic_checked_div_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -1386,7 +1269,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_MOD: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_mod_int64(a, b, &v) != 0) {
+            if (wl_columnar_arithmetic_checked_mod_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -1416,7 +1299,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SHL: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_shl_int64(a, b, &v) != 0) {
+            if (wl_columnar_arithmetic_checked_shl_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -1426,7 +1309,7 @@ col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
         case WL_PLAN_EXPR_ARITH_SHR: {
             int64_t b = filt_pop(&s), a = filt_pop(&s);
             int64_t v;
-            if (wl_columnar_ops_checked_shr_int64(a, b, &v) != 0) {
+            if (wl_columnar_arithmetic_checked_shr_int64(a, b, &v) != 0) {
                 *out_val = 0;
                 return 1;
             }
@@ -6939,7 +6822,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
             case WIRELOG_AGG_SUM:
             {
                 int64_t next;
-                if (wl_columnar_ops_checked_add_int64(cur, agg_val,
+                if (wl_columnar_arithmetic_checked_add_int64(cur, agg_val,
                     &next) != 0) {
                     col_row_buf_release(&row_rb);
                     col_expr_compiled_free(agg_ce);

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -90,7 +90,7 @@ wirelog_lockfree_queue_src = files('util/lockfree_queue.c', )
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
 wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
-                           'columnar/ops.c', 'columnar/eval_stack.c', 'columnar/eval.c',
+                           'columnar/ops.c', 'columnar/arithmetic.c', 'columnar/eval_stack.c', 'columnar/eval.c',
                            'columnar/arrangement.c', 'columnar/frontier.c', 'columnar/frontier_epoch.c',
                            'columnar/mobius.c', 'columnar/session.c', 'columnar/session_hash.c',
                            'columnar/delta_pool.c', 'columnar/lftj.c',


### PR DESCRIPTION
## Summary
- extract checked int64 arithmetic helpers from `wirelog/columnar/ops.c` into `wirelog/columnar/arithmetic.c`
- keep internal naming and wire the source into library, test, and benchmark builds
- preserve expression evaluation and reduce overflow semantics

Closes the next atomic unit of #1087.

## Validation
- `meson compile -C builddir`
- focused expression/arithmetic/filter/hash/string tests
- `meson test -C builddir --suite abi --print-errorlogs`
- `scripts/ci/check-text-size.sh builddir/libwirelog.so`

Related: #1087
