### PR TITLE
fix: clean up delta relations on evaluation errors

### DIFF
--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -796,6 +796,11 @@ stride_error:
         if (outer_rc != 0) {
             /* Issue #282: Restore diff_operators_active on error path */
             sess->diff_operators_active = saved_diff_operators_active;
+            for (uint32_t ri = 0; ri < nrels; ri++) {
+                session_remove_rel(sess, sp->relations[ri].delta_name);
+                if (delta_rels[ri])
+                    col_rel_destroy(delta_rels[ri]);
+            }
             free(snap);
             free((void *)delta_rels);
             return outer_rc;


### PR DESCRIPTION
Closes #1109

## Summary
- remove session-owned delta relations on the `stride_error` cleanup path
- destroy locally owned `delta_rels` entries before releasing the array
- preserve pool/cache lifecycle handling and avoid unsafe pool resets

## Validation
- `meson compile -C builddir`
- focused TDD tests: 6 passed
- `meson test -C builddir --print-errorlogs`: 278 passed, 11 expected performance-gate skips, 0 failures
- `git diff --check`