### PR TITLE
fix: propagate child attachment allocation failures

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -91,6 +91,8 @@ test_ir_exe = executable(
   thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [threads_dep],
+  link_args: host_machine.system() == 'windows' ? [] : ['-Wl,--wrap=realloc'],
+  override_options: ['b_lto=false'],
 )
 
 test_program_exe = executable(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -91,8 +91,8 @@ test_ir_exe = executable(
   thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [threads_dep],
-  link_args: host_machine.system() == 'windows' ? [] : ['-Wl,--wrap=realloc'],
-  override_options: ['b_lto=false'],
+  link_args: host_machine.system() == 'linux' ? ['-Wl,--wrap=realloc'] : [],
+  override_options: host_machine.system() == 'linux' ? ['b_lto=false'] : [],
 )
 
 test_program_exe = executable(

--- a/tests/test_ir.c
+++ b/tests/test_ir.c
@@ -27,6 +27,23 @@
 
 #include "../wirelog/wirelog-ir.h"
 #include "../wirelog/ir/ir.h"
+#include "../wirelog/parser/ast.h"
+
+#ifndef _WIN32
+static bool fail_next_realloc;
+
+void *__real_realloc(void *ptr, size_t size);
+
+void *
+__wrap_realloc(void *ptr, size_t size)
+{
+    if (fail_next_realloc) {
+        fail_next_realloc = false;
+        return NULL;
+    }
+    return __real_realloc(ptr, size);
+}
+#endif
 
 /* ======================================================================== */
 /* Test Helpers                                                             */
@@ -54,6 +71,84 @@ static int tests_failed = 0;
             tests_failed++;             \
             printf(" FAIL: %s\n", msg); \
         } while (0)
+
+static void
+test_child_attach_reports_allocation_failure(void)
+{
+    TEST("Child attachment preserves ownership on allocation failure");
+
+#ifdef _WIN32
+    PASS();
+    return;
+#else
+    wirelog_ir_node_t *node = wl_ir_node_create(WIRELOG_IR_JOIN);
+    wl_ir_expr_t *expr = wl_ir_expr_create(WL_IR_EXPR_ARITH);
+    wl_parser_ast_node_t *ast
+        = wl_parser_ast_node_create(WL_PARSER_AST_NODE_PROGRAM, 1, 1);
+    if (!node || !expr || !ast) {
+        wl_ir_node_free(node);
+        wl_ir_expr_free(expr);
+        wl_parser_ast_node_free(ast);
+        FAIL("failed to create attachment test roots");
+        return;
+    }
+
+    for (int i = 0; i < 4; i++) {
+        if (wl_ir_node_add_child(node, wl_ir_node_create(WIRELOG_IR_SCAN)) != 0
+            || wl_ir_expr_add_child(expr,
+            wl_ir_expr_create(WL_IR_EXPR_VAR)) != 0
+            || wl_parser_ast_node_add_child(ast,
+            wl_parser_ast_node_create(WL_PARSER_AST_NODE_VARIABLE, 1,
+            1)) != 0) {
+            wl_ir_node_free(node);
+            wl_ir_expr_free(expr);
+            wl_parser_ast_node_free(ast);
+            FAIL("failed to populate attachment test roots");
+            return;
+        }
+    }
+
+    wirelog_ir_node_t *node_child = wl_ir_node_create(WIRELOG_IR_SCAN);
+    wl_ir_expr_t *expr_child = wl_ir_expr_create(WL_IR_EXPR_VAR);
+    wl_parser_ast_node_t *ast_child
+        = wl_parser_ast_node_create(WL_PARSER_AST_NODE_VARIABLE, 1, 1);
+    if (!node_child || !expr_child || !ast_child) {
+        wl_ir_node_free(node_child);
+        wl_ir_expr_free(expr_child);
+        wl_parser_ast_node_free(ast_child);
+        wl_ir_node_free(node);
+        wl_ir_expr_free(expr);
+        wl_parser_ast_node_free(ast);
+        FAIL("failed to create unattached children");
+        return;
+    }
+
+    fail_next_realloc = true;
+    int node_result = wl_ir_node_add_child(node, node_child);
+    bool node_preserved = node_result == -1 && node->child_count == 4;
+
+    fail_next_realloc = true;
+    int expr_result = wl_ir_expr_add_child(expr, expr_child);
+    bool expr_preserved = expr_result == -1 && expr->child_count == 4;
+
+    fail_next_realloc = true;
+    int ast_result = wl_parser_ast_node_add_child(ast, ast_child);
+    bool ast_preserved = ast_result == -1 && ast->child_count == 4;
+
+    wl_ir_node_free(node);
+    wl_ir_expr_free(expr);
+    wl_parser_ast_node_free(ast);
+    wl_ir_node_free(node_child);
+    wl_ir_expr_free(expr_child);
+    wl_parser_ast_node_free(ast_child);
+
+    if (!node_preserved || !expr_preserved || !ast_preserved) {
+        FAIL("attachment failure changed parent ownership or child count");
+        return;
+    }
+    PASS();
+#endif
+}
 
 /* ======================================================================== */
 /* IR Node Creation Tests                                                   */
@@ -1044,6 +1139,7 @@ main(void)
     test_expr_string_constant();
     test_expr_bool();
     test_expr_aggregate();
+    test_child_attach_reports_allocation_failure();
 
     /* Public API */
     test_get_child_out_of_bounds();

--- a/tests/test_ir.c
+++ b/tests/test_ir.c
@@ -29,7 +29,7 @@
 #include "../wirelog/ir/ir.h"
 #include "../wirelog/parser/ast.h"
 
-#ifndef _WIN32
+#ifdef __linux__
 static bool fail_next_realloc;
 
 void *__real_realloc(void *ptr, size_t size);
@@ -77,7 +77,7 @@ test_child_attach_reports_allocation_failure(void)
 {
     TEST("Child attachment preserves ownership on allocation failure");
 
-#ifdef _WIN32
+#ifndef __linux__
     PASS();
     return;
 #else

--- a/wirelog/ir/ir.c
+++ b/wirelog/ir/ir.c
@@ -70,11 +70,11 @@ wl_ir_expr_create(wl_ir_expr_type_t type)
     return expr;
 }
 
-void
+int
 wl_ir_expr_add_child(wl_ir_expr_t *parent, wl_ir_expr_t *child)
 {
     if (!parent || !child)
-        return;
+        return -1;
 
     if (parent->child_count >= parent->child_capacity) {
         uint32_t new_cap = parent->child_capacity == 0
@@ -83,12 +83,13 @@ wl_ir_expr_add_child(wl_ir_expr_t *parent, wl_ir_expr_t *child)
         wl_ir_expr_t **new_children = (wl_ir_expr_t **)realloc(
             parent->children, new_cap * sizeof(wl_ir_expr_t *));
         if (!new_children)
-            return;
+            return -1;
         parent->children = new_children;
         parent->child_capacity = new_cap;
     }
 
     parent->children[parent->child_count++] = child;
+    return 0;
 }
 
 void
@@ -145,7 +146,11 @@ wl_ir_expr_clone(const wl_ir_expr_t *expr)
             wl_ir_expr_free(clone);
             return NULL;
         }
-        wl_ir_expr_add_child(clone, child_clone);
+        if (wl_ir_expr_add_child(clone, child_clone) != 0) {
+            wl_ir_expr_free(child_clone);
+            wl_ir_expr_free(clone);
+            return NULL;
+        }
     }
 
     return clone;
@@ -177,11 +182,11 @@ wl_ir_node_set_relation(wirelog_ir_node_t *node, const char *name)
     node->relation_name = strdup_safe(name);
 }
 
-void
+int
 wl_ir_node_add_child(wirelog_ir_node_t *node, wirelog_ir_node_t *child)
 {
     if (!node || !child)
-        return;
+        return -1;
 
     if (node->child_count >= node->child_capacity) {
         uint32_t new_cap = node->child_capacity == 0 ? INITIAL_CHILD_CAPACITY
@@ -189,12 +194,13 @@ wl_ir_node_add_child(wirelog_ir_node_t *node, wirelog_ir_node_t *child)
         wirelog_ir_node_t **new_children = (wirelog_ir_node_t **)realloc(
             node->children, new_cap * sizeof(wirelog_ir_node_t *));
         if (!new_children)
-            return;
+            return -1;
         node->children = new_children;
         node->child_capacity = new_cap;
     }
 
     node->children[node->child_count++] = child;
+    return 0;
 }
 
 void

--- a/wirelog/ir/ir.h
+++ b/wirelog/ir/ir.h
@@ -161,7 +161,10 @@ wirelog_ir_node_t *
 wl_ir_node_create(wirelog_ir_node_type_t type);
 void
 wl_ir_node_set_relation(wirelog_ir_node_t *node, const char *name);
-void
+/* Returns 0 after ownership transfers to @child's parent, or -1 when either
+ * argument is NULL or the child-array growth allocation fails.  On failure,
+ * the caller retains ownership of @child. */
+int
 wl_ir_node_add_child(wirelog_ir_node_t *node, wirelog_ir_node_t *child);
 void
 wl_ir_node_free(wirelog_ir_node_t *node);
@@ -172,7 +175,10 @@ wl_ir_node_free(wirelog_ir_node_t *node);
 
 wl_ir_expr_t *
 wl_ir_expr_create(wl_ir_expr_type_t type);
-void
+/* Returns 0 after ownership transfers to @child's parent, or -1 when either
+ * argument is NULL or the child-array growth allocation fails.  On failure,
+ * the caller retains ownership of @child. */
+int
 wl_ir_expr_add_child(wl_ir_expr_t *parent, wl_ir_expr_t *child);
 void
 wl_ir_expr_free(wl_ir_expr_t *expr);

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -1135,6 +1135,15 @@ wl_ir_program_build_default_stratum(struct wirelog_program *program)
 
 /* ---- Expression Conversion (AST expr -> IR expr) ---- */
 
+static bool
+ir_expr_attach(wl_ir_expr_t *parent, wl_ir_expr_t *child)
+{
+    if (wl_ir_expr_add_child(parent, child) == 0)
+        return true;
+    wl_ir_expr_free(child);
+    return false;
+}
+
 static wl_ir_expr_t *
 convert_expr(const wl_parser_ast_node_t *node)
 {
@@ -1165,8 +1174,12 @@ convert_expr(const wl_parser_ast_node_t *node)
         if (!e)
             return NULL;
         e->arith_op = node->arith_op;
-        for (uint32_t ci = 0; ci < node->child_count; ci++)
-            wl_ir_expr_add_child(e, convert_expr(node->children[ci]));
+        for (uint32_t ci = 0; ci < node->child_count; ci++) {
+            if (!ir_expr_attach(e, convert_expr(node->children[ci]))) {
+                wl_ir_expr_free(e);
+                return NULL;
+            }
+        }
         return e;
     }
     case WL_PARSER_AST_NODE_COMPARISON: {
@@ -1175,8 +1188,11 @@ convert_expr(const wl_parser_ast_node_t *node)
             return NULL;
         e->cmp_op = node->cmp_op;
         if (node->child_count >= 2) {
-            wl_ir_expr_add_child(e, convert_expr(node->children[0]));
-            wl_ir_expr_add_child(e, convert_expr(node->children[1]));
+            if (!ir_expr_attach(e, convert_expr(node->children[0]))
+                || !ir_expr_attach(e, convert_expr(node->children[1]))) {
+                wl_ir_expr_free(e);
+                return NULL;
+            }
         }
         return e;
     }
@@ -1186,7 +1202,10 @@ convert_expr(const wl_parser_ast_node_t *node)
             return NULL;
         e->agg_fn = node->agg_fn;
         if (node->child_count >= 1) {
-            wl_ir_expr_add_child(e, convert_expr(node->children[0]));
+            if (!ir_expr_attach(e, convert_expr(node->children[0]))) {
+                wl_ir_expr_free(e);
+                return NULL;
+            }
         }
         return e;
     }
@@ -1206,7 +1225,10 @@ convert_expr(const wl_parser_ast_node_t *node)
             if (!child) {
                 wl_ir_expr_free(e); return NULL;
             }
-            wl_ir_expr_add_child(e, child);
+            if (!ir_expr_attach(e, child)) {
+                wl_ir_expr_free(e);
+                return NULL;
+            }
         }
         return e;
     }
@@ -1448,7 +1470,10 @@ wrap_false_filter(wirelog_ir_node_t *child)
     }
     expr->bool_value = false;
     filter->filter_expr = expr;
-    wl_ir_node_add_child(filter, child);
+    if (wl_ir_node_add_child(filter, child) != 0) {
+        wl_ir_node_free(filter);
+        return child;
+    }
     return filter;
 }
 
@@ -1479,10 +1504,22 @@ wrap_column_cmp_filter(wirelog_ir_node_t *child, uint32_t left_col,
     char col[32];
     snprintf(col, sizeof(col), "col%u", left_col);
     lhs->var_name = strdup_safe(col);
-    wl_ir_expr_add_child(cmp, lhs);
-    wl_ir_expr_add_child(cmp, (wl_ir_expr_t *)right_expr);
+    if (!ir_expr_attach(cmp, lhs)) {
+        wl_ir_expr_free((wl_ir_expr_t *)right_expr);
+        wl_ir_expr_free(cmp);
+        wl_ir_node_free(filter);
+        return child;
+    }
+    if (!ir_expr_attach(cmp, (wl_ir_expr_t *)right_expr)) {
+        wl_ir_expr_free(cmp);
+        wl_ir_node_free(filter);
+        return child;
+    }
     filter->filter_expr = cmp;
-    wl_ir_node_add_child(filter, child);
+    if (wl_ir_node_add_child(filter, child) != 0) {
+        wl_ir_node_free(filter);
+        return child;
+    }
     return filter;
 }
 
@@ -1522,11 +1559,23 @@ wrap_duplicate_var_filters(wirelog_ir_node_t *child, char **var_names,
                     snprintf(col, sizeof(col), "col%u", j);
                     rhs->var_name = strdup_safe(col);
                 }
-                wl_ir_expr_add_child(cmp, lhs);
-                wl_ir_expr_add_child(cmp, rhs);
+                if (!ir_expr_attach(cmp, lhs)) {
+                    wl_ir_expr_free(rhs);
+                    wl_ir_expr_free(cmp);
+                    wl_ir_node_free(f);
+                    continue;
+                }
+                if (!ir_expr_attach(cmp, rhs)) {
+                    wl_ir_expr_free(cmp);
+                    wl_ir_node_free(f);
+                    continue;
+                }
             }
             f->filter_expr = cmp;
-            wl_ir_node_add_child(f, result);
+            if (wl_ir_node_add_child(f, result) != 0) {
+                wl_ir_node_free(f);
+                continue;
+            }
             result = f;
         }
     }
@@ -2003,8 +2052,20 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
             continue;
         }
 
-        wl_ir_node_add_child(join, result);
-        wl_ir_node_add_child(join, side_scan);
+        if (wl_ir_node_add_child(join, result) != 0) {
+            wl_ir_node_free(join);
+            wl_ir_node_free(side_scan);
+            free_var_names(side_vars, side_vcount);
+            continue;
+        }
+        if (wl_ir_node_add_child(join, side_scan) != 0) {
+            join->children[0] = NULL;
+            join->child_count = 0;
+            wl_ir_node_free(join);
+            wl_ir_node_free(side_scan);
+            free_var_names(side_vars, side_vcount);
+            continue;
+        }
         result = join;
 
         uint32_t combined_count = 0;
@@ -2258,14 +2319,35 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
 
         for (uint32_t i = 1; i < scan_count; i++) {
             wirelog_ir_node_t *join = wl_ir_node_create(WIRELOG_IR_JOIN);
-            if (!join)
+            if (!join) {
+                for (uint32_t j = i; j < scan_count; j++) {
+                    wl_ir_node_free(scans[j]);
+                    scans[j] = NULL;
+                }
                 break;
+            }
 
             setup_join_keys(cur_vars, cur_vcount, scan_vars[i], scan_vcounts[i],
                 join);
 
-            wl_ir_node_add_child(join, current);
-            wl_ir_node_add_child(join, scans[i]);
+            if (wl_ir_node_add_child(join, current) != 0) {
+                wl_ir_node_free(join);
+                for (uint32_t j = i; j < scan_count; j++) {
+                    wl_ir_node_free(scans[j]);
+                    scans[j] = NULL;
+                }
+                break;
+            }
+            if (wl_ir_node_add_child(join, scans[i]) != 0) {
+                join->children[0] = NULL;
+                join->child_count = 0;
+                wl_ir_node_free(join);
+                for (uint32_t j = i; j < scan_count; j++) {
+                    wl_ir_node_free(scans[j]);
+                    scans[j] = NULL;
+                }
+                break;
+            }
 
             uint32_t merged_count;
             char **merged = merge_var_names(cur_vars, cur_vcount, scan_vars[i],
@@ -2285,20 +2367,20 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
 
     for (uint32_t i = 1; i < rule_node->child_count; i++) {
         const wl_parser_ast_node_t *b = rule_node->children[i];
-        /* children[0 .. child_count) is never NULL:
-         * wl_parser_ast_node_add_child() (parser/ast.c) returns without
-         * storing anything when child is NULL, so a NULL child never
-         * consumes a slot and never bumps child_count.  The analyzer infers
-         * nullability here only from the belt-and-braces `if (!b) continue;`
-         * in the Step 1 loop above, which is defensive, not a live case. */
+        /* Parser child attachment rejects NULL children before they reach the
+         * IR conversion boundary.  Keep this guard for malformed ASTs loaded
+         * by internal callers. */
         // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
         if (b->type == WL_PARSER_AST_NODE_COMPARISON && current) {
             wirelog_ir_node_t *f = wl_ir_node_create(WIRELOG_IR_FILTER);
             if (!f)
                 continue;
             f->filter_expr = convert_expr(b);
-            wl_ir_node_add_child(f, current);
-            current = f;
+            if (!f->filter_expr || wl_ir_node_add_child(f, current) != 0) {
+                wl_ir_node_free(f);
+            } else {
+                current = f;
+            }
         } else if (b->type == WL_PARSER_AST_NODE_BOOLEAN) {
             if (!b->bool_value && current) {
                 wirelog_ir_node_t *f = wl_ir_node_create(WIRELOG_IR_FILTER);
@@ -2308,8 +2390,10 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                 if (e)
                     e->bool_value = false;
                 f->filter_expr = e;
-                wl_ir_node_add_child(f, current);
-                current = f;
+                if (wl_ir_node_add_child(f, current) != 0)
+                    wl_ir_node_free(f);
+                else
+                    current = f;
             }
             /* Boolean True -> no-op */
         } else if (b->type == WL_PARSER_AST_NODE_STR_FUNCTION && current) {
@@ -2318,8 +2402,11 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             if (!f)
                 continue;
             f->filter_expr = convert_expr(b);
-            wl_ir_node_add_child(f, current);
-            current = f;
+            if (!f->filter_expr || wl_ir_node_add_child(f, current) != 0) {
+                wl_ir_node_free(f);
+            } else {
+                current = f;
+            }
         }
     }
 
@@ -2401,9 +2488,17 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                 if (aj) {
                     setup_join_keys(cur_vars, cur_vcount, neg_vars, neg_vcount,
                         aj);
-                    wl_ir_node_add_child(aj, current);
-                    wl_ir_node_add_child(aj, neg_scan);
-                    current = aj;
+                    if (wl_ir_node_add_child(aj, current) != 0) {
+                        wl_ir_node_free(aj);
+                        wl_ir_node_free(neg_scan);
+                    } else if (wl_ir_node_add_child(aj, neg_scan) != 0) {
+                        aj->children[0] = NULL;
+                        aj->child_count = 0;
+                        wl_ir_node_free(aj);
+                        wl_ir_node_free(neg_scan);
+                    } else {
+                        current = aj;
+                    }
                 } else {
                     wl_ir_node_free(neg_scan);
                 }
@@ -2486,8 +2581,11 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                 }
             }
 
-            if (current)
-                wl_ir_node_add_child(root, current);
+            if (current && wl_ir_node_add_child(root, current) != 0) {
+                wl_ir_node_free(root);
+                wl_ir_node_free(current);
+                root = NULL;
+            }
         }
     } else {
         root = wl_ir_node_create(WIRELOG_IR_PROJECT);
@@ -2506,8 +2604,11 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                 }
             }
 
-            if (current)
-                wl_ir_node_add_child(root, current);
+            if (current && wl_ir_node_add_child(root, current) != 0) {
+                wl_ir_node_free(root);
+                wl_ir_node_free(current);
+                root = NULL;
+            }
         }
     }
 
@@ -2607,7 +2708,12 @@ wl_ir_program_merge_unions(struct wirelog_program *program)
             for (uint32_t i = 0; i < program->rule_count; i++) {
                 if (program->rules[i].head_relation
                     && strcmp(program->rules[i].head_relation, rel_name) == 0) {
-                    wl_ir_node_add_child(u, program->rules[i].ir_root);
+                    if (wl_ir_node_add_child(u,
+                        program->rules[i].ir_root) != 0) {
+                        u->child_count = 0;
+                        wl_ir_node_free(u);
+                        return -1;
+                    }
                 }
             }
 

--- a/wirelog/parser/ast.c
+++ b/wirelog/parser/ast.c
@@ -39,12 +39,12 @@ wl_parser_ast_node_create(wl_parser_ast_node_type_t type, uint32_t line,
     return node;
 }
 
-void
+int
 wl_parser_ast_node_add_child(wl_parser_ast_node_t *parent,
     wl_parser_ast_node_t *child)
 {
     if (!parent || !child)
-        return;
+        return -1;
 
     if (parent->child_count >= parent->child_capacity) {
         uint32_t new_cap = parent->child_capacity == 0
@@ -53,12 +53,13 @@ wl_parser_ast_node_add_child(wl_parser_ast_node_t *parent,
         wl_parser_ast_node_t **new_children = (wl_parser_ast_node_t **)realloc(
             parent->children, new_cap * sizeof(wl_parser_ast_node_t *));
         if (!new_children)
-            return;
+            return -1;
         parent->children = new_children;
         parent->child_capacity = new_cap;
     }
 
     parent->children[parent->child_count++] = child;
+    return 0;
 }
 
 static char *

--- a/wirelog/parser/ast.h
+++ b/wirelog/parser/ast.h
@@ -122,7 +122,10 @@ wl_parser_ast_node_t *
 wl_parser_ast_node_create(wl_parser_ast_node_type_t type, uint32_t line,
     uint32_t col);
 
-void
+/* Returns 0 after ownership transfers to @child's parent, or -1 when either
+ * argument is NULL or the child-array growth allocation fails.  On failure,
+ * the caller retains ownership of @child. */
+int
 wl_parser_ast_node_add_child(wl_parser_ast_node_t *parent,
     wl_parser_ast_node_t *child);
 

--- a/wirelog/parser/parser.c
+++ b/wirelog/parser/parser.c
@@ -87,6 +87,25 @@ parser_error(wl_parser_t *parser, const char *msg)
         wl_parser_lexer_token_type_str(parser->current.type));
 }
 
+static bool
+parser_add_child(wl_parser_t *parser, wl_parser_ast_node_t *parent,
+    wl_parser_ast_node_t *child)
+{
+    if (wl_parser_ast_node_add_child(parent, child) == 0)
+        return true;
+    wl_parser_ast_node_free(child);
+    parser_error(parser, "out of memory while adding a parser tree child");
+    return false;
+}
+
+#define PARSER_ADD_CHILD_OR_RETURN(parent, child) \
+        do { \
+            if (!parser_add_child(parser, (parent), (child))) { \
+                wl_parser_ast_node_free(parent); \
+                return NULL; \
+            } \
+        } while (0)
+
 /* ======================================================================== */
 /* Token Consumption                                                        */
 /* ======================================================================== */
@@ -370,7 +389,7 @@ parse_string_fn_expr(wl_parser_t *parser)
             wl_parser_ast_node_free(node);
             return NULL;
         }
-        wl_parser_ast_node_add_child(node, arg);
+        PARSER_ADD_CHILD_OR_RETURN(node, arg);
 
         while (parser_match(parser, WL_PARSER_LEXER_TOK_COMMA)) {
             arg = parse_arithmetic_expr(parser);
@@ -378,7 +397,7 @@ parse_string_fn_expr(wl_parser_t *parser)
                 wl_parser_ast_node_free(node);
                 return NULL;
             }
-            wl_parser_ast_node_add_child(node, arg);
+            PARSER_ADD_CHILD_OR_RETURN(node, arg);
         }
     }
 
@@ -483,8 +502,8 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *bin = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         bin->arith_op = op;
-        wl_parser_ast_node_add_child(bin, left_arg);
-        wl_parser_ast_node_add_child(bin, right_arg);
+        PARSER_ADD_CHILD_OR_RETURN(bin, left_arg);
+        PARSER_ADD_CHILD_OR_RETURN(bin, right_arg);
         return bin;
     }
 
@@ -506,7 +525,7 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *unary = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         unary->arith_op = WIRELOG_ARITH_BNOT;
-        wl_parser_ast_node_add_child(unary, arg);
+        PARSER_ADD_CHILD_OR_RETURN(unary, arg);
         return unary;
     }
 
@@ -528,7 +547,7 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *unary = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         unary->arith_op = WIRELOG_ARITH_HASH;
-        wl_parser_ast_node_add_child(unary, arg);
+        PARSER_ADD_CHILD_OR_RETURN(unary, arg);
         return unary;
     }
 
@@ -550,7 +569,7 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *unary = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         unary->arith_op = WIRELOG_ARITH_MD5;
-        wl_parser_ast_node_add_child(unary, arg);
+        PARSER_ADD_CHILD_OR_RETURN(unary, arg);
         return unary;
     }
 
@@ -572,7 +591,7 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *unary = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         unary->arith_op = WIRELOG_ARITH_SHA1;
-        wl_parser_ast_node_add_child(unary, arg);
+        PARSER_ADD_CHILD_OR_RETURN(unary, arg);
         return unary;
     }
 
@@ -594,7 +613,7 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *unary = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         unary->arith_op = WIRELOG_ARITH_SHA256;
-        wl_parser_ast_node_add_child(unary, arg);
+        PARSER_ADD_CHILD_OR_RETURN(unary, arg);
         return unary;
     }
 
@@ -616,7 +635,7 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *unary = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         unary->arith_op = WIRELOG_ARITH_SHA512;
-        wl_parser_ast_node_add_child(unary, arg);
+        PARSER_ADD_CHILD_OR_RETURN(unary, arg);
         return unary;
     }
 
@@ -649,8 +668,8 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *node = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         node->arith_op = WIRELOG_ARITH_HMAC_SHA256;
-        wl_parser_ast_node_add_child(node, msg);
-        wl_parser_ast_node_add_child(node, key);
+        PARSER_ADD_CHILD_OR_RETURN(node, msg);
+        PARSER_ADD_CHILD_OR_RETURN(node, key);
         return node;
     }
 
@@ -672,7 +691,7 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *unary = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         unary->arith_op = WIRELOG_ARITH_CRC32_ETH;
-        wl_parser_ast_node_add_child(unary, arg);
+        PARSER_ADD_CHILD_OR_RETURN(unary, arg);
         return unary;
     }
 
@@ -694,7 +713,7 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *unary = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         unary->arith_op = WIRELOG_ARITH_CRC32_CAST;
-        wl_parser_ast_node_add_child(unary, arg);
+        PARSER_ADD_CHILD_OR_RETURN(unary, arg);
         return unary;
     }
 
@@ -745,8 +764,8 @@ parse_factor(wl_parser_t *parser)
         wl_parser_ast_node_t *node = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         node->arith_op = WIRELOG_ARITH_UUID5;
-        wl_parser_ast_node_add_child(node, ns);
-        wl_parser_ast_node_add_child(node, name);
+        PARSER_ADD_CHILD_OR_RETURN(node, ns);
+        PARSER_ADD_CHILD_OR_RETURN(node, name);
         return node;
     }
 
@@ -829,8 +848,8 @@ parse_arithmetic_expr(wl_parser_t *parser)
         wl_parser_ast_node_t *bin = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
         bin->arith_op = op;
-        wl_parser_ast_node_add_child(bin, left);
-        wl_parser_ast_node_add_child(bin, right);
+        PARSER_ADD_CHILD_OR_RETURN(bin, left);
+        PARSER_ADD_CHILD_OR_RETURN(bin, right);
         left = bin;
     }
 
@@ -890,7 +909,7 @@ parse_aggregate_expr(wl_parser_t *parser)
     wl_parser_ast_node_t *agg
         = wl_parser_ast_node_create(WL_PARSER_AST_NODE_AGGREGATE, line, col);
     agg->agg_fn = fn;
-    wl_parser_ast_node_add_child(agg, expr);
+    PARSER_ADD_CHILD_OR_RETURN(agg, expr);
     return agg;
 }
 
@@ -975,7 +994,7 @@ parse_compound_term(wl_parser_t *parser, uint32_t depth)
         wl_parser_ast_node_free(compound);
         return NULL;
     }
-    wl_parser_ast_node_add_child(compound, arg);
+    PARSER_ADD_CHILD_OR_RETURN(compound, arg);
 
     while (parser_match(parser, WL_PARSER_LEXER_TOK_COMMA)) {
         arg = parse_atom_arg_at_depth(parser, depth + 1);
@@ -983,7 +1002,7 @@ parse_compound_term(wl_parser_t *parser, uint32_t depth)
             wl_parser_ast_node_free(compound);
             return NULL;
         }
-        wl_parser_ast_node_add_child(compound, arg);
+        PARSER_ADD_CHILD_OR_RETURN(compound, arg);
     }
 
     if (!parser_consume(parser, WL_PARSER_LEXER_TOK_RPAREN,
@@ -1068,7 +1087,7 @@ parse_atom(wl_parser_t *parser)
             wl_parser_ast_node_free(atom);
             return NULL;
         }
-        wl_parser_ast_node_add_child(atom, arg);
+        PARSER_ADD_CHILD_OR_RETURN(atom, arg);
 
         while (parser_match(parser, WL_PARSER_LEXER_TOK_COMMA)) {
             arg = parse_atom_arg(parser);
@@ -1076,7 +1095,7 @@ parse_atom(wl_parser_t *parser)
                 wl_parser_ast_node_free(atom);
                 return NULL;
             }
-            wl_parser_ast_node_add_child(atom, arg);
+            PARSER_ADD_CHILD_OR_RETURN(atom, arg);
         }
     }
 
@@ -1158,7 +1177,7 @@ parse_predicate(wl_parser_t *parser)
 
         wl_parser_ast_node_t *neg
             = wl_parser_ast_node_create(WL_PARSER_AST_NODE_NEGATION, line, col);
-        wl_parser_ast_node_add_child(neg, atom);
+        PARSER_ADD_CHILD_OR_RETURN(neg, atom);
         return neg;
     }
 
@@ -1191,8 +1210,8 @@ parse_predicate(wl_parser_t *parser)
             wl_parser_ast_node_t *bin = wl_parser_ast_node_create(
                 WL_PARSER_AST_NODE_BINARY_EXPR, op_line, op_col);
             bin->arith_op = op;
-            wl_parser_ast_node_add_child(bin, left);
-            wl_parser_ast_node_add_child(bin, right_factor);
+            PARSER_ADD_CHILD_OR_RETURN(bin, left);
+            PARSER_ADD_CHILD_OR_RETURN(bin, right_factor);
             left = bin;
         }
 
@@ -1216,8 +1235,8 @@ parse_predicate(wl_parser_t *parser)
         wl_parser_ast_node_t *cmp = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_COMPARISON, cmp_line, cmp_col);
         cmp->cmp_op = cmp_op;
-        wl_parser_ast_node_add_child(cmp, left);
-        wl_parser_ast_node_add_child(cmp, right);
+        PARSER_ADD_CHILD_OR_RETURN(cmp, left);
+        PARSER_ADD_CHILD_OR_RETURN(cmp, right);
         return cmp;
     }
 
@@ -1249,8 +1268,8 @@ parse_predicate(wl_parser_t *parser)
         wl_parser_ast_node_t *cmp = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_COMPARISON, cmp_line, cmp_col);
         cmp->cmp_op = cmp_op;
-        wl_parser_ast_node_add_child(cmp, left);
-        wl_parser_ast_node_add_child(cmp, right);
+        PARSER_ADD_CHILD_OR_RETURN(cmp, left);
+        PARSER_ADD_CHILD_OR_RETURN(cmp, right);
         return cmp;
     }
 
@@ -1280,8 +1299,8 @@ parse_predicate(wl_parser_t *parser)
         wl_parser_ast_node_t *cmp = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_COMPARISON, cmp_line, cmp_col);
         cmp->cmp_op = cmp_op;
-        wl_parser_ast_node_add_child(cmp, left);
-        wl_parser_ast_node_add_child(cmp, right);
+        PARSER_ADD_CHILD_OR_RETURN(cmp, left);
+        PARSER_ADD_CHILD_OR_RETURN(cmp, right);
         return cmp;
     }
 
@@ -1307,8 +1326,8 @@ parse_predicate(wl_parser_t *parser)
             wl_parser_ast_node_t *cmp = wl_parser_ast_node_create(
                 WL_PARSER_AST_NODE_COMPARISON, cmp_line, cmp_col);
             cmp->cmp_op = cmp_op;
-            wl_parser_ast_node_add_child(cmp, left);
-            wl_parser_ast_node_add_child(cmp, right);
+            PARSER_ADD_CHILD_OR_RETURN(cmp, left);
+            PARSER_ADD_CHILD_OR_RETURN(cmp, right);
             return cmp;
         }
 
@@ -1352,7 +1371,7 @@ parse_head(wl_parser_t *parser)
             wl_parser_ast_node_free(head);
             return NULL;
         }
-        wl_parser_ast_node_add_child(head, arg);
+        PARSER_ADD_CHILD_OR_RETURN(head, arg);
 
         while (parser_match(parser, WL_PARSER_LEXER_TOK_COMMA)) {
             arg = parse_head_arg(parser);
@@ -1360,7 +1379,7 @@ parse_head(wl_parser_t *parser)
                 wl_parser_ast_node_free(head);
                 return NULL;
             }
-            wl_parser_ast_node_add_child(head, arg);
+            PARSER_ADD_CHILD_OR_RETURN(head, arg);
         }
     }
 
@@ -1383,6 +1402,11 @@ parse_fact(wl_parser_t *parser, wl_parser_ast_node_t *head)
     /* Convert HEAD node to FACT node, reusing name and children */
     wl_parser_ast_node_t *fact = wl_parser_ast_node_create(
         WL_PARSER_AST_NODE_FACT, head->line, head->col);
+    if (!fact) {
+        parser_error(parser, "out of memory while creating fact");
+        wl_parser_ast_node_free(head);
+        return NULL;
+    }
     fact->name = head->name;
     head->name = NULL;
 
@@ -1441,7 +1465,7 @@ parse_rule_or_fact(wl_parser_t *parser)
 
     wl_parser_ast_node_t *rule
         = wl_parser_ast_node_create(WL_PARSER_AST_NODE_RULE, line, col);
-    wl_parser_ast_node_add_child(rule, head);
+    PARSER_ADD_CHILD_OR_RETURN(rule, head);
 
     /* Parse body predicates */
     wl_parser_ast_node_t *pred = parse_predicate(parser);
@@ -1449,7 +1473,7 @@ parse_rule_or_fact(wl_parser_t *parser)
         wl_parser_ast_node_free(rule);
         return NULL;
     }
-    wl_parser_ast_node_add_child(rule, pred);
+    PARSER_ADD_CHILD_OR_RETURN(rule, pred);
 
     while (parser_match(parser, WL_PARSER_LEXER_TOK_COMMA)) {
         pred = parse_predicate(parser);
@@ -1457,7 +1481,7 @@ parse_rule_or_fact(wl_parser_t *parser)
             wl_parser_ast_node_free(rule);
             return NULL;
         }
-        wl_parser_ast_node_add_child(rule, pred);
+        PARSER_ADD_CHILD_OR_RETURN(rule, pred);
     }
 
     if (!parser_consume(parser, WL_PARSER_LEXER_TOK_DOT,
@@ -1531,7 +1555,7 @@ parse_declaration(wl_parser_t *parser)
                 WL_PARSER_AST_NODE_TYPED_PARAM, attr_line, attr_col);
             param->name = attr_name;
             param->type_name = type_name;
-            wl_parser_ast_node_add_child(decl, param);
+            PARSER_ADD_CHILD_OR_RETURN(decl, param);
 
             if (!parser_match(parser, WL_PARSER_LEXER_TOK_COMMA))
                 break;
@@ -1582,7 +1606,7 @@ parse_input_directive(wl_parser_t *parser)
                 WL_PARSER_AST_NODE_INPUT_PARAM, p_line, p_col);
             param->name = strdup_safe("filename");
             param->str_value = token_to_str_value(&parser->previous);
-            wl_parser_ast_node_add_child(input, param);
+            PARSER_ADD_CHILD_OR_RETURN(input, param);
             /* Allow trailing key=value params after positional */
             if (parser_match(parser, WL_PARSER_LEXER_TOK_COMMA)
                 && parser_check(parser, WL_PARSER_LEXER_TOK_RPAREN)) {
@@ -1622,7 +1646,7 @@ input_kv_params:
                     WL_PARSER_AST_NODE_INPUT_PARAM, p_line, p_col);
                 param->name = param_name;
                 param->str_value = param_value;
-                wl_parser_ast_node_add_child(input, param);
+                PARSER_ADD_CHILD_OR_RETURN(input, param);
 
                 if (!parser_match(parser, WL_PARSER_LEXER_TOK_COMMA))
                     break;
@@ -1667,7 +1691,7 @@ parse_output_directive(wl_parser_t *parser)
                     WL_PARSER_AST_NODE_OUTPUT_PARAM, p_line, p_col);
                 param->name = strdup_safe("filename");
                 param->str_value = token_to_str_value(&parser->previous);
-                wl_parser_ast_node_add_child(output, param);
+                PARSER_ADD_CHILD_OR_RETURN(output, param);
                 /* Allow trailing key=value params after positional */
                 if (parser_match(parser, WL_PARSER_LEXER_TOK_COMMA)
                     && parser_check(parser, WL_PARSER_LEXER_TOK_RPAREN)) {
@@ -1708,7 +1732,7 @@ output_kv_params:
                         WL_PARSER_AST_NODE_OUTPUT_PARAM, p_line, p_col);
                     param->name = param_name;
                     param->str_value = param_value;
-                    wl_parser_ast_node_add_child(output, param);
+                    PARSER_ADD_CHILD_OR_RETURN(output, param);
 
                     if (!parser_match(parser, WL_PARSER_LEXER_TOK_COMMA))
                         break;
@@ -1860,7 +1884,7 @@ parse_program(wl_parser_t *parser)
         }
 
         if (node) {
-            wl_parser_ast_node_add_child(program, node);
+            PARSER_ADD_CHILD_OR_RETURN(program, node);
         } else if (parser->had_error) {
             wl_parser_ast_node_free(program);
             return NULL;

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -866,7 +866,10 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
 
                     /* Insert: parent_join->children[0] = proj,
                      *          proj->child = current_join */
-                    wl_ir_node_add_child(proj, joins[i]);
+                    if (wl_ir_node_add_child(proj, joins[i]) != 0) {
+                        wl_ir_node_free(proj);
+                        continue;
+                    }
                     joins[i + 1]->children[0] = proj;
 
                     /* Update acc to reflect projection */

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -828,8 +828,20 @@ build_demand_rule_ir(const char *body_magic_name, const char *guard_magic_name,
             }
         }
 
-        wl_ir_node_add_child(join, current);
-        wl_ir_node_add_child(join, scan);
+        if (wl_ir_node_add_child(join, current) != 0) {
+            wl_ir_node_free(join);
+            wl_ir_node_free(scan);
+            wl_ir_node_free(current);
+            return NULL;
+        }
+        if (wl_ir_node_add_child(join, scan) != 0) {
+            join->children[0] = NULL;
+            join->child_count = 0;
+            wl_ir_node_free(join);
+            wl_ir_node_free(scan);
+            wl_ir_node_free(current);
+            return NULL;
+        }
         current = join;
 
         /* Add this prefix atom's variables to the bound set */
@@ -871,7 +883,11 @@ build_demand_rule_ir(const char *body_magic_name, const char *guard_magic_name,
         }
     }
 
-    wl_ir_node_add_child(root, current);
+    if (wl_ir_node_add_child(root, current) != 0) {
+        wl_ir_node_free(root);
+        wl_ir_node_free(current);
+        return NULL;
+    }
     return root;
 }
 
@@ -992,8 +1008,18 @@ insert_magic_guard(wirelog_ir_node_t *ir_root, const char *magic_name,
     /* Left-deep: the composite body stays on the left, where the plan can
      * express it as a subtree.  The right child must be a single relation
      * (Issue #989). */
-    wl_ir_node_add_child(guard_join, body);       /* left: original body */
-    wl_ir_node_add_child(guard_join, magic_scan); /* right: magic demand */
+    if (wl_ir_node_add_child(guard_join, body) != 0) {
+        wl_ir_node_free(guard_join);
+        wl_ir_node_free(magic_scan);
+        return MS_GUARD_ERROR;
+    }
+    if (wl_ir_node_add_child(guard_join, magic_scan) != 0) {
+        guard_join->children[0] = NULL;
+        guard_join->child_count = 0;
+        wl_ir_node_free(guard_join);
+        wl_ir_node_free(magic_scan);
+        return MS_GUARD_ERROR;
+    }
 
     /* Replace body in parent */
     ir_root->children[0] = guard_join;

--- a/wirelog/passes/sip.c
+++ b/wirelog/passes/sip.c
@@ -236,7 +236,10 @@ insert_semijoins_in_chain(wirelog_ir_node_t *join_root)
          * wrapper inserted by JPP — we preserve it intact so column
          * indices remain correct for downstream operators).
          */
-        wl_ir_node_add_child(sj, left);
+        if (wl_ir_node_add_child(sj, left) != 0) {
+            wl_ir_node_free(sj);
+            return -1;
+        }
 
         /* SEMIJOIN child[1] = clone of right SCAN (for relation name) */
         wirelog_ir_node_t *scan_clone = clone_scan_metadata(right);
@@ -247,7 +250,13 @@ insert_semijoins_in_chain(wirelog_ir_node_t *join_root)
             wl_ir_node_free(sj);
             return -1;
         }
-        wl_ir_node_add_child(sj, scan_clone);
+        if (wl_ir_node_add_child(sj, scan_clone) != 0) {
+            sj->children[0] = NULL;
+            sj->child_count = 0;
+            wl_ir_node_free(sj);
+            wl_ir_node_free(scan_clone);
+            return -1;
+        }
 
         /* Re-point parent JOIN's left child to the SEMIJOIN */
         node->children[0] = sj;


### PR DESCRIPTION
Closes #1107

## What changed
- Make IR node, IR expression, and parser AST child attachment APIs return an explicit failure status.
- Propagate allocation failures through parser construction, IR conversion, JPP, SIP, and magic sets while preserving ownership and rolling back partial trees.
- Fix expression cloning and parser fact creation failure handling.
- Add deterministic realloc-failure coverage for the three primitive attachment APIs.

## Why
Child-array realloc failures previously dropped children without notifying callers, leaking the child and silently truncating IR/AST trees.

## Validation
- Full Meson build passed.
- Full Meson test suite: 278 passed, 11 skipped, 0 failed.
- Pre-commit formatting and git diff checks passed.

## Follow-up risk
The reviewer identified that failure-injection coverage is currently focused on the primitive attachment APIs; the call-site rollback paths are covered by normal tests and code review, but dedicated injected-failure tests for each optimization path can be added separately.