### PR TITLE
fix: initialize bdx snapshot before OOM exits

### DIFF
--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -4795,6 +4795,8 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
     /* Issue #361: Pre-allocate worker contexts and delta_rels arrays once.
      * Reuse across iterations to avoid calloc/free overhead per sub-pass
      * (~14k iterations for CRDT). */
+    /* Keep this initialized before any goto done path. */
+    uint32_t *bdx_snap = NULL;
     col_eval_tdd_worker_ctx_t *ctxs
         = (col_eval_tdd_worker_ctx_t *)calloc(
             W, sizeof(col_eval_tdd_worker_ctx_t));
@@ -4823,7 +4825,6 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
     /* Issue #390: BDX snap array — pre-subpass IDB sizes per worker/relation.
      * Used to truncate worker IDB back to clean partition state after each
      * sub-pass (removes cross-partition pollution from join output). */
-    uint32_t *bdx_snap = NULL;
     if (bdx_mode) {
         bdx_snap = (uint32_t *)calloc(
             (size_t)W * nrels, sizeof(uint32_t));


### PR DESCRIPTION
Closes #1108

## Summary
Hoist the `bdx_snap` declaration and NULL initialization before the worker-context allocations that can jump to `done:`.

This ensures the cleanup path always passes either NULL or a valid allocation to `free()`, eliminating the undefined behavior on OOM paths. The adjacent zero-size `calloc(nrels, ...)` concern remains out of scope.

## Validation
- `meson compile -C builddir`
- `meson test -C builddir --print-errorlogs`
- Result: 278 passed, 11 skipped, 0 failed
- Focused TDD tests: recursive, integration, and multiworker passed
- `git diff --check` and uncrustify pre-commit hook passed