### PR TITLE
fix: clear the remaining bugprone-multi-level-implicit-pointer-conversion sites

### DIFF
--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -357,7 +357,7 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
      * per iteration (14K+ iterations for CRDT). */
     uint32_t *snap = (uint32_t *)malloc(nrels * sizeof(uint32_t));
     if (!snap) {
-        free(delta_rels);
+        free((void *)delta_rels);
         return ENOMEM;
     }
 
@@ -797,7 +797,7 @@ stride_error:
             /* Issue #282: Restore diff_operators_active on error path */
             sess->diff_operators_active = saved_diff_operators_active;
             free(snap);
-            free(delta_rels);
+            free((void *)delta_rels);
             return outer_rc;
         }
 
@@ -855,7 +855,7 @@ stride_error:
                 col_rel_destroy(delta_rels[ri]);
         }
         free(snap);
-        free(delta_rels);
+        free((void *)delta_rels);
         return agg_rc;
     }
 
@@ -867,7 +867,7 @@ stride_error:
         session_remove_rel(sess, dname);
     }
     free(snap);
-    free(delta_rels);
+    free((void *)delta_rels);
     delta_pool_reset(sess->delta_pool);
     sess->rotation_ops->rotate_eval_arena(sess);
     col_mat_cache_clear(&sess->mat_cache);
@@ -1185,7 +1185,7 @@ col_eval_nonrecursive_relation_parallel(const wl_plan_relation_t *rp,
     nonrec_rule_worker_ctx_t *ctxs = (nonrec_rule_worker_ctx_t *)calloc(
         W, sizeof(nonrec_rule_worker_ctx_t));
     if (!worker_rels || !ctxs) {
-        free(worker_rels);
+        free((void *)worker_rels);
         free(ctxs);
         free(ops_copy);
         tdd_cleanup_workers(coord);
@@ -1332,10 +1332,10 @@ col_eval_nonrecursive_relation_parallel(const wl_plan_relation_t *rp,
                     for (uint32_t ri = 0; ri < coord->nrels + 1; ri++)
                         col_rel_destroy(worker_rels[w][ri]);
                 }
-                free(worker_rels[w]);
+                free((void *)worker_rels[w]);
             }
         }
-        free(worker_rels);
+        free((void *)worker_rels);
     }
     tdd_cleanup_workers(coord);
     if (!merge_started && rc == EOVERFLOW)
@@ -1439,7 +1439,7 @@ tdd_init_workers(wl_col_session_t *coord, uint32_t W)
                 /* Free any unowned partition slots on error */
                 for (uint32_t w = 0; w < W; w++)
                     col_rel_destroy(parts[w]); /* NULL-safe */
-                free(parts);
+                free((void *)parts);
             }
         }
 
@@ -1651,8 +1651,8 @@ cleanup:
                 col_rel_destroy(worker_rels[w][r]);
         }
         for (uint32_t w = 0; w < W; w++)
-            free(worker_rels[w]);
-        free(worker_rels);
+            free((void *)worker_rels[w]);
+        free((void *)worker_rels);
     }
     if (rc != 0)
         tdd_cleanup_workers(coord);
@@ -1756,7 +1756,7 @@ tdd_seed_global_read_initial_deltas(const wl_plan_stratum_t *sp,
         if (rc != 0) {
             for (uint32_t w = 0; w < W; w++)
                 col_rel_destroy(parts[w]);
-            free(parts);
+            free((void *)parts);
             return rc;
         }
 
@@ -1782,7 +1782,7 @@ tdd_seed_global_read_initial_deltas(const wl_plan_stratum_t *sp,
         }
         for (uint32_t w = 0; w < W; w++)
             col_rel_destroy(parts[w]);
-        free(parts);
+        free((void *)parts);
         if (rc != 0)
             return rc;
     }
@@ -3263,7 +3263,7 @@ tdd_init_workers_hybrid(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
                 }
                 for (uint32_t w = 0; w < W; w++)
                     col_rel_destroy(parts[w]);
-                free(parts);
+                free((void *)parts);
             }
         } else if (edb_part_name && rel->nrows > 0
             && strcmp(name, edb_part_name) == 0
@@ -3299,7 +3299,7 @@ tdd_init_workers_hybrid(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
                 }
                 for (uint32_t w = 0; w < W; w++)
                     col_rel_destroy(parts[w]);
-                free(parts);
+                free((void *)parts);
             }
         } else {
             /* Zero-copy EDB sharing: workers borrow the coordinator's
@@ -3874,7 +3874,7 @@ tdd_save_coord_idb(const wl_plan_stratum_t *sp, wl_col_session_t *coord)
 fail:
     for (uint32_t ri = 0; ri < sp->relation_count; ri++)
         col_rel_destroy(saved[ri]);
-    free(saved);
+    free((void *)saved);
     return NULL;
 }
 
@@ -3927,7 +3927,7 @@ tdd_free_saved_coord_idb(const wl_plan_stratum_t *sp, col_rel_t **saved)
         return;
     for (uint32_t ri = 0; ri < sp->relation_count; ri++)
         col_rel_destroy(saved[ri]);
-    free(saved);
+    free((void *)saved);
 }
 
 /*
@@ -4083,7 +4083,7 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
         if (rc != 0) {
             for (uint32_t w = 0; w < W; w++)
                 col_rel_destroy(parts[w]);
-            free(parts);
+            free((void *)parts);
             col_rel_destroy(combined);
             return rc;
         }
@@ -4111,7 +4111,7 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
             snap[w * nrels + ri] = widb ? widb->nrows : 0;
             col_rel_destroy(parts[w]);
         }
-        free(parts);
+        free((void *)parts);
         coord->tdd_exchange_scatter_ns += now_ns() - scatter_t0;
 
         /* Step 8: Broadcast combined_delta as $d$ via col_shared zero-copy */
@@ -4275,7 +4275,7 @@ tdd_owner_exchange_deltas(const wl_plan_stratum_t *sp,
         if (rc != 0) {
             for (uint32_t w = 0; w < W; w++)
                 col_rel_destroy(parts[w]);
-            free(parts);
+            free((void *)parts);
             return rc;
         }
 
@@ -4330,7 +4330,7 @@ tdd_owner_exchange_deltas(const wl_plan_stratum_t *sp,
 
         for (uint32_t w = 0; w < W; w++)
             col_rel_destroy(parts[w]);
-        free(parts);
+        free((void *)parts);
         coord->tdd_exchange_scatter_ns += now_ns() - scatter_t0;
         if (rc != 0)
             return rc;
@@ -4494,7 +4494,7 @@ tdd_global_read_exchange_deltas(const wl_plan_stratum_t *sp,
             }
             for (uint32_t w = 0; w < W; w++)
                 col_rel_destroy(parts[w]);
-            free(parts);
+            free((void *)parts);
             return rc;
         }
 
@@ -4520,7 +4520,7 @@ tdd_global_read_exchange_deltas(const wl_plan_stratum_t *sp,
         }
         for (uint32_t w = 0; w < W; w++)
             col_rel_destroy(parts[w]);
-        free(parts);
+        free((void *)parts);
         if (rc != 0)
             return rc;
     }
@@ -4958,7 +4958,8 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
 
             /* Reset worker contexts for this sub-pass (reuse allocation) */
             for (uint32_t w = 0; w < W; w++) {
-                memset(ctxs[w].delta_rels, 0, nrels * sizeof(col_rel_t *));
+                memset((void *)ctxs[w].delta_rels, 0,
+                    nrels * sizeof(col_rel_t *));
                 ctxs[w].sp = sp;
                 ctxs[w].worker_sess = &coord->tdd_workers[w];
                 ctxs[w].stratum_idx = stratum_idx;
@@ -5046,7 +5047,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
 
                     /* Clear and reconstruct from queue messages. */
                     for (uint32_t w = 0; w < W; w++)
-                        memset(ctxs[w].delta_rels, 0,
+                        memset((void *)ctxs[w].delta_rels, 0,
                             nrels * sizeof(col_rel_t *));
                     wl_columnar_eval_tdd_queue_reconstruct_delta_matrix(
                         ctxs, msgs, msg_count, W, nrels);

--- a/wirelog/columnar/eval_delta.c
+++ b/wirelog/columnar/eval_delta.c
@@ -118,7 +118,7 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
     int64_t **retract_data = (int64_t **)calloc(rc_cnt, sizeof(int64_t *));
     uint32_t *retract_nrows = (uint32_t *)calloc(rc_cnt, sizeof(uint32_t));
     if (!retract_data || !retract_nrows) {
-        free(retract_data);
+        free((void *)retract_data);
         free(retract_nrows);
         return ENOMEM;
     }
@@ -205,7 +205,7 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
             r->retract_backup_sorted_nrows = 0;
             r->retract_backup_run_count = 0;
         }
-        free(retract_data);
+        free((void *)retract_data);
         free(retract_nrows);
         return rc;
     }
@@ -243,7 +243,7 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
                     }
                     free(retract_data[i]);
                 }
-                free(retract_data);
+                free((void *)retract_data);
                 free(retract_nrows);
                 return rc;
             }
@@ -296,7 +296,7 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
             if (!src_buf) {
                 for (uint32_t i = 0; i < rc_cnt; i++)
                     free(retract_data[i]);
-                free(retract_data);
+                free((void *)retract_data);
                 free(retract_nrows);
                 return ENOMEM;
             }
@@ -344,7 +344,7 @@ col_stratum_step_retraction_nonrecursive(const wl_plan_stratum_t *sp,
     /* Cleanup: free stolen retraction buffers */
     for (uint32_t i = 0; i < rc_cnt; i++)
         free(retract_data[i]);
-    free(retract_data);
+    free((void *)retract_data);
     free(retract_nrows);
     return 0;
 }
@@ -368,7 +368,7 @@ col_stratum_step_with_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
     uint32_t *prev_nrows = (uint32_t *)calloc(rc_cnt, sizeof(uint32_t));
     uint32_t *prev_ncols = (uint32_t *)calloc(rc_cnt, sizeof(uint32_t));
     if (!prev_data || !prev_nrows || !prev_ncols) {
-        free(prev_data);
+        free((void *)prev_data);
         free(prev_nrows);
         free(prev_ncols);
         return ENOMEM;
@@ -505,7 +505,7 @@ cleanup:
         }
         free(prev_data[i]);
     }
-    free(prev_data);
+    free((void *)prev_data);
     free(prev_nrows);
     free(prev_ncols);
     return rc;

--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -181,7 +181,7 @@ col_join_reserve_exact(col_rel_t *rel, uint32_t nrows)
         for (uint32_t c = 0; c < rel->ncols; c++)
             memcpy(new_cols[c], rel->columns[c],
                 sizeof(int64_t) * rel->nrows);
-        free(rel->columns);
+        free((void *)rel->columns);
         rel->columns = new_cols;
         rel->arena_owned = false;
     } else if (rel->columns) {

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -524,7 +524,7 @@ cleanup:
         }
         dp->slot_used = pool_slot_base;
     }
-    free(results);
+    free((void *)results);
     COL_SESSION(sess)->kfusion_cleanup_ns += now_ns() - _phase_t0;
     return rc;
 }
@@ -633,7 +633,7 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
     COL_SESSION(sess)->kfusion_alloc_ns += now_ns() - _phase_t0;
     if (!results || !workers || !worker_sess) {
         free(live_indices);
-        free(results);
+        free((void *)results);
         free(workers);
         free(worker_sess);
         return ENOMEM;
@@ -869,7 +869,7 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         } else {
             merged = col_rel_merge_k(compact, n_results);
         }
-        free(compact);
+        free((void *)compact);
         if (!merged) {
             rc = ENOMEM;
             goto cleanup_results;
@@ -964,7 +964,7 @@ cleanup_wq:
         wl_arena_free(worker_sess[d].eval_arena);
     }
     free(worker_sess);
-    free(results);
+    free((void *)results);
     free(workers);
     free(live_indices);
     COL_SESSION(sess)->kfusion_cleanup_ns += now_ns() - _phase_t0;

--- a/wirelog/ir/ir.c
+++ b/wirelog/ir/ir.c
@@ -81,7 +81,7 @@ wl_ir_expr_add_child(wl_ir_expr_t *parent, wl_ir_expr_t *child)
                                ? INITIAL_CHILD_CAPACITY
                                : parent->child_capacity * 2;
         wl_ir_expr_t **new_children = (wl_ir_expr_t **)realloc(
-            parent->children, new_cap * sizeof(wl_ir_expr_t *));
+            (void *)parent->children, new_cap * sizeof(wl_ir_expr_t *));
         if (!new_children)
             return;
         parent->children = new_children;
@@ -100,7 +100,7 @@ wl_ir_expr_free(wl_ir_expr_t *expr)
     for (uint32_t i = 0; i < expr->child_count; i++) {
         wl_ir_expr_free(expr->children[i]);
     }
-    free(expr->children);
+    free((void *)expr->children);
     free(expr->var_name);
     free(expr->str_value);
     free(expr);
@@ -187,7 +187,7 @@ wl_ir_node_add_child(wirelog_ir_node_t *node, wirelog_ir_node_t *child)
         uint32_t new_cap = node->child_capacity == 0 ? INITIAL_CHILD_CAPACITY
                                                      : node->child_capacity * 2;
         wirelog_ir_node_t **new_children = (wirelog_ir_node_t **)realloc(
-            node->children, new_cap * sizeof(wirelog_ir_node_t *));
+            (void *)node->children, new_cap * sizeof(wirelog_ir_node_t *));
         if (!new_children)
             return;
         node->children = new_children;
@@ -207,7 +207,7 @@ wl_ir_node_free(wirelog_ir_node_t *node)
     for (uint32_t i = 0; i < node->child_count; i++) {
         wl_ir_node_free(node->children[i]);
     }
-    free(node->children);
+    free((void *)node->children);
 
     /* Free relation name */
     free(node->relation_name);
@@ -217,7 +217,7 @@ wl_ir_node_free(wirelog_ir_node_t *node)
         for (uint32_t i = 0; i < node->column_count; i++) {
             free(node->column_names[i]); /* NULL-safe: free(NULL) is no-op */
         }
-        free(node->column_names);
+        free((void *)node->column_names);
     }
     free(node->column_types);
 
@@ -227,7 +227,7 @@ wl_ir_node_free(wirelog_ir_node_t *node)
         for (uint32_t i = 0; i < node->project_count; i++) {
             wl_ir_expr_free(node->project_exprs[i]);
         }
-        free(node->project_exprs);
+        free((void *)node->project_exprs);
     }
 
     /* Free FILTER expression */
@@ -238,13 +238,13 @@ wl_ir_node_free(wirelog_ir_node_t *node)
         for (uint32_t i = 0; i < node->join_key_count; i++) {
             free(node->join_left_keys[i]);
         }
-        free(node->join_left_keys);
+        free((void *)node->join_left_keys);
     }
     if (node->join_right_keys) {
         for (uint32_t i = 0; i < node->join_key_count; i++) {
             free(node->join_right_keys[i]);
         }
-        free(node->join_right_keys);
+        free((void *)node->join_right_keys);
     }
 
     /* Free AGGREGATE data */

--- a/wirelog/parser/ast.c
+++ b/wirelog/parser/ast.c
@@ -51,7 +51,7 @@ wl_parser_ast_node_add_child(wl_parser_ast_node_t *parent,
                                ? INITIAL_CHILD_CAPACITY
                                : parent->child_capacity * 2;
         wl_parser_ast_node_t **new_children = (wl_parser_ast_node_t **)realloc(
-            parent->children, new_cap * sizeof(wl_parser_ast_node_t *));
+            (void *)parent->children, new_cap * sizeof(wl_parser_ast_node_t *));
         if (!new_children)
             return;
         parent->children = new_children;
@@ -111,7 +111,7 @@ wl_parser_ast_node_free(wl_parser_ast_node_t *node)
     for (uint32_t i = 0; i < node->child_count; i++) {
         wl_parser_ast_node_free(node->children[i]);
     }
-    free(node->children);
+    free((void *)node->children);
     free(node->name);
     free(node->str_value);
     free(node->type_name);

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -256,8 +256,8 @@ free_join_keys(wirelog_ir_node_t *node)
         free(node->join_left_keys[i]);
         free(node->join_right_keys[i]);
     }
-    free(node->join_left_keys);
-    free(node->join_right_keys);
+    free((void *)node->join_left_keys);
+    free((void *)node->join_right_keys);
     node->join_left_keys = NULL;
     node->join_right_keys = NULL;
     node->join_key_count = 0;
@@ -413,7 +413,7 @@ greedy_order(wirelog_ir_node_t **scans, uint32_t nscan, uint32_t *order,
         }
     }
 
-    free(acc);
+    free((void *)acc);
     free(is_idb);
     free(used);
 
@@ -479,12 +479,12 @@ rebuild_chain(wirelog_ir_node_t **join_nodes, uint32_t njoin,
         /* Merge into accumulated */
         uint32_t new_count;
         char **new_acc = merge_vars(acc, acc_count, svars, scount, &new_count);
-        free(acc);
+        free((void *)acc);
         acc = new_acc;
         acc_count = new_count;
     }
 
-    free(acc);
+    free((void *)acc);
 }
 
 /* ======================================================================== */
@@ -702,8 +702,8 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
     wirelog_ir_node_t **joins
         = (wirelog_ir_node_t **)calloc(depth, sizeof(wirelog_ir_node_t *));
     if (!scans || !joins) {
-        free(scans);
-        free(joins);
+        free((void *)scans);
+        free((void *)joins);
         return 0;
     }
 
@@ -718,8 +718,8 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
      * head_var_count on top of this. */
     size_t total_cols;
     if (!scan_columns_total(scans, nscan, &total_cols)) {
-        free(scans);
-        free(joins);
+        free((void *)scans);
+        free((void *)joins);
         return 0;
     }
 
@@ -730,8 +730,8 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
     /* Build mutable accumulated set */
     char **acc = (char **)calloc(total_cols, sizeof(char *));
     if (!acc) {
-        free(scans);
-        free(joins);
+        free((void *)scans);
+        free((void *)joins);
         return 0;
     }
     for (uint32_t i = 0; i < acc_count; i++)
@@ -758,9 +758,9 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
     char **phys_names = (char **)calloc(total_cols, sizeof(char *));
     uint32_t phys_count = 0;
     if (!phys_names) {
-        free(acc);
-        free(scans);
-        free(joins);
+        free((void *)acc);
+        free((void *)scans);
+        free((void *)joins);
         return 0;
     }
     /* Initial physical layout: S0 columns || S1 columns (with duplicates) */
@@ -903,7 +903,7 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
             }
         }
 
-        free(needed);
+        free((void *)needed);
 
         /* Merge next scan's vars into acc and physical layout for the next
          * iteration.  phys_names gets ALL scan columns (join-key duplicates
@@ -919,10 +919,10 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
         }
     }
 
-    free(phys_names);
-    free(acc);
-    free(scans);
-    free(joins);
+    free((void *)phys_names);
+    free((void *)acc);
+    free((void *)scans);
+    free((void *)joins);
     return projections;
 }
 
@@ -965,8 +965,8 @@ optimize_chain(wirelog_ir_node_t *join_root, char **head_vars,
         = (wirelog_ir_node_t **)calloc(depth, sizeof(wirelog_ir_node_t *));
     uint32_t *order = (uint32_t *)calloc(nscan, sizeof(uint32_t));
     if (!scans || !joins || !order) {
-        free(scans);
-        free(joins);
+        free((void *)scans);
+        free((void *)joins);
         free(order);
         return result;
     }
@@ -977,8 +977,8 @@ optimize_chain(wirelog_ir_node_t *join_root, char **head_vars,
 
     if (actual_scans != nscan) {
         /* Not a clean left-deep chain; skip */
-        free(scans);
-        free(joins);
+        free((void *)scans);
+        free((void *)joins);
         free(order);
         return result;
     }
@@ -994,7 +994,7 @@ optimize_chain(wirelog_ir_node_t *join_root, char **head_vars,
             for (uint32_t i = 0; i < nscan; i++)
                 ordered[i] = scans[order[i]];
             rebuild_chain(joins, depth, ordered, nscan);
-            free(ordered);
+            free((void *)ordered);
         }
         result.reordered = true;
     }
@@ -1006,8 +1006,8 @@ optimize_chain(wirelog_ir_node_t *join_root, char **head_vars,
     result.projections_inserted
         = insert_projections(join_root, head_vars, head_var_count);
 
-    free(scans);
-    free(joins);
+    free((void *)scans);
+    free((void *)joins);
     free(order);
 
     return result;
@@ -1091,7 +1091,7 @@ optimize_tree(wirelog_ir_node_t *ir, uint32_t *chains_examined,
     jpp_chain_result_t result
         = optimize_chain(root, head_vars, head_var_count, idb_names, idb_count);
 
-    free(head_vars);
+    free((void *)head_vars);
 
     if (result.reordered)
         (*joins_reordered)++;
@@ -1171,7 +1171,7 @@ wl_jpp_apply(struct wirelog_program *prog, wl_jpp_stats_t *stats)
             &projections_inserted, idb_names, idb_count);
     }
 
-    free(idb_names);
+    free((void *)idb_names);
 
     if (stats) {
         stats->joins_reordered = joins_reordered;


### PR DESCRIPTION
Closes #1101.

Clears all **74** remaining `bugprone-multi-level-implicit-pointer-conversion` diagnostics in the library, one commit per file. Each is an explicit `(void *)` at a `free()`, `realloc()` or `memset()` argument — the convention `cb0eb32` established and `f1d2a2c`, `a385b85`, `e2cae61` and `162e2d7` applied. `.clang-tidy` is untouched, zero `NOLINT` is added, and no other check is weakened.

| Commit | File | Sites |
|---|---|---|
| `ec271eb` | `wirelog/passes/jpp.c` | 28 |
| `f6bc5de` | `wirelog/columnar/eval_delta.c` | 7 |
| `2e7ebc6` | `wirelog/columnar/eval.c` | 24 |
| `8350201` | `wirelog/ir/ir.c` | 8 |
| `ef81d40` | `wirelog/parser/ast.c` | 2 |
| `53b40bf` | `wirelog/columnar/join.c` | 1 |
| `f88aef5` | `wirelog/columnar/kfusion.c` | 4 |

## The issue inventory was stale — seven files, not six

`eval.c` was split after #1101 was filed; `bcdb49c` extracted `eval_delta.c` and took 7 of the sites with it. The issue lists `eval.c` at 31 and does not mention `eval_delta.c`. The total is unchanged (24 + 7 = 31). Recorded in [a comment on the issue](https://github.com/semantic-reasoning/wirelog/issues/1101#issuecomment-5311089694).

## Every site was audited, not cast blind

This check draws the eye to "a pointer array is freed as an opaque blob — were the elements freed?" Casting converts that signal into silence, so each of the 74 sites was traced to its allocation and classified. Highlights:

- **`jpp.c:997`** — `ordered[]` holds `scans[order[i]]`, which `rebuild_chain` wires into the live tree at 457/458/473. Freeing the elements would be a use-after-free on the IR being optimised. 26 of jpp.c's 28 arrays hold aliased or borrowed elements; only `join_left_keys`/`join_right_keys` own theirs, and those are already freed elementwise first.
- **`eval.c:1188/1338/1655`** — `col_rel_t ***` triple pointers. Inner arrays are freed before the outer; element ownership is partitioned by frontier counters (`built_workers`, `tdd_workers_count`); the outer array is never transferred because `session.c:1518-1519` gives the worker its own.
- **`kfusion.c:872`** — `compact[]` holds borrowed aliases of `results[d]`. Freeing its elements would double-free. This rests on `col_rel_merge_k` never adopting its inputs, verified by reading it end to end.
- **`join.c:184`** — the arena-migration shape. The array is heap, the per-column buffers are arena-owned. Same field and type as the twelve sites `#1079` cleared in `relation.c`, which had left this file as the lone holdout.

No single-level pointer was cast anywhere. The adjacent traps are real — `jpp.c:966-969` and `kfusion.c:966-969` are each four consecutive frees of four different types where exactly one may be cast.

## Validation

Run on this combined branch, not only on the per-file branches:

- **clang-tidy: 74 → 0** across all 71 library translation units, zero compile errors. Proven sensitive first: reverting the `join.c` cast on a probe copy reports 1, the real file reports 0.
- **`meson test -C build`** — 278 passed, 0 failed, 11 skipped (pre-existing environmental gates). **`--suite abi`** — 33 passed, 0 failed.
- **`uncrustify --check`** — PASS on all seven files, each a formatting fixed point.
- **editorconfig-checker v3.0.3**, the version pinned in `lint-pr.yml` — clean.
- **Codegen**: byte-identical assembly for every file. `eval.c` is the one exception and only under `-g`, where `.text`, `.rodata`, `.data`, `.eh_frame`, `.symtab` and every `.rela` section are identical and only `.debug_info`/`.debug_line` shift, from the single required rewrap at `eval.c:4961` (83 columns against `code_width = 80`).
- The seven file blobs on this branch are byte-identical to the individually reviewed candidates.

## Two things worth knowing if you re-run the scan

The scan is unusually easy to get a false "clean" from. Five distinct ways were hit during this work, each reporting zero and looking like success — clang-tidy writes to **stderr**; `compile_commands.json` holds one entry per link target (129–167 per file) so a plain `-p build` run never finishes; the `file` field is relative to `directory`; the `command` string's source path wins over the `file` field when scanning a copy; and `.clang-tidy` is found by walking up from the **source**, not from `-p`. Details in the issue comment.

`numstat` and a byte-delta check are both satisfied by a cast placed on the wrong adjacent line. This catches that in one command:

```
sed 's/(void \*)//g' <modified> | cmp - <original>
```

For a file that already had casts at HEAD (`eval.c` had 18), strip both sides.

## Scope

This does **not** make the repository clean for this check. It clears the library (`wirelog/**` production sources, the scope #1101 states). A first-party sweep including `tests/` finds roughly 35 more, excluded by repository policy. There is no clang-tidy job in CI — `efbde27` removed it — so nothing prevents regression; a ratchet is proposed in #1100.

Note the commit messages deliberately do **not** reuse the rationale from `f1d2a2c`/`a385b85`, which open by citing the clang-tidy job in `lint-pr.yml` as a hard gate. That predates `efbde27` and is no longer true of their own base.

## Bugs found while auditing, filed not fixed

Fixing any of these here would have forfeited the codegen-neutrality that licenses 74 edits with no new tests.

- **#1108** — `eval.c:4826`: `bdx_snap`'s initializer is bypassed by `goto done` at 4803/4814, so `free(bdx_snap)` frees an indeterminate pointer. Undefined behaviour under C11 6.2.4p6, corroborated by both clang-analyzer and GCC `-Wmaybe-uninitialized`.
- **#1111** — `jpp.c`: `rebuild_chain()` destroys the existing join keys before allocating, so an OOM leaves the node with zero keys and the query runs as a **cross product with exit status 0**. Wrong answers, not degraded performance.
- **#1109** — `eval.c:800`: the `stride_error` path frees `delta_rels` without the element-destroy loop its sibling paths perform. Unconditional, and scales with delta size.
- **#1107** — `add_child()` silently drops the child on realloc failure across three functions, leaking it and returning a truncated tree; ~35 callers discard the `void` return.