### PR TITLE
fix: clear clang-tidy findings in partition.c, relation.c and exec_plan_gen.c

### DIFF
--- a/tests/test_partition.c
+++ b/tests/test_partition.c
@@ -579,6 +579,85 @@ test_merge_roundtrip(void)
     return 0;
 }
 
+/*
+ * Regression test (Issue #1078): pins the empty-output representation that
+ * both partition.c null-dereference invariants rely on.  This is a property
+ * of partition/merge OUTPUTS only, not of 0-row relations in general: a
+ * freshly built col_rel_new_auto() source has nrows == 0 but columns
+ * != NULL, because col_rel_set_schema() allocates COL_REL_INIT_CAP.  The
+ * two output paths deliberately drop that allocation instead --
+ * col_rel_partition_by_key() frees it for every partition with
+ * counts[w] == 0 (partition.c:148-152), and col_rel_merge_partitions()
+ * frees it when total_rows == 0 (partition.c:287-291) -- so both keep the
+ * schema (ncols) while carrying columns == NULL.
+ *
+ * Characterization test, not TDD: it passes before and after the change,
+ * because #1078 fixed only false-positive analyzer diagnostics and altered
+ * no behavior.  Its job is to fail loudly if either output representation
+ * is ever changed, which would invalidate the recorded invariants.
+ */
+static int
+test_merge_all_empty_partitions(void)
+{
+    TEST("merge of all-empty partitions yields empty relation");
+
+    col_rel_t *src = col_rel_new_auto("empty", 3);
+    if (!src) {
+        FAIL("alloc");
+        return 1;
+    }
+
+    col_rel_t *parts[4] = { NULL };
+    uint32_t key_cols[] = { 0 };
+    int rc = col_rel_partition_by_key(src, key_cols, 1, 4, parts);
+    if (rc != 0) {
+        FAIL("partition returned error");
+        col_rel_destroy(src);
+        return 1;
+    }
+
+    /* Site 1 invariant: every empty partition drops its columns array. */
+    for (uint32_t w = 0; w < 4; w++) {
+        if (parts[w]->nrows != 0 || parts[w]->columns != NULL) {
+            FAIL("empty partition did not free its columns allocation");
+            destroy_parts(parts, 4);
+            col_rel_destroy(src);
+            return 1;
+        }
+    }
+
+    col_rel_t *merged = NULL;
+    rc = col_rel_merge_partitions(parts, 4, &merged);
+    if (rc != 0) {
+        FAIL("merge returned error");
+        destroy_parts(parts, 4);
+        col_rel_destroy(src);
+        return 1;
+    }
+
+    /* Site 2 invariant: the merged output likewise carries columns == NULL. */
+    const char *err = NULL;
+    if (!merged)
+        err = "merge produced NULL relation";
+    else if (merged->nrows != 0)
+        err = "merged nrows != 0";
+    else if (merged->ncols != 3)
+        err = "merged ncols != 3";
+    else if (merged->columns != NULL)
+        err = "empty merged relation kept a columns allocation";
+
+    col_rel_destroy(merged);
+    destroy_parts(parts, 4);
+    col_rel_destroy(src);
+
+    if (err) {
+        FAIL(err);
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
 static int
 test_partition_balance(void)
 {
@@ -1283,6 +1362,7 @@ main(void)
     test_schema_propagation();
     test_multi_column_key();
     test_merge_roundtrip();
+    test_merge_all_empty_partitions();
     test_partition_balance();
     test_skewed_keys();
     test_preserves_all_columns();

--- a/wirelog/columnar/partition.c
+++ b/wirelog/columnar/partition.c
@@ -172,6 +172,13 @@ col_rel_partition_by_key(const col_rel_t *src,
         memset(offsets, 0, num_workers * sizeof(uint32_t));
         for (uint32_t i = 0; i < nrows; i++) {
             uint32_t p = part_idx[i];
+            /* out_parts[p]->columns is NULL only for counts[p] == 0,
+             * where the default allocation was freed above.  part_idx[i]
+             * comes from the same pure row_partition_colmajor() computation
+             * that incremented counts[p] in pass 1, so every p reached here has
+             * counts[p] > 0 and a live columns array.  The analyzer cannot
+             * relate the counts array to part_idx across the two passes. */
+            // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
             out_parts[p]->columns[c][offsets[p]] = src->columns[c][i];
             offsets[p]++;
         }
@@ -286,7 +293,12 @@ col_rel_merge_partitions(col_rel_t **parts, uint32_t num_workers,
     /* Copy partition data contiguously per column */
     uint32_t row_offset = 0;
     for (uint32_t w = 0; w < num_workers; w++) {
-        if (parts[w]->nrows > 0) {
+        /* merged->columns is NULL only for total_rows == 0, which implies
+         * every parts[w]->nrows == 0 because total_rows is their exact
+         * sum.  The analyzer cannot derive "sum == 0 => each term == 0",
+         * so the total_rows guard is spelled out.  It costs nothing:
+         * merged->nrows is set to total_rows == 0 either way. */
+        if (total_rows > 0 && parts[w]->nrows > 0) {
             for (uint32_t c = 0; c < ncols; c++)
                 memcpy(merged->columns[c] + row_offset,
                     parts[w]->columns[c],

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -124,13 +124,13 @@ col_rel_free_contents(col_rel_t *r)
                 if (!r->col_shared[c])
                     free(r->columns[c]);
             }
-            free(r->columns);
+            free((void *)r->columns);
         } else {
             col_columns_free(r->columns, r->ncols);
         }
     } else {
         /* Arena owns column buffers; only free the columns array itself */
-        free(r->columns);
+        free((void *)r->columns);
     }
     free(r->col_shared);
     col_columns_free(r->retract_backup_columns, r->ncols);
@@ -140,7 +140,7 @@ col_rel_free_contents(col_rel_t *r)
     if (r->col_names) {
         for (uint32_t i = 0; i < r->ncols; i++)
             free(r->col_names[i]);
-        free(r->col_names);
+        free((void *)r->col_names);
     }
     free(r->dedup_slots);
     free(r->compound_arity_map);
@@ -204,7 +204,7 @@ col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names)
             if (!r->col_names[i]) {
                 for (uint32_t j = 0; j < i; j++)
                     free(r->col_names[j]);
-                free(r->col_names);
+                free((void *)r->col_names);
                 col_columns_free(r->columns, ncols);
                 r->col_names = NULL;
                 r->columns = NULL;
@@ -458,7 +458,7 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
                 memcpy(new_cols[c], r->columns[c],
                     sizeof(int64_t) * r->nrows);
             /* Don't free arena columns; just free the columns array */
-            free(r->columns);
+            free((void *)r->columns);
             r->columns = new_cols;
             r->arena_owned = false;
         } else if (r->columns) {
@@ -544,10 +544,10 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
                 }
                 if (!ok) {
                     /* Arena alloc failed; don't free arena columns */
-                    free(new_cols);
+                    free((void *)new_cols);
                     return ENOMEM;
                 }
-                free(dst->columns); /* free old columns array only */
+                free((void *)dst->columns); /* free old columns array only */
                 dst->columns = new_cols;
             } else {
                 /* Fallback to heap if arena unavailable */
@@ -558,7 +558,7 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
                 for (uint32_t c = 0; c < dst->ncols; c++)
                     memcpy(new_cols[c], dst->columns[c],
                         sizeof(int64_t) * dst->nrows);
-                free(dst->columns);
+                free((void *)dst->columns);
                 dst->columns = new_cols;
                 dst->arena_owned = false;
             }
@@ -624,14 +624,14 @@ col_rel_compact(col_rel_t *r)
                     if (!r->col_shared[c])
                         free(r->columns[c]);
                 }
-                free(r->columns);
+                free((void *)r->columns);
                 free(r->col_shared);
                 r->col_shared = NULL;
             } else {
                 col_columns_free(r->columns, r->ncols);
             }
         } else {
-            free(r->columns);
+            free((void *)r->columns);
         }
         r->columns = NULL;
         r->capacity = 0;
@@ -672,7 +672,7 @@ col_rel_compact(col_rel_t *r)
             for (uint32_t c = 0; c < r->ncols; c++)
                 memcpy(new_cols[c], r->columns[c],
                     (size_t)r->nrows * sizeof(int64_t));
-            free(r->columns);
+            free((void *)r->columns);
             r->columns = new_cols;
             r->arena_owned = false;
         } else {
@@ -976,7 +976,7 @@ col_rel_pool_new_auto(delta_pool_t *pool, wl_arena_t *arena,
                     r->arena_owned = true;
                 } else {
                     /* Arena alloc failed for some columns; free and retry */
-                    free(r->columns);
+                    free((void *)r->columns);
                     r->columns = NULL;
                 }
             }

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -69,7 +69,11 @@ make_delta_name(const char *name)
     char *d = (char *)malloc(len + 4); /* "$d$" (3) + name + NUL */
     if (!d)
         return NULL;
-    memcpy(d, "$d$", 3);
+    /* Copy the literal's NUL too: after this memcpy the buffer must be
+     * NUL-terminated (bugprone-not-null-terminated-result).  Do not write
+     * sizeof("$d$") - 1 -- that silences the check without terminating.
+     * d[3] is overwritten by the next memcpy. */
+    memcpy(d, "$d$", sizeof("$d$"));
     memcpy(d + 3, name, len + 1);
     return d;
 }
@@ -2101,7 +2105,7 @@ clone_lftj_opaque(const wl_plan_op_t *src, wl_plan_op_t *dst)
     dm->rel_names = (char **)malloc(sm->k * sizeof(char *));
     dm->key_cols = (uint32_t *)malloc(sm->k * sizeof(uint32_t));
     if (!dm->rel_names || !dm->key_cols) {
-        free(dm->rel_names);
+        free((void *)dm->rel_names);
         free(dm->key_cols);
         free(dm);
         return -1;
@@ -2112,7 +2116,7 @@ clone_lftj_opaque(const wl_plan_op_t *src, wl_plan_op_t *dst)
         if (!dm->rel_names[i]) {
             for (uint32_t j = 0; j < i; j++)
                 free(dm->rel_names[j]);
-            free(dm->rel_names);
+            free((void *)dm->rel_names);
             free(dm->key_cols);
             free(dm);
             return -1;
@@ -2214,7 +2218,7 @@ clone_plan_op(const wl_plan_op_t *src, wl_plan_op_t *dst)
             if (!lk[i]) {
                 for (uint32_t j = 0; j < i; j++)
                     free(lk[j]);
-                free(lk);
+                free((void *)lk);
                 return -1;
             }
         }
@@ -2229,7 +2233,7 @@ clone_plan_op(const wl_plan_op_t *src, wl_plan_op_t *dst)
             if (!rk[i]) {
                 for (uint32_t j = 0; j < i; j++)
                     free(rk[j]);
-                free(rk);
+                free((void *)rk);
                 return -1;
             }
         }
@@ -2454,7 +2458,7 @@ free_k_fusion_opaque(wl_plan_op_t *op)
                 free(meta->k_ops[d]);
             }
         }
-        free(meta->k_ops);
+        free((void *)meta->k_ops);
     }
     free(meta->k_op_counts);
     free(meta);
@@ -2474,7 +2478,7 @@ free_lftj_opaque(wl_plan_op_t *op)
     if (meta->rel_names) {
         for (uint32_t i = 0; i < meta->k; i++)
             free(meta->rel_names[i]);
-        free(meta->rel_names);
+        free((void *)meta->rel_names);
     }
     free(meta->key_cols);
     free(meta);
@@ -2532,7 +2536,7 @@ expand_multiway_k_fusion(const wl_plan_op_t *ops, uint32_t op_count,
     meta->k_ops = (wl_plan_op_t **)calloc(k, sizeof(wl_plan_op_t *));
     meta->k_op_counts = (uint32_t *)calloc(k, sizeof(uint32_t));
     if (!meta->k_ops || !meta->k_op_counts) {
-        free(meta->k_ops);
+        free((void *)meta->k_ops);
         free(meta->k_op_counts);
         free(meta);
         free(result);
@@ -2669,7 +2673,7 @@ fail:
             free(meta->k_ops[d]);
         }
     }
-    free(meta->k_ops);
+    free((void *)meta->k_ops);
     free(meta->k_op_counts);
     free(meta);
     free(result);
@@ -2730,7 +2734,7 @@ rewrite_multiway_delta(wl_plan_t *plan)
             }
             free(dpos);
         }
-        free(idb_names);
+        free((void *)idb_names);
     }
 }
 
@@ -2812,7 +2816,7 @@ build_lftj_op(const wl_plan_op_t *ops, uint32_t start, uint32_t len,
     meta->rel_names = (char **)malloc(k * sizeof(char *));
     meta->key_cols = (uint32_t *)malloc(k * sizeof(uint32_t));
     if (!meta->rel_names || !meta->key_cols) {
-        free(meta->rel_names);
+        free((void *)meta->rel_names);
         free(meta->key_cols);
         free(meta);
         return -1;
@@ -2821,7 +2825,7 @@ build_lftj_op(const wl_plan_op_t *ops, uint32_t start, uint32_t len,
     /* Validate "colN" format before parsing */
     if (strncmp(lk0, "col", 3) != 0 || !isdigit((unsigned char)lk0[3])
         || strncmp(rk0, "col", 3) != 0 || !isdigit((unsigned char)rk0[3])) {
-        free(meta->rel_names);
+        free((void *)meta->rel_names);
         free(meta->key_cols);
         free(meta);
         return -1;
@@ -2842,7 +2846,7 @@ build_lftj_op(const wl_plan_op_t *ops, uint32_t start, uint32_t len,
         if (!meta->rel_names[q]) {
             for (uint32_t p = 0; p < k; p++)
                 free(meta->rel_names[p]);
-            free(meta->rel_names);
+            free((void *)meta->rel_names);
             free(meta->key_cols);
             free(meta);
             return -1;
@@ -3250,7 +3254,7 @@ plan_refsets_free(wl_plan_refset_t *refs, uint32_t count)
     for (uint32_t r = 0; r < count; r++) {
         for (uint32_t i = 0; i < refs[r].count; i++)
             free(refs[r].names[i]);
-        free(refs[r].names);
+        free((void *)refs[r].names);
     }
     free(refs);
 }
@@ -3456,7 +3460,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
         free(edb_decl_w);
         free(edb_graph_idx);
         free(edb_has_graph);
-        free(edb_rels);
+        free((void *)edb_rels);
         free(plan);
         return -1;
     }
@@ -3483,8 +3487,8 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
         if (!is_idb || has_facts) {
             if (edb_count >= edb_cap) {
                 edb_cap *= 2;
-                char **tmp
-                    = (char **)realloc(edb_rels, edb_cap * sizeof(char *));
+                char **tmp = (char **)realloc((void *)edb_rels,
+                        edb_cap * sizeof(char *));
                 if (!tmp) {
                     for (uint32_t j = 0; j < edb_count; j++)
                         free(edb_rels[j]);


### PR DESCRIPTION
Closes #1078. Closes #1079. Closes #1080.

Three independent per-file clang-tidy cleanups for the 0.60.0 release, bundled because they touch disjoint files and were developed in parallel. Each commit is self-contained and independently revertable.

| Commit | Issue | File | Findings |
|---|---|---|---|
| `1542312` | #1078 | `wirelog/columnar/partition.c` | 2 x `clang-analyzer-core.NullDereference` |
| `2e7a2ea` | #1079 | `wirelog/columnar/relation.c` | 12 x `bugprone-multi-level-implicit-pointer-conversion` |
| `eef6b85` | #1080 | `wirelog/exec_plan_gen.c` | 15 x same, plus 1 x `bugprone-not-null-terminated-result` |

`.clang-tidy` is untouched and no check is weakened. Exactly one `NOLINT` is added, in `partition.c`, scoped to a single line and a single named check.

## What changed

**#1078 — `partition.c`.** Both diagnostics are false positives; there is no reachable path that dereferences a NULL `columns` array.

- The pass-3 scatter store carries a `NOLINTNEXTLINE` and a comment recording the invariant: `out_parts[p]->columns` is NULL only when `counts[p] == 0`, and `part_idx[i]` comes from the same pure `row_partition_colmajor()` computation that incremented `counts[p]` in pass 1, so every `p` reached at the store has `counts[p] > 0`. The analyzer cannot relate the two passes. A runtime guard was rejected deliberately: `out_parts[w]->nrows` is set to `counts[w]` unconditionally, so skipping a store would emit a partition with `nrows > 0` and `columns == NULL` — a NULL-deref landmine for consumers in `columnar/eval.c` and `columnar/diff.c`. An `assert()` also silences the check but is not free here, because release builds ship with `b_ndebug=false`.
- The merge copy loop is fixed with real code rather than a suppression: `total_rows > 0 &&` is added to the condition. It is redundant at runtime and cannot change behaviour, since `merged->nrows` is set to `total_rows` either way.
- Adds `test_merge_all_empty_partitions()`, pinning the empty-output representation both invariants depend on. Neither fact had coverage. It is a characterization test and passes before and after.

**#1079 — `relation.c`.** Explicit `(void *)` at twelve `free()` sites. This is the convention already used inside this module at `columnar/internal.h:149` and `:164` on the same `int64_t **` type, established by `cb0eb32` and applied at scale by `f1d2a2c` and `a385b85`. Every site was checked individually for ownership: each frees only the pointer array while the pointees are handled correctly elsewhere.

**#1080 — `exec_plan_gen.c`.** Explicit `(void *)` at fifteen sites, plus the line-72 `memcpy`, where the finding is a false positive — the following `memcpy` copies `len + 1` bytes, carrying the name's NUL to the last byte of the allocation. Resolved by copying the literal's terminator rather than by suppression.

Worth flagging for review: `memcpy(d, "$d$", sizeof("$d$") - 1)` is **also** accepted by clang-tidy, because the checker cannot constant-fold a `sizeof` expression and gives up. That variant compiles to assembly byte-identical to the defect this PR fixes. Replacing the `memcpy` with plain stores has the same property. The comment warns against both by name, since the checker cannot defend this line.

## Validation

Run on this combined branch, not only on the individual branches:

- **clang-tidy** — zero user-code diagnostics for all three files. `partition.c` reports exactly one NOLINT suppression, confirming the merge-loop fix is real code rather than a second suppression. Baselines were re-run through the same harness first to prove it was sensitive rather than mis-pointed.
- **`meson test -C build`** — 278 passed, 0 failed, 11 skipped. The 11 skips are pre-existing environmental gates (perf gates needing the `performance` cpufreq governor, non-release HEAD, absent DOOP datasets).
- **`uncrustify -c uncrustify.cfg --check`** — PASS on all four changed files, and idempotent.
- **editorconfig-checker v3.0.3**, the version pinned in `lint-pr.yml` — clean.
- **Behavioural inertness.** #1079 compiles to byte-identical assembly under both gcc and clang. #1080 differs by 27 assembly lines, fully accounted for: 24 `__LINE__` immediates at the 12 `WL_LOG` call sites below the edit, each shifted by exactly +4, plus a three-line store fusion in `make_delta_name` where `movw` + `movb` become one `movl` writing `"$d$\0"` — one instruction and three bytes fewer.
- #1078 additionally passes under `-fsanitize=address,undefined` with leak detection on.

The four file blobs on this branch are byte-identical to the individually reviewed candidates; the cherry-picks introduced no drift.

## Scope

This does not make the repository clean for these checks, and the commit messages say so. **74 further `bugprone-multi-level-implicit-pointer-conversion` sites remain across 6 files** — `columnar/eval.c` 31, `passes/jpp.c` 28, `ir/ir.c` 8, `columnar/kfusion.c` 4, `parser/ast.c` 2, `columnar/join.c` 1. The last of those, `free(rel->columns)` at `columnar/join.c:184`, is the identical field and type as the sites fixed here, so the columnar module is left visibly inconsistent. Tracked in #1101.

Nothing guards against regression: no workflow invokes clang-tidy, so these files can silently drift back. A ratchet suite is proposed in #1100.

## Follow-ups filed, deliberately not fixed here

- #1100 — clang-tidy ratchet suite over an allowlist of known-clean files
- #1101 — the remaining 74 sites
- #1102 — `exec_plan_gen.c`: a comment that falsely claims `build_lftj_op()` frees the chain's operators, and a real leak on `clone_plan_op()` failure (cleanup runs `o < ni`, skipping the partially built element)
- #1103 — `relation.c`: memory-ledger accounting is asymmetric between free, growth and compaction
- #1104 — `make_delta_name()`: the `"$d$<name>"` invariant has no direct test coverage, which matters more now that the checker is known not to defend it