### PR TITLE
clang-tidy ratchet (#1100) and all-or-nothing JPP chain rebuild (#1111)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,12 @@
 # NOTE: // NOLINT and // NOLINTNEXTLINE comments are the sole permitted
 # use of C++-style (//) comments in this codebase. They are tool-required
 # pragmas for clang-tidy suppression, not code comments. This is a
-# documented policy exception -- see docs/LINTING.md for details.
+# documented policy exception.
+#
+# ENFORCEMENT (issue #1100): scripts/ci/clang-tidy-allowlist.txt is the
+# register of sources that must stay clean under this config;
+# clang-tidy-backlog.txt holds the ones that are not clean yet. Both are
+# enforced by scripts/ci/check-clang-tidy-ratchet.py (meson suite 'tidy').
 #
 # CHECK SELECTION STRATEGY: Explicit C-safe allowlist.
 # We do NOT use wildcards (e.g., bugprone-*) because they silently include

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -121,7 +121,12 @@ jobs:
       CC: sccache gcc
 
     steps:
+      # fetch-depth 0: the clang-tidy backlog monotonicity check below
+      # compares against the MERGE BASE with the base branch, and a shallow
+      # clone has none.  Matches rc-changelog-freeze and the uncrustify job.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -139,6 +144,68 @@ jobs:
 
       - name: Test
         run: meson test -C builddir --print-errorlogs
+
+      # =======================================================================
+      # Issue #1100: clang-tidy ratchet CI gate
+      #
+      # Installed AFTER the Test step on purpose: the tidy suite runs in a
+      # default `meson test` (there is no add_test_setup in this project), so
+      # having clang-tidy on PATH earlier would run the ~15 s scan twice.
+      # Without it there, the Test step reports the tidy tests as SKIPped and
+      # the dedicated step below runs them once with WIRELOG_TIDY_REQUIRED=1,
+      # which turns any skip into a failure.
+      #
+      # This is the only job that installs clang-tidy, so the ratchet's
+      # guarantee is Linux/gcc-configured-build only.  The other jobs
+      # (build-arm, build-matrix macOS + MSVC, build-mbedtls,
+      # sanitizer-matrix, tsan) skip it at runtime rather than reporting a
+      # verdict from a configuration the allowlist was not calibrated for.
+      # =======================================================================
+      - name: Install clang-tidy (pinned major)
+        run: |
+          major="$(grep -vE '^[[:space:]]*(#|$)' \
+                     scripts/ci/clang-tidy-supported-majors.txt | head -1)"
+          echo "Pinned clang-tidy major: $major"
+          wget -qO llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh "$major"
+          sudo apt-get install -y "clang-tidy-$major"
+          "clang-tidy-$major" --version
+
+      - name: clang-tidy ratchet gate
+        env:
+          WIRELOG_TIDY_REQUIRED: "1"
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: |
+          major="$(grep -vE '^[[:space:]]*(#|$)' \
+                     scripts/ci/clang-tidy-supported-majors.txt | head -1)"
+          export CLANG_TIDY="clang-tidy-$major"
+
+          # The backlog monotonicity check needs the base ref present as a
+          # remote-tracking ref so it can resolve a merge base.  The
+          # checkout above is full-depth, so this is normally a no-op; the
+          # `|| true` keeps a transient network blip from masking the real
+          # verdict with a bare `git fetch` exit code.
+          #
+          # If the ref still cannot be resolved, the check does NOT skip:
+          # WIRELOG_TIDY_REQUIRED=1 above turns every skip into a failure,
+          # deliberately, because a demotion guard that silently skips in CI
+          # is not a guard.  Expect a named failure, not a silent pass.
+          base="${GITHUB_BASE_REF:-main}"
+          git fetch --no-tags origin \
+            "$base:refs/remotes/origin/$base" || true
+          export WIRELOG_TIDY_BASE_REF="origin/$base"
+
+          meson test -C builddir --suite tidy --print-errorlogs || {
+            echo "=== clang-tidy ratchet failed. Context:"
+            echo "=== clang-tidy version:"
+            "$CLANG_TIDY" --version
+            echo "=== allowlist size: $(grep -cvE '^[[:space:]]*(#|$)' \
+              scripts/ci/clang-tidy-allowlist.txt)"
+            echo "=== backlog size:   $(grep -cvE '^[[:space:]]*(#|$)' \
+              scripts/ci/clang-tidy-backlog.txt)"
+            exit 1
+          }
 
       # =======================================================================
       # Issue #744: SBOM snapshot CI gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,43 @@ After fork, call `wl_log_init()` again if the child changes the sink.
 The header at `wirelog/util/log.h` is internal — enforced by
 `scripts/check_log_header_not_public.sh`. Never include it from a
 public header.
+
+## clang-tidy Ratchet (Issue #1100)
+
+`meson test --suite tidy` re-runs clang-tidy over every source in
+`scripts/ci/clang-tidy-allowlist.txt` (58 files today) and fails on any
+diagnostic. The 13 files that are not clean yet live in
+`scripts/ci/clang-tidy-backlog.txt` and are skipped. The two lists must
+partition the `libwirelog.so` entries of `build/compile_commands.json`
+exactly, so an allowlist line cannot simply be deleted; moving one to the
+backlog is caught separately by
+`scripts/ci/check-clang-tidy-backlog-monotonic.sh`. **Fix the file, do not
+demote it.**
+
+The gate SKIPs (exit 77) with a named reason unless clang-tidy is present
+at a major listed in `scripts/ci/clang-tidy-supported-majors.txt`, the host
+is Linux on x86_64, and the compilation database is free of `-fsanitize=`
+and MSVC command lines — the allowlist was calibrated on one toolchain,
+one architecture and one build configuration, and `clang-analyzer-*`
+results move between LLVM releases and between targets. CI's
+`build-primary` job sets `WIRELOG_TIDY_REQUIRED=1`, which turns those skips
+into failures; `WIRELOG_TIDY_SKIP=1` forces a skip and
+`WIRELOG_TIDY_JOBS=N` overrides the parallelism (default `min(8, ncpu)`).
+
+Cost is ~113 s of summed CPU, so the wall-clock hit depends entirely on
+core count: about +15 s on an 8-core workstation, but roughly **+60 s on a
+standard 2-vCPU GitHub runner**, where `min(8, ncpu)` yields 2 jobs.
+
+After a toolchain bump, re-derive the lists with:
+
+```
+scripts/ci/check-clang-tidy-ratchet.py --build-dir build --mode regenerate
+```
+
+Two limitations are known and deliberate. Each file is analysed under the
+single command line meson recorded for it, so `exec_plan_gen.c` is only
+ever scanned with `ENABLE_K_FUSION` at its `#ifndef` default of 1 — the
+`ENABLE_K_FUSION=0` variant `bench_flowlog_seq` builds is never seen — and
+`relation.c`'s `#ifdef WL_RADIX_BENCH` regions are never scanned at all,
+even though both files are allowlisted (#1115). And the backlog carries no
+diagnostic counts, because counts are toolchain-version-dependent (#1114).

--- a/scripts/ci/check-clang-tidy-backlog-monotonic.sh
+++ b/scripts/ci/check-clang-tidy-backlog-monotonic.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# scripts/ci/check-clang-tidy-backlog-monotonic.sh - Issue #1100.
+#
+# Copyright (C) CleverPlant
+# Licensed under LGPL-3.0
+#
+# scripts/ci/clang-tidy-allowlist.txt and clang-tidy-backlog.txt must
+# partition the libwirelog.so sources exactly, which is what makes DELETING
+# an allowlist line fail check-clang-tidy-ratchet.py.
+#
+# DEMOTION is the hole that assertion leaves.  Moving a line from the
+# allowlist to the backlog keeps the partition exact, so the ratchet still
+# passes -- and it is the cheapest possible way to make a regression go
+# away.  This check closes it: the backlog is monotonically
+# non-increasing, so any line ADDED to it relative to the merge base is a
+# failure.
+#
+# This is a diff over the LIST FILE, not over sources.  A merge-base diff
+# of the sources would be wrong (editing a header changes what clang-tidy
+# reports in translation units the diff never touches); a merge-base diff
+# of a hand-maintained register has no such problem.
+#
+# The comparison point is the MERGE BASE, not the tip of the base ref.
+# Diffing the tip produces a false failure whenever the base advances by
+# CLEANING a file: removing a backlog line on main makes that line read as
+# an addition on every open branch that has not rebased, in PRs that never
+# touched the file.
+#
+# `git merge-base` is resolved explicitly and the diff runs against the
+# WORKING TREE rather than HEAD.  That DIFFERS from the `git diff
+# base...HEAD` form used in lint-pr.yml; it is not a superset of it, and
+# the two are incomparable:
+#
+#   - this form additionally catches an UNCOMMITTED demotion, which matters
+#     because the ratchet itself analyses the working tree, so the two
+#     gates judge the same bytes;
+#   - three-dot additionally catches a demotion that was COMMITTED and then
+#     reverted in the working tree only, which this form reports as clean.
+#     That case does not matter in CI, which always checks out a clean tree
+#     -- the pushed branch still carries the commit, so the diff sees it.
+#
+# Base ref: $WIRELOG_TIDY_BASE_REF, else origin/main.  When the ref or the
+# merge base cannot be resolved -- a shallow clone, a tarball export, a
+# fresh worktree with no remote -- the check SKIPs rather than inventing a
+# verdict, unless WIRELOG_TIDY_REQUIRED=1 (which CI sets): a demotion guard
+# that quietly skips in CI is not a guard, so there it is a failure.  CI
+# therefore checks out with fetch-depth 0; a shallow clone has no merge
+# base and would fail rather than pass.
+#
+# Exit codes:
+#   0  - no entries added to the backlog
+#   1  - entries added, or the backlog file is missing
+#   77 - SKIP; git history for the base ref is unavailable
+
+set -uo pipefail
+
+SKIP_EXIT=77
+required="${WIRELOG_TIDY_REQUIRED:-0}"
+
+# skip <reason...> -- SKIP, or FAIL when the caller forbade skipping.
+skip() {
+    if [ "$required" = "1" ]; then
+        echo "check-clang-tidy-backlog-monotonic: FAIL: $* " \
+             "(WIRELOG_TIDY_REQUIRED=1 forbids skipping)" >&2
+        exit 1
+    fi
+    echo "check-clang-tidy-backlog-monotonic: SKIP: $*"
+    exit "$SKIP_EXIT"
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+backlog_rel="scripts/ci/clang-tidy-backlog.txt"
+backlog="$repo_root/$backlog_rel"
+base_ref="${WIRELOG_TIDY_BASE_REF:-origin/main}"
+
+if [ ! -f "$backlog" ]; then
+    echo "check-clang-tidy-backlog-monotonic: FAIL: missing $backlog" >&2
+    exit 1
+fi
+
+if ! command -v git > /dev/null 2>&1; then
+    skip "git is not on PATH"
+fi
+
+if ! git -C "$repo_root" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    skip "$repo_root is not a git work tree"
+fi
+
+if ! git -C "$repo_root" rev-parse --verify --quiet "$base_ref^{commit}" \
+        > /dev/null 2>&1; then
+    skip "base ref '$base_ref' does not resolve (shallow clone or no" \
+         "remote); set WIRELOG_TIDY_BASE_REF to override"
+fi
+
+# Resolve the fork point.  Without it there is no honest comparison to make
+# -- see the merge-base rationale in the header.
+merge_base="$(git -C "$repo_root" merge-base "$base_ref" HEAD 2> /dev/null \
+              || true)"
+if [ -z "$merge_base" ]; then
+    skip "no merge base between '$base_ref' and HEAD (shallow clone?);" \
+         "deepen the fetch or set WIRELOG_TIDY_BASE_REF to override"
+fi
+
+# The fork point may predate the backlog file itself, in which case git diff
+# reports every line as an addition.  Every line being new is exactly right
+# for the commit that introduces the register and there is nothing to
+# ratchet against, so this is a pass rather than a skip -- it must not turn
+# into a failure under WIRELOG_TIDY_REQUIRED=1 on the introducing PR.
+#
+# This branch is a LOCAL-ONLY weakening: it also returns 0, even under
+# WIRELOG_TIDY_REQUIRED=1, for a branch forked before the register existed
+# that never merges main, and for a WIRELOG_TIDY_BASE_REF pointed at an old
+# tag.  Neither is reachable in CI once #1100 lands -- on a pull_request
+# merge ref the merge base is always the base-branch tip, which has the
+# file, and WIRELOG_TIDY_BASE_REF is origin/$GITHUB_BASE_REF, never a tag.
+if ! git -C "$repo_root" cat-file -e "$merge_base:$backlog_rel" 2> /dev/null
+then
+    echo "check-clang-tidy-backlog-monotonic: OK ($backlog_rel does not" \
+         "exist at the merge base with $base_ref yet; nothing to compare" \
+         "against)"
+    exit 0
+fi
+
+# --unified=0 so context lines cannot be mistaken for additions; '+++' is
+# the file header, and comment / blank lines are not entries.
+added=$(git -C "$repo_root" diff --unified=0 "$merge_base" -- "$backlog_rel" \
+        | sed -n 's/^+\([^+].*\)$/\1/p' \
+        | sed 's/[[:space:]]*$//' \
+        | grep -v '^#' \
+        | grep -v '^$' \
+        || true)
+
+if [ -n "$added" ]; then
+    echo "check-clang-tidy-backlog-monotonic: FAIL: entries added to" \
+         "$backlog_rel relative to the merge base with $base_ref" \
+         "($merge_base):" >&2
+    echo "" >&2
+    printf '  %s\n' $added >&2
+    echo "" >&2
+    echo "The backlog may only shrink.  If one of these came from the" >&2
+    echo "allowlist, the file regressed and the fix is to fix the file, not" >&2
+    echo "to demote it.  If it is a genuinely new source that is not clean" >&2
+    echo "on arrival, say so explicitly in the PR description; a reviewer" >&2
+    echo "has to agree to it." >&2
+    exit 1
+fi
+
+echo "check-clang-tidy-backlog-monotonic: OK (no entries added vs the merge" \
+     "base with $base_ref)"
+exit 0

--- a/scripts/ci/check-clang-tidy-ratchet.py
+++ b/scripts/ci/check-clang-tidy-ratchet.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+"""clang-tidy ratchet: files already clean must stay clean (Issue #1100).
+
+No CI job has run clang-tidy since `efbde27` removed the job, so the only
+thing keeping the tree lint-clean has been reviewer attention.  It does not
+hold: `wirelog/ir/program.c` was clean, regressed after `f1d2a2c`, and now
+reports `bugprone-branch-clone` with nothing failing.
+
+This gate is a ratchet over the `libwirelog.so` translation units in the
+build's `compile_commands.json`:
+
+  - `scripts/ci/clang-tidy-allowlist.txt` lists the files that are clean
+    today.  Every one of them is analysed on every run; a single diagnostic
+    fails the build.
+  - `scripts/ci/clang-tidy-backlog.txt` lists the files that are not clean
+    yet.  They are not analysed.  The backlog carries no diagnostic counts:
+    counts are toolchain-version-dependent (LLVM 22 renamed the
+    `clang-analyzer-valist.*` checks out from under `.clang-tidy`; see
+    #1114), so a count would turn a toolchain bump into a spurious
+    failure.
+  - The two lists must partition the selected translation units exactly.
+    That assertion is what stops a regression being made to disappear by
+    deleting the allowlist line.  Demotion -- moving a line from the
+    allowlist to the backlog -- keeps the partition exact, so it is caught
+    separately by `scripts/ci/check-clang-tidy-backlog-monotonic.sh`.
+
+Detection detail that matters: clang-tidy writes diagnostics to STDOUT and
+exits 0 even when it reports them.  The exit code is therefore useless as a
+pass/fail signal.  A file fails when any stdout line matches
+`<path>:<line>:<col>: warning|error:` and `<path>` resolves under
+`wirelog/`.  A non-zero exit with no such line is a harness error (missing
+file, unparseable database) and is never reported as a pass.
+
+Calibration guards (the allowlist was derived on one toolchain and one
+build configuration; 9 of the 13 backlog diagnostics are path-sensitive
+`clang-analyzer-*` results that move between LLVM releases).  The gate
+SKIPs, with a named reason, unless all of the following hold:
+
+  - `clang-tidy --version` reports a major listed in
+    `scripts/ci/clang-tidy-supported-majors.txt`;
+  - the host is Linux on x86_64;
+  - the selected database entries carry no `-fsanitize=` and no MSVC-style
+    command line.
+
+The architecture guard is not redundant with the OS one: `build-arm`
+(`.github/workflows/ci-pr.yml`, ubuntu-24.04-arm) is Linux, uninstrumented
+and not MSVC, and runs an unfiltered `meson test`.  It is protected today
+only by clang-tidy 22 being absent from that image, which is an accident of
+the runner rather than a guarantee.  `clang-analyzer-*` results are
+target-dependent, so an image bump could otherwise yield an aarch64 verdict
+against an x86_64-calibrated allowlist.
+
+Environment:
+
+  WIRELOG_TIDY_REQUIRED=1  turn every skip into a failure (CI sets this)
+  WIRELOG_TIDY_SKIP=1      force a skip, so the gate can be stood down
+                           without being deleted
+  WIRELOG_TIDY_JOBS=N      override the parallelism (default min(8, ncpu))
+  CLANG_TIDY               override the clang-tidy executable
+
+KNOWN LIMITATION -- single preprocessor configuration.  Each file is
+analysed exactly once, under the one command line meson recorded for it.
+Code behind non-default preprocessor conditionals is therefore never seen,
+even for allowlisted files:
+
+  - `wirelog/exec_plan_gen.c` is only ever analysed with `ENABLE_K_FUSION`
+    at the value 1, which the `#ifndef` default at `:43-44` supplies
+    because the database entry carries no `-DENABLE_K_FUSION`.  Every
+    `#if ENABLE_K_FUSION` guard in the file (e.g. `:1866`) therefore has
+    one arm that is never seen, and the `ENABLE_K_FUSION=0` variant that
+    `bench_flowlog_seq` builds (`bench/meson.build:126`) is never analysed
+    at all.
+  - `wirelog/columnar/relation.c` is only ever analysed with
+    `WL_RADIX_BENCH` undefined, so every `#ifdef WL_RADIX_BENCH` region in
+    the file (e.g. `:56`) is invisible to the gate.  The macro is set only
+    by `bench/meson.build:109`.
+
+Those line references are single examples, not an enumeration -- both files
+carry several such guards, and the limitation is a property of the scan, not
+of any particular guard.  Do not turn this into an exhaustive list: it would
+go stale on the next edit to either file without anything failing.
+
+Both files are on the allowlist, so the ratchet asserts "clean" over code
+it has not looked at.  Covering both configurations needs a second scan
+pass and is tracked as #1115.
+
+Exit codes:
+   0 - every allowlisted file is clean
+   1 - a diagnostic was reported, a list is out of sync, or a harness error
+  77 - skipped (meson SKIP), with the reason on stdout
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import pathlib
+import platform
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+
+SKIP_EXIT = 77
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+ALLOWLIST = REPO_ROOT / "scripts/ci/clang-tidy-allowlist.txt"
+BACKLOG = REPO_ROOT / "scripts/ci/clang-tidy-backlog.txt"
+SUPPORTED_MAJORS = REPO_ROOT / "scripts/ci/clang-tidy-supported-majors.txt"
+CONFIG_FILE = REPO_ROOT / ".clang-tidy"
+FIXTURE = REPO_ROOT / "tests/clang_tidy_fixture.c"
+
+# A parse that silently selected nothing would make the partition assertion
+# trivially true -- the exact shape of failure this gate exists to catch.
+# Demand a plausible floor rather than merely non-empty, in the spirit of
+# scripts/ci/check-doop-catalogue.sh.
+MIN_ENTRIES = 50
+
+# clang-tidy writes these to stdout.  Anchored at the start of the line so
+# that a diagnostic quoted inside a note's source snippet cannot match.
+DIAG_RE = re.compile(r"^(?P<path>.+?):(?P<line>\d+):(?P<col>\d+): "
+                     r"(?P<severity>warning|error): (?P<message>.*)$")
+CHECK_RE = re.compile(r"\[([A-Za-z0-9_.,-]+)\]\s*$")
+VERSION_RE = re.compile(r"LLVM version (\d+)\.")
+
+# The marker comment in tests/clang_tidy_fixture.c that pins the line the
+# sensitivity check expects its one diagnostic on.
+FIXTURE_MARKER = "WL_TIDY_FIXTURE_EXPECT"
+FIXTURE_CHECK = "bugprone-integer-division"
+
+
+class GateError(Exception):
+    """A harness problem: the gate could not decide clean vs. dirty."""
+
+
+class SkipGate(Exception):
+    """A calibration guard rejected this environment."""
+
+
+# ---------------------------------------------------------------------------
+# List files
+# ---------------------------------------------------------------------------
+
+def read_list(path: pathlib.Path) -> list[str]:
+    """Read a `#`-commented, one-path-per-line register."""
+    if not path.is_file():
+        raise GateError(f"list file missing: {path}")
+    entries: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        entries.append(line)
+    duplicates = sorted({e for e in entries if entries.count(e) > 1})
+    if duplicates:
+        raise GateError(
+            f"{path.name} has duplicate entries: {', '.join(duplicates)}")
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Compilation database
+# ---------------------------------------------------------------------------
+
+def entry_command(entry: dict) -> list[str]:
+    """Return an entry's command line as a token list."""
+    if "arguments" in entry:
+        return list(entry["arguments"])
+    if "command" in entry:
+        return shlex.split(entry["command"])
+    raise GateError("compilation database entry has neither 'command' nor "
+                    "'arguments'")
+
+
+def entry_source(entry: dict) -> pathlib.Path:
+    """Resolve an entry's `file` against its `directory`.
+
+    The in-database form is relative (`../wirelog/ir/program.c`); diagnostic
+    paths and list entries are not.  Everything is normalised here so the
+    three can be compared.
+    """
+    return (pathlib.Path(entry["directory"]) / entry["file"]).resolve()
+
+
+def select_entries(build_dir: pathlib.Path) -> list[dict]:
+    """Pick one canonical entry per libwirelog.so translation unit."""
+    db_path = build_dir / "compile_commands.json"
+    if not db_path.is_file():
+        raise SkipGate(f"no compilation database at {db_path}")
+    try:
+        db = json.loads(db_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise GateError(f"cannot parse {db_path}: {exc}") from exc
+
+    selected: dict[pathlib.Path, dict] = {}
+    for entry in db:
+        if "libwirelog.so" not in entry.get("output", ""):
+            continue
+        source = entry_source(entry)
+        # Deterministic pick if a future build grows more than one shared
+        # library target for the same source.
+        previous = selected.get(source)
+        if previous is None or entry["output"] < previous["output"]:
+            selected[source] = entry
+
+    if len(selected) < MIN_ENTRIES:
+        raise GateError(
+            f"selected only {len(selected)} libwirelog.so translation "
+            f"unit(s) from {db_path} (expected at least {MIN_ENTRIES}). "
+            "The database shrank drastically or this selector broke; "
+            "either way the partition assertion below would be meaningless.")
+    return [selected[key] for key in sorted(selected)]
+
+
+def rel_to_repo(path: pathlib.Path) -> str:
+    """Repo-relative POSIX path, or the absolute path when outside."""
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def prune_db(entries: list[dict], workdir: pathlib.Path) -> pathlib.Path:
+    """Write the selected entries to a private compilation database.
+
+    Never into the build directory, where the pruned copy could shadow the
+    real one.  Each entry's `directory` is preserved verbatim so its
+    relative `-I` flags keep resolving.
+    """
+    db_path = workdir / "compile_commands.json"
+    db_path.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Calibration guards
+# ---------------------------------------------------------------------------
+
+def supported_majors() -> list[str]:
+    majors = read_list(SUPPORTED_MAJORS)
+    if not majors:
+        raise GateError(f"{SUPPORTED_MAJORS.name} lists no versions")
+    return majors
+
+
+def resolve_clang_tidy() -> str:
+    # Versioned names first: an unsuffixed `clang-tidy` is whatever the
+    # distribution happens to default to, so preferring it would SKIP for a
+    # developer who has clang-tidy-20 as the default and a supported
+    # clang-tidy-22 installed alongside it.  CI is unaffected either way --
+    # it exports CLANG_TIDY explicitly.
+    override = os.environ.get("CLANG_TIDY")
+    candidates = [override] if override else []
+    for major in supported_majors():
+        candidates.append(f"clang-tidy-{major}")
+    candidates.append("clang-tidy")
+    for candidate in candidates:
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    raise SkipGate("clang-tidy not found on PATH")
+
+
+def check_version(exe: str) -> str:
+    try:
+        proc = subprocess.run([exe, "--version"], capture_output=True,
+                              text=True, check=False)
+    except OSError as exc:
+        raise SkipGate(f"cannot run {exe}: {exc}") from exc
+    match = VERSION_RE.search(proc.stdout)
+    if match is None:
+        raise SkipGate(f"cannot parse a version out of `{exe} --version`")
+    major = match.group(1)
+    allowed = supported_majors()
+    if major not in allowed:
+        raise SkipGate(
+            f"clang-tidy major {major} is not in the supported set "
+            f"({', '.join(allowed)}); the allowlist was calibrated against "
+            f"those and clang-analyzer results move between releases. "
+            f"Update {rel_to_repo(SUPPORTED_MAJORS)} once the lists have "
+            "been re-derived on the new toolchain.")
+    return match.group(0).removeprefix("LLVM version ").rstrip(".")
+
+
+SUPPORTED_ARCHES = ("x86_64", "amd64")
+
+
+def check_platform() -> None:
+    # Mirrors the `if not is_windows` guard the ABI gates already use in
+    # tests/meson.build.  The allowlist was derived on Linux only.
+    if not sys.platform.startswith("linux"):
+        raise SkipGate(f"host platform is {sys.platform}, not Linux; the "
+                       "allowlist was calibrated on Linux only")
+    # Not redundant with the OS check: the build-arm job is Linux,
+    # uninstrumented and not MSVC, and runs an unfiltered `meson test`.
+    # clang-analyzer results are target-dependent, so an aarch64 verdict
+    # against an x86_64-calibrated allowlist would be noise either way it
+    # came out.
+    machine = platform.machine()
+    if machine not in SUPPORTED_ARCHES:
+        raise SkipGate(f"host arch is {machine}; the allowlist was "
+                       "calibrated on x86_64 only")
+
+
+def check_configuration(entries: list[dict]) -> None:
+    for entry in entries:
+        tokens = entry_command(entry)
+        for token in tokens:
+            if token.startswith("-fsanitize="):
+                raise SkipGate(
+                    "the build is instrumented "
+                    f"({token} on {rel_to_repo(entry_source(entry))}); the "
+                    "allowlist was calibrated against an uninstrumented "
+                    "default build")
+        compiler = pathlib.PurePath(tokens[0]).name.lower() if tokens else ""
+        if compiler in ("cl", "cl.exe"):
+            raise SkipGate("the database records MSVC-style command lines, "
+                           "which clang-tidy cannot consume as-is")
+
+
+# ---------------------------------------------------------------------------
+# Running clang-tidy
+# ---------------------------------------------------------------------------
+
+class Result:
+    def __init__(self, source: pathlib.Path, returncode: int,
+                 stdout: str, stderr: str, diagnostics: list[str]):
+        self.source = source
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.diagnostics = diagnostics
+
+
+def parse_diagnostics(stdout: str, cwd: pathlib.Path) -> list[str]:
+    """Keep the stdout diagnostics whose path lands under wirelog/.
+
+    Paths arrive in both relative (`../wirelog/ir/program.c`) and absolute
+    form depending on how the file entered the invocation, so both are
+    resolved against the invocation's working directory before filtering.
+    Without this, a file could be scanned and have its diagnostics
+    attributed to nothing.
+    """
+    wirelog_dir = REPO_ROOT / "wirelog"
+    kept: list[str] = []
+    for line in stdout.splitlines():
+        match = DIAG_RE.match(line)
+        if match is None:
+            continue
+        raw = pathlib.Path(match.group("path"))
+        resolved = raw if raw.is_absolute() else (cwd / raw)
+        try:
+            resolved = resolved.resolve()
+        except OSError:
+            continue
+        if not resolved.is_relative_to(wirelog_dir):
+            continue
+        kept.append("{}:{}:{}: {}: {}".format(
+            rel_to_repo(resolved), match.group("line"), match.group("col"),
+            match.group("severity"), match.group("message")))
+    return kept
+
+
+def run_clang_tidy(exe: str, db_dir: pathlib.Path, entry: dict) -> Result:
+    source = entry_source(entry)
+    cwd = pathlib.Path(entry["directory"])
+    argv = [exe, f"--config-file={CONFIG_FILE}", "-p", str(db_dir),
+            str(source)]
+    proc = subprocess.run(argv, cwd=str(cwd), capture_output=True, text=True,
+                          check=False)
+    return Result(source, proc.returncode, proc.stdout, proc.stderr,
+                  parse_diagnostics(proc.stdout, cwd))
+
+
+def job_count() -> int:
+    override = os.environ.get("WIRELOG_TIDY_JOBS")
+    if override:
+        try:
+            value = int(override)
+        except ValueError as exc:
+            raise GateError(
+                f"WIRELOG_TIDY_JOBS={override!r} is not an integer") from exc
+        if value < 1:
+            raise GateError(f"WIRELOG_TIDY_JOBS={value} must be >= 1")
+        return value
+    return min(8, os.cpu_count() or 1)
+
+
+def run_all(exe: str, db_dir: pathlib.Path,
+            entries: list[dict]) -> list[Result]:
+    jobs = job_count()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+        futures = [pool.submit(run_clang_tidy, exe, db_dir, entry)
+                   for entry in entries]
+        return [future.result() for future in futures]
+
+
+def report_failures(results: list[Result]) -> int:
+    """Print the failures; return the process exit code."""
+    dirty = [r for r in results if r.diagnostics]
+    # A non-zero exit with no diagnostics on stdout means clang-tidy could
+    # not do its job.  Never report that as a pass.
+    broken = [r for r in results if r.returncode != 0 and not r.diagnostics]
+
+    if broken:
+        print("check-clang-tidy-ratchet: FAIL: clang-tidy failed to run "
+              "cleanly (harness error, not a lint result):", file=sys.stderr)
+        for result in broken:
+            print(f"  {rel_to_repo(result.source)}: "
+                  f"exit {result.returncode}", file=sys.stderr)
+            for line in result.stderr.splitlines():
+                print(f"    {line}", file=sys.stderr)
+        return 1
+
+    if not dirty:
+        return 0
+
+    print("check-clang-tidy-ratchet: FAIL: allowlisted file(s) are no "
+          "longer clang-tidy clean:", file=sys.stderr)
+    print("", file=sys.stderr)
+    for result in dirty:
+        print(f"  {rel_to_repo(result.source)}", file=sys.stderr)
+        for diagnostic in result.diagnostics:
+            print(f"    {diagnostic}", file=sys.stderr)
+        if result.stderr.strip():
+            for line in result.stderr.splitlines():
+                print(f"    [stderr] {line}", file=sys.stderr)
+        print("", file=sys.stderr)
+    print("Fix the diagnostics.  Do NOT move the file to "
+          f"{rel_to_repo(BACKLOG)}: the backlog is monotonically "
+          "non-increasing and check-clang-tidy-backlog-monotonic.sh will "
+          "reject the demotion.", file=sys.stderr)
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+
+def mode_ratchet(exe: str, entries: list[dict]) -> int:
+    selected = {rel_to_repo(entry_source(e)): e for e in entries}
+    allow = read_list(ALLOWLIST)
+    backlog = read_list(BACKLOG)
+
+    fixture_rel = rel_to_repo(FIXTURE)
+    if fixture_rel in allow or fixture_rel in backlog:
+        raise GateError(
+            f"{fixture_rel} is a sensitivity fixture and must not appear in "
+            "either list; it is deliberately not part of any build target")
+
+    overlap = sorted(set(allow) & set(backlog))
+    missing = sorted(set(selected) - set(allow) - set(backlog))
+    unknown = sorted((set(allow) | set(backlog)) - set(selected))
+
+    if overlap or missing or unknown:
+        print("check-clang-tidy-ratchet: FAIL: the allowlist and the backlog "
+              "no longer partition the libwirelog.so sources.", file=sys.stderr)
+        if overlap:
+            print("  listed in BOTH files:", file=sys.stderr)
+            for path in overlap:
+                print(f"    {path}", file=sys.stderr)
+        if missing:
+            print("  built but listed in NEITHER file (add a new file to the "
+                  "allowlist if it is clean, to the backlog if it is not):",
+                  file=sys.stderr)
+            for path in missing:
+                print(f"    {path}", file=sys.stderr)
+        if unknown:
+            print("  listed but no longer built (a deleted or renamed "
+                  "source, or an allowlist line dropped to hide a "
+                  "regression):", file=sys.stderr)
+            for path in unknown:
+                print(f"    {path}", file=sys.stderr)
+        return 1
+
+    targets = [selected[path] for path in allow]
+    with tempfile.TemporaryDirectory(prefix="wl-tidy-") as tmp:
+        workdir = pathlib.Path(tmp)
+        prune_db([selected[p] for p in sorted(selected)], workdir)
+        results = run_all(exe, workdir, targets)
+
+    rc = report_failures(results)
+    if rc == 0:
+        print(f"check-clang-tidy-ratchet: OK; {len(allow)} file(s) clean, "
+              f"{len(backlog)} in backlog")
+    return rc
+
+
+def rewrite_for_fixture(entry: dict, fixture: pathlib.Path,
+                        stem: str) -> dict:
+    """Retarget a donor database entry at the fixture.
+
+    Six things describe the translation unit and all six must move together:
+    `file`, `output`, `-o`, `-MQ`, `-MF` and the trailing `-c <source>`.
+    Rewriting only `file` leaves clang-tidy analysing the DONOR source and
+    reporting the fixture clean at exit 0 -- a silently vacuous check.
+    """
+    tokens = entry_command(entry)
+    obj = f"{stem}.o"
+    out: list[str] = []
+    index = 0
+    seen = {"-o": False, "-MQ": False, "-MF": False, "-c": False}
+    while index < len(tokens):
+        token = tokens[index]
+        if token in ("-o", "-MQ", "-MF", "-c") and index + 1 < len(tokens):
+            seen[token] = True
+            out.append(token)
+            out.append(str(fixture) if token == "-c"
+                       else (obj + ".d" if token == "-MF" else obj))
+            index += 2
+            continue
+        out.append(token)
+        index += 1
+    unrewritten = sorted(flag for flag, hit in seen.items() if not hit)
+    if unrewritten:
+        raise GateError(
+            "donor compilation entry has no "
+            f"{', '.join(unrewritten)}; refusing to build a fixture command "
+            "that might still point at the donor source")
+    return {
+        "directory": entry["directory"],
+        "command": shlex.join(out),
+        "file": str(fixture),
+        "output": obj,
+    }
+
+
+def fixture_expected_line() -> int:
+    if not FIXTURE.is_file():
+        raise GateError(f"sensitivity fixture missing: {FIXTURE}")
+    lines = FIXTURE.read_text(encoding="utf-8").splitlines()
+    hits = [n for n, text in enumerate(lines, 1) if FIXTURE_MARKER in text]
+    if len(hits) != 1:
+        raise GateError(
+            f"expected exactly one {FIXTURE_MARKER} marker in "
+            f"{rel_to_repo(FIXTURE)}, found {len(hits)}")
+    return hits[0]
+
+
+def mode_sensitivity(exe: str, entries: list[dict]) -> int:
+    """Prove the gate can still see a diagnostic it is supposed to see.
+
+    A ratchet that reports everything clean because it silently analysed the
+    wrong file, or lost its configuration, passes just as loudly as one that
+    works.  This is the control: a fixture that is never compiled by any
+    meson target, carrying one deliberate `bugprone-integer-division`.
+    Zero diagnostics, a different check, a different line, or a compile
+    error all fail.
+    """
+    expected_line = fixture_expected_line()
+    donor = entries[0]
+
+    with tempfile.TemporaryDirectory(prefix="wl-tidy-fixture-") as tmp:
+        workdir = pathlib.Path(tmp)
+        synthetic = rewrite_for_fixture(donor, FIXTURE, "wl_tidy_fixture")
+        prune_db([synthetic], workdir)
+        result = run_clang_tidy(exe, workdir, synthetic)
+
+    diagnostics = [line for line in result.stdout.splitlines()
+                   if DIAG_RE.match(line)]
+    problems: list[str] = []
+    if len(diagnostics) != 1:
+        problems.append(f"expected 1 diagnostic, got {len(diagnostics)}")
+    else:
+        match = DIAG_RE.match(diagnostics[0])
+        assert match is not None
+        check = CHECK_RE.search(match.group("message"))
+        name = check.group(1) if check else "<no check name>"
+        if name != FIXTURE_CHECK:
+            problems.append(f"expected check {FIXTURE_CHECK}, got {name}")
+        if int(match.group("line")) != expected_line:
+            problems.append(f"expected the diagnostic on line "
+                            f"{expected_line}, got {match.group('line')}")
+        if match.group("severity") != "warning":
+            problems.append(
+                f"expected a warning, got {match.group('severity')}")
+
+    if not problems:
+        print("check-clang-tidy-ratchet: OK; sensitivity fixture reports "
+              f"exactly one {FIXTURE_CHECK} at "
+              f"{rel_to_repo(FIXTURE)}:{expected_line}")
+        return 0
+
+    print("check-clang-tidy-ratchet: FAIL: the sensitivity fixture did not "
+          "behave as expected, so a clean ratchet run proves nothing:",
+          file=sys.stderr)
+    for problem in problems:
+        print(f"  {problem}", file=sys.stderr)
+    print(f"  clang-tidy exit {result.returncode}", file=sys.stderr)
+    print("  --- stdout ---", file=sys.stderr)
+    for line in result.stdout.splitlines():
+        print(f"  {line}", file=sys.stderr)
+    print("  --- stderr ---", file=sys.stderr)
+    for line in result.stderr.splitlines():
+        print(f"  {line}", file=sys.stderr)
+    return 1
+
+
+def mode_regenerate(exe: str, entries: list[dict]) -> int:
+    """Maintainer helper: print the clean/dirty split of every selected TU.
+
+    Not wired into CI.  Run it after a toolchain bump to re-derive the two
+    lists, then review the move of every single line by hand.
+    """
+    with tempfile.TemporaryDirectory(prefix="wl-tidy-") as tmp:
+        workdir = pathlib.Path(tmp)
+        prune_db(entries, workdir)
+        results = run_all(exe, workdir, entries)
+    for result in sorted(results, key=lambda r: r.source):
+        state = "DIRTY" if result.diagnostics else "clean"
+        print(f"{state} {rel_to_repo(result.source)} "
+              f"({len(result.diagnostics)})")
+    return 0
+
+
+MODES = {
+    "ratchet": mode_ratchet,
+    "sensitivity": mode_sensitivity,
+    "regenerate": mode_regenerate,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--build-dir", required=True,
+                        help="meson build directory holding "
+                             "compile_commands.json")
+    parser.add_argument("--mode", choices=sorted(MODES), default="ratchet")
+    args = parser.parse_args()
+
+    required = os.environ.get("WIRELOG_TIDY_REQUIRED") == "1"
+
+    try:
+        if os.environ.get("WIRELOG_TIDY_SKIP") == "1":
+            raise SkipGate("WIRELOG_TIDY_SKIP=1 in the environment")
+        check_platform()
+        if not CONFIG_FILE.is_file():
+            raise GateError(f"clang-tidy config missing: {CONFIG_FILE}")
+        exe = resolve_clang_tidy()
+        version = check_version(exe)
+        entries = select_entries(pathlib.Path(args.build_dir).resolve())
+        check_configuration(entries)
+        print(f"check-clang-tidy-ratchet: using {exe} (LLVM {version}), "
+              f"{len(entries)} libwirelog.so translation unit(s), "
+              f"{job_count()} job(s)")
+        return MODES[args.mode](exe, entries)
+    except SkipGate as skip:
+        if required:
+            print(f"check-clang-tidy-ratchet: FAIL: {skip} "
+                  "(WIRELOG_TIDY_REQUIRED=1 forbids skipping)",
+                  file=sys.stderr)
+            return 1
+        print(f"check-clang-tidy-ratchet: SKIP: {skip}")
+        return SKIP_EXIT
+    except GateError as err:
+        print(f"check-clang-tidy-ratchet: FAIL: {err}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -1,0 +1,108 @@
+# scripts/ci/clang-tidy-allowlist.txt - Issue #1100.
+#
+# The libwirelog.so sources that are clang-tidy clean under the repository
+# .clang-tidy.  scripts/ci/check-clang-tidy-ratchet.py analyses every file
+# listed here on every run; one diagnostic fails the build.
+#
+# This is a ratchet register, in the shape of
+# scripts/ci/phase-label-allowlist.txt:
+#
+#   - It may only GROW.  A file moves here when it is cleaned up.
+#   - It may not shrink.  Together with clang-tidy-backlog.txt it must
+#     partition the libwirelog.so translation units in
+#     compile_commands.json exactly, so deleting a line to hide a
+#     regression fails the partition assertion.
+#   - Moving a line to the backlog fails
+#     scripts/ci/check-clang-tidy-backlog-monotonic.sh.  Fix the file.
+#
+# Paths are repository-relative and sorted under the C locale (LC_ALL=C
+# sort).  Keep it that way: a re-sort under a collating locale moves
+# diff.c relative to diff_arrangement.c and produces a spurious diff.
+#
+# LIMITATION -- x86_64 Linux only.  clang-analyzer results are target- and
+# toolchain-dependent, so "clean" below is a claim about x86_64 Linux at
+# the LLVM major in clang-tidy-supported-majors.txt, and nothing else.  The
+# gate SKIPs elsewhere rather than reporting an uncalibrated verdict.
+#
+# LIMITATION -- one preprocessor configuration only.  Each file is analysed
+# under the single command line meson recorded for it, so code behind
+# non-default conditionals is never seen even though the file is listed as
+# clean here:
+#
+#   wirelog/exec_plan_gen.c   analysed only with ENABLE_K_FUSION at 1, the
+#                             #ifndef default at :43-44, because the
+#                             database entry carries no -DENABLE_K_FUSION.
+#                             Every #if ENABLE_K_FUSION guard in the file
+#                             (e.g. :1866) has an arm that is never seen,
+#                             and the ENABLE_K_FUSION=0 variant that
+#                             bench_flowlog_seq builds
+#                             (bench/meson.build:126) is never analysed.
+#   wirelog/columnar/relation.c
+#                             analysed only with WL_RADIX_BENCH undefined,
+#                             so every #ifdef WL_RADIX_BENCH region in the
+#                             file (e.g. :56) is invisible here.  The macro
+#                             is set only by bench/meson.build:109.
+#
+# The line references above are examples, NOT an enumeration -- both files
+# carry several such guards.  Please keep it that way: an exhaustive list
+# would go stale on the next edit to either file with nothing to catch it.
+#
+# Covering both configurations needs a second scan pass; tracked as #1115.
+wirelog/api_facade.c
+wirelog/arena/arena.c
+wirelog/arena/compound_arena.c
+wirelog/columnar/arithmetic.c
+wirelog/columnar/cache.c
+wirelog/columnar/compound_side.c
+wirelog/columnar/delta_pool.c
+wirelog/columnar/diff.c
+wirelog/columnar/diff_arrangement.c
+wirelog/columnar/diff_bridge.c
+wirelog/columnar/diff_trace.c
+wirelog/columnar/diff_vtable.c
+wirelog/columnar/eval_dedup.c
+wirelog/columnar/eval_stack.c
+wirelog/columnar/eval_tdd_plan.c
+wirelog/columnar/filter.c
+wirelog/columnar/frontier.c
+wirelog/columnar/frontier_epoch.c
+wirelog/columnar/handle_remap.c
+wirelog/columnar/handle_remap_apply.c
+wirelog/columnar/handle_remap_apply_side.c
+wirelog/columnar/inline.c
+wirelog/columnar/lftj.c
+wirelog/columnar/mem_ledger.c
+wirelog/columnar/ops.c
+wirelog/columnar/partition.c
+wirelog/columnar/progress.c
+wirelog/columnar/relation.c
+wirelog/columnar/rotation_pinned.c
+wirelog/columnar/rotation_standard.c
+wirelog/columnar/session.c
+wirelog/columnar/session_hash.c
+wirelog/crc32.c
+wirelog/exec_plan_gen.c
+wirelog/intern.c
+wirelog/io/csv_adapter.c
+wirelog/io/csv_reader.c
+wirelog/io/io_adapter.c
+wirelog/io/io_ctx.c
+wirelog/ir/api.c
+wirelog/ir/ir.c
+wirelog/parser/ast.c
+wirelog/parser/lexer.c
+wirelog/parser/parser.c
+wirelog/passes/fusion.c
+wirelog/passes/magic_sets.c
+wirelog/passes/sip.c
+wirelog/passes/subsumption.c
+wirelog/session.c
+wirelog/session_facts.c
+wirelog/string_ops.c
+wirelog/thread_c11.c
+wirelog/util/lockfree_queue.c
+wirelog/util/log.c
+wirelog/util/log_emit.c
+wirelog/wirelog-easy.c
+wirelog/wirelog_advanced.c
+wirelog/workqueue.c

--- a/scripts/ci/clang-tidy-backlog.txt
+++ b/scripts/ci/clang-tidy-backlog.txt
@@ -1,0 +1,47 @@
+# scripts/ci/clang-tidy-backlog.txt - Issue #1100.
+#
+# The libwirelog.so sources that are NOT clang-tidy clean yet.  They are
+# excluded from the scan by scripts/ci/check-clang-tidy-ratchet.py; the
+# ratchet only guarantees that the files in clang-tidy-allowlist.txt stay
+# clean.
+#
+# The register is monotonically non-increasing:
+#
+#   - Entries may be REMOVED, by cleaning the file up and moving it to
+#     clang-tidy-allowlist.txt.
+#   - Entries may NOT be ADDED.  Demoting a file that regressed keeps the
+#     allowlist/backlog partition exact, so the ratchet itself would still
+#     pass -- which makes it the cheapest way to make a regression
+#     disappear.  scripts/ci/check-clang-tidy-backlog-monotonic.sh diffs
+#     this file against the merge base with the base branch (not its tip,
+#     which would flag a line that main removed while your branch was
+#     open) and rejects additions.
+#   - A genuinely new source file that is not clean on arrival is the one
+#     case that needs a line added here, and it needs an explicit decision
+#     recorded in the PR description.
+#
+# NO DIAGNOSTIC COUNTS.  A count would look like useful precision and is
+# not: the numbers are toolchain-version-dependent.  LLVM 22 renamed the
+# clang-analyzer-valist.* checks out from under .clang-tidy:58 (see #1114),
+# which would have moved counts here with no source change at all.  Run
+#   scripts/ci/check-clang-tidy-ratchet.py --build-dir build --mode regenerate
+# for the current numbers.
+#
+# Paths are repository-relative and sorted under the C locale (LC_ALL=C
+# sort), matching clang-tidy-allowlist.txt.
+#
+# wirelog/ir/program.c is the reason this issue exists: it was clean, and
+# regressed to bugprone-branch-clone after f1d2a2c with nothing failing.
+wirelog/columnar/arrangement.c
+wirelog/columnar/eval.c
+wirelog/columnar/eval_delta.c
+wirelog/columnar/eval_plan.c
+wirelog/columnar/eval_tdd_queue.c
+wirelog/columnar/expr.c
+wirelog/columnar/join.c
+wirelog/columnar/kfusion.c
+wirelog/columnar/merge.c
+wirelog/columnar/mobius.c
+wirelog/ir/program.c
+wirelog/ir/stratify.c
+wirelog/passes/jpp.c

--- a/scripts/ci/clang-tidy-supported-majors.txt
+++ b/scripts/ci/clang-tidy-supported-majors.txt
@@ -1,0 +1,19 @@
+# scripts/ci/clang-tidy-supported-majors.txt - Issue #1100.
+#
+# LLVM major versions the clang-tidy ratchet is calibrated for, one per
+# line, most preferred first.  scripts/ci/check-clang-tidy-ratchet.py SKIPs
+# on any other major; .github/workflows/ci-pr.yml installs the first entry.
+#
+# Why a pin at all: 9 of the 13 backlog diagnostics are path-sensitive
+# clang-analyzer results that move between LLVM releases, and LLVM 22
+# renamed the clang-analyzer-valist.* checks out from under .clang-tidy
+# entirely (see #1114).  An unpinned gate would fail, or silently stop
+# covering checks, on the first toolchain bump.
+#
+# To adopt a new major: run
+#   scripts/ci/check-clang-tidy-ratchet.py --build-dir build --mode regenerate
+# on the new toolchain, review every line that changes state, update
+# clang-tidy-allowlist.txt / clang-tidy-backlog.txt, then edit this file.
+# Note that clang-tidy-backlog.txt is monotonically non-increasing, so a
+# bump that dirties a currently clean file must fix it, not demote it.
+22

--- a/tests/clang_tidy_fixture.c
+++ b/tests/clang_tidy_fixture.c
@@ -1,0 +1,32 @@
+/*
+ * tests/clang_tidy_fixture.c - clang-tidy sensitivity fixture (Issue #1100).
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ *
+ * This file is NOT compiled by any meson target and is NOT listed in
+ * scripts/ci/clang-tidy-allowlist.txt or clang-tidy-backlog.txt.  It exists
+ * only so scripts/ci/check-clang-tidy-ratchet.py --mode sensitivity can
+ * prove that the ratchet can still see a diagnostic it is supposed to see.
+ *
+ * A ratchet that reports every file clean because it lost its config, or
+ * because it silently analysed the wrong source, passes exactly as loudly
+ * as one that works.  Issue #1079 -- a symlinked build directory quietly
+ * changing what was analysed -- is that failure mode.  This is the control.
+ *
+ * The body below must produce EXACTLY ONE diagnostic under the repository
+ * .clang-tidy: bugprone-integer-division, on the marked line.  Zero
+ * diagnostics, a different check, a different line, or a compile error all
+ * fail the check.  Do not "fix" the integer division below, and do not add
+ * anything else to this file.
+ */
+
+double wl_clang_tidy_fixture_ratio(int a, int b);
+
+double
+wl_clang_tidy_fixture_ratio(int a, int b)
+{
+    double ratio = a / b; /* WL_TIDY_FIXTURE_EXPECT integer-division */
+
+    return ratio;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -303,6 +303,15 @@ test_jpp_exe = executable(
   thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [threads_dep],
+  # Issue #1111: the allocation-failure sweeps need calloc AND malloc
+  # interposition -- jpp.c allocates its key arrays with calloc and the key
+  # strings through strdup_safe(), which uses malloc.
+  #
+  # b_lto=false is MANDATORY, not tidiness: with -flto the linker resolves
+  # the calls before --wrap is applied, the wrappers are never reached, and
+  # NO diagnostic is emitted.  The sweeps would pass while testing nothing.
+  link_args: host_machine.system() == 'linux' ? ['-Wl,--wrap=calloc', '-Wl,--wrap=malloc'] : [],
+  override_options: host_machine.system() == 'linux' ? ['b_lto=false'] : [],
 )
 
 test('jpp', test_jpp_exe)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -758,6 +758,62 @@ if sh.found()
        suite: 'sbom')
 endif
 
+# Issue #1100: clang-tidy ratchet (suite 'tidy').  No CI job has run
+# clang-tidy since efbde27 removed it, and wirelog/ir/program.c regressed
+# after f1d2a2c with nothing failing.  The gate re-analyses every file in
+# scripts/ci/clang-tidy-allowlist.txt on every run; the 13 files in
+# clang-tidy-backlog.txt are excluded, and the two lists must partition the
+# libwirelog.so entries of compile_commands.json exactly.
+#
+# As with the perf gate above, suite membership excludes nothing (there is
+# no add_test_setup in this project), so these run in a default
+# `meson test`.  Opting out is a runtime decision instead: the ratchet SKIPs
+# unless clang-tidy is present at a supported major
+# (scripts/ci/clang-tidy-supported-majors.txt), the host is Linux on
+# x86_64, and the database is free of -fsanitize= / MSVC command lines --
+# so the sanitizer, tsan, macOS, MSVC and build-arm jobs skip it rather
+# than reporting an uncalibrated verdict.  The arch guard is what covers
+# build-arm: it is Linux, uninstrumented and not MSVC, so only the target
+# check distinguishes it.  WIRELOG_TIDY_REQUIRED=1 (set by build-primary)
+# turns those skips into failures; WIRELOG_TIDY_SKIP=1 forces a skip.
+#
+# Cost: ~12-16 s wall at 8 jobs, ~113 s summed CPU, on a suite whose
+# baseline is ~20 s wall.  priority: 100 starts it early so it overlaps the
+# rest rather than trailing them.  The 900 s timeout is generous against
+# the 12.7 s worst single file (exec_plan_gen.c) on a loaded runner.
+if not is_windows
+  test('clang_tidy_ratchet', py3,
+       args: [meson.project_source_root() / 'scripts/ci/check-clang-tidy-ratchet.py',
+              '--build-dir', meson.project_build_root(),
+              '--mode', 'ratchet'],
+       suite: 'tidy',
+       timeout: 900,
+       priority: 100)
+
+  # Sensitivity control: a fixture that no meson target compiles and that
+  # appears in neither list, carrying one deliberate bugprone-integer-
+  # division.  Without it a ratchet that silently analysed the wrong file
+  # (issue #1079's symlinked build dir) would report everything clean.
+  test('clang_tidy_sensitivity', py3,
+       args: [meson.project_source_root() / 'scripts/ci/check-clang-tidy-ratchet.py',
+              '--build-dir', meson.project_build_root(),
+              '--mode', 'sensitivity'],
+       suite: 'tidy',
+       timeout: 300,
+       priority: 100)
+
+  # Demotion guard: the partition assertion above catches a DELETED
+  # allowlist line, but moving one to the backlog keeps the partition exact.
+  # Compares against the merge base with the base branch, so a backlog line
+  # that main removes while a branch is open is not misread as an addition.
+  # SKIPs when no merge base is available (shallow clone, tarball).
+  if sh.found()
+    test('clang_tidy_backlog_monotonic', sh,
+         args: [meson.project_source_root() / 'scripts/ci/check-clang-tidy-backlog-monotonic.sh'],
+         suite: 'tidy')
+  endif
+endif
+
 # Issue #689 / Blocker B2: standalone-include compile matrix for the
 # public-headers SSoT.  One executable per public header, each
 # compiled in isolation against tests/standalone/test_standalone_<H>.c

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -12,9 +12,93 @@
 #include "../wirelog/wirelog-parser.h"
 
 #include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* ======================================================================== */
+/* Allocator interposition for the JPP OOM sweeps (Issue #1111)             */
+/* ======================================================================== */
+
+/*
+ * jpp.c must be all-or-nothing per join chain: an allocation failure inside
+ * wl_jpp_apply() may leave a plan unoptimized, but must never leave a JOIN
+ * node carrying keys that do not describe the join it sits on.  The failure
+ * the issue names is a JOIN left with ZERO keys, which exec_plan_gen.c runs
+ * as a cross product -- wrong answers, exit status 0.
+ *
+ * Reaching those paths needs allocator interposition, so tests/meson.build
+ * links this binary with --wrap=calloc AND --wrap=malloc.  Both are needed:
+ * the key arrays come from calloc, but the key STRINGS come from
+ * strdup_safe(), which uses malloc (wirelog/ir/ir.c).  A calloc-only sweep
+ * can never exercise the unchecked strdup path, and that path is not merely
+ * "a different failure mode": exec_plan_gen.c's resolve_key_to_colN() falls
+ * back to column 0 when a key name is NULL, so a NULL key silently produces
+ * a WRONG join rather than a cross product.
+ *
+ * The wrap must be paired with b_lto=false in tests/meson.build.  Under
+ * -flto the wrappers are never reached and no diagnostic is emitted.
+ */
+
+#ifdef __linux__
+
+static bool jpp_oom_armed;
+static long jpp_calloc_countdown = -1; /* < 0: count but never fail */
+static long jpp_malloc_countdown = -1;
+static unsigned long jpp_calloc_calls;
+static unsigned long jpp_malloc_calls;
+
+void *__real_calloc(size_t nmemb, size_t size);
+void *__real_malloc(size_t size);
+
+void *
+__wrap_calloc(size_t nmemb, size_t size)
+{
+    if (jpp_oom_armed) {
+        jpp_calloc_calls++;
+        if (jpp_calloc_countdown >= 0 && jpp_calloc_countdown-- == 0)
+            return NULL;
+    }
+    return __real_calloc(nmemb, size);
+}
+
+void *
+__wrap_malloc(size_t size)
+{
+    if (jpp_oom_armed) {
+        jpp_malloc_calls++;
+        if (jpp_malloc_countdown >= 0 && jpp_malloc_countdown-- == 0)
+            return NULL;
+    }
+    return __real_malloc(size);
+}
+
+/*
+ * Arm the countdowns.  A negative countdown counts calls without failing
+ * any.  Arming is scoped to the wl_jpp_apply() call itself so that parsing
+ * and program construction never see a failing allocator.
+ */
+static void
+jpp_oom_arm(long calloc_nth, long malloc_nth)
+{
+    jpp_calloc_countdown = calloc_nth;
+    jpp_malloc_countdown = malloc_nth;
+    jpp_calloc_calls = 0;
+    jpp_malloc_calls = 0;
+    jpp_oom_armed = true;
+}
+
+static void
+jpp_oom_disarm(void)
+{
+    jpp_oom_armed = false;
+    jpp_calloc_countdown = -1;
+    jpp_malloc_countdown = -1;
+}
+
+#endif /* __linux__ */
 
 /* ======================================================================== */
 /* Test Helpers                                                             */
@@ -1740,6 +1824,353 @@ test_jpp_wide_head_antijoin_key(void)
 }
 
 /* ======================================================================== */
+/* OOM sweep over wl_jpp_apply (Issue #1111)                                */
+/* ======================================================================== */
+
+/*
+ * TWO fixtures, and neither is redundant.  They share a body and differ only
+ * in how wide the head is, which decides whether insert_projections() fires.
+ * jpp.c builds join keys at two independent sites, and each fixture is the
+ * sole cover for one of them.  Measured, by reverting one site at a time
+ * against the finished fix:
+ *
+ *   - Revert only rebuild_chain() to destroy-then-allocate: BOTH fixtures
+ *     fail at calloc #9, "1 of 3 join(s) have zero keys (cross product)".
+ *   - Revert only the key recomputation above an inserted projection in
+ *     insert_projections(): Fixture A PASSES and Fixture B fails at
+ *     calloc #27, same message.
+ *
+ * So dropping Fixture B would silently retire all coverage of the second
+ * site.  Fixture A is kept because it isolates the issue's named defect to
+ * rebuild_chain() alone: with no PROJECT in the tree, a zero-key JOIN cannot
+ * be blamed on, or repaired by, insert_projections().
+ *
+ * Connectivity is equally load-bearing: a, b, c and d form a single connected
+ * conjunct (x-y, y-w, w-v, v-z), so every JOIN in the rebuilt chain shares at
+ * least one variable with its accumulated left side and a zero-key JOIN is
+ * therefore always a defect here.  For a DISCONNECTED rule a zero-key JOIN is
+ * the CORRECT answer -- a cross product is what a disconnected conjunct means
+ * -- so that assertion would be wrong on correct code.
+ *
+ * The body order (a, d, c, b) is deliberately non-optimal so that greedy_order
+ * reports a change and rebuild_chain() actually runs.
+ */
+#define JPP_OOM_DECLS              \
+        ".decl a(x: int32, y: int32)\n" \
+        ".decl b(y: int32, w: int32)\n" \
+        ".decl c(w: int32, v: int32)\n" \
+        ".decl d(v: int32, z: int32)\n"
+
+/* Everything from here to the sweep driver is Linux-only: without --wrap
+ * there is nothing to drive it, and leaving the helpers defined elsewhere
+ * would break the macOS and MSVC builds on -Wunused-function. */
+#ifdef __linux__
+
+/* Fixture A -- every body variable is live in the head, so no PROJECT is
+ * inserted and rebuild_chain() is the only key-building site in play. */
+static const char *const JPP_OOM_SRC_ALL_LIVE = JPP_OOM_DECLS
+    ".decl p(x: int32, y: int32, w: int32, v: int32, z: int32)\n"
+    "p(x, y, w, v, z) :- a(x, y), d(v, z), c(w, v), b(y, w).\n";
+
+/* Fixture B -- same body, narrow head, so intermediate PROJECTs ARE inserted.
+ * This is the one that reaches the second build-then-install site, the key
+ * recomputation above an inserted projection in insert_projections(). */
+static const char *const JPP_OOM_SRC_PROJECTED = JPP_OOM_DECLS
+    ".decl q(x: int32, z: int32)\n"
+    "q(x, z) :- a(x, y), d(v, z), c(w, v), b(y, w).\n";
+
+#define JPP_OOM_MAX_JOINS 16
+#define JPP_OOM_SWEEP_MAX 64
+
+typedef struct {
+    const wirelog_ir_node_t *node;
+    const wirelog_ir_node_t *child0;
+    const wirelog_ir_node_t *child1;
+} jpp_join_snapshot_t;
+
+/*
+ * Look through any PROJECT wrapper.  insert_projections() legitimately
+ * splices a PROJECT between two JOINs, which is a structural change that is
+ * NOT a reorder; comparing raw child pointers would read it as one.  Only
+ * the operand underneath tells us whether rebuild_chain() committed.
+ */
+static const wirelog_ir_node_t *
+strip_projects(const wirelog_ir_node_t *node)
+{
+    while (node && node->type == WIRELOG_IR_PROJECT && node->child_count > 0)
+        node = node->children[0];
+    return node;
+}
+
+static uint32_t
+snapshot_joins(const wirelog_ir_node_t *node, jpp_join_snapshot_t *out,
+    uint32_t max)
+{
+    if (!node || max == 0)
+        return 0;
+    uint32_t n = 0;
+    if (node->type == WIRELOG_IR_JOIN) {
+        out[0].node = node;
+        out[0].child0 = node->child_count > 0
+            ? strip_projects(node->children[0])
+            : NULL;
+        out[0].child1 = node->child_count > 1
+            ? strip_projects(node->children[1])
+            : NULL;
+        n = 1;
+    }
+    for (uint32_t i = 0; i < node->child_count && n < max; i++)
+        n += snapshot_joins(node->children[i], out + n, max - n);
+    return n;
+}
+
+/*
+ * Every JOIN reachable from @node is tallied into:
+ *   @zero_keys: JOINs left with no join key at all (the cross-product bug),
+ *   @null_elems: JOINs claiming N keys but holding a NULL name in [0, N)
+ *                (the wrong-column bug behind the unchecked strdup).
+ */
+static void
+tally_join_keys(const wirelog_ir_node_t *node, uint32_t *njoin,
+    uint32_t *zero_keys, uint32_t *null_elems)
+{
+    if (!node)
+        return;
+    if (node->type == WIRELOG_IR_JOIN) {
+        (*njoin)++;
+        if (node->join_key_count == 0) {
+            (*zero_keys)++;
+        } else if (!node->join_left_keys || !node->join_right_keys) {
+            (*null_elems)++;
+        } else {
+            for (uint32_t i = 0; i < node->join_key_count; i++) {
+                if (!node->join_left_keys[i] || !node->join_right_keys[i]) {
+                    (*null_elems)++;
+                    break;
+                }
+            }
+        }
+    }
+    for (uint32_t i = 0; i < node->child_count; i++)
+        tally_join_keys(node->children[i], njoin, zero_keys, null_elems);
+}
+
+/* True when no snapshotted JOIN has had either child pointer replaced. */
+static bool
+joins_children_unchanged(const wirelog_ir_node_t *ir,
+    const jpp_join_snapshot_t *before, uint32_t nbefore)
+{
+    jpp_join_snapshot_t after[JPP_OOM_MAX_JOINS];
+    uint32_t nafter = snapshot_joins(ir, after, JPP_OOM_MAX_JOINS);
+
+    if (nafter != nbefore)
+        return false;
+    for (uint32_t i = 0; i < nbefore; i++) {
+        bool matched = false;
+        for (uint32_t j = 0; j < nafter; j++) {
+            if (after[j].node != before[i].node)
+                continue;
+            matched = true;
+            if (after[j].child0 != before[i].child0
+                || after[j].child1 != before[i].child1)
+                return false;
+            break;
+        }
+        if (!matched)
+            return false;
+    }
+    return true;
+}
+
+/*
+ * One sweep step.  Returns NULL when the invariants hold, otherwise a static
+ * description of the violation.  @fail_calloc / @fail_malloc select which
+ * allocation inside wl_jpp_apply() returns NULL (< 0 fails none).
+ */
+static const char *
+jpp_oom_step(const char *src, const char *relation, long fail_calloc,
+    long fail_malloc, wl_jpp_stats_t *out_stats)
+{
+    static char detail[192];
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return "parse failed";
+
+    wirelog_ir_node_t *ir = find_relation_ir(prog, relation);
+    if (!ir) {
+        wirelog_program_free(prog);
+        return "relation IR not found";
+    }
+
+    jpp_join_snapshot_t before[JPP_OOM_MAX_JOINS];
+    uint32_t nbefore = snapshot_joins(ir, before, JPP_OOM_MAX_JOINS);
+    if (nbefore != 3) {
+        wirelog_program_free(prog);
+        return "fixture no longer builds a 3-join chain";
+    }
+
+    wl_jpp_stats_t stats = { 0, 0, 0, 0 };
+    jpp_oom_arm(fail_calloc, fail_malloc);
+    int rc = wl_jpp_apply(prog, &stats);
+    jpp_oom_disarm();
+
+    const char *problem = NULL;
+
+    /* Unconditional, at every sweep index. */
+    if (rc != 0) {
+        snprintf(detail, sizeof(detail), "rc=%d (expected 0)", rc);
+        problem = detail;
+    }
+
+    uint32_t njoin = 0, zero_keys = 0, null_elems = 0;
+    if (!problem) {
+        tally_join_keys(ir, &njoin, &zero_keys, &null_elems);
+        if (njoin != nbefore) {
+            snprintf(detail, sizeof(detail), "join count %u -> %u", nbefore,
+                njoin);
+            problem = detail;
+        } else if (null_elems != 0) {
+            snprintf(detail, sizeof(detail),
+                "%u join(s) claim keys but hold a NULL key name", null_elems);
+            problem = detail;
+        }
+    }
+
+    /* Structural contract: the pass either declined outright, leaving every
+     * child pointer as it found it, or it committed a full rebuild, in which
+     * case every JOIN of this connected chain must carry keys. */
+    if (!problem) {
+        if (joins_children_unchanged(ir, before, nbefore)) {
+            if (stats.joins_reordered != 0) {
+                snprintf(detail, sizeof(detail),
+                    "chain untouched but joins_reordered=%u",
+                    stats.joins_reordered);
+                problem = detail;
+            }
+        } else if (stats.joins_reordered != 1) {
+            snprintf(detail, sizeof(detail),
+                "chain rewired but joins_reordered=%u",
+                stats.joins_reordered);
+            problem = detail;
+        } else if (zero_keys != 0) {
+            snprintf(detail, sizeof(detail),
+                "chain rebuilt but %u of %u join(s) have zero keys "
+                "(cross product)",
+                zero_keys, njoin);
+            problem = detail;
+        }
+    }
+
+    if (out_stats)
+        *out_stats = stats;
+    wirelog_program_free(prog);
+    return problem;
+}
+
+static void
+run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
+    bool expect_projections)
+{
+    TEST(name);
+
+    char buf[256];
+
+    /* Unarmed baseline: proves the fixture still has the properties the
+     * sweep assertions rely on, and measures how many allocations the sweep
+     * has to cover. */
+    wl_jpp_stats_t base = { 0, 0, 0, 0 };
+    const char *problem = jpp_oom_step(src, relation, -1, -1, &base);
+    if (problem) {
+        FAIL(problem);
+        return;
+    }
+    if (base.joins_reordered != 1) {
+        snprintf(buf, sizeof(buf),
+            "fixture no longer reorders (joins_reordered=%u)",
+            base.joins_reordered);
+        FAIL(buf);
+        return;
+    }
+    if (expect_projections != (base.projections_inserted > 0)) {
+        snprintf(buf, sizeof(buf),
+            "fixture projections_inserted=%u, expected %s",
+            base.projections_inserted, expect_projections ? "> 0" : "0");
+        FAIL(buf);
+        return;
+    }
+
+    unsigned long ncalloc = jpp_calloc_calls;
+    unsigned long nmalloc = jpp_malloc_calls;
+    if (ncalloc == 0 || nmalloc == 0) {
+        /* Either --wrap did not take effect (b_lto slipped back on) or the
+         * pass stopped allocating; both make the sweep vacuous. */
+        snprintf(buf, sizeof(buf),
+            "allocator interposition inert: calloc=%lu malloc=%lu", ncalloc,
+            nmalloc);
+        FAIL(buf);
+        return;
+    }
+    if (ncalloc >= JPP_OOM_SWEEP_MAX || nmalloc >= JPP_OOM_SWEEP_MAX) {
+        snprintf(buf, sizeof(buf),
+            "sweep width %d no longer covers calloc=%lu malloc=%lu",
+            JPP_OOM_SWEEP_MAX, ncalloc, nmalloc);
+        FAIL(buf);
+        return;
+    }
+
+    /* The two routes are swept separately so that a regression in one is
+     * reported on its own terms: the calloc route reaches the key ARRAYS and
+     * the accumulator, the malloc route reaches the key STRINGS. */
+    for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
+        problem = jpp_oom_step(src, relation, n, -1, NULL);
+        if (problem) {
+            snprintf(buf, sizeof(buf), "calloc #%ld: %s", n, problem);
+            FAIL(buf);
+            return;
+        }
+    }
+    for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
+        problem = jpp_oom_step(src, relation, -1, n, NULL);
+        if (problem) {
+            snprintf(buf, sizeof(buf), "malloc #%ld: %s", n, problem);
+            FAIL(buf);
+            return;
+        }
+    }
+
+    PASS();
+}
+#endif /* __linux__ */
+
+static void
+test_jpp_oom_all_live_head(void)
+{
+#ifndef __linux__
+    TEST("jpp #1111: OOM sweep, all head variables live (no PROJECT)");
+    PASS();
+    return;
+#else
+    run_jpp_oom_sweep(
+        "jpp #1111: OOM sweep, all head variables live (no PROJECT)",
+        JPP_OOM_SRC_ALL_LIVE, "p", false);
+#endif
+}
+
+static void
+test_jpp_oom_projected_head(void)
+{
+#ifndef __linux__
+    TEST("jpp #1111: OOM sweep, narrow head (PROJECTs inserted)");
+    PASS();
+    return;
+#else
+    run_jpp_oom_sweep("jpp #1111: OOM sweep, narrow head (PROJECTs inserted)",
+        JPP_OOM_SRC_PROJECTED, "q", true);
+#endif
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -1790,6 +2221,10 @@ main(void)
     test_jpp_wide_head_antijoin_key();
     test_jpp_nullary_chain();
     test_jpp_plan_unchanged_narrow();
+
+    /* Allocation-failure sweeps (issue #1111) */
+    test_jpp_oom_all_live_head();
+    test_jpp_oom_projected_head();
 
     printf("\n  Total: %d  Passed: %d  Failed: %d\n\n", tests_run, tests_passed,
         tests_failed);

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -171,23 +171,80 @@ var_in_set(const char *var, char **set, uint32_t nset)
 /* ======================================================================== */
 
 /*
- * Mirrors the logic of setup_join_keys() in program.c but operates
- * on variable name arrays directly.
+ * A join key set that has been fully built but not yet installed on a node.
+ *
+ * Key construction is split into a build step that allocates but mutates no
+ * IR node, and an install step that mutates one node but allocates nothing.
+ * That split is what lets a caller be all-or-nothing: it can build every key
+ * set it needs first, and only start destroying the old keys once every
+ * replacement is in hand.  Building in place instead -- destroy, then
+ * allocate -- leaves a JOIN with zero keys when the allocation fails, and a
+ * zero-key JOIN is executed as a cross product, so the query silently returns
+ * wrong answers with exit status 0 (issue #1111).
+ *
+ * The strings are OWNED copies, never aliases into a SCAN's column_names:
+ * install hands them straight to node->join_left_keys/join_right_keys, whose
+ * elements are freed by free_join_keys() and wl_ir_node_free().
+ */
+typedef struct {
+    char **left;
+    char **right;
+    uint32_t count;
+} jpp_staged_keys_t;
+
+/*
+ * Release a staged key set that was never installed.  Safe on a zeroed
+ * struct and on one that install() has already emptied.
  */
 static void
-jpp_setup_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
-    uint32_t right_count, wirelog_ir_node_t *join)
+jpp_free_staged_keys(jpp_staged_keys_t *staged)
 {
+    if (!staged)
+        return;
+    for (uint32_t i = 0; i < staged->count; i++) {
+        free(staged->left[i]);
+        free(staged->right[i]);
+    }
+    free((void *)staged->left);
+    free((void *)staged->right);
+    staged->left = NULL;
+    staged->right = NULL;
+    staged->count = 0;
+}
+
+/*
+ * Build the join key set for a JOIN of @left_vars against @right_vars.
+ * Mirrors the logic of setup_join_keys() in program.c but operates on
+ * variable name arrays directly and touches no IR node.
+ *
+ * Returns false ONLY on allocation failure; *out is empty in that case and
+ * needs no cleanup.  A true return with out->count == 0 means the two sides
+ * share no variable, which is a legitimate cross product -- `p(x,y) :- a(x),
+ * b(y).` has no join key and ir/program.c's setup_join_keys() produces the
+ * same empty set.  Keeping those two outcomes on separate channels (the bool
+ * and the count) is the point: the old in-place builder reported both as
+ * "node now has zero keys".
+ */
+static bool
+jpp_build_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
+    uint32_t right_count, jpp_staged_keys_t *out)
+{
+    out->left = NULL;
+    out->right = NULL;
+    out->count = 0;
+
     uint32_t key_count
         = count_shared_vars(left_vars, left_count, right_vars, right_count);
     if (key_count == 0)
-        return;
+        return true;
 
-    join->join_left_keys = (char **)calloc(key_count, sizeof(char *));
-    join->join_right_keys = (char **)calloc(key_count, sizeof(char *));
-    if (!join->join_left_keys || !join->join_right_keys)
-        return;
-    join->join_key_count = key_count;
+    char **left = (char **)calloc(key_count, sizeof(char *));
+    char **right = (char **)calloc(key_count, sizeof(char *));
+    if (!left || !right) {
+        free((void *)left);
+        free((void *)right);
+        return false;
+    }
 
     uint32_t k = 0;
     for (uint32_t i = 0; i < left_count; i++) {
@@ -197,13 +254,34 @@ jpp_setup_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
             if (!right_vars[j])
                 continue;
             if (strcmp(left_vars[i], right_vars[j]) == 0) {
-                join->join_left_keys[k] = strdup_safe(left_vars[i]);
-                join->join_right_keys[k] = strdup_safe(right_vars[j]);
+                left[k] = strdup_safe(left_vars[i]);
+                right[k] = strdup_safe(right_vars[j]);
+                if (!left[k] || !right[k]) {
+                    /* A NULL key name is not a benign short key list:
+                     * exec_plan_gen.c's resolve_key_to_colN() falls back to
+                     * column 0 for a NULL name, turning the join into a
+                     * silently WRONG join rather than a cross product, and
+                     * ir.c prints key names through %s. */
+                    free(left[k]);
+                    free(right[k]);
+                    for (uint32_t f = 0; f < k; f++) {
+                        free(left[f]);
+                        free(right[f]);
+                    }
+                    free((void *)left);
+                    free((void *)right);
+                    return false;
+                }
                 k++;
                 break;
             }
         }
     }
+
+    out->left = left;
+    out->right = right;
+    out->count = k;
+    return true;
 }
 
 /* ======================================================================== */
@@ -261,6 +339,28 @@ free_join_keys(wirelog_ir_node_t *node)
     node->join_left_keys = NULL;
     node->join_right_keys = NULL;
     node->join_key_count = 0;
+}
+
+/* ======================================================================== */
+/* Internal: install a staged key set on a JOIN node                        */
+/* ======================================================================== */
+
+/*
+ * Replace @node's join keys with the previously built @staged set.
+ * Allocates nothing and therefore cannot fail: every caller may treat this
+ * as the commit half of a build-then-install pair.  Ownership of the staged
+ * arrays and strings transfers to @node, and @staged is left empty.
+ */
+static void
+jpp_install_join_keys(wirelog_ir_node_t *node, jpp_staged_keys_t *staged)
+{
+    free_join_keys(node);
+    node->join_left_keys = staged->left;
+    node->join_right_keys = staged->right;
+    node->join_key_count = staged->count;
+    staged->left = NULL;
+    staged->right = NULL;
+    staged->count = 0;
 }
 
 /* ======================================================================== */
@@ -440,51 +540,104 @@ greedy_order(wirelog_ir_node_t **scans, uint32_t nscan, uint32_t *order,
  *   join_nodes[0] = JOIN(ordered[0], ordered[1])
  *   join_nodes[1] = JOIN(join_nodes[0], ordered[2])
  *   ...
+ *
+ * All-or-nothing.  The work is split into two phases:
+ *
+ *   Phase 1 computes and allocates every replacement key set but mutates
+ *   nothing, so a failure anywhere in it can be reported with the chain
+ *   still exactly as it was found.  Hoisting the computation ahead of the
+ *   mutation is sound because every input to it comes from
+ *   scan_vars(ordered_scans[k]) or from the accumulator, and the two node
+ *   sets are disjoint: collect_scans() yields only non-JOIN nodes and
+ *   collect_joins() only JOIN nodes, so nothing here reads a join_nodes[i]
+ *   child that phase 2 goes on to overwrite.
+ *
+ *   Phase 2 rewires the children and installs the staged keys.  It performs
+ *   no allocation and cannot fail.
+ *
+ * Returns true when the chain was rebuilt, false when it was left untouched.
+ * The caller must not count a false return as a reorder (issue #1111).
  */
-static void
+static bool
 rebuild_chain(wirelog_ir_node_t **join_nodes, uint32_t njoin,
     wirelog_ir_node_t **ordered_scans, uint32_t nscan)
 {
     if (njoin == 0 || nscan < 2)
-        return;
+        return false;
 
-    /* First pass: clear old join keys on all JOIN nodes */
-    for (uint32_t i = 0; i < njoin; i++)
-        free_join_keys(join_nodes[i]);
+    /* ---- Phase 1: compute only.  Allocates; mutates nothing. ---- */
 
-    /* Build the chain bottom-up */
-    /* Deepest join: children are ordered_scans[0] and ordered_scans[1] */
-    join_nodes[0]->children[0] = ordered_scans[0];
-    join_nodes[0]->children[1] = ordered_scans[1];
+    jpp_staged_keys_t *staged
+        = (jpp_staged_keys_t *)calloc(njoin, sizeof(jpp_staged_keys_t));
+    if (!staged) {
+        WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_WARN,
+            "jpp: cannot stage join keys for a chain of %u joins; leaving "
+            "the chain in its original order",
+            njoin);
+        return false;
+    }
 
-    /* Set up join keys for deepest */
+    /* Deepest join: children will be ordered_scans[0] and ordered_scans[1] */
     uint32_t lcount, rcount;
     char **lvars = scan_vars(ordered_scans[0], &lcount);
     char **rvars = scan_vars(ordered_scans[1], &rcount);
-    jpp_setup_join_keys(lvars, lcount, rvars, rcount, join_nodes[0]);
+    bool ok = jpp_build_join_keys(lvars, lcount, rvars, rcount, &staged[0]);
 
     /* Accumulate variable set */
-    uint32_t acc_count;
-    char **acc = merge_vars(lvars, lcount, rvars, rcount, &acc_count);
+    uint32_t acc_count = 0;
+    char **acc = NULL;
+    if (ok) {
+        acc = merge_vars(lvars, lcount, rvars, rcount, &acc_count);
+        ok = acc != NULL;
+    }
 
     /* Remaining joins */
-    for (uint32_t i = 1; i < njoin; i++) {
-        join_nodes[i]->children[0] = join_nodes[i - 1];
-        join_nodes[i]->children[1] = ordered_scans[i + 1];
-
+    for (uint32_t i = 1; ok && i < njoin; i++) {
         uint32_t scount;
         char **svars = scan_vars(ordered_scans[i + 1], &scount);
-        jpp_setup_join_keys(acc, acc_count, svars, scount, join_nodes[i]);
+        ok = jpp_build_join_keys(acc, acc_count, svars, scount, &staged[i]);
+        if (!ok)
+            break;
 
         /* Merge into accumulated */
         uint32_t new_count;
         char **new_acc = merge_vars(acc, acc_count, svars, scount, &new_count);
+        if (!new_acc) {
+            ok = false;
+            break;
+        }
         free((void *)acc);
         acc = new_acc;
         acc_count = new_count;
     }
 
     free((void *)acc);
+
+    if (!ok) {
+        for (uint32_t i = 0; i < njoin; i++)
+            jpp_free_staged_keys(&staged[i]);
+        free(staged);
+        WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_WARN,
+            "jpp: cannot rebuild the join keys for a chain of %u scans; "
+            "leaving the chain in its original order",
+            nscan);
+        return false;
+    }
+
+    /* ---- Phase 2: commit only.  No allocation; cannot fail. ---- */
+
+    join_nodes[0]->children[0] = ordered_scans[0];
+    join_nodes[0]->children[1] = ordered_scans[1];
+    jpp_install_join_keys(join_nodes[0], &staged[0]);
+
+    for (uint32_t i = 1; i < njoin; i++) {
+        join_nodes[i]->children[0] = join_nodes[i - 1];
+        join_nodes[i]->children[1] = ordered_scans[i + 1];
+        jpp_install_join_keys(join_nodes[i], &staged[i]);
+    }
+
+    free(staged);
+    return true;
 }
 
 /* ======================================================================== */
@@ -890,14 +1043,30 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
 
                     /* Recalculate join keys for parent join using PROJECTED acc.
                      * After projection, column indices change, so join keys must
-                     * reference the projected columns in the PROJECT output. */
-                    free_join_keys(joins[i + 1]);
+                     * reference the projected columns in the PROJECT output.
+                     *
+                     * Build first, install second, for the same reason as
+                     * rebuild_chain(): freeing the old keys up front and then
+                     * failing to allocate the new ones leaves this JOIN with
+                     * zero keys, which executes as a cross product (#1111).
+                     * Keeping the existing keys is correct as a fallback -- a
+                     * variable shared with scans[i + 2] is by construction in
+                     * the `needed` set and so survives the PROJECT, making the
+                     * recomputed key NAMES identical to the ones already on
+                     * the node. */
                     uint32_t rscount;
                     char **rsvars = scan_vars(scans[i + 2], &rscount);
                     /* Use projected acc (current acc after shrinking) which has
                      * correct indices for the columns in the PROJECT output */
-                    jpp_setup_join_keys(acc, acc_count, rsvars, rscount,
-                        joins[i + 1]);
+                    jpp_staged_keys_t rkeys = { 0 };
+                    if (jpp_build_join_keys(acc, acc_count, rsvars, rscount,
+                        &rkeys)) {
+                        jpp_install_join_keys(joins[i + 1], &rkeys);
+                    } else {
+                        WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_WARN,
+                            "jpp: cannot recompute the join keys above an "
+                            "inserted projection; keeping the existing keys");
+                    }
 
                     projections++;
                 } else {
@@ -996,10 +1165,13 @@ optimize_chain(wirelog_ir_node_t *join_root, char **head_vars,
         if (ordered) {
             for (uint32_t i = 0; i < nscan; i++)
                 ordered[i] = scans[order[i]];
-            rebuild_chain(joins, depth, ordered, nscan);
+            /* Only a chain that was actually rebuilt counts as reordered.
+             * Reporting the reorder unconditionally overstated the statistic
+             * both when rebuild_chain() declined and when this calloc failed
+             * so it never ran at all (issue #1111). */
+            result.reordered = rebuild_chain(joins, depth, ordered, nscan);
             free((void *)ordered);
         }
-        result.reordered = true;
     }
 
     /* Intermediate column projection elimination (Issue #191).


### PR DESCRIPTION
Two independent units, each developed, reviewed and gated separately, combined here for one CI run.

- `fix(jpp)` — Closes #1111
- `ci: clang-tidy ratchet` — Closes #1100

They are disjoint apart from `tests/meson.build`, which auto-merged. The combined tree was re-validated after the merge, not just the two units separately; see Verification.

## #1111 — the join chain could be rewired with its keys destroyed

`rebuild_chain()` freed each join's key set before allocating the replacement. An allocation failure part-way through left the plan **rewired with zero-key joins**, and that does not surface as an error: `exec_plan_gen.c` maps a NULL key name to `col0`, so the query returns a **cross product at exit 0**. A wrong answer, not a diagnosable failure.

Key computation is now split from installation. `jpp_build_join_keys()` stages an owned copy and reports allocation failure on a channel distinct from "these relations share no variables" — the old `void`-returning helper expressed both as "the node now has zero keys", which is the root cause. `jpp_install_join_keys()` adopts the staged set and allocates nothing. `rebuild_chain()` runs phase 1 (compute everything, mutate nothing) then phase 2 (commit, infallible).

Two design points worth flagging for review:

- **Neither shape suggested in the issue works alone.** Build-before-destroy per node leaves earlier nodes rewired while node *i* still points at its original right operand carrying keys computed for its original left input — wrong keys, which is worse than the cross product being fixed. "Leave the original chain intact" is unimplementable because restoring the old keys needs an allocation *in order to recover from an allocation failure*, and that recursion has no fixed point. Staging the new set is the only variant that terminates.
- **Failure is still not propagated.** JPP is a pure optimizer and `wirelog_optimize()` aborts its whole pass sequence on non-zero, so propagating would turn a transient allocation failure into a user-visible error for a query the engine can answer correctly. That silence is only defensible *now that the pass leaves the plan intact*; before this change it was wrong. A WARN records the missed optimization.

The statistic fix (`result.reordered` reported reorders that had been abandoned) is bundled deliberately: changing `rebuild_chain` to return `bool` is what supplies the correct value, so splitting them would produce a first commit that is knowingly incomplete.

Tested by sweeping single allocation failures across `calloc` and `malloc` via `--wrap`, over two fixtures — an all-live head (no PROJECT) and a narrow head (PROJECTs inserted) — which cover the `rebuild_chain` and `insert_projections` sites respectively. Reverting only `rebuild_chain` fails both fixtures; reverting only `insert_projections` fails the second and passes the first, so neither fixture is redundant. `b_lto=false` on the test target is mandatory rather than tidy: under LTO the wrappers are never reached and nothing reports it, so the sweep also asserts its interposition counters are non-zero.

## #1100 — nothing stops a clean file from silently regressing

clang-tidy was a CI gate until `efbde27` removed it. Re-enabling it wholesale is not available: 13 of the 71 `libwirelog.so` translation units are not clean today.

`clang-tidy-allowlist.txt` (58 paths) must stay clean; `clang-tidy-backlog.txt` (13) may be dirty and may only shrink. The two must partition the library exactly — that assertion is what makes *deleting* an allowlist line fail, and a second check makes *demoting* a line fail, closing both cheap ways to make a regression disappear. A source built but listed in neither register fails closed, which costs one deliberate line per new file and keeps coverage from decaying silently.

The gate is built on measured properties of this repo's compile database, not assumed ones:

- `compile_commands.json` holds up to **194** entries for one file, amplifying a scan ~62x, so the DB is pruned per run.
- The `file` field is relative to `directory`, so it is resolved rather than passed through — passing it from another cwd yields zero warnings.
- The source path inside `command` **beats** the `file` field. Rewriting only `file` gives exit 0 with no output — a vacuous check that reports any file clean. The sensitivity fixture therefore rewrites all six of `file`, `output`, `-o`, `-MQ`, `-MF`, `-c`, and refuses to run if a donor entry lacks `-MQ`.
- Diagnostics arrive on **stdout**; stderr carries only the count, and the exit status is 0 even with diagnostics present. Neither is usable as the verdict.

A ratchet that analyses nothing reports every file clean, so a calibration fixture pins exactly one `bugprone-integer-division`. This is load-bearing rather than decorative: with a no-op `clang-tidy` on `PATH`, `--mode ratchet` alone reports `OK; 58 file(s) clean` at exit 0, and only the fixture catches it. It **fails** rather than skips.

The verdict is calibrated to x86_64 Linux with a pinned clang-tidy major, because `clang-analyzer` results are target- and version-dependent. Every other configuration skips with a named reason. CI sets `WIRELOG_TIDY_REQUIRED=1`, turning those skips into failures, so an image bump or a failed install surfaces as a named error instead of quietly disarming the gate.

The monotonicity check compares against the **merge base**, not the base-ref tip; a tip diff reports a false failure on every unrebased branch whenever the base advances by *cleaning* a file. `build-primary` therefore checks out at full depth — a partial deepen cannot work, since checkout leaves HEAD shallow too.

### Two things a reviewer should know before approving

1. **The demotion guard is inert on this branch.** `clang-tidy-backlog.txt` does not exist at the merge base, so the check returns `OK (nothing to compare against)` — even under `WIRELOG_TIDY_REQUIRED=1`. This is unavoidable for the commit that introduces the register (the alternative blocks its own PR), but it means the green run here is evidence about two of the three tests only. The guard was verified in a throwaway repository instead: uncommitted demotion, committed demotion, and a simulated `refs/pull/N/merge` checkout all fail correctly, while the base-advances-by-cleaning case passes. It fails *open*, so if it were broken we are back to today's state rather than somewhere worse.
2. **`suite: 'tidy'` excludes nothing.** This project has no `add_test_setup`, so all three tests also run in a bare `meson test`; the opt-out is `WIRELOG_TIDY_SKIP` at runtime, and it deliberately loses to `WIRELOG_TIDY_REQUIRED=1` in CI. Cost is ~15 s wall at 8 jobs, roughly 60 s on a 2-vCPU runner.

## Verification

Each unit passed an independent review plus separate final design and risk gates, each held by a different agent, all echoing the candidate tree they judged. Every commit tree matches the tree that was approved.

Re-validated on the **combined** branch, since `tests/meson.build` auto-merged and no unit's gates saw the merged file:

- Full suite in-source: **292 total, 281 Ok, 0 Fail, 11 Skipped** — the 11 are the pre-existing cpufreq-gated perf skips, none new.
- The two units do not interact: `wirelog/passes/jpp.c` is in the **backlog**, not the allowlist (it carries 8 pre-existing `clang-analyzer-security.ArrayBound` diagnostics, unchanged from `main` — measured on both sides), and #1111 adds no library sources, so the partition is untouched.
- `git diff --name-only -- wirelog/` for the #1100 commit is empty: the gate touches no library source.

Note for anyone reproducing locally: `sbom_snapshot` fails if you have a `.venv` in the repository root, because `.venv` is not in `.gitignore` and `check-sbom-snapshot.sh` runs `syft dir:"$repo_root"`. Unrelated to this PR and absent in CI; confirmed by moving the directory outside the tree, after which the test passes.

## Follow-ups

Non-blocking findings raised by the gates, to be filed separately rather than folded in here:

- The check set itself is unguarded — editing `.clang-tidy`'s `Checks:` list makes a regression vanish tree-wide while keeping the partition exact and adding nothing to the backlog. It is loud where the two guarded moves are quiet, but it is a third move and deserves a digest or count over that block.
- The registers describe adding a genuinely-new unclean source to the backlog as a reviewer-approved path, but no override exists, so such a PR hard-fails. The tree should not claim both.
- `--mode regenerate` skips on any clang-tidy major not already listed, yet the instructions say to run it before editing that list.
- `merge_vars()` in `jpp.c` calls `calloc(na + nb, ...)` and treats NULL as OOM; for an all-nullary chain that is `calloc(0)`, which may legitimately return NULL. `scan_columns_total()` in the same file already clamps to 1 for exactly this reason.
- `jpp.c` installs a PROJECT whose `column_names[p]` comes from an **unchecked** `strdup_safe`. Pre-existing and a naming defect rather than a wrong answer, but it now sits beside code that hardens the analogous NULL.
- The sweep asserts key *presence*, not key *names*, and `realloc` is not interposed, so one of the three allocator entry points into `wl_jpp_apply` has no sweep coverage.
- On non-Linux the sweep emits a PASS under the **same test name** as the real sweep, so a green macOS log is indistinguishable from one that actually ran.
