### PR TITLE
fix(jpp): two silent wrong answers on allocation failure, and complete the OOM sweep

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -307,10 +307,15 @@ test_jpp_exe = executable(
   # interposition -- jpp.c allocates its key arrays with calloc and the key
   # strings through strdup_safe(), which uses malloc.
   #
+  # Issue #1119: realloc as well.  insert_projections() reaches realloc only
+  # through wl_ir_node_add_child(), and that is the ONLY route to the
+  # accumulator desynchronisation fixed in the same commit that added this
+  # wrap -- neither the calloc nor the malloc sweep can reach it.
+  #
   # b_lto=false is MANDATORY, not tidiness: with -flto the linker resolves
   # the calls before --wrap is applied, the wrappers are never reached, and
   # NO diagnostic is emitted.  The sweeps would pass while testing nothing.
-  link_args: host_machine.system() == 'linux' ? ['-Wl,--wrap=calloc', '-Wl,--wrap=malloc'] : [],
+  link_args: host_machine.system() == 'linux' ? ['-Wl,--wrap=calloc', '-Wl,--wrap=malloc', '-Wl,--wrap=realloc'] : [],
   override_options: host_machine.system() == 'linux' ? ['b_lto=false'] : [],
 )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -312,9 +312,36 @@ test_jpp_exe = executable(
   # accumulator desynchronisation fixed in the same commit that added this
   # wrap -- neither the calloc nor the malloc sweep can reach it.
   #
-  # b_lto=false is MANDATORY, not tidiness: with -flto the linker resolves
-  # the calls before --wrap is applied, the wrappers are never reached, and
-  # NO diagnostic is emitted.  The sweeps would pass while testing nothing.
+  # b_lto=false is kept because it is the PORTABLE guarantee that --wrap is
+  # applied before the linker can resolve these calls internally, and the
+  # project default is b_lto=true.  Keep the two ternaries on the SAME
+  # predicate so the pairing cannot drift apart.
+  #
+  # Do not read more into it than that.  Measured on gcc 16.2.1 with this
+  # binutils, forcing b_lto=true on this target alone did NOT break the
+  # interposition: the objects were genuinely LTO (gnu.lto ELF sections
+  # present, zero calloc@plt), yet every allocation still routed through
+  # __wrap_calloc, the baseline counts were unchanged, and with the
+  # insert_projections() goto reverted the LTO build still reported
+  # "realloc #0 ... zero keys (cross product)".  So --wrap surviving -flto is
+  # toolchain-dependent, and on at least one mainstream toolchain it survives.
+  #
+  # Consequently the build does NOT enforce the pairing, and neither does the
+  # test: run_jpp_oom_sweep()'s "allocator interposition inert" assertion
+  # detects one specific condition, ZERO recorded wrapper calls in the unarmed
+  # baseline.  Dropping override_options here is not guaranteed to reach that
+  # condition -- done on gcc 16.2.1 it yields a green 30/30 with a fully live
+  # sweep, not a failure.
+  #
+  # The error direction is at least safe: where LTO genuinely does defeat the
+  # wrap the counts fall to zero and the assertion fires, and where it does
+  # not the sweep is live.  Neither branch leaves a quietly vacuous sweep.
+  #
+  # Threading precondition: the wrap state is process-global and non-atomic.
+  # It is sound because arming is scoped to the wl_jpp_apply() call and that
+  # pass spawns nothing.  If program construction ever leaves an allocating
+  # background thread live, the sweep goes flaky rather than wrong; TSan is
+  # the guard, and the counters would then need to be _Atomic.
   link_args: host_machine.system() == 'linux' ? ['-Wl,--wrap=calloc', '-Wl,--wrap=malloc', '-Wl,--wrap=realloc'] : [],
   override_options: host_machine.system() == 'linux' ? ['b_lto=false'] : [],
 )

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -2040,17 +2040,133 @@ joins_children_unchanged(const wirelog_ir_node_t *ir,
     return true;
 }
 
+/* ------------------------------------------------------------------ */
+/* Canonical plan signature (Issue #1119 item 4)                       */
+/* ------------------------------------------------------------------ */
+
+/*
+ * tally_join_keys() proves a JOIN has keys and that they are not NULL.  It
+ * cannot see a join carrying the WRONG-but-non-NULL key name, nor a scan
+ * order that moved, nor a chain that came out a different shape.  A canonical
+ * rendering of the committed tree covers all three in one comparison against
+ * the unarmed baseline.
+ *
+ * PROJECT nodes are descended THROUGH rather than rendered, because their
+ * presence is legitimately variable: an allocation failure may make jpp.c
+ * decline a projection, and declining is correct degradation, not a defect.
+ * Everything else -- join structure, key pairs, scan relation order -- must be
+ * bit-identical to the plan the same fixture produces with no failure
+ * injected, whenever the pass reports that it committed a rebuild.
+ *
+ * Measured on both fixtures: zero committed-plan differences across the whole
+ * sweep, before and after the projection fixes, except on unfixed jpp.c where
+ * fixture B differs exactly at the cross-product steps.
+ *
+ * Forward risk worth stating: both fixtures are all-EDB, so the issue #394
+ * EDB tie-break cannot fire and cannot vary.  A future fixture with an
+ * IDB/EDB tie could legitimately commit a different-but-correct order under
+ * an idb_names allocation failure; this invariant would then need a stated
+ * exception.  It would fail loudly rather than silently, which is the point.
+ *
+ * KNOWN BLIND SPOT, and it follows directly from stripping PROJECTs: because
+ * this rendering descends through a PROJECT rather than recording what that
+ * PROJECT emits, it cannot see a JOIN carrying a key its own child no longer
+ * emits.  Nothing else in this file can either -- tally_join_keys() sees a
+ * non-empty, non-NULL key list and is satisfied.  That shape is not
+ * hypothetical: it is exactly what the empty-key-set guard rejected for this
+ * issue produced, and exactly why those steps were silent while
+ * exec_plan_gen.c's resolve_key_to_colN() fell back to col0.
+ *
+ * It is unreachable today for a structural reason, not by luck: the key
+ * recompute above an inserted projection derives its keys from the PROJECTED
+ * acc[], the same array phys_names[] is rebuilt from, so the keys and the
+ * emitted layout cannot disagree.  If that derivation ever changes -- keys
+ * taken from a pre-projection set, or the layout rebuilt from something other
+ * than acc[] -- this apparatus goes blind to the resulting wrong answer, and
+ * the invariant would need to compare keys against the child's real output
+ * columns instead of stripping the node away.
+ */
+typedef struct {
+    char buf[512];
+    size_t len;
+    bool overflow;
+} jpp_sig_t;
+
+static void
+sig_puts(jpp_sig_t *s, const char *text)
+{
+    size_t n = strlen(text);
+    if (s->overflow || s->len + n + 1 > sizeof(s->buf)) {
+        s->overflow = true;
+        return;
+    }
+    memcpy(s->buf + s->len, text, n);
+    s->len += n;
+    s->buf[s->len] = '\0';
+}
+
+static void
+sig_render(jpp_sig_t *s, const wirelog_ir_node_t *n)
+{
+    if (!n) {
+        sig_puts(s, "_");
+        return;
+    }
+
+    /* Descend through PROJECT: see the note above. */
+    if (n->type == WIRELOG_IR_PROJECT) {
+        sig_render(s, n->child_count > 0 ? n->children[0] : NULL);
+        return;
+    }
+
+    if (n->type == WIRELOG_IR_SCAN) {
+        sig_puts(s, "S[");
+        sig_puts(s, n->relation_name ? n->relation_name : "(null)");
+        sig_puts(s, "]");
+        return;
+    }
+
+    if (n->type == WIRELOG_IR_JOIN) {
+        sig_puts(s, "J{");
+        for (uint32_t k = 0; k < n->join_key_count; k++) {
+            const char *l = n->join_left_keys ? n->join_left_keys[k] : NULL;
+            const char *r = n->join_right_keys ? n->join_right_keys[k] : NULL;
+            if (k)
+                sig_puts(s, ",");
+            sig_puts(s, l ? l : "(null)");
+            sig_puts(s, "=");
+            sig_puts(s, r ? r : "(null)");
+        }
+        sig_puts(s, "}");
+    } else {
+        char kind[24];
+        snprintf(kind, sizeof(kind), "T%d", (int)n->type);
+        sig_puts(s, kind);
+    }
+
+    sig_puts(s, "(");
+    for (uint32_t i = 0; i < n->child_count; i++) {
+        if (i)
+            sig_puts(s, " ");
+        sig_render(s, n->children[i]);
+    }
+    sig_puts(s, ")");
+}
+
 /*
  * One sweep step.  Returns NULL when the invariants hold, otherwise a static
  * description of the violation.  @fail_calloc / @fail_malloc / @fail_realloc
  * select which allocation inside wl_jpp_apply() returns NULL (< 0 fails
- * none).
+ * none).  @expect_sig, when non-NULL, is the canonical plan the unarmed run
+ * committed; @out_sig, when non-NULL, receives this run's.
  */
 static const char *
 jpp_oom_step(const char *src, const char *relation, long fail_calloc,
-    long fail_malloc, long fail_realloc, wl_jpp_stats_t *out_stats)
+    long fail_malloc, long fail_realloc, wl_jpp_stats_t *out_stats,
+    const char *expect_sig, jpp_sig_t *out_sig)
 {
-    static char detail[192];
+    /* Wide enough to hold two rendered plan signatures. */
+    static char detail[1152];
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
     if (!prog)
@@ -2132,6 +2248,23 @@ jpp_oom_step(const char *src, const char *relation, long fail_calloc,
         }
     }
 
+    /* The committed plan must be the plan.  Only meaningful when the pass
+     * says it committed a rebuild; a declined pass legitimately leaves the
+     * parser's original chain, which is a different tree. */
+    if (!problem && (out_sig || stats.joins_reordered == 1)) {
+        jpp_sig_t sig = { { 0 }, 0, false };
+        sig_render(&sig, ir);
+        if (sig.overflow) {
+            problem = "plan signature overflowed";
+        } else if (expect_sig && strcmp(sig.buf, expect_sig) != 0) {
+            snprintf(detail, sizeof(detail), "committed plan %s, expected %s",
+                sig.buf, expect_sig);
+            problem = detail;
+        }
+        if (out_sig)
+            *out_sig = sig;
+    }
+
     if (out_stats)
         *out_stats = stats;
     wirelog_program_free(prog);
@@ -2150,7 +2283,9 @@ run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
      * sweep assertions rely on, and measures how many allocations the sweep
      * has to cover. */
     wl_jpp_stats_t base = { 0, 0, 0, 0 };
-    const char *problem = jpp_oom_step(src, relation, -1, -1, -1, &base);
+    jpp_sig_t base_sig = { { 0 }, 0, false };
+    const char *problem
+        = jpp_oom_step(src, relation, -1, -1, -1, &base, NULL, &base_sig);
     if (problem) {
         FAIL(problem);
         return;
@@ -2205,7 +2340,8 @@ run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
      * realloc route reaches wl_ir_node_add_child()'s child array -- the only
      * way to make insert_projections() abandon a projection midway. */
     for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
-        problem = jpp_oom_step(src, relation, n, -1, -1, NULL);
+        problem = jpp_oom_step(src, relation, n, -1, -1, NULL,
+                base_sig.buf, NULL);
         if (problem) {
             snprintf(buf, sizeof(buf), "calloc #%ld: %s", n, problem);
             FAIL(buf);
@@ -2213,7 +2349,8 @@ run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
         }
     }
     for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
-        problem = jpp_oom_step(src, relation, -1, n, -1, NULL);
+        problem = jpp_oom_step(src, relation, -1, n, -1, NULL,
+                base_sig.buf, NULL);
         if (problem) {
             snprintf(buf, sizeof(buf), "malloc #%ld: %s", n, problem);
             FAIL(buf);
@@ -2221,7 +2358,8 @@ run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
         }
     }
     for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
-        problem = jpp_oom_step(src, relation, -1, -1, n, NULL);
+        problem = jpp_oom_step(src, relation, -1, -1, n, NULL,
+                base_sig.buf, NULL);
         if (problem) {
             snprintf(buf, sizeof(buf), "realloc #%ld: %s", n, problem);
             FAIL(buf);

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -2386,22 +2386,36 @@ run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
         FAIL(buf);
         return;
     }
-    if (ncalloc >= JPP_OOM_SWEEP_MAX || nmalloc >= JPP_OOM_SWEEP_MAX
-        || nrealloc >= JPP_OOM_SWEEP_MAX) {
-        snprintf(buf, sizeof(buf),
-            "sweep width %d no longer covers calloc=%lu malloc=%lu "
-            "realloc=%lu",
-            JPP_OOM_SWEEP_MAX, ncalloc, nmalloc, nrealloc);
-        FAIL(buf);
-        return;
-    }
+    /*
+     * Sweep exactly as far as the unarmed run allocates, not a fixed 64.
+     *
+     * Soundness (audited across 72,283 injection points on four builds): no
+     * injected failure ever INCREASED an allocation count.  Every failure
+     * path in this pass abandons work rather than retrying it, so the unarmed
+     * baseline bounds every armed run and an index past it fails nothing.
+     * JPP_OOM_SWEEP_MAX survives only as a hard cap on runtime.
+     *
+     * This DELETES the "sweep width no longer covers calloc=.." tripwire,
+     * which was today the only thing that would notice wl_jpp_apply()
+     * starting to allocate an order of magnitude more than it does now.
+     * Nothing replaces it; the bounds simply follow the pass, up to the cap.
+     */
+    long ccap = ncalloc < (unsigned long)JPP_OOM_SWEEP_MAX
+        ? (long)ncalloc
+        : (long)JPP_OOM_SWEEP_MAX;
+    long mcap = nmalloc < (unsigned long)JPP_OOM_SWEEP_MAX
+        ? (long)nmalloc
+        : (long)JPP_OOM_SWEEP_MAX;
+    long rcap = nrealloc < (unsigned long)JPP_OOM_SWEEP_MAX
+        ? (long)nrealloc
+        : (long)JPP_OOM_SWEEP_MAX;
 
     /* The three routes are swept separately so that a regression in one is
      * reported on its own terms: the calloc route reaches the key ARRAYS and
      * the accumulator, the malloc route reaches the key STRINGS, and the
      * realloc route reaches wl_ir_node_add_child()'s child array -- the only
      * way to make insert_projections() abandon a projection midway. */
-    for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
+    for (long n = 0; n < ccap; n++) {
         problem = jpp_oom_step(src, relation, n, -1, -1, NULL,
                 base_sig.buf, NULL);
         if (problem) {
@@ -2410,7 +2424,7 @@ run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
             return;
         }
     }
-    for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
+    for (long n = 0; n < mcap; n++) {
         problem = jpp_oom_step(src, relation, -1, n, -1, NULL,
                 base_sig.buf, NULL);
         if (problem) {
@@ -2419,13 +2433,58 @@ run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
             return;
         }
     }
-    for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
+    for (long n = 0; n < rcap; n++) {
         problem = jpp_oom_step(src, relation, -1, -1, n, NULL,
                 base_sig.buf, NULL);
         if (problem) {
             snprintf(buf, sizeof(buf), "realloc #%ld: %s", n, problem);
             FAIL(buf);
             return;
+        }
+    }
+
+    /*
+     * Correlated calloc x malloc, realloc disabled (issue #1119 item 6).
+     *
+     * Honest accounting.  For the two defects this file was written against,
+     * the nested product adds nothing OPERATIONALLY: the 1-D loops above run
+     * first and return on the first failure, so a defect either of them
+     * red-lights is reported before this loop is ever entered.
+     *
+     * It does reach genuinely correlated failures that no single-index run
+     * reaches.  Measured with only the unchecked-strdup fix reverted, fixture
+     * B reports 4 one-dimensional failures against 90 nested, of which 52 are
+     * at pairs where NEITHER index fails alone -- calloc #5 + malloc #0 is
+     * the first.  So this is a real regression net for a future defect that
+     * needs two failures at once, not a restatement of the 1-D sweeps.
+     *
+     * It is affordable because the product follows the measured counts rather
+     * than JPP_OOM_SWEEP_MAX squared: 25 x 6 = 150 steps for fixture A and
+     * 35 x 14 = 490 for fixture B, 640 in total.
+     *
+     * Runtime for the whole 30-test binary, named by build because the spread
+     * is wide: about 25 ms in this project's default buildtype (release,
+     * optimization=s, what CI runs), about 30 ms at -O0, and under 0.2 s under
+     * -Db_sanitize=address,undefined on the machine this was written on -- a
+     * measurement of the same binary on slower hardware put the sanitizer
+     * figure nearer 1.8 s.  The sanitizer number is the one that matters:
+     * test('jpp', ...) declares no timeout kwarg and CI sets no multiplier, so
+     * meson's default 30 s applies and even the pessimistic figure keeps well
+     * over an order of magnitude of margin.
+     *
+     * realloc is held out of the product deliberately: folding it in would
+     * cube the cost, and the realloc route already has the 1-D sweep above.
+     */
+    for (long c = 0; c < ccap; c++) {
+        for (long m = 0; m < mcap; m++) {
+            problem = jpp_oom_step(src, relation, c, m, -1, NULL,
+                    base_sig.buf, NULL);
+            if (problem) {
+                snprintf(buf, sizeof(buf), "calloc #%ld + malloc #%ld: %s", c,
+                    m, problem);
+                FAIL(buf);
+                return;
+            }
         }
     }
 

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -46,8 +46,12 @@
  *              insert_projections() can abandon a projection midway, and it
  *              is reachable from neither of the other two.
  *
- * The wrap must be paired with b_lto=false in tests/meson.build.  Under
- * -flto the wrappers are never reached and no diagnostic is emitted.
+ * The wrap is paired with b_lto=false in tests/meson.build as the portable
+ * guarantee that the linker cannot resolve these calls before --wrap applies.
+ * That pairing is NOT self-enforcing, and the stronger claim once made here --
+ * that -flto silently defeats the wrappers -- did not reproduce: on gcc 16.2.1
+ * a forced-LTO build of this target kept every wrapper live.  See the longer
+ * note at the link_args line in tests/meson.build.
  */
 
 #ifdef __linux__
@@ -1933,7 +1937,10 @@ test_jpp_wide_head_antijoin_key(void)
  * in how wide the head is, which decides whether insert_projections() fires.
  * jpp.c builds join keys at two independent sites, and each fixture is the
  * sole cover for one of them.  Measured, by reverting one site at a time
- * against the finished fix:
+ * against the finished fix, as of commit 0a94da7 -- these are the record of
+ * that counterfactual experiment, not a live invariant, and the two indices
+ * will drift the moment jpp.c's allocation order changes.  The surrounding
+ * claims stay true either way:
  *
  *   - Revert only rebuild_chain() to destroy-then-allocate: BOTH fixtures
  *     fail at calloc #9, "1 of 3 join(s) have zero keys (cross product)".
@@ -2268,7 +2275,13 @@ jpp_oom_step(const char *src, const char *relation, long fail_calloc,
 
     const char *problem = NULL;
 
-    /* Unconditional, at every sweep index. */
+    /* Unconditional, at every sweep index -- and a POLICY PIN, not a
+     * correctness assertion.  jpp.h reserves -1 for allocation failure but
+     * the pass deliberately degrades instead of propagating it, because
+     * wirelog_optimize() aborts its whole pass sequence on any non-zero
+     * return and JPP is a pure optimizer.  Anyone who later decides to
+     * propagate -1 will see this fail and be forced to revisit the choice
+     * consciously; that is what it is for. */
     if (rc != 0) {
         snprintf(detail, sizeof(detail), "rc=%d (expected 0)", rc);
         problem = detail;
@@ -2301,7 +2314,26 @@ jpp_oom_step(const char *src, const char *relation, long fail_calloc,
 
     /* Structural contract: the pass either declined outright, leaving every
      * child pointer as it found it, or it committed a full rebuild, in which
-     * case every JOIN of this connected chain must carry keys. */
+     * case every JOIN of this connected chain must carry keys.
+     *
+     * Why the two strongest wrong-answer detectors -- the zero_keys
+     * cross-product check below and the plan signature after it -- are gated
+     * on the pass having COMMITTED, and why that gate must not be "fixed" by
+     * removing it:
+     *
+     * insert_projections() runs even when rebuild_chain() declined, so a large
+     * share of armed steps (measured: about 45%, 5,700 of 12,562 injection
+     * points) legitimately end with joins_reordered == 0.  Those steps still
+     * hold the parser's ORIGINAL chain, whose body order is deliberately
+     * non-optimal -- and that un-reordered tree legitimately contains one
+     * zero-key JOIN, because a cross product is what the unoptimised order
+     * means.  Asserting unconditionally would therefore produce roughly 5,700
+     * false failures, not extra coverage.
+     *
+     * The gate does not hide the defect it was built for: reverting the
+     * insert_projections() goto adds exactly 65 zero-key instances and every
+     * one of them falls inside the joins_reordered == 1 slice, so every one is
+     * reported. */
     if (!problem) {
         if (joins_children_unchanged(ir, before, nbefore)) {
             if (stats.joins_reordered != 0) {

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -1980,6 +1980,39 @@ tally_join_keys(const wirelog_ir_node_t *node, uint32_t *njoin,
         tally_join_keys(node->children[i], njoin, zero_keys, null_elems);
 }
 
+/*
+ * Count PROJECT nodes that name their own output columns but leave one of
+ * those names NULL.
+ *
+ * exec_plan_gen.c hands a PROJECT's column_names[] back verbatim as the
+ * node's output layout, and resolve_key_to_colN() answers "col0" for any key
+ * it cannot find in that layout.  So a NULL entry is not cosmetic: where the
+ * missing name is a join key of the JOIN above, the join silently reads the
+ * wrong column; everywhere else it is a naming defect.  Either way jpp.c must
+ * decline the projection rather than install it half-named.
+ *
+ * A PROJECT with no column_names[] at all is a different, legitimate shape
+ * (nothing claims to name the columns), so only allocated arrays are checked.
+ */
+static void
+tally_null_project_names(const wirelog_ir_node_t *node, uint32_t *nproject,
+    uint32_t *null_names)
+{
+    if (!node)
+        return;
+    if (node->type == WIRELOG_IR_PROJECT && node->column_names) {
+        (*nproject)++;
+        for (uint32_t i = 0; i < node->column_count; i++) {
+            if (!node->column_names[i]) {
+                (*null_names)++;
+                break;
+            }
+        }
+    }
+    for (uint32_t i = 0; i < node->child_count; i++)
+        tally_null_project_names(node->children[i], nproject, null_names);
+}
+
 /* True when no snapshotted JOIN has had either child pointer replaced. */
 static bool
 joins_children_unchanged(const wirelog_ir_node_t *ir,
@@ -2059,6 +2092,17 @@ jpp_oom_step(const char *src, const char *relation, long fail_calloc,
         } else if (null_elems != 0) {
             snprintf(detail, sizeof(detail),
                 "%u join(s) claim keys but hold a NULL key name", null_elems);
+            problem = detail;
+        }
+    }
+
+    if (!problem) {
+        uint32_t nproject = 0, null_names = 0;
+        tally_null_project_names(ir, &nproject, &null_names);
+        if (null_names != 0) {
+            snprintf(detail, sizeof(detail),
+                "%u of %u project(s) hold a NULL output column name",
+                null_names, nproject);
             problem = detail;
         }
     }

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -165,6 +165,7 @@ jpp_zero_calloc_watch_end(void)
 static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
+static int tests_skipped = 0;
 
 #define TEST(name)                            \
         do {                                      \
@@ -182,6 +183,19 @@ static int tests_failed = 0;
         do {                                  \
             tests_failed++;                   \
             printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
+
+/*
+ * A test that could not run here, as distinct from one that ran and passed.
+ * exit 77 is this repo's skip idiom but is unusable in this binary: 77 is a
+ * whole-process verdict and test_jpp runs 30 tests in one process.  So the
+ * skip is reported per test, and counted separately in the summary, while
+ * tests_run still advances so the numbering stays stable across platforms.
+ */
+#define SKIP(reason)                         \
+        do {                                     \
+            tests_skipped++;                     \
+            printf(" ... SKIP: %s\n", (reason)); \
         } while (0)
 
 /* ======================================================================== */
@@ -2496,8 +2510,9 @@ static void
 test_jpp_oom_all_live_head(void)
 {
 #ifndef __linux__
-    TEST("jpp #1111: OOM sweep, all head variables live (no PROJECT)");
-    PASS();
+    TEST("jpp #1111: OOM sweep, all head variables live (no PROJECT)"
+        " (skipped: no --wrap)");
+    SKIP("--wrap is a GNU ld/lld feature with no ld64 or MSVC equivalent");
     return;
 #else
     run_jpp_oom_sweep(
@@ -2510,8 +2525,9 @@ static void
 test_jpp_oom_projected_head(void)
 {
 #ifndef __linux__
-    TEST("jpp #1111: OOM sweep, narrow head (PROJECTs inserted)");
-    PASS();
+    TEST("jpp #1111: OOM sweep, narrow head (PROJECTs inserted)"
+        " (skipped: no --wrap)");
+    SKIP("--wrap is a GNU ld/lld feature with no ld64 or MSVC equivalent");
     return;
 #else
     run_jpp_oom_sweep("jpp #1111: OOM sweep, narrow head (PROJECTs inserted)",
@@ -2575,7 +2591,7 @@ main(void)
     test_jpp_oom_all_live_head();
     test_jpp_oom_projected_head();
 
-    printf("\n  Total: %d  Passed: %d  Failed: %d\n\n", tests_run, tests_passed,
-        tests_failed);
+    printf("\n  Total: %d  Passed: %d  Failed: %d  Skipped: %d\n\n", tests_run,
+        tests_passed, tests_failed, tests_skipped);
     return tests_failed > 0 ? 1 : 0;
 }

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -60,6 +60,23 @@ static unsigned long jpp_calloc_calls;
 static unsigned long jpp_malloc_calls;
 static unsigned long jpp_realloc_calls;
 
+/*
+ * Issue #1119 item 1: a separate, independently scoped observation.
+ *
+ * C permits calloc(0, n) and calloc(n, 0) to return NULL, and a caller cannot
+ * tell that apart from OOM.  jpp.c must therefore never ASK for zero
+ * elements; scan_columns_total() already clamps to 1 for exactly this reason.
+ * Counting the requests tests the argument jpp.c passes rather than emulating
+ * a hostile allocator that no CI machine runs -- and it also catches a future
+ * zero-size calloc whose NULL return would happen to be benign.
+ *
+ * __wrap_calloc is process-wide, so the watch is scoped to the one
+ * wl_jpp_apply() call under test; a stray zero-size calloc from the parser
+ * must not be attributed to the pass.
+ */
+static bool jpp_zero_calloc_watch;
+static unsigned long jpp_zero_calloc_calls;
+
 void *__real_calloc(size_t nmemb, size_t size);
 void *__real_malloc(size_t size);
 void *__real_realloc(void *ptr, size_t size);
@@ -67,6 +84,8 @@ void *__real_realloc(void *ptr, size_t size);
 void *
 __wrap_calloc(size_t nmemb, size_t size)
 {
+    if (jpp_zero_calloc_watch && (nmemb == 0 || size == 0))
+        jpp_zero_calloc_calls++;
     if (jpp_oom_armed) {
         jpp_calloc_calls++;
         if (jpp_calloc_countdown >= 0 && jpp_calloc_countdown-- == 0)
@@ -121,6 +140,20 @@ jpp_oom_disarm(void)
     jpp_calloc_countdown = -1;
     jpp_malloc_countdown = -1;
     jpp_realloc_countdown = -1;
+}
+
+static void
+jpp_zero_calloc_watch_begin(void)
+{
+    jpp_zero_calloc_calls = 0;
+    jpp_zero_calloc_watch = true;
+}
+
+static unsigned long
+jpp_zero_calloc_watch_end(void)
+{
+    jpp_zero_calloc_watch = false;
+    return jpp_zero_calloc_calls;
 }
 
 #endif /* __linux__ */
@@ -1616,6 +1649,16 @@ test_jpp_nullary_chain(void)
      *
      * Answers are unaffected here (a nullary join is a cross product), so
      * nothing but the plan shows the difference.  Pin the plan.
+     *
+     * The same rule pins the other half of that clamp (issue #1119 item 1):
+     * this chain is where merge_vars() is asked to allocate na + nb == 0
+     * elements.  Nothing here can observe a platform whose calloc(0, n)
+     * returns NULL -- glibc and musl both return non-NULL -- so instead of
+     * emulating one, count the zero-size REQUESTS and require none.  That
+     * tests the argument jpp.c passes rather than the allocator's reply, and
+     * it also catches a future zero-size calloc whose NULL return happens to
+     * be benign today.  Measured before the clamp: 2 such calls, one per
+     * merge_vars() call site.
      */
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(".decl e()\n"
@@ -1634,12 +1677,31 @@ test_jpp_nullary_chain(void)
     }
 
     wl_jpp_stats_t stats = { 0, 0, 0 };
+#ifdef __linux__
+    jpp_zero_calloc_watch_begin();
+#endif
     int rc = wl_jpp_apply(prog, &stats);
+#ifdef __linux__
+    unsigned long zero_callocs = jpp_zero_calloc_watch_end();
+#endif
     if (rc != 0) {
         FAIL("expected 0");
         wirelog_program_free(prog);
         return;
     }
+
+#ifdef __linux__
+    if (zero_callocs != 0) {
+        char zbuf[160];
+        snprintf(zbuf, sizeof(zbuf),
+            "%lu calloc request(s) for zero elements; calloc(0, n) may "
+            "return NULL and would be misread as OOM",
+            zero_callocs);
+        FAIL(zbuf);
+        wirelog_program_free(prog);
+        return;
+    }
+#endif
 
     if (stats.chains_examined != 1 || stats.joins_reordered != 1
         || stats.projections_inserted != 0) {

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -30,13 +30,21 @@
  * as a cross product -- wrong answers, exit status 0.
  *
  * Reaching those paths needs allocator interposition, so tests/meson.build
- * links this binary with --wrap=calloc AND --wrap=malloc.  Both are needed:
- * the key arrays come from calloc, but the key STRINGS come from
- * strdup_safe(), which uses malloc (wirelog/ir/ir.c).  A calloc-only sweep
- * can never exercise the unchecked strdup path, and that path is not merely
- * "a different failure mode": exec_plan_gen.c's resolve_key_to_colN() falls
- * back to column 0 when a key name is NULL, so a NULL key silently produces
- * a WRONG join rather than a cross product.
+ * links this binary with --wrap=calloc, --wrap=malloc AND --wrap=realloc.
+ * All three are needed:
+ *
+ *   calloc  -- the key ARRAYS and every scratch array in the pass.
+ *   malloc  -- the key STRINGS, which come from strdup_safe()
+ *              (wirelog/ir/ir.c).  A calloc-only sweep can never exercise
+ *              the unchecked strdup path, and that path is not merely "a
+ *              different failure mode": exec_plan_gen.c's
+ *              resolve_key_to_colN() falls back to column 0 when a key name
+ *              is NULL, so a NULL key silently produces a WRONG join rather
+ *              than a cross product.
+ *   realloc -- the child-pointer array grown by wl_ir_node_add_child()
+ *              (issue #1119).  This is the only route by which
+ *              insert_projections() can abandon a projection midway, and it
+ *              is reachable from neither of the other two.
  *
  * The wrap must be paired with b_lto=false in tests/meson.build.  Under
  * -flto the wrappers are never reached and no diagnostic is emitted.
@@ -47,11 +55,14 @@
 static bool jpp_oom_armed;
 static long jpp_calloc_countdown = -1; /* < 0: count but never fail */
 static long jpp_malloc_countdown = -1;
+static long jpp_realloc_countdown = -1;
 static unsigned long jpp_calloc_calls;
 static unsigned long jpp_malloc_calls;
+static unsigned long jpp_realloc_calls;
 
 void *__real_calloc(size_t nmemb, size_t size);
 void *__real_malloc(size_t size);
+void *__real_realloc(void *ptr, size_t size);
 
 void *
 __wrap_calloc(size_t nmemb, size_t size)
@@ -75,18 +86,31 @@ __wrap_malloc(size_t size)
     return __real_malloc(size);
 }
 
+void *
+__wrap_realloc(void *ptr, size_t size)
+{
+    if (jpp_oom_armed) {
+        jpp_realloc_calls++;
+        if (jpp_realloc_countdown >= 0 && jpp_realloc_countdown-- == 0)
+            return NULL;
+    }
+    return __real_realloc(ptr, size);
+}
+
 /*
  * Arm the countdowns.  A negative countdown counts calls without failing
  * any.  Arming is scoped to the wl_jpp_apply() call itself so that parsing
  * and program construction never see a failing allocator.
  */
 static void
-jpp_oom_arm(long calloc_nth, long malloc_nth)
+jpp_oom_arm(long calloc_nth, long malloc_nth, long realloc_nth)
 {
     jpp_calloc_countdown = calloc_nth;
     jpp_malloc_countdown = malloc_nth;
+    jpp_realloc_countdown = realloc_nth;
     jpp_calloc_calls = 0;
     jpp_malloc_calls = 0;
+    jpp_realloc_calls = 0;
     jpp_oom_armed = true;
 }
 
@@ -96,6 +120,7 @@ jpp_oom_disarm(void)
     jpp_oom_armed = false;
     jpp_calloc_countdown = -1;
     jpp_malloc_countdown = -1;
+    jpp_realloc_countdown = -1;
 }
 
 #endif /* __linux__ */
@@ -1984,12 +2009,13 @@ joins_children_unchanged(const wirelog_ir_node_t *ir,
 
 /*
  * One sweep step.  Returns NULL when the invariants hold, otherwise a static
- * description of the violation.  @fail_calloc / @fail_malloc select which
- * allocation inside wl_jpp_apply() returns NULL (< 0 fails none).
+ * description of the violation.  @fail_calloc / @fail_malloc / @fail_realloc
+ * select which allocation inside wl_jpp_apply() returns NULL (< 0 fails
+ * none).
  */
 static const char *
 jpp_oom_step(const char *src, const char *relation, long fail_calloc,
-    long fail_malloc, wl_jpp_stats_t *out_stats)
+    long fail_malloc, long fail_realloc, wl_jpp_stats_t *out_stats)
 {
     static char detail[192];
     wirelog_error_t err;
@@ -2011,7 +2037,7 @@ jpp_oom_step(const char *src, const char *relation, long fail_calloc,
     }
 
     wl_jpp_stats_t stats = { 0, 0, 0, 0 };
-    jpp_oom_arm(fail_calloc, fail_malloc);
+    jpp_oom_arm(fail_calloc, fail_malloc, fail_realloc);
     int rc = wl_jpp_apply(prog, &stats);
     jpp_oom_disarm();
 
@@ -2080,7 +2106,7 @@ run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
      * sweep assertions rely on, and measures how many allocations the sweep
      * has to cover. */
     wl_jpp_stats_t base = { 0, 0, 0, 0 };
-    const char *problem = jpp_oom_step(src, relation, -1, -1, &base);
+    const char *problem = jpp_oom_step(src, relation, -1, -1, -1, &base);
     if (problem) {
         FAIL(problem);
         return;
@@ -2102,28 +2128,40 @@ run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
 
     unsigned long ncalloc = jpp_calloc_calls;
     unsigned long nmalloc = jpp_malloc_calls;
-    if (ncalloc == 0 || nmalloc == 0) {
+    unsigned long nrealloc = jpp_realloc_calls;
+    /* realloc is reached ONLY through wl_ir_node_add_child(), and the pass
+     * calls that only when it inserts a PROJECT: rebuild_chain() rewires
+     * children[] in place on JOIN nodes that already have the capacity.  So
+     * fixture A legitimately measures realloc=0 and only fixture B can hold
+     * the wrap to account. */
+    if (ncalloc == 0 || nmalloc == 0
+        || (expect_projections && nrealloc == 0)) {
         /* Either --wrap did not take effect (b_lto slipped back on) or the
          * pass stopped allocating; both make the sweep vacuous. */
         snprintf(buf, sizeof(buf),
-            "allocator interposition inert: calloc=%lu malloc=%lu", ncalloc,
-            nmalloc);
+            "allocator interposition inert: calloc=%lu malloc=%lu "
+            "realloc=%lu",
+            ncalloc, nmalloc, nrealloc);
         FAIL(buf);
         return;
     }
-    if (ncalloc >= JPP_OOM_SWEEP_MAX || nmalloc >= JPP_OOM_SWEEP_MAX) {
+    if (ncalloc >= JPP_OOM_SWEEP_MAX || nmalloc >= JPP_OOM_SWEEP_MAX
+        || nrealloc >= JPP_OOM_SWEEP_MAX) {
         snprintf(buf, sizeof(buf),
-            "sweep width %d no longer covers calloc=%lu malloc=%lu",
-            JPP_OOM_SWEEP_MAX, ncalloc, nmalloc);
+            "sweep width %d no longer covers calloc=%lu malloc=%lu "
+            "realloc=%lu",
+            JPP_OOM_SWEEP_MAX, ncalloc, nmalloc, nrealloc);
         FAIL(buf);
         return;
     }
 
-    /* The two routes are swept separately so that a regression in one is
+    /* The three routes are swept separately so that a regression in one is
      * reported on its own terms: the calloc route reaches the key ARRAYS and
-     * the accumulator, the malloc route reaches the key STRINGS. */
+     * the accumulator, the malloc route reaches the key STRINGS, and the
+     * realloc route reaches wl_ir_node_add_child()'s child array -- the only
+     * way to make insert_projections() abandon a projection midway. */
     for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
-        problem = jpp_oom_step(src, relation, n, -1, NULL);
+        problem = jpp_oom_step(src, relation, n, -1, -1, NULL);
         if (problem) {
             snprintf(buf, sizeof(buf), "calloc #%ld: %s", n, problem);
             FAIL(buf);
@@ -2131,9 +2169,17 @@ run_jpp_oom_sweep(const char *name, const char *src, const char *relation,
         }
     }
     for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
-        problem = jpp_oom_step(src, relation, -1, n, NULL);
+        problem = jpp_oom_step(src, relation, -1, n, -1, NULL);
         if (problem) {
             snprintf(buf, sizeof(buf), "malloc #%ld: %s", n, problem);
+            FAIL(buf);
+            return;
+        }
+    }
+    for (long n = 0; n < JPP_OOM_SWEEP_MAX; n++) {
+        problem = jpp_oom_step(src, relation, -1, -1, n, NULL);
+        if (problem) {
+            snprintf(buf, sizeof(buf), "realloc #%ld: %s", n, problem);
             FAIL(buf);
             return;
         }

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -1013,6 +1013,28 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
                             }
                             proj->project_indices[p] = phys_idx;
                             proj->column_names[p] = strdup_safe(acc[v]);
+                            if (!proj->column_names[p]) {
+                                /* A half-named PROJECT is not a cosmetic
+                                 * defect: exec_plan_gen.c returns
+                                 * column_names[] verbatim as this node's
+                                 * output layout, and resolve_key_to_colN()
+                                 * answers "col0" for any key it cannot find
+                                 * there -- so where the missing name is a
+                                 * join key of the JOIN above, the join reads
+                                 * the WRONG column and still reports success.
+                                 *
+                                 * Declining is exact here: proj is still
+                                 * detached, and neither the children[0]
+                                 * splice nor the acc[]/phys_names[] rewrites
+                                 * below have run, so nothing outside proj has
+                                 * been touched yet. */
+                                WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_WARN,
+                                    "jpp: cannot name the columns of an "
+                                    "inserted projection; leaving this level "
+                                    "unprojected");
+                                wl_ir_node_free(proj);
+                                goto next_level;
+                            }
                             p++;
                         }
                     }

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -1020,8 +1020,11 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
                     /* Insert: parent_join->children[0] = proj,
                      *          proj->child = current_join */
                     if (wl_ir_node_add_child(proj, joins[i]) != 0) {
+                        WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_WARN,
+                            "jpp: cannot attach an inserted projection; "
+                            "leaving this level unprojected");
                         wl_ir_node_free(proj);
-                        continue;
+                        goto next_level;
                     }
                     joins[i + 1]->children[0] = proj;
 
@@ -1075,6 +1078,17 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
             }
         }
 
+        /*
+         * Abandoning ONE projection must not abandon the loop's bookkeeping.
+         * `continue` here would skip both the free() below and the tail merge
+         * of scans[i + 2] into acc[] and phys_names[], leaving the next
+         * iteration to run on an accumulator that no longer describes the
+         * chain: jpp_build_join_keys() would then find no shared variable,
+         * succeed with count == 0, and jpp_install_join_keys() would replace
+         * that JOIN's correct keys with an empty set -- a cross product, and
+         * exactly the #1111 signature.  Jump past the projection work only.
+         */
+next_level:
         free((void *)needed);
 
         /* Merge next scan's vars into acc and physical layout for the next

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -291,8 +291,21 @@ jpp_build_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
 static char **
 merge_vars(char **a, uint32_t na, char **b, uint32_t nb, uint32_t *out_count)
 {
-    /* Upper bound on merged size */
-    char **merged = (char **)calloc(na + nb, sizeof(char *));
+    /*
+     * Upper bound on merged size, clamped to at least one element.
+     *
+     * na + nb == 0 is reachable and legitimate: `.decl p()` is legal and
+     * leaves column_count == 0, so an all-nullary chain merges two empty
+     * sets.  C permits calloc(0, n) to return NULL and a caller cannot tell
+     * that apart from OOM, which would decline the reorder for a chain that
+     * is perfectly optimizable.  scan_columns_total() above clamps for
+     * exactly this reason; the clamp is safe here for the same reason it is
+     * safe there -- every write into merged[] is bounded by na + nb, so a
+     * zero-total merge performs no writes at all.
+     */
+    size_t merged_cap = (size_t)na + (size_t)nb;
+    char **merged
+        = (char **)calloc(merged_cap > 0 ? merged_cap : 1, sizeof(char *));
     if (!merged) {
         *out_count = 0;
         return NULL;

--- a/wirelog/passes/jpp.h
+++ b/wirelog/passes/jpp.h
@@ -68,7 +68,10 @@ typedef struct {
  *
  * Returns:
  *    0: Success (stats populated if non-NULL).
- *   -1: Memory allocation error.
+ *   -1: Memory allocation error.  RESERVED -- not produced today: JPP is a
+ *       pure optimizer and wirelog_optimize() aborts its whole pass sequence
+ *       on any non-zero return, so an allocation failure degrades to a less
+ *       optimized plan and still reports 0.
  *   -2: Invalid program (NULL).
  */
 int


### PR DESCRIPTION
Filed as follow-up cleanup after #1111 (issue #1119). It is not cleanup. Two of the items were **live wrong-answer defects in merged `main`**, and the issue text as I originally filed it was wrong about both — see the [correction comment](https://github.com/semantic-reasoning/wirelog/issues/1119#issuecomment-5316417458). Each defect was reproduced independently by two agents before any fix was written.

Seven commits, each building and passing on its own.

## The two defects

**A cross product, from an accumulator that fell out of sync.** `insert_projections()` reached `wl_ir_node_add_child()`'s failure path with `wl_ir_node_free(proj); continue;`. That `continue` skipped `free(needed)` — an 80-byte leak — and, worse, the tail block that merges `scans[i + 2]` into `acc[]` and `phys_names[]`. The next iteration then ran on an accumulator that no longer described the chain: `jpp_build_join_keys()` found no shared variable, returned `true` with `count == 0`, and `jpp_install_join_keys()` replaced that JOIN's correct keys with an empty set. `exec_plan_gen.c` runs a zero-key JOIN as a cross product, so the query returned wrong answers at exit status 0 — the #1111 signature, still present after #1111.

Reaching it requires `realloc` interposition: `wl_ir_node_add_child()` is the only route, and it is reachable **only** from `insert_projections()`, because `rebuild_chain()` rewires `children[]` in place on JOINs that already have capacity. That is why the calloc and malloc sweeps added in #1111 passed straight over it.

**A join silently reading the wrong column.** `proj->column_names[p] = strdup_safe(acc[v])` was unchecked, so a PROJECT could be installed carrying a NULL output column name. `exec_plan_gen.c` hands `column_names[]` back verbatim as the node's output layout, and `resolve_key_to_colN()` answers `col0` for any key it cannot find there — so where the missing name is a join key of the JOIN above, the join reads the wrong column. `project_indices` are never consulted for key resolution. The sweep already reached this on merged code and passed: NULL names at fixture B malloc 6, 7, 10 and 11, with a key genuinely failing to resolve at 7 and 11.

Declining is exact rather than lossy, which is what makes the fix small: the strdup loop runs *before* `wl_ir_node_add_child()`, before the `children[0]` splice and before the `acc[]`/`phys_names[]` rewrites, so nothing outside the still-detached node has been mutated.

Both fixes take a forward `goto` to a label just before `free(needed)`. That is not a stylistic choice: two of the four abandon-points in that block already reached the same epilogue by plain fall-through, so the `goto` makes the two deep exits behave like the two shallow ones that were already correct. `break` was never the smaller option — `free(needed)` lives inside the loop body, so `break` would itself have leaked.

## A guard that was designed, measured, and rejected

An earlier plan included refusing to install an empty key set over a non-empty one, as defence in depth. Built in isolation and swept over 68,921 injection steps, it makes the sweep report **zero failures** while leaving a JOIN holding key `v` over a PROJECT that emits only `x` — `resolve_key_to_colN()` falls back to `col0` and the join reads `x`. It converts a loud cross product into a quiet wrong answer *and* removes the signal that detects it, in 374 steps carrying no NULL name at all. After the root-cause fix it never fires. It is not implemented in any form; the reviewer confirmed `jpp_install_join_keys`, `jpp_build_join_keys` and `rebuild_chain` are byte-identical to `main`.

## The rest

- **`merge_vars()` no longer asks `calloc` for zero elements.** `.decl p()` is legal, so an all-nullary chain merges two empty sets, and C permits `calloc(0, n)` to return NULL — indistinguishable from OOM, so the pass would decline to reorder a perfectly optimizable chain. `scan_columns_total()` in the same file already clamps for exactly this reason. Tested by **counting** zero-size requests rather than emulating an allocator no CI machine runs; an audit of all 20 `calloc(` sites in `jpp.c` confirms this was the last unguarded one.
- **A PROJECT-stripped plan signature** compares the committed tree against the unarmed baseline, covering issue item 4 — wrong-but-non-NULL key names, scan order and shape — which `tally_join_keys()` cannot see. It descends *through* PROJECT nodes because their presence legitimately varies: an allocation failure may drop a projection, and that is correct degradation. It replaced a test-side mirror of `exec_plan_gen.c`'s layout logic, which would have rotted silently.
- **Sweep bounds now follow the measured baseline** instead of a fixed 0..63, plus a correlated calloc × malloc product. The comment is explicit that this deletes the `ncalloc >= JPP_OOM_SWEEP_MAX` tripwire and that nothing replaces it.
- **The non-Linux stubs now report SKIP**, not PASS under the same test name, so a green macOS or MSVC log is no longer indistinguishable from a Linux run that actually swept.
- **Documentation**: `jpp.h`'s `-1` return marked reserved and not produced (JPP is a pure optimizer and `wirelog_optimize()` aborts its whole pass sequence on non-zero, so it degrades and still returns 0); the `rc == 0` assertion labelled a policy pin on that choice; the counterfactual sweep indices date-stamped rather than deleted.

## Two claims corrected in the tree

- **`--wrap` survives `-flto` on gcc 16.2.1.** I asserted the opposite throughout this work — that `b_lto=false`'s absence is silent — and a gate tested it: forcing `b_lto=true` on `test_jpp` produced genuinely LTO objects (42 and 75 `gnu.lto` sections against 0 normally) and the sweep stayed fully live — identical baseline counts, zero `calloc@plt`, and the cross product still reported with the `goto` reverted. `b_lto=false` is kept as the portable guarantee, but the comment no longer claims the build or the test enforces the pairing, because on this toolchain neither does. The error direction is safe: where LTO does defeat the wrap, counts go to zero and the inertness assertion fires.
- **The signature invariant's blind spot is stated where it is defined.** Stripping PROJECTs means it cannot see a JOIN carrying a key its child no longer emits — exactly the shape the rejected guard produced. Unreachable today only because the key recompute derives keys from the projected `acc[]`, so keys and layout cannot disagree.

## Verification

Reviewer plus separate final design and risk gates, each held by a different agent, all echoing the candidate tree they judged; the final commit tree matches the approved tree exactly.

- Full suite **292 / 281 Ok / 0 Fail / 11 Skipped**, no new skip, re-run after rebasing onto current `main` and its new ratchet script.
- Every defect caught at a named index by counterfactual: reverting only the `goto` gives `realloc #0 … zero keys (cross product)`; only the strdup check gives `malloc #6 … NULL output column name`; only the clamp gives `2 calloc request(s) for zero elements`; a synthetic wrong-but-non-NULL key is caught by the signature and by nothing else.
- **12,562 injection points** measured: armed maximum allocation counts equal the unarmed baseline exactly on both fixtures, and every index the new caps skip fails nothing — so the truncation hides nothing.
- Non-failing path proved unchanged by linking a full-fidelity IR dumper against both `main` and the candidate and diffing **388 programs**: 11,750 lines byte-identical.
- ASan/UBSan clean; reverting only the `goto` reproduces `Direct leak of 80 byte(s)`. TSan clean. Release at `-Dwirelog_log_max_level=error` strips both new `WL_LOG` sites, verified against a debug build as positive control.
- 0 of 24 `test_jpp` objects carry `-flto` against 71/71 for the library, so the `b_lto=false` override is effective.

Note for reviewers on the history: the seven units were validated as one tree and then split into seven commits, each verified to build and pass. The final tree is the gated one; the six intermediate trees were not individually gated.

## Follow-ups, not folded in here

Both final gates independently asked for the `ncalloc >= JPP_OOM_SWEEP_MAX` tripwire to be restored as a hard failure — it costs one `if` now that the caps clamp anyway, and today's headroom is 35 against 64. Also worth doing: widening the zero-size-calloc watch from one test to the sweep's whole armed window. Both are code changes and belong in their own commit.

Separately, the same unchecked-`strdup_safe`-into-`column_names` shape exists in `sip.c`, `magic_sets.c` and `program.c`. Same class, different files, out of scope here.

Closes #1119
