### PR TITLE
fix(columnar): clear remaining ops clang-tidy diagnostics

### DIFF
--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -219,7 +219,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         if (ce_map) {
             for (uint32_t c = 0; c < ce_map_count; c++)
                 wl_columnar_expr_compiled_free(ce_map[c]);
-            free(ce_map);
+            free((void *)ce_map);
         }
         free(tmp);
         col_rel_destroy(out);
@@ -242,7 +242,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                         if (ce_map) {
                             for (uint32_t i = 0; i < ce_map_count; i++)
                                 wl_columnar_expr_compiled_free(ce_map[i]);
-                            free(ce_map);
+                            free((void *)ce_map);
                         }
                         col_row_buf_release(&row_rb);
                         free(tmp);
@@ -260,7 +260,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                         if (ce_map) {
                             for (uint32_t i = 0; i < ce_map_count; i++)
                                 wl_columnar_expr_compiled_free(ce_map[i]);
-                            free(ce_map);
+                            free((void *)ce_map);
                         }
                         col_row_buf_release(&row_rb);
                         free(tmp);
@@ -281,7 +281,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
             if (ce_map) {
                 for (uint32_t c = 0; c < ce_map_count; c++)
                     wl_columnar_expr_compiled_free(ce_map[c]);
-                free(ce_map);
+                free((void *)ce_map);
             }
             col_row_buf_release(&row_rb);
             free(tmp);
@@ -295,7 +295,7 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
     if (ce_map) {
         for (uint32_t c = 0; c < ce_map_count; c++)
             wl_columnar_expr_compiled_free(ce_map[c]);
-        free(ce_map);
+        free((void *)ce_map);
     }
     col_row_buf_release(&row_rb);
     free(tmp);

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -724,8 +724,10 @@ col_op_lftj(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
                         if (!(prev_sarr
                             && prev_sarr->indexed_rows
                             == inputs[j].nrows
-                            && prev_sarr->nrows > 0))
+                            && prev_sarr->nrows > 0)) {
                             free((void *)inputs[j].data);
+                            inputs[j].data = NULL;
+                        }
                     }
                 }
                 rc = ENOMEM;


### PR DESCRIPTION
Resolves the remaining clang-tidy diagnostics in` wirelog/columnar/ops.c` after #1087 module extraction. Makes all ce_map frees explicit void-pointer conversions.

Related: #1077 #1087
Validation: focused columnar tests, text-size budget, and ABI suite.