### PR TITLE
refactor(columnar): extract compiled expression evaluator

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -30,6 +30,7 @@ bench_backend_src = files(
   subdir_wirelog / 'columnar/cache.c',
   subdir_wirelog / 'columnar/ops.c',
   subdir_wirelog / 'columnar/arithmetic.c',
+  subdir_wirelog / 'columnar/expr.c',
   subdir_wirelog / 'columnar/eval_stack.c',
   subdir_wirelog / 'columnar/eval.c',
   subdir_wirelog / 'columnar/arrangement.c',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -816,6 +816,7 @@ backend_src = files(
   '../wirelog/columnar/cache.c',
   '../wirelog/columnar/ops.c',
   '../wirelog/columnar/arithmetic.c',
+  '../wirelog/columnar/expr.c',
   '../wirelog/columnar/eval_stack.c',
   '../wirelog/columnar/eval.c',
   '../wirelog/columnar/arrangement.c',

--- a/wirelog/columnar/expr.c
+++ b/wirelog/columnar/expr.c
@@ -1,0 +1,462 @@
+/*
+ * columnar/expr.c - Compiled columnar expression evaluator
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#include "columnar/internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    int64_t vals[COL_FILTER_STACK];
+    uint32_t top;
+} expr_stack_t;
+
+static inline void
+expr_push(expr_stack_t *s, int64_t v)
+{
+    if (s->top < COL_FILTER_STACK)
+        s->vals[s->top++] = v;
+}
+static inline int64_t
+expr_pop(expr_stack_t *s)
+{
+    return s->top != 0 ? s->vals[--s->top] : 0;
+}
+
+/*
+ * wl_columnar_expr_parse_var_col:
+ * Parse a WL_PLAN_EXPR_VAR token at buf[i] (not yet consumed; i points at
+ * the opcode byte itself).  If successful, advance *pos past the full token
+ * and store the extracted column index in *col_out.
+ * Returns true on success, false on malformed bytecode.
+ *
+ * VAR encoding: [0x01][name_len:u16 LE][name:u8*name_len]
+ * where name is "colN" (N is the decimal column index).
+ */
+bool
+wl_columnar_expr_parse_var_col(const uint8_t *buf, uint32_t size, uint32_t *pos,
+    uint32_t *col_out)
+{
+    uint32_t i = *pos;
+    if (i >= size || buf[i] != (uint8_t)WL_PLAN_EXPR_VAR)
+        return false;
+    i++; /* consume opcode */
+    if (i + 2 > size)
+        return false;
+    uint16_t nlen;
+    memcpy(&nlen, buf + i, 2);
+    i += 2;
+    if (i + nlen > size)
+        return false;
+    /* name must start with "col" followed by decimal digits */
+    if (nlen < 4 || buf[i] != 'c' || buf[i + 1] != 'o' || buf[i + 2] != 'l')
+        return false;
+    /* parse digits */
+    uint32_t col = 0;
+    uint32_t digits = nlen - 3;
+    if (digits == 0 || digits > 9) /* no digits or overflow guard */
+        return false;
+    for (uint32_t d = 0; d < digits; d++) {
+        uint8_t ch = buf[i + 3 + d];
+        if (ch < '0' || ch > '9')
+            return false;
+        col = col * 10 + (uint32_t)(ch - '0');
+    }
+    i += nlen;
+    *pos = i;
+    *col_out = col;
+    return true;
+}
+
+/* ======================================================================== */
+/* Pre-compiled expression evaluator                                        */
+/* ======================================================================== */
+
+/*
+ * expr_instr_t: single decoded instruction.
+ *
+ * op   — WL_PLAN_EXPR_* opcode.
+ * iarg — for WL_PLAN_EXPR_VAR: column index pre-parsed from "colN".
+ * larg — for WL_PLAN_EXPR_CONST_INT / BOOL: immediate int64 value.
+ * Operator opcodes (arithmetic, comparison, aggregate) leave iarg/larg at 0.
+ */
+typedef struct {
+    uint8_t op;
+    uint32_t iarg;
+    int64_t larg;
+} expr_instr_t;
+
+struct wl_columnar_expr_compiled {
+    expr_instr_t *instrs;
+    uint32_t ninstr;
+    /* Issue #966: fixed for the whole expression, so it is resolved once here
+     * rather than passed to the per-row evaluator.  Borrowed -- wl_plan_t
+     * documents its intern as outliving the plan, which outlives any compiled
+     * expression.  NULL is legal and matches the interpreter's own NULL-intern
+     * fallbacks. */
+    const wl_intern_t *intern;
+};
+
+void
+wl_columnar_expr_compiled_free(wl_columnar_expr_compiled_t *c)
+{
+    if (c) {
+        free(c->instrs);
+        free(c);
+    }
+}
+
+/*
+ * wl_columnar_expr_compile:
+ * Walk the bytecode buffer once and produce a pre-compiled instruction array.
+ * Variable names ("colN") are resolved to column indices here so that the
+ * per-row evaluator (wl_columnar_expr_eval_compiled) never calls strtol.
+ *
+ * Returns NULL if the expression contains unsupported opcodes (CONST_STR,
+ * hash/crypto functions) or if allocation fails.  Callers fall back to
+ * col_eval_expr_run in that case.
+ */
+wl_columnar_expr_compiled_t *
+wl_columnar_expr_compile(const uint8_t *buf, uint32_t size,
+    const wl_intern_t *intern)
+{
+    if (!buf || size == 0)
+        return NULL;
+
+    /* Pass 1: validate bytecode and count instructions. */
+    uint32_t ninstr = 0;
+    uint32_t i = 0;
+    while (i < size) {
+        uint8_t tag = buf[i];
+        switch ((wl_plan_expr_tag_t)tag) {
+        case WL_PLAN_EXPR_VAR: {
+            uint32_t pos = i;
+            uint32_t col = 0;
+            if (!wl_columnar_expr_parse_var_col(buf, size, &pos, &col))
+                return NULL;
+            i = pos;
+            break;
+        }
+        case WL_PLAN_EXPR_CONST_INT:
+            i++;
+            if (i + 8 > size)
+                return NULL;
+            i += 8;
+            break;
+        case WL_PLAN_EXPR_BOOL:
+            i++;
+            if (i + 1 > size)
+                return NULL;
+            i++;
+            break;
+        case WL_PLAN_EXPR_CONST_STR:
+            return NULL; /* unsupported: fall back to slow path */
+        /* Arithmetic operators (no payload) */
+        case WL_PLAN_EXPR_ARITH_ADD:
+        case WL_PLAN_EXPR_ARITH_SUB:
+        case WL_PLAN_EXPR_ARITH_MUL:
+        case WL_PLAN_EXPR_ARITH_DIV:
+        case WL_PLAN_EXPR_ARITH_MOD:
+        case WL_PLAN_EXPR_ARITH_BAND:
+        case WL_PLAN_EXPR_ARITH_BOR:
+        case WL_PLAN_EXPR_ARITH_BXOR:
+        case WL_PLAN_EXPR_ARITH_BNOT:
+        case WL_PLAN_EXPR_ARITH_SHL:
+        case WL_PLAN_EXPR_ARITH_SHR:
+        /* Comparison operators (no payload) */
+        case WL_PLAN_EXPR_CMP_EQ:
+        case WL_PLAN_EXPR_CMP_NEQ:
+        case WL_PLAN_EXPR_CMP_LT:
+        case WL_PLAN_EXPR_CMP_GT:
+        case WL_PLAN_EXPR_CMP_LTE:
+        case WL_PLAN_EXPR_CMP_GTE:
+        /* Issue #966: string-ordering comparisons (no payload).  #962 made
+         * these correct by emitting them; they were absent here, so any
+         * predicate containing one fell to `default: return NULL` and the
+         * whole expression was demoted to the interpreter.  Measured at
+         * ~66 ns/cmp of the ~77 ns regression -- the demotion, not the
+         * strcmp. */
+        case WL_PLAN_EXPR_CMP_STR_EQ:
+        case WL_PLAN_EXPR_CMP_STR_NEQ:
+        case WL_PLAN_EXPR_CMP_STR_LT:
+        case WL_PLAN_EXPR_CMP_STR_GT:
+        case WL_PLAN_EXPR_CMP_STR_LTE:
+        case WL_PLAN_EXPR_CMP_STR_GTE:
+        /* Aggregate operators (no payload) */
+        case WL_PLAN_EXPR_AGG_COUNT:
+        case WL_PLAN_EXPR_AGG_SUM:
+        case WL_PLAN_EXPR_AGG_MIN:
+        case WL_PLAN_EXPR_AGG_MAX:
+            i++;
+            break;
+        default:
+            return NULL; /* hash/UUID/crypto: unsupported, use slow path */
+        }
+        ninstr++;
+    }
+
+    if (ninstr == 0)
+        return NULL;
+
+    wl_columnar_expr_compiled_t *c =
+        (wl_columnar_expr_compiled_t *)malloc(
+        sizeof(wl_columnar_expr_compiled_t));
+    if (!c)
+        return NULL;
+    c->instrs =
+        (expr_instr_t *)malloc(ninstr * sizeof(expr_instr_t));
+    if (!c->instrs) {
+        free(c);
+        return NULL;
+    }
+    c->ninstr = ninstr;
+    c->intern = intern;
+
+    /* Pass 2: fill instruction array. */
+    uint32_t j = 0;
+    i = 0;
+    while (i < size && j < ninstr) {
+        expr_instr_t *instr = &c->instrs[j++];
+        instr->op = buf[i];
+        instr->iarg = 0;
+        instr->larg = 0;
+        switch ((wl_plan_expr_tag_t)buf[i]) {
+        case WL_PLAN_EXPR_VAR: {
+            uint32_t pos = i;
+            wl_columnar_expr_parse_var_col(buf, size, &pos, &instr->iarg);
+            i = pos;
+            break;
+        }
+        case WL_PLAN_EXPR_CONST_INT:
+            i++; /* skip opcode */
+            memcpy(&instr->larg, buf + i, 8);
+            i += 8;
+            break;
+        case WL_PLAN_EXPR_BOOL:
+            i++; /* skip opcode */
+            instr->larg = buf[i++] ? 1 : 0;
+            break;
+        default:
+            i++; /* operator: consume opcode byte only */
+            break;
+        }
+    }
+    return c;
+}
+
+/*
+ * wl_columnar_expr_eval_compiled:
+ * Fast postfix evaluator using a pre-compiled instruction array.
+ * VAR instructions use pre-parsed column indices — no strtol per row.
+ * Returns 0 on success with result in *out_val, non-zero on error.
+ */
+/*
+ * Issue #966: string comparison on the compiled path.
+ *
+ * The six CMP_STR arms below are transcribed from the interpreter's block in
+ * col_eval_expr rather than paraphrased, because their fallbacks are NOT
+ * symmetric and the asymmetry is load-bearing: when either reverse lookup
+ * fails, EQ/NEQ fall back to comparing the raw ids, while LT/GT/LTE/GTE
+ * yield false.  Collapsing the two families into one shape would be a silent
+ * wrong-answer change, and #962's sweep found no program in this tree that
+ * compares symbols -- nothing existing would catch it.
+ */
+int
+wl_columnar_expr_eval_compiled(const wl_columnar_expr_compiled_t *c,
+    const int64_t *row,
+    uint32_t ncols, int64_t *out_val)
+{
+    const wl_intern_t *intern = c->intern;
+    expr_stack_t s;
+    s.top = 0;
+    for (uint32_t k = 0; k < c->ninstr; k++) {
+        const expr_instr_t *in = &c->instrs[k];
+        switch ((wl_plan_expr_tag_t)in->op) {
+        case WL_PLAN_EXPR_VAR:
+            expr_push(&s, (in->iarg < ncols) ? row[in->iarg] : 0);
+            break;
+        case WL_PLAN_EXPR_CMP_STR_EQ: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            expr_push(&s,
+                (sa && sb) ? (strcmp(sa, sb) == 0 ? 1 : 0) : (a == b ? 1 : 0));
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_STR_NEQ: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            expr_push(&s,
+                (sa && sb) ? (strcmp(sa, sb) != 0 ? 1 : 0) : (a != b ? 1 : 0));
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_STR_LT: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            expr_push(&s, (sa && sb) ? (strcmp(sa, sb) < 0 ? 1 : 0) : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_STR_GT: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            expr_push(&s, (sa && sb) ? (strcmp(sa, sb) > 0 ? 1 : 0) : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_STR_LTE: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            expr_push(&s, (sa && sb) ? (strcmp(sa, sb) <= 0 ? 1 : 0) : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_STR_GTE: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
+            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
+            expr_push(&s, (sa && sb) ? (strcmp(sa, sb) >= 0 ? 1 : 0) : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CONST_INT:
+        case WL_PLAN_EXPR_BOOL:
+            expr_push(&s, in->larg);
+            break;
+        case WL_PLAN_EXPR_ARITH_ADD: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            int64_t v;
+            if (wl_columnar_arithmetic_checked_add_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            expr_push(&s, v);
+            break;
+        }
+        case WL_PLAN_EXPR_ARITH_SUB: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            int64_t v;
+            if (wl_columnar_arithmetic_checked_sub_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            expr_push(&s, v);
+            break;
+        }
+        case WL_PLAN_EXPR_ARITH_MUL: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            int64_t v;
+            if (wl_columnar_arithmetic_checked_mul_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            expr_push(&s, v);
+            break;
+        }
+        case WL_PLAN_EXPR_ARITH_DIV: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            int64_t v;
+            if (wl_columnar_arithmetic_checked_div_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            expr_push(&s, v);
+            break;
+        }
+        case WL_PLAN_EXPR_ARITH_MOD: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            int64_t v;
+            if (wl_columnar_arithmetic_checked_mod_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            expr_push(&s, v);
+            break;
+        }
+        case WL_PLAN_EXPR_ARITH_BAND: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            expr_push(&s, a & b);
+            break;
+        }
+        case WL_PLAN_EXPR_ARITH_BOR: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            expr_push(&s, a | b);
+            break;
+        }
+        case WL_PLAN_EXPR_ARITH_BXOR: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            expr_push(&s, a ^ b);
+            break;
+        }
+        case WL_PLAN_EXPR_ARITH_BNOT: {
+            int64_t a = expr_pop(&s);
+            expr_push(&s, ~a);
+            break;
+        }
+        case WL_PLAN_EXPR_ARITH_SHL: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            int64_t v;
+            if (wl_columnar_arithmetic_checked_shl_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            expr_push(&s, v);
+            break;
+        }
+        case WL_PLAN_EXPR_ARITH_SHR: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            int64_t v;
+            if (wl_columnar_arithmetic_checked_shr_int64(a, b, &v) != 0) {
+                *out_val = 0;
+                return 1;
+            }
+            expr_push(&s, v);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_EQ: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            expr_push(&s, a == b ? 1 : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_NEQ: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            expr_push(&s, a != b ? 1 : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_LT: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            expr_push(&s, a < b ? 1 : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_GT: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            expr_push(&s, a > b ? 1 : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_LTE: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            expr_push(&s, a <= b ? 1 : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_CMP_GTE: {
+            int64_t b = expr_pop(&s), a = expr_pop(&s);
+            expr_push(&s, a >= b ? 1 : 0);
+            break;
+        }
+        case WL_PLAN_EXPR_AGG_COUNT:
+        case WL_PLAN_EXPR_AGG_SUM:
+        case WL_PLAN_EXPR_AGG_MIN:
+        case WL_PLAN_EXPR_AGG_MAX:
+            break;
+        default:
+            *out_val = 0;
+            return 1;
+        }
+    }
+    *out_val = s.top > 0 ? s.vals[s.top - 1] : 0;
+    return 0;
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1601,6 +1601,20 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
 /* ======================================================================== */
 
 /* Checked expression arithmetic (columnar/arithmetic.c). */
+typedef struct wl_columnar_expr_compiled wl_columnar_expr_compiled_t;
+
+wl_columnar_expr_compiled_t *
+wl_columnar_expr_compile(const uint8_t *buf, uint32_t size,
+    const wl_intern_t *intern);
+void
+wl_columnar_expr_compiled_free(wl_columnar_expr_compiled_t *c);
+int
+wl_columnar_expr_eval_compiled(const wl_columnar_expr_compiled_t *c,
+    const int64_t *row, uint32_t ncols, int64_t *out_val);
+bool
+wl_columnar_expr_parse_var_col(const uint8_t *buf, uint32_t size,
+    uint32_t *pos, uint32_t *col_out);
+
 int
 wl_columnar_arithmetic_checked_add_int64(int64_t a, int64_t b, int64_t *out);
 int

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -971,396 +971,6 @@ col_eval_expr_i64(const uint8_t *buf, uint32_t size, const int64_t *row,
 }
 
 /* ======================================================================== */
-/* Pre-compiled expression evaluator                                        */
-/* ======================================================================== */
-
-/* Forward declaration: parse_var_col is defined in the FILTER section. */
-static bool parse_var_col(const uint8_t *buf, uint32_t size, uint32_t *pos,
-    uint32_t *col_out);
-
-/*
- * col_expr_instr_t: single decoded instruction.
- *
- * op   — WL_PLAN_EXPR_* opcode.
- * iarg — for WL_PLAN_EXPR_VAR: column index pre-parsed from "colN".
- * larg — for WL_PLAN_EXPR_CONST_INT / BOOL: immediate int64 value.
- * Operator opcodes (arithmetic, comparison, aggregate) leave iarg/larg at 0.
- */
-typedef struct {
-    uint8_t op;
-    uint32_t iarg;
-    int64_t larg;
-} col_expr_instr_t;
-
-typedef struct {
-    col_expr_instr_t *instrs;
-    uint32_t ninstr;
-    /* Issue #966: fixed for the whole expression, so it is resolved once here
-     * rather than passed to the per-row evaluator.  Borrowed -- wl_plan_t
-     * documents its intern as outliving the plan, which outlives any compiled
-     * expression.  NULL is legal and matches the interpreter's own NULL-intern
-     * fallbacks. */
-    const wl_intern_t *intern;
-} col_expr_compiled_t;
-
-static void
-col_expr_compiled_free(col_expr_compiled_t *c)
-{
-    if (c) {
-        free(c->instrs);
-        free(c);
-    }
-}
-
-/*
- * col_expr_compile:
- * Walk the bytecode buffer once and produce a pre-compiled instruction array.
- * Variable names ("colN") are resolved to column indices here so that the
- * per-row evaluator (col_eval_expr_compiled) never calls strtol.
- *
- * Returns NULL if the expression contains unsupported opcodes (CONST_STR,
- * hash/crypto functions) or if allocation fails.  Callers fall back to
- * col_eval_expr_run in that case.
- */
-static col_expr_compiled_t *
-col_expr_compile(const uint8_t *buf, uint32_t size, const wl_intern_t *intern)
-{
-    if (!buf || size == 0)
-        return NULL;
-
-    /* Pass 1: validate bytecode and count instructions. */
-    uint32_t ninstr = 0;
-    uint32_t i = 0;
-    while (i < size) {
-        uint8_t tag = buf[i];
-        switch ((wl_plan_expr_tag_t)tag) {
-        case WL_PLAN_EXPR_VAR: {
-            uint32_t pos = i;
-            uint32_t col = 0;
-            if (!parse_var_col(buf, size, &pos, &col))
-                return NULL;
-            i = pos;
-            break;
-        }
-        case WL_PLAN_EXPR_CONST_INT:
-            i++;
-            if (i + 8 > size)
-                return NULL;
-            i += 8;
-            break;
-        case WL_PLAN_EXPR_BOOL:
-            i++;
-            if (i + 1 > size)
-                return NULL;
-            i++;
-            break;
-        case WL_PLAN_EXPR_CONST_STR:
-            return NULL; /* unsupported: fall back to slow path */
-        /* Arithmetic operators (no payload) */
-        case WL_PLAN_EXPR_ARITH_ADD:
-        case WL_PLAN_EXPR_ARITH_SUB:
-        case WL_PLAN_EXPR_ARITH_MUL:
-        case WL_PLAN_EXPR_ARITH_DIV:
-        case WL_PLAN_EXPR_ARITH_MOD:
-        case WL_PLAN_EXPR_ARITH_BAND:
-        case WL_PLAN_EXPR_ARITH_BOR:
-        case WL_PLAN_EXPR_ARITH_BXOR:
-        case WL_PLAN_EXPR_ARITH_BNOT:
-        case WL_PLAN_EXPR_ARITH_SHL:
-        case WL_PLAN_EXPR_ARITH_SHR:
-        /* Comparison operators (no payload) */
-        case WL_PLAN_EXPR_CMP_EQ:
-        case WL_PLAN_EXPR_CMP_NEQ:
-        case WL_PLAN_EXPR_CMP_LT:
-        case WL_PLAN_EXPR_CMP_GT:
-        case WL_PLAN_EXPR_CMP_LTE:
-        case WL_PLAN_EXPR_CMP_GTE:
-        /* Issue #966: string-ordering comparisons (no payload).  #962 made
-         * these correct by emitting them; they were absent here, so any
-         * predicate containing one fell to `default: return NULL` and the
-         * whole expression was demoted to the interpreter.  Measured at
-         * ~66 ns/cmp of the ~77 ns regression -- the demotion, not the
-         * strcmp. */
-        case WL_PLAN_EXPR_CMP_STR_EQ:
-        case WL_PLAN_EXPR_CMP_STR_NEQ:
-        case WL_PLAN_EXPR_CMP_STR_LT:
-        case WL_PLAN_EXPR_CMP_STR_GT:
-        case WL_PLAN_EXPR_CMP_STR_LTE:
-        case WL_PLAN_EXPR_CMP_STR_GTE:
-        /* Aggregate operators (no payload) */
-        case WL_PLAN_EXPR_AGG_COUNT:
-        case WL_PLAN_EXPR_AGG_SUM:
-        case WL_PLAN_EXPR_AGG_MIN:
-        case WL_PLAN_EXPR_AGG_MAX:
-            i++;
-            break;
-        default:
-            return NULL; /* hash/UUID/crypto: unsupported, use slow path */
-        }
-        ninstr++;
-    }
-
-    if (ninstr == 0)
-        return NULL;
-
-    col_expr_compiled_t *c =
-        (col_expr_compiled_t *)malloc(sizeof(col_expr_compiled_t));
-    if (!c)
-        return NULL;
-    c->instrs =
-        (col_expr_instr_t *)malloc(ninstr * sizeof(col_expr_instr_t));
-    if (!c->instrs) {
-        free(c);
-        return NULL;
-    }
-    c->ninstr = ninstr;
-    c->intern = intern;
-
-    /* Pass 2: fill instruction array. */
-    uint32_t j = 0;
-    i = 0;
-    while (i < size && j < ninstr) {
-        col_expr_instr_t *instr = &c->instrs[j++];
-        instr->op = buf[i];
-        instr->iarg = 0;
-        instr->larg = 0;
-        switch ((wl_plan_expr_tag_t)buf[i]) {
-        case WL_PLAN_EXPR_VAR: {
-            uint32_t pos = i;
-            parse_var_col(buf, size, &pos, &instr->iarg);
-            i = pos;
-            break;
-        }
-        case WL_PLAN_EXPR_CONST_INT:
-            i++; /* skip opcode */
-            memcpy(&instr->larg, buf + i, 8);
-            i += 8;
-            break;
-        case WL_PLAN_EXPR_BOOL:
-            i++; /* skip opcode */
-            instr->larg = buf[i++] ? 1 : 0;
-            break;
-        default:
-            i++; /* operator: consume opcode byte only */
-            break;
-        }
-    }
-    return c;
-}
-
-/*
- * col_eval_expr_compiled:
- * Fast postfix evaluator using a pre-compiled instruction array.
- * VAR instructions use pre-parsed column indices — no strtol per row.
- * Returns 0 on success with result in *out_val, non-zero on error.
- */
-/*
- * Issue #966: string comparison on the compiled path.
- *
- * The six CMP_STR arms below are transcribed from the interpreter's block in
- * col_eval_expr rather than paraphrased, because their fallbacks are NOT
- * symmetric and the asymmetry is load-bearing: when either reverse lookup
- * fails, EQ/NEQ fall back to comparing the raw ids, while LT/GT/LTE/GTE
- * yield false.  Collapsing the two families into one shape would be a silent
- * wrong-answer change, and #962's sweep found no program in this tree that
- * compares symbols -- nothing existing would catch it.
- */
-static int
-col_eval_expr_compiled(const col_expr_compiled_t *c, const int64_t *row,
-    uint32_t ncols, int64_t *out_val)
-{
-    const wl_intern_t *intern = c->intern;
-    filt_stack_t s;
-    s.top = 0;
-    for (uint32_t k = 0; k < c->ninstr; k++) {
-        const col_expr_instr_t *in = &c->instrs[k];
-        switch ((wl_plan_expr_tag_t)in->op) {
-        case WL_PLAN_EXPR_VAR:
-            filt_push(&s, (in->iarg < ncols) ? row[in->iarg] : 0);
-            break;
-        case WL_PLAN_EXPR_CMP_STR_EQ: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
-            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
-            filt_push(&s,
-                (sa && sb) ? (strcmp(sa, sb) == 0 ? 1 : 0) : (a == b ? 1 : 0));
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_STR_NEQ: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
-            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
-            filt_push(&s,
-                (sa && sb) ? (strcmp(sa, sb) != 0 ? 1 : 0) : (a != b ? 1 : 0));
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_STR_LT: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
-            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
-            filt_push(&s, (sa && sb) ? (strcmp(sa, sb) < 0 ? 1 : 0) : 0);
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_STR_GT: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
-            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
-            filt_push(&s, (sa && sb) ? (strcmp(sa, sb) > 0 ? 1 : 0) : 0);
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_STR_LTE: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
-            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
-            filt_push(&s, (sa && sb) ? (strcmp(sa, sb) <= 0 ? 1 : 0) : 0);
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_STR_GTE: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            const char *sa = intern ? wl_intern_reverse(intern, a) : NULL;
-            const char *sb = intern ? wl_intern_reverse(intern, b) : NULL;
-            filt_push(&s, (sa && sb) ? (strcmp(sa, sb) >= 0 ? 1 : 0) : 0);
-            break;
-        }
-        case WL_PLAN_EXPR_CONST_INT:
-        case WL_PLAN_EXPR_BOOL:
-            filt_push(&s, in->larg);
-            break;
-        case WL_PLAN_EXPR_ARITH_ADD: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            int64_t v;
-            if (wl_columnar_arithmetic_checked_add_int64(a, b, &v) != 0) {
-                *out_val = 0;
-                return 1;
-            }
-            filt_push(&s, v);
-            break;
-        }
-        case WL_PLAN_EXPR_ARITH_SUB: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            int64_t v;
-            if (wl_columnar_arithmetic_checked_sub_int64(a, b, &v) != 0) {
-                *out_val = 0;
-                return 1;
-            }
-            filt_push(&s, v);
-            break;
-        }
-        case WL_PLAN_EXPR_ARITH_MUL: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            int64_t v;
-            if (wl_columnar_arithmetic_checked_mul_int64(a, b, &v) != 0) {
-                *out_val = 0;
-                return 1;
-            }
-            filt_push(&s, v);
-            break;
-        }
-        case WL_PLAN_EXPR_ARITH_DIV: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            int64_t v;
-            if (wl_columnar_arithmetic_checked_div_int64(a, b, &v) != 0) {
-                *out_val = 0;
-                return 1;
-            }
-            filt_push(&s, v);
-            break;
-        }
-        case WL_PLAN_EXPR_ARITH_MOD: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            int64_t v;
-            if (wl_columnar_arithmetic_checked_mod_int64(a, b, &v) != 0) {
-                *out_val = 0;
-                return 1;
-            }
-            filt_push(&s, v);
-            break;
-        }
-        case WL_PLAN_EXPR_ARITH_BAND: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a & b);
-            break;
-        }
-        case WL_PLAN_EXPR_ARITH_BOR: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a | b);
-            break;
-        }
-        case WL_PLAN_EXPR_ARITH_BXOR: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a ^ b);
-            break;
-        }
-        case WL_PLAN_EXPR_ARITH_BNOT: {
-            int64_t a = filt_pop(&s);
-            filt_push(&s, ~a);
-            break;
-        }
-        case WL_PLAN_EXPR_ARITH_SHL: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            int64_t v;
-            if (wl_columnar_arithmetic_checked_shl_int64(a, b, &v) != 0) {
-                *out_val = 0;
-                return 1;
-            }
-            filt_push(&s, v);
-            break;
-        }
-        case WL_PLAN_EXPR_ARITH_SHR: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            int64_t v;
-            if (wl_columnar_arithmetic_checked_shr_int64(a, b, &v) != 0) {
-                *out_val = 0;
-                return 1;
-            }
-            filt_push(&s, v);
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_EQ: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a == b ? 1 : 0);
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_NEQ: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a != b ? 1 : 0);
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_LT: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a < b ? 1 : 0);
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_GT: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a > b ? 1 : 0);
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_LTE: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a <= b ? 1 : 0);
-            break;
-        }
-        case WL_PLAN_EXPR_CMP_GTE: {
-            int64_t b = filt_pop(&s), a = filt_pop(&s);
-            filt_push(&s, a >= b ? 1 : 0);
-            break;
-        }
-        case WL_PLAN_EXPR_AGG_COUNT:
-        case WL_PLAN_EXPR_AGG_SUM:
-        case WL_PLAN_EXPR_AGG_MIN:
-        case WL_PLAN_EXPR_AGG_MAX:
-            break;
-        default:
-            *out_val = 0;
-            return 1;
-        }
-    }
-    *out_val = s.top > 0 ? s.vals[s.top - 1] : 0;
-    return 0;
-}
-
-/* ======================================================================== */
 /* Operator Implementations                                                  */
 /* ======================================================================== */
 
@@ -1518,16 +1128,16 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
     }
 
     /* Pre-compile map expressions once to avoid per-row strtol. */
-    col_expr_compiled_t **ce_map = NULL;
+    wl_columnar_expr_compiled_t **ce_map = NULL;
     uint32_t ce_map_count = 0;
     if (op->map_exprs && op->map_expr_count > 0) {
-        ce_map = (col_expr_compiled_t **)calloc(pc,
-                sizeof(col_expr_compiled_t *));
+        ce_map = (wl_columnar_expr_compiled_t **)calloc(pc,
+                sizeof(wl_columnar_expr_compiled_t *));
         if (ce_map) {
             ce_map_count = (op->map_expr_count < pc) ? op->map_expr_count : pc;
             for (uint32_t c = 0; c < ce_map_count; c++) {
                 if (op->map_exprs[c].data && op->map_exprs[c].size > 0)
-                    ce_map[c] = col_expr_compile(op->map_exprs[c].data,
+                    ce_map[c] = wl_columnar_expr_compile(op->map_exprs[c].data,
                             op->map_exprs[c].size,
                             sess ? sess->intern : NULL);
             }
@@ -1540,7 +1150,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
     if (!col_row_buf_init(&row_rb, e.rel->ncols)) {
         if (ce_map) {
             for (uint32_t c = 0; c < ce_map_count; c++)
-                col_expr_compiled_free(ce_map[c]);
+                wl_columnar_expr_compiled_free(ce_map[c]);
             free(ce_map);
         }
         free(tmp);
@@ -1558,11 +1168,12 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                 && op->map_exprs[c].size > 0) {
                 if (ce_map && c < ce_map_count && ce_map[c]) {
                     int64_t val = 0;
-                    if (col_eval_expr_compiled(ce_map[c], row, e.rel->ncols,
+                    if (wl_columnar_expr_eval_compiled(ce_map[c], row,
+                        e.rel->ncols,
                         &val) != 0) {
                         if (ce_map) {
                             for (uint32_t i = 0; i < ce_map_count; i++)
-                                col_expr_compiled_free(ce_map[i]);
+                                wl_columnar_expr_compiled_free(ce_map[i]);
                             free(ce_map);
                         }
                         col_row_buf_release(&row_rb);
@@ -1580,7 +1191,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                         &val, sess->intern) != 0) {
                         if (ce_map) {
                             for (uint32_t i = 0; i < ce_map_count; i++)
-                                col_expr_compiled_free(ce_map[i]);
+                                wl_columnar_expr_compiled_free(ce_map[i]);
                             free(ce_map);
                         }
                         col_row_buf_release(&row_rb);
@@ -1601,7 +1212,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         if (rc != 0) {
             if (ce_map) {
                 for (uint32_t c = 0; c < ce_map_count; c++)
-                    col_expr_compiled_free(ce_map[c]);
+                    wl_columnar_expr_compiled_free(ce_map[c]);
                 free(ce_map);
             }
             col_row_buf_release(&row_rb);
@@ -1615,7 +1226,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
 
     if (ce_map) {
         for (uint32_t c = 0; c < ce_map_count; c++)
-            col_expr_compiled_free(ce_map[c]);
+            wl_columnar_expr_compiled_free(ce_map[c]);
         free(ce_map);
     }
     col_row_buf_release(&row_rb);
@@ -1646,51 +1257,6 @@ typedef struct {
 } simple_filter_cmp_t;
 
 /*
- * parse_var_col:
- * Parse a WL_PLAN_EXPR_VAR token at buf[i] (not yet consumed; i points at
- * the opcode byte itself).  If successful, advance *pos past the full token
- * and store the extracted column index in *col_out.
- * Returns true on success, false on malformed bytecode.
- *
- * VAR encoding: [0x01][name_len:u16 LE][name:u8*name_len]
- * where name is "colN" (N is the decimal column index).
- */
-static bool
-parse_var_col(const uint8_t *buf, uint32_t size, uint32_t *pos,
-    uint32_t *col_out)
-{
-    uint32_t i = *pos;
-    if (i >= size || buf[i] != (uint8_t)WL_PLAN_EXPR_VAR)
-        return false;
-    i++; /* consume opcode */
-    if (i + 2 > size)
-        return false;
-    uint16_t nlen;
-    memcpy(&nlen, buf + i, 2);
-    i += 2;
-    if (i + nlen > size)
-        return false;
-    /* name must start with "col" followed by decimal digits */
-    if (nlen < 4 || buf[i] != 'c' || buf[i + 1] != 'o' || buf[i + 2] != 'l')
-        return false;
-    /* parse digits */
-    uint32_t col = 0;
-    uint32_t digits = nlen - 3;
-    if (digits == 0 || digits > 9) /* no digits or overflow guard */
-        return false;
-    for (uint32_t d = 0; d < digits; d++) {
-        uint8_t ch = buf[i + 3 + d];
-        if (ch < '0' || ch > '9')
-            return false;
-        col = col * 10 + (uint32_t)(ch - '0');
-    }
-    i += nlen;
-    *pos = i;
-    *col_out = col;
-    return true;
-}
-
-/*
  * filter_is_simple_cmp:
  * Inspect the bytecode buffer and return true if it encodes exactly one
  * of:
@@ -1713,7 +1279,7 @@ filter_is_simple_cmp(const uint8_t *buf, uint32_t size,
 
     /* --- First operand: must be VAR("colA") --- */
     uint32_t col_a = 0;
-    if (!parse_var_col(buf, size, &pos, &col_a))
+    if (!wl_columnar_expr_parse_var_col(buf, size, &pos, &col_a))
         return false;
 
     /* --- Second operand: CONST_INT or VAR("colB") --- */
@@ -1729,7 +1295,7 @@ filter_is_simple_cmp(const uint8_t *buf, uint32_t size,
         pos += 8;
         b_is_const = true;
     } else if (pos < size && buf[pos] == (uint8_t)WL_PLAN_EXPR_VAR) {
-        if (!parse_var_col(buf, size, &pos, &col_b))
+        if (!wl_columnar_expr_parse_var_col(buf, size, &pos, &col_b))
             return false;
         b_is_const = false;
     } else {
@@ -2366,15 +1932,15 @@ col_op_filter(const wl_plan_op_t *op, eval_stack_t *stack,
     }
 
     /* Slow path: pre-compile expression once, then evaluate per row. */
-    col_expr_compiled_t *ce =
+    wl_columnar_expr_compiled_t *ce =
         (buf && bsz > 0)
-        ? col_expr_compile(buf, bsz, sess ? sess->intern : NULL)
+        ? wl_columnar_expr_compile(buf, bsz, sess ? sess->intern : NULL)
         : NULL;
 
     /* Row scratch, hoisted out of the loop (#1000). */
     col_row_buf_t row_rb;
     if (!col_row_buf_init(&row_rb, e.rel->ncols)) {
-        col_expr_compiled_free(ce);
+        wl_columnar_expr_compiled_free(ce);
         col_rel_destroy(out);
         if (e.owned)
             col_rel_destroy(e.rel);
@@ -2389,7 +1955,8 @@ col_op_filter(const wl_plan_op_t *op, eval_stack_t *stack,
             pass = 1;
         } else if (ce) {
             int64_t val = 0;
-            pass = (col_eval_expr_compiled(ce, row, e.rel->ncols, &val) == 0)
+            pass = (wl_columnar_expr_eval_compiled(ce, row, e.rel->ncols,
+                &val) == 0)
                        ? (val != 0 ? 1 : 0)
                        : 0; /* on error: reject row */
         } else {
@@ -2400,7 +1967,7 @@ col_op_filter(const wl_plan_op_t *op, eval_stack_t *stack,
             int rc = col_rel_append_row(out, row);
             if (rc != 0) {
                 col_row_buf_release(&row_rb);
-                col_expr_compiled_free(ce);
+                wl_columnar_expr_compiled_free(ce);
                 col_rel_destroy(out);
                 if (e.owned)
                     col_rel_destroy(e.rel);
@@ -2409,7 +1976,7 @@ col_op_filter(const wl_plan_op_t *op, eval_stack_t *stack,
         }
     }
     col_row_buf_release(&row_rb);
-    col_expr_compiled_free(ce);
+    wl_columnar_expr_compiled_free(ce);
 
     if (e.owned)
         col_rel_destroy(e.rel);
@@ -2473,13 +2040,15 @@ fill_filtered_rel(const uint8_t *buf, uint32_t bsz, col_rel_t *rel,
     }
 
     /* Slow path: compile once, evaluate per row */
-    col_expr_compiled_t *ce = col_expr_compile(buf, bsz, intern);
+    wl_columnar_expr_compiled_t *ce = wl_columnar_expr_compile(buf, bsz,
+            intern);
     for (uint32_t r = 0; r < rel->nrows; r++) {
         col_rel_row_copy_out(rel, r, row_buf);
         int pass;
         if (ce) {
             int64_t val = 0;
-            pass = (col_eval_expr_compiled(ce, row_buf, rel->ncols, &val) == 0)
+            pass = (wl_columnar_expr_eval_compiled(ce, row_buf, rel->ncols,
+                &val) == 0)
                        ? (val != 0 ? 1 : 0)
                        : 0; /* fail-closed: reject row on eval error */
         } else {
@@ -2490,12 +2059,12 @@ fill_filtered_rel(const uint8_t *buf, uint32_t bsz, col_rel_t *rel,
         }
         if (pass && col_rel_append_row(out, row_buf) != 0) {
             col_row_buf_release(&rb);
-            col_expr_compiled_free(ce);
+            wl_columnar_expr_compiled_free(ce);
             return ENOMEM;
         }
     }
     col_row_buf_release(&rb);
-    col_expr_compiled_free(ce);
+    wl_columnar_expr_compiled_free(ce);
     return 0;
 }
 
@@ -6697,15 +6266,15 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
         return ENOMEM;
     }
 
-    col_expr_compiled_t *agg_ce = NULL;
+    wl_columnar_expr_compiled_t *agg_ce = NULL;
     if (op->agg_expr.data && op->agg_expr.size > 0)
-        agg_ce = col_expr_compile(op->agg_expr.data, op->agg_expr.size,
+        agg_ce = wl_columnar_expr_compile(op->agg_expr.data, op->agg_expr.size,
                 sess ? sess->intern : NULL);
 
     /* Row scratch, hoisted out of the loop (#1000). */
     col_row_buf_t row_rb;
     if (!col_row_buf_init(&row_rb, in->ncols)) {
-        col_expr_compiled_free(agg_ce);
+        wl_columnar_expr_compiled_free(agg_ce);
         free(tmp);
         col_rel_destroy(out);
         if (e.owned)
@@ -6723,7 +6292,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
         map_cap <<= 1;
     if ((uint64_t)map_cap < desired) {
         col_row_buf_release(&row_rb);
-        col_expr_compiled_free(agg_ce);
+        wl_columnar_expr_compiled_free(agg_ce);
         free(tmp);
         col_rel_destroy(out);
         if (e.owned)
@@ -6734,7 +6303,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
             sizeof(*groups));
     if (!groups) {
         col_row_buf_release(&row_rb);
-        col_expr_compiled_free(agg_ce);
+        wl_columnar_expr_compiled_free(agg_ce);
         free(tmp);
         col_rel_destroy(out);
         if (e.owned)
@@ -6753,11 +6322,12 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
             && op->agg_expr.data && op->agg_expr.size > 0) {
             if (agg_ce) {
                 int64_t val = 0;
-                if (col_eval_expr_compiled(agg_ce, row, in->ncols, &val) == 0)
+                if (wl_columnar_expr_eval_compiled(agg_ce, row, in->ncols,
+                    &val) == 0)
                     agg_val = val;
                 else {
                     col_row_buf_release(&row_rb);
-                    col_expr_compiled_free(agg_ce);
+                    wl_columnar_expr_compiled_free(agg_ce);
                     free(groups);
                     free(tmp);
                     col_rel_destroy(out);
@@ -6772,7 +6342,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                     agg_val = val;
                 } else {
                     col_row_buf_release(&row_rb);
-                    col_expr_compiled_free(agg_ce);
+                    wl_columnar_expr_compiled_free(agg_ce);
                     free(groups);
                     free(tmp);
                     col_rel_destroy(out);
@@ -6825,7 +6395,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                 if (wl_columnar_arithmetic_checked_add_int64(cur, agg_val,
                     &next) != 0) {
                     col_row_buf_release(&row_rb);
-                    col_expr_compiled_free(agg_ce);
+                    wl_columnar_expr_compiled_free(agg_ce);
                     free(groups);
                     free(tmp);
                     col_rel_destroy(out);
@@ -6860,7 +6430,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
             int rc = col_rel_append_row(out, tmp);
             if (rc != 0) {
                 col_row_buf_release(&row_rb);
-                col_expr_compiled_free(agg_ce);
+                wl_columnar_expr_compiled_free(agg_ce);
                 free(groups);
                 free(tmp);
                 col_rel_destroy(out);
@@ -6874,7 +6444,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
     }
 
     col_row_buf_release(&row_rb);
-    col_expr_compiled_free(agg_ce);
+    wl_columnar_expr_compiled_free(agg_ce);
     free(groups);
     free(tmp);
     if (e.owned)

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -90,7 +90,7 @@ wirelog_lockfree_queue_src = files('util/lockfree_queue.c', )
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
 wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
-                           'columnar/ops.c', 'columnar/arithmetic.c', 'columnar/eval_stack.c', 'columnar/eval.c',
+                           'columnar/ops.c', 'columnar/arithmetic.c', 'columnar/expr.c', 'columnar/eval_stack.c', 'columnar/eval.c',
                            'columnar/arrangement.c', 'columnar/frontier.c', 'columnar/frontier_epoch.c',
                            'columnar/mobius.c', 'columnar/session.c', 'columnar/session_hash.c',
                            'columnar/delta_pool.c', 'columnar/lftj.c',


### PR DESCRIPTION
## Summary
- extract the compiled expression evaluator and variable-column parser from `wirelog/columnar/ops.c` into `wirelog/columnar/expr.c`
- expose only internal `wl_columnar_expr_*` seams through `columnar/internal.h`
- wire the new translation unit into library, test, and benchmark builds

Stacked on #1092; continuation of #1087.

## Validation
- `meson compile -C builddir`
- 11 expression/filter/hash/CRC/string/join focused tests
- `meson test -C builddir --suite abi --print-errorlogs` (33/33)
- `scripts/ci/check-text-size.sh builddir/libwirelog.so`
