### PR TITLE
clang-tidy backlog: clear and promote arrangement.c, program.c and stratify.c (#1074, #1082, #1083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **Out-of-range dependency-graph edges no longer corrupt SCC detection**
+  (#1083): `wl_ir_stratify_scc_detect()` builds its adjacency list in two
+  passes that disagreed with each other. The counting pass reserved a slot
+  for every edge with an in-range `from`; the fill pass stored only edges
+  with an in-range `from` *and* `to`. An edge with an out-of-range `to`
+  therefore reserved a slot that was never written, and `adj_start[]` still
+  spanned it, so the traversal used an indeterminate value as an array index
+  -- producing an out-of-bounds read and, depending on that value,
+  out-of-bounds writes, through `disc[]`, `low[]`, `on_stack[]`, `stack[]`,
+  `adj_start[]` and `result->scc_id[]`. Both passes now test both endpoints.
+
+  Not reachable through `wirelog_parse_string()` or any other public entry
+  point: `wl_ir_stratify_dep_graph_build()` is the only in-tree producer of
+  a dependency graph and has never emitted an out-of-range endpoint. The
+  defect was reachable only by an embedder or a test constructing a
+  `wl_ir_stratify_dep_graph_t` by hand, which `stratify.h` now documents as
+  supported for this one function.
+
 ### Performance
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,32 @@ All notable changes to wirelog are documented in this file.
   `wl_ir_stratify_dep_graph_t` by hand, which `stratify.h` now documents as
   supported for this one function.
 
+- **Arrangement row counts that overflow their hash-table sizes are rejected**
+  (#1074): the arrangement layer sized both its bucket array and its chain
+  array from `nrows * 2` in 32-bit arithmetic, and neither computation
+  checked for wrap. `arr_next_pow2` returns 0 rather than saturating, so the
+  bucket count was 0 for every `nrows` in `[0x40000001, 0x7FFFFFFF]` and
+  again in `[0xC0000001, 0xFFFFFFFF]` -- 2147483646 row counts, about half
+  the 32-bit space. A zero bucket count matched a freshly zeroed
+  arrangement's own bucket count, so the allocation was skipped and the
+  bucket-head array stayed `NULL`, giving an out-of-bounds read through a
+  null pointer while indexing. Separately, the incremental update path sized
+  its chain array as `nrows * 2` clamped up to a 16-entry floor, so a
+  two-billion-row relation was indexed into a 64-byte allocation -- an
+  out-of-bounds write. That path was not covered by the bucket-count check,
+  because `arr_next_pow2(0)` is 16 and matches the existing bucket count, so
+  the load-factor test never diverted to a full rebuild. Both paths now
+  reject the relation as unrepresentable.
+
+  The incremental guard is deliberately broader than the unsafe range. A row
+  count in `[0x80000000, 0xC0000000]` whose load factor had changed used to
+  divert to a full rebuild and complete safely, and is now refused as well.
+  That case needs a relation of at least 2^31 rows -- some 34 GB of backing
+  store across two columns -- and the success it gives up was a 16-bucket
+  table with 134-million-entry chains, so one test on the row count ahead of
+  both products is worth more than preserving it. The cost is one comparison
+  per arrangement build, not per row.
+
 ### Performance
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,11 @@ public header.
 ## clang-tidy Ratchet (Issue #1100)
 
 `meson test --suite tidy` re-runs clang-tidy over every source in
-`scripts/ci/clang-tidy-allowlist.txt` (58 files today) and fails on any
-diagnostic. The 13 files that are not clean yet live in
-`scripts/ci/clang-tidy-backlog.txt` and are skipped. The two lists must
+`scripts/ci/clang-tidy-allowlist.txt` and fails on any diagnostic. The
+files that are not clean yet live in `scripts/ci/clang-tidy-backlog.txt`
+and are skipped. Neither count is written down here on purpose: they move
+whenever a file is promoted, and `.github/workflows/ci-pr.yml` derives
+both at runtime. The two lists must
 partition the `libwirelog.so` entries of `build/compile_commands.json`
 exactly, so an allowlist line cannot simply be deleted; moving one to the
 backlog is caught separately by

--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -78,6 +78,7 @@ wirelog/io/io_ctx.c
 wirelog/ir/api.c
 wirelog/ir/ir.c
 wirelog/ir/program.c
+wirelog/ir/stratify.c
 wirelog/parser/ast.c
 wirelog/parser/lexer.c
 wirelog/parser/parser.c

--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -40,6 +40,7 @@ wirelog/api_facade.c
 wirelog/arena/arena.c
 wirelog/arena/compound_arena.c
 wirelog/columnar/arithmetic.c
+wirelog/columnar/arrangement.c
 wirelog/columnar/cache.c
 wirelog/columnar/compound_side.c
 wirelog/columnar/delta_pool.c

--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -77,6 +77,7 @@ wirelog/io/io_adapter.c
 wirelog/io/io_ctx.c
 wirelog/ir/api.c
 wirelog/ir/ir.c
+wirelog/ir/program.c
 wirelog/parser/ast.c
 wirelog/parser/lexer.c
 wirelog/parser/parser.c

--- a/scripts/ci/clang-tidy-backlog.txt
+++ b/scripts/ci/clang-tidy-backlog.txt
@@ -41,5 +41,4 @@ wirelog/columnar/join.c
 wirelog/columnar/kfusion.c
 wirelog/columnar/merge.c
 wirelog/columnar/mobius.c
-wirelog/ir/stratify.c
 wirelog/passes/jpp.c

--- a/scripts/ci/clang-tidy-backlog.txt
+++ b/scripts/ci/clang-tidy-backlog.txt
@@ -31,7 +31,6 @@
 #
 # wirelog/ir/program.c is the reason this issue exists: it was clean, and
 # regressed to bugprone-branch-clone after f1d2a2c with nothing failing.
-wirelog/columnar/arrangement.c
 wirelog/columnar/eval.c
 wirelog/columnar/eval_delta.c
 wirelog/columnar/eval_plan.c

--- a/scripts/ci/clang-tidy-backlog.txt
+++ b/scripts/ci/clang-tidy-backlog.txt
@@ -41,6 +41,5 @@ wirelog/columnar/join.c
 wirelog/columnar/kfusion.c
 wirelog/columnar/merge.c
 wirelog/columnar/mobius.c
-wirelog/ir/program.c
 wirelog/ir/stratify.c
 wirelog/passes/jpp.c

--- a/scripts/ci/clang-tidy-supported-majors.txt
+++ b/scripts/ci/clang-tidy-supported-majors.txt
@@ -4,7 +4,7 @@
 # line, most preferred first.  scripts/ci/check-clang-tidy-ratchet.py SKIPs
 # on any other major; .github/workflows/ci-pr.yml installs the first entry.
 #
-# Why a pin at all: 9 of the 13 backlog diagnostics are path-sensitive
+# Why a pin at all: most backlog diagnostics are path-sensitive
 # clang-analyzer results that move between LLVM releases, and check names
 # can change between LLVM releases (see #1114).  An unpinned gate would
 # fail, or silently stop covering checks, on the first toolchain bump.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1777,6 +1777,27 @@ test_arrangement_exe = executable(
 test('arrangement', test_arrangement_exe)
 
 # ============================================================================
+# Arrangement next-pow2 Overflow Tests (Issue #1074)
+# ============================================================================
+
+test_arrangement_pow2_overflow_exe = executable(
+  'test_arrangement_pow2_overflow',
+  files('test_arrangement_pow2_overflow.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('arrangement_pow2_overflow', test_arrangement_pow2_overflow_exe)
+
+# ============================================================================
 # Delta Arrangement Cache Tests (Phase 3C - 3C-001-Ext)
 # ============================================================================
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -117,6 +117,17 @@ test_stratify_exe = executable(
   dependencies: [threads_dep],
 )
 
+test_stratify_scc_bounds_exe = executable(
+  'test_stratify_scc_bounds',
+  files('test_stratify_scc_bounds.c'),
+  parser_src,
+  ir_src,
+  io_src,
+  thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
+)
+
 test_parse_duplicate_decl_no_leak_exe = executable(
   'test_parse_duplicate_decl_no_leak',
   files('test_parse_duplicate_decl_no_leak.c'),
@@ -137,6 +148,7 @@ test('parser', test_parser_exe)
 test('ir', test_ir_exe)
 test('program', test_program_exe)
 test('stratify', test_stratify_exe)
+test('stratify_scc_bounds', test_stratify_scc_bounds_exe)
 test('parse_duplicate_decl_no_leak', test_parse_duplicate_decl_no_leak_exe)
 
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -805,9 +805,10 @@ endif
 # Issue #1100: clang-tidy ratchet (suite 'tidy').  No CI job has run
 # clang-tidy since efbde27 removed it, and wirelog/ir/program.c regressed
 # after f1d2a2c with nothing failing.  The gate re-analyses every file in
-# scripts/ci/clang-tidy-allowlist.txt on every run; the 13 files in
+# scripts/ci/clang-tidy-allowlist.txt on every run; the files in
 # clang-tidy-backlog.txt are excluded, and the two lists must partition the
-# libwirelog.so entries of compile_commands.json exactly.
+# libwirelog.so entries of compile_commands.json exactly.  Neither count is
+# recorded here: promoting a file moves both.
 #
 # As with the perf gate above, suite membership excludes nothing (there is
 # no add_test_setup in this project), so these run in a default

--- a/tests/test_arrangement_pow2_overflow.c
+++ b/tests/test_arrangement_pow2_overflow.c
@@ -1,0 +1,374 @@
+/*
+ * test_arrangement_pow2_overflow.c - Issue #1074
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ *
+ * arr_next_pow2() smears the low bits of n-1 upward and returns n + 1.  For
+ * n > 0x80000000 the smear saturates to 0xFFFFFFFF and the return wraps to 0,
+ * so the "next power of two" of a large row count is zero.  Two call sites in
+ * wirelog/columnar/arrangement.c consume that:
+ *
+ *   1. arr_build_full() computes nbuckets = arr_next_pow2(nrows * 2).  With
+ *      nbuckets == 0 and a freshly zeroed arrangement, `nbuckets !=
+ *      arr->nbuckets` is false, the bucket-head allocation is skipped, and
+ *      ht_head stays NULL.  arr_index_rows() then loads arr->ht_head[bucket]
+ *      through a null pointer.  Sweeping all 2^32 row counts, nbuckets is 0
+ *      for nrows in [0x40000001, 0x7FFFFFFF] and again in
+ *      [0xC0000001, 0xFFFFFFFF] -- 2147483646 values, about half the space.
+ *
+ *   2. arr_update_incremental() sizes the chain array as nrows * 2, which
+ *      wraps to 0 for nrows >= 0x80000000 and is then clamped up to the
+ *      16-entry floor.  A 64-byte chain array for a two-billion-row relation
+ *      is a heap-buffer-overflow WRITE in arr_index_rows().  arr_next_pow2(0)
+ *      is 16, so `needed != arr->nbuckets` does not fire and the full rebuild
+ *      -- and case 1's guard with it -- is never reached.
+ *
+ * Both cases are unrepresentable relations, so both must be rejected rather
+ * than indexed.
+ *
+ * Column sizing: ARR_HASH_TILE is 1024, and arr_hash_rows_batch() hashes a
+ * whole tile before arr_index_rows() touches any bucket.  A column shorter
+ * than one tile would fault inside the batch hash instead of at the site
+ * under test, so the fixture supplies 4096 rows of real backing store and
+ * only the row *count* is oversized.
+ *
+ * Private struct access:
+ *   col_rel_t and wl_col_session_t are private to the columnar backend.  The
+ *   mirrors below copy the initial, stable fields, exactly as
+ *   tests/test_arrangement.c does.  Keep them in sync.
+ */
+
+#include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ----------------------------------------------------------------
+ * Test framework
+ * ---------------------------------------------------------------- */
+
+static int test_count = 0;
+static int pass_count = 0;
+static int fail_count = 0;
+
+#define TEST(name)                                      \
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
+
+#define PASS()            \
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                    \
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
+
+#define ASSERT(cond, msg) \
+        do {                  \
+            if (!(cond))      \
+            FAIL(msg);    \
+        } while (0)
+
+/* ----------------------------------------------------------------
+ * Fixture sizing
+ * ---------------------------------------------------------------- */
+
+/* Real rows of backing store per column: >= ARR_HASH_TILE (1024) so the
+ * batch hash stays in bounds for the first tile of every case below. */
+#define FIXTURE_ROWS 4096u
+
+/* Smallest nrows for which arr_next_pow2(nrows * 2) == 0. */
+#define NROWS_ZERO_BUCKETS 0x40000001u
+
+/* Smallest nrows for which nrows * 2 wraps, undersizing the chain array. */
+#define NROWS_CAP_WRAP 0x80000000u
+
+/* ----------------------------------------------------------------
+ * Private struct mirrors (see tests/test_arrangement.c)
+ * ---------------------------------------------------------------- */
+
+typedef struct {
+    char *name;
+    uint32_t ncols;
+    uint32_t _ncols_pad; /* explicit alignment padding */
+    int64_t **columns;
+    uint32_t nrows;
+    uint32_t capacity;
+    /* omitted: col_names, schema, schema_ok, timestamps */
+} test_col_rel_mirror_t;
+
+typedef struct {
+    wl_session_t base;
+    const void *frontier_ops;
+    const void *rotation_ops;
+    const void *plan;
+    const void *intern;
+    test_col_rel_mirror_t **rels;
+    uint32_t nrels;
+    uint32_t rel_cap;
+    /* omitted: delta_cb, delta_data, eval_arena, mat_cache, etc. */
+} test_col_session_mirror_t;
+
+/* ----------------------------------------------------------------
+ * Helpers
+ * ---------------------------------------------------------------- */
+
+static void
+noop_cb(const char *r, const int64_t *row, uint32_t nc, void *u)
+{
+    (void)r;
+    (void)row;
+    (void)nc;
+    (void)u;
+}
+
+static const char *const FIXTURE_SRC = ".decl edge(x: int32, y: int32)\n"
+    "edge(1, 2). edge(2, 3). edge(3, 4).\n"
+    ".decl reach(x: int32, y: int32)\n"
+    "reach(x, y) :- edge(x, y).\n";
+
+static int
+make_session(const char *src, wl_session_t **out_sess, wl_plan_t **out_plan,
+    wirelog_program_t **out_prog)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    if (!prog)
+        return -1;
+
+    wl_fusion_apply(prog, NULL);
+    wl_jpp_apply(prog, NULL);
+    wl_sip_apply(prog, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(prog, &plan) != 0) {
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    wl_session_t *sess = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    if (wl_session_load_facts(sess, prog) != 0) {
+        wl_session_destroy(sess);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    if (wl_session_snapshot(sess, noop_cb, NULL) != 0) {
+        wl_session_destroy(sess);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        return -1;
+    }
+
+    *out_sess = sess;
+    *out_plan = plan;
+    *out_prog = prog;
+    return 0;
+}
+
+static void
+free_session(wl_session_t *sess, wl_plan_t *plan, wirelog_program_t *prog)
+{
+    wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+}
+
+static test_col_rel_mirror_t *
+find_rel_mirror(wl_session_t *sess, const char *rel_name)
+{
+    test_col_session_mirror_t *ms = (test_col_session_mirror_t *)sess;
+    for (uint32_t i = 0; i < ms->nrels; i++) {
+        test_col_rel_mirror_t *r = ms->rels[i];
+        if (r && r->name && strcmp(r->name, rel_name) == 0)
+            return r;
+    }
+    return NULL;
+}
+
+/*
+ * oversize_rel: point every column at FIXTURE_ROWS rows of test-owned backing
+ * store and claim `nrows` rows.  The relation keeps ownership of its own
+ * buffers, which are handed back by restore_rel() before the session is
+ * destroyed, so nothing here changes what the session frees.
+ *
+ * Returns 0 on success.  `saved` receives the original column pointers and
+ * must have room for rel->ncols entries.
+ */
+static int
+oversize_rel(test_col_rel_mirror_t *rel, uint32_t nrows, int64_t **saved,
+    int64_t **backing)
+{
+    for (uint32_t c = 0; c < rel->ncols; c++) {
+        backing[c] = (int64_t *)malloc(FIXTURE_ROWS * sizeof(int64_t));
+        if (!backing[c]) {
+            for (uint32_t d = 0; d < c; d++)
+                free(backing[d]);
+            return -1;
+        }
+        for (uint32_t i = 0; i < FIXTURE_ROWS; i++)
+            backing[c][i] = (int64_t)i + (int64_t)c;
+    }
+    for (uint32_t c = 0; c < rel->ncols; c++) {
+        saved[c] = rel->columns[c];
+        rel->columns[c] = backing[c];
+    }
+    rel->nrows = nrows;
+    rel->capacity = nrows;
+    return 0;
+}
+
+static void
+restore_rel(test_col_rel_mirror_t *rel, uint32_t nrows, uint32_t capacity,
+    int64_t **saved, int64_t **backing)
+{
+    for (uint32_t c = 0; c < rel->ncols; c++) {
+        rel->columns[c] = saved[c];
+        free(backing[c]);
+    }
+    rel->nrows = nrows;
+    rel->capacity = capacity;
+}
+
+/* ================================================================
+ * Test 1: arr_build_full must reject a row count whose bucket count
+ * overflows to zero, instead of indexing through a NULL ht_head.
+ * ================================================================ */
+static void
+test_build_full_rejects_zero_nbuckets(void)
+{
+    TEST("arr_build_full: nrows with zero bucket count is rejected");
+
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    ASSERT(make_session(FIXTURE_SRC, &sess, &plan, &prog) == 0,
+        "session creation failed");
+
+    test_col_rel_mirror_t *rel = find_rel_mirror(sess, "edge");
+    if (!rel) {
+        free_session(sess, plan, prog);
+        FAIL("relation 'edge' not found");
+    }
+
+    uint32_t orig_nrows = rel->nrows;
+    uint32_t orig_capacity = rel->capacity;
+    int64_t *saved[2] = { NULL, NULL };
+    int64_t *backing[2] = { NULL, NULL };
+    if (rel->ncols != 2
+        || oversize_rel(rel, NROWS_ZERO_BUCKETS, saved, backing) != 0) {
+        free_session(sess, plan, prog);
+        FAIL("fixture setup failed");
+    }
+
+    uint32_t key_cols[] = { 0 };
+    col_arrangement_t *arr
+        = col_session_get_arrangement(sess, "edge", key_cols, 1);
+
+    restore_rel(rel, orig_nrows, orig_capacity, saved, backing);
+    free_session(sess, plan, prog);
+
+    ASSERT(arr == NULL,
+        "an unrepresentable row count must not produce an arrangement");
+    PASS();
+}
+
+/* ================================================================
+ * Test 2: arr_update_incremental must reject a row count whose chain
+ * array size wraps, instead of writing past a 16-entry allocation.
+ *
+ * The arrangement is first built at the relation's real size, so
+ * arr->nbuckets is the 16-entry floor.  arr_next_pow2(nrows * 2) is
+ * also 16 once nrows * 2 wraps to 0, so the load-factor check does
+ * not divert to arr_build_full and this path must guard itself.
+ * ================================================================ */
+static void
+test_update_incremental_rejects_wrapped_cap(void)
+{
+    TEST("arr_update_incremental: nrows with wrapped chain cap is rejected");
+
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    ASSERT(make_session(FIXTURE_SRC, &sess, &plan, &prog) == 0,
+        "session creation failed");
+
+    test_col_rel_mirror_t *rel = find_rel_mirror(sess, "edge");
+    if (!rel) {
+        free_session(sess, plan, prog);
+        FAIL("relation 'edge' not found");
+    }
+
+    uint32_t key_cols[] = { 0 };
+    col_arrangement_t *arr
+        = col_session_get_arrangement(sess, "edge", key_cols, 1);
+    if (!arr || arr->nbuckets != 16u) {
+        free_session(sess, plan, prog);
+        FAIL("baseline arrangement must exist with the 16-bucket floor");
+    }
+
+    uint32_t orig_nrows = rel->nrows;
+    uint32_t orig_capacity = rel->capacity;
+    int64_t *saved[2] = { NULL, NULL };
+    int64_t *backing[2] = { NULL, NULL };
+    if (rel->ncols != 2
+        || oversize_rel(rel, NROWS_CAP_WRAP, saved, backing) != 0) {
+        free_session(sess, plan, prog);
+        FAIL("fixture setup failed");
+    }
+
+    col_arrangement_t *grown
+        = col_session_get_arrangement(sess, "edge", key_cols, 1);
+
+    restore_rel(rel, orig_nrows, orig_capacity, saved, backing);
+    free_session(sess, plan, prog);
+
+    ASSERT(grown == NULL,
+        "an unrepresentable row count must not extend an arrangement");
+    PASS();
+}
+
+/* ================================================================
+ * main
+ * ================================================================ */
+
+int
+main(void)
+{
+    printf("\n=== Arrangement next-pow2 Overflow Tests (Issue #1074) ===\n\n");
+
+    test_build_full_rejects_zero_nbuckets();
+    test_update_incremental_rejects_wrapped_cap();
+
+    printf("\nResults: %d/%d passed", pass_count, test_count);
+    if (fail_count > 0)
+        printf(", %d FAILED", fail_count);
+    printf("\n\n");
+
+    return fail_count > 0 ? 1 : 0;
+}

--- a/tests/test_inline_slot_types.py
+++ b/tests/test_inline_slot_types.py
@@ -27,6 +27,10 @@
 #     from the data,
 #   * an int64 slot declared explicitly must still reject a symbol,
 #   * and a compound-free relation must be untouched.
+#
+# `string` and `symbol` are two spellings of one slot type.  Every case
+# above spells it `symbol`, so one case spells it `string` -- otherwise
+# nothing in the tree would notice if that spelling stopped decoding.
 
 import os
 import subprocess
@@ -62,6 +66,16 @@ o(a,b,c) :- p(a, pair(b,c)).
 # applied slot 0's type to the whole compound would fail here.
 MIXED = '''\
 .decl p(id: int64, lbl: pair(symbol, int64) inline)
+.decl o(a: int64, b: symbol, c: int64)
+.input p(filename="%s")
+.output o
+o(a,b,c) :- p(a, pair(b,c)).
+'''
+
+# The `string` spelling of a symbol slot, mixed the same way as above so a
+# pass cannot come from every slot happening to be interned.
+STRING_SPELLING = '''\
+.decl p(id: int64, lbl: pair(string, int64) inline)
 .decl o(a: int64, b: symbol, c: int64)
 .input p(filename="%s")
 .output o
@@ -130,6 +144,13 @@ def main() -> int:
         r = run(exe, MIXED, td, "mix", "1\taa\t7\n")
         if 'o(1, "aa", 7)' not in r.stdout:
             fail("mixed slots: expected o(1, \"aa\", 7); stdout=%r stderr=%r"
+                 % (r.stdout.strip(), r.stderr.strip()))
+
+        # `string` names the same slot type as `symbol`.
+        r = run(exe, STRING_SPELLING, td, "str", "1\tcc\t9\n")
+        if 'o(1, "cc", 9)' not in r.stdout:
+            fail("string slot spelling: expected o(1, \"cc\", 9); "
+                 "stdout=%r stderr=%r"
                  % (r.stdout.strip(), r.stderr.strip()))
 
         # Control: no compound anywhere, unchanged.

--- a/tests/test_stratify_scc_bounds.c
+++ b/tests/test_stratify_scc_bounds.c
@@ -1,0 +1,179 @@
+/*
+ * test_stratify_scc_bounds.c - SCC detection against out-of-range edges
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Issue #1083.  wl_ir_stratify_scc_detect() builds its adjacency list in two
+ * passes.  The counting pass reserved a slot for every edge whose `from` was
+ * in range; the fill pass only stored edges whose `from` AND `to` were both
+ * in range.  An edge with an in-range `from` and an out-of-range `to`
+ * therefore reserved a slot that was never written, while adj_start[] still
+ * spanned it -- so the traversal read an indeterminate neighbour index and
+ * used it to subscript disc[], low[], on_stack[], stack[], adj_start[] and
+ * result->scc_id[].
+ *
+ * wl_ir_stratify_dep_graph_build() has never emitted an out-of-range
+ * endpoint, so the defect is latent through the in-tree producer.  These
+ * tests build the graph by hand instead; the documented contract of
+ * wl_ir_stratify_scc_detect() (stratify.h) is what licenses that, not the
+ * fact that other tests happen to call the function directly.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../wirelog/ir/stratify.h"
+
+/* ======================================================================== */
+/* Test Helpers                                                             */
+/* ======================================================================== */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                      \
+        do {                                \
+            tests_run++;                    \
+            printf("  [TEST] %-55s", name); \
+            fflush(stdout);                 \
+        } while (0)
+
+#define PASS()             \
+        do {                   \
+            tests_passed++;    \
+            printf(" PASS\n"); \
+        } while (0)
+
+#define FAIL(msg)                   \
+        do {                            \
+            tests_failed++;             \
+            printf(" FAIL: %s\n", msg); \
+        } while (0)
+
+/* ======================================================================== */
+/* Tests                                                                    */
+/* ======================================================================== */
+
+/*
+ * Chain 0 -> 1 -> 2 plus one edge whose `to` is out of range.
+ *
+ * The out-of-range edge is deliberately hung off node 2, the LAST node of
+ * the chain, and MUST NOT be moved to node 0.  The unwritten slot reads back
+ * as 0 (the adjacency array is zero-filled), i.e. a phantom edge to node 0.
+ * On node 2 that phantom closes the cycle 0 -> 1 -> 2 -> 0 and collapses
+ * three components into one, which this test detects.  On node 0 it would be
+ * a self-loop, which changes no SCC boundary, and the test would pass on
+ * broken code.  Same for any node that already reaches 0.
+ */
+static void
+test_scc_out_of_range_to_is_ignored(void)
+{
+    TEST("scc: edge with out-of-range 'to' does not join components");
+
+    wl_ir_stratify_dep_edge_t edges[] = {
+        { 0, 1, WL_IR_STRATIFY_DEP_POSITIVE },
+        { 1, 2, WL_IR_STRATIFY_DEP_POSITIVE },
+        { 2, 9, WL_IR_STRATIFY_DEP_POSITIVE }, /* 9 >= relation_count */
+    };
+    wl_ir_stratify_dep_graph_t graph = {
+        .relation_count = 3,
+        .relation_map = NULL,
+        .edges = edges,
+        .edge_count = 3,
+        .edge_capacity = 3,
+    };
+
+    wl_ir_stratify_scc_result_t *scc = wl_ir_stratify_scc_detect(&graph);
+    if (!scc) {
+        FAIL("scc_detect returned NULL");
+        return;
+    }
+
+    if (scc->scc_count != 3) {
+        FAIL("expected 3 singleton SCCs");
+        wl_ir_stratify_scc_free(scc);
+        return;
+    }
+
+    if (scc->scc_id[0] == scc->scc_id[1] || scc->scc_id[1] == scc->scc_id[2]
+        || scc->scc_id[0] == scc->scc_id[2]) {
+        FAIL("nodes were merged into a shared SCC");
+        wl_ir_stratify_scc_free(scc);
+        return;
+    }
+
+    wl_ir_stratify_scc_free(scc);
+    PASS();
+}
+
+/*
+ * Every edge has an out-of-range `from`, so no adjacency slot is reserved at
+ * all and the adjacency array has length zero.
+ *
+ * This case carries NO regression power: it passes both before and after the
+ * #1083 fix.  It is kept as an executable witness that the two
+ * clang-analyzer-core.NullDereference reports at stratify.c:303 and :338 were
+ * false positives -- the total_adj == 0 path really is taken, really does
+ * leave the fill loop and the traversal with nothing to dereference, and
+ * really does return a well-formed result.
+ */
+static void
+test_scc_out_of_range_from_yields_empty_adjacency(void)
+{
+    TEST("scc: all edges out of range -> empty adjacency, no crash");
+
+    wl_ir_stratify_dep_edge_t edges[] = {
+        { 9, 0, WL_IR_STRATIFY_DEP_POSITIVE }, /* 9 >= relation_count */
+    };
+    wl_ir_stratify_dep_graph_t graph = {
+        .relation_count = 2,
+        .relation_map = NULL,
+        .edges = edges,
+        .edge_count = 1,
+        .edge_capacity = 1,
+    };
+
+    wl_ir_stratify_scc_result_t *scc = wl_ir_stratify_scc_detect(&graph);
+    if (!scc) {
+        FAIL("scc_detect returned NULL");
+        return;
+    }
+
+    if (scc->scc_count != 2) {
+        FAIL("expected 2 singleton SCCs");
+        wl_ir_stratify_scc_free(scc);
+        return;
+    }
+
+    if (scc->scc_id[0] == scc->scc_id[1]) {
+        FAIL("nodes were merged into a shared SCC");
+        wl_ir_stratify_scc_free(scc);
+        return;
+    }
+
+    wl_ir_stratify_scc_free(scc);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Main                                                                     */
+/* ======================================================================== */
+
+int
+main(void)
+{
+    printf("\n=== wirelog SCC Edge-Bounds Tests ===\n\n");
+
+    test_scc_out_of_range_to_is_ignored();
+    test_scc_out_of_range_from_yields_empty_adjacency();
+
+    printf("\n=== Results: %d passed, %d failed, %d total ===\n\n",
+        tests_passed, tests_failed, tests_run);
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -193,7 +193,15 @@ arr_key_cols_valid(const col_rel_t *rel, const uint32_t *key_cols,
     return true;
 }
 
-/* Round n up to the next power of 2; minimum 16. */
+/*
+ * Round n up to the next power of 2; minimum 16.
+ *
+ * Returns 0 -- not a saturated value -- for every n above 0x80000000: the
+ * smear fills to 0xFFFFFFFF and `n + 1u` wraps.  Callers must reject that
+ * themselves; both in this file do, below.  The byte-identical
+ * wl_columnar_filter_next_pow2 in filter.c has the same return and more
+ * callers.  See follow-up issue (next_pow2 family).
+ */
 static uint32_t
 arr_next_pow2(uint32_t n)
 {
@@ -234,6 +242,46 @@ arr_build_full(col_arrangement_t *arr, const col_rel_t *rel)
     uint32_t nrows = rel->nrows;
     uint32_t nbuckets = arr_next_pow2(nrows > 0 ? nrows * 2u : 16u);
 
+    /*
+     * arr_next_pow2 returns 0 above 0x80000000, so nbuckets is 0 for nrows
+     * in [0x40000001, 0x7FFFFFFF] and again in [0xC0000001, 0xFFFFFFFF] --
+     * 2147483646 row counts, about half the 32-bit space.  Zero would then
+     * pass the "size changed" test below against a zeroed arrangement, skip
+     * the allocation, and leave arr_index_rows to load ht_head[hash & ~0u]
+     * through a NULL pointer.
+     *
+     * Test the bucket count, not the row count.  Beyond being this file's
+     * own invalid-arrangement predicate -- col_arrangement_find_first uses
+     * `arr->nbuckets == 0`, where `< 16u` would invent a second and
+     * unstated minimum -- it is the form the analyzer can use.  It clears
+     * the memset below when non-zero-ness is established by a test on the
+     * value flowing into it, or on its producer's output, and not when the
+     * test is on the producer's input domain.  So the same guard written
+     * against nrows here still reports the diagnostic, as does making
+     * arr_next_pow2 saturate by rejecting its input; a saturation applied
+     * after the smear, which constrains what it returns, does clear it.
+     * A primitive-only fix was available; this one is preferred because it
+     * rejects the relation rather than silently resizing it.
+     *
+     * The domain left open is deliberate.  Row counts in
+     * [0x80000000, 0xC0000000] still build here, degenerately -- nbuckets
+     * floors at 16 for two billion rows -- and that is memory-safe: the
+     * chain sizing below takes max(nrows, ht_cap * 2), which never lands
+     * under nrows, unlike the bare nrows * 2u in arr_update_incremental.
+     * Unifying the two guards on row count measures one diagnostic, so the
+     * asymmetry with that function is required rather than an oversight.
+     *
+     * ENOMEM is reused deliberately: the relation is unrepresentable rather
+     * than out of memory, and EOVERFLOW would say so.  It is not that
+     * EOVERFLOW is unavailable -- join.c, which consumes these
+     * arrangements, returns it as rc=84 in nine places.  It is that all
+     * seven call sites of this function and arr_update_incremental discard
+     * the value and collapse to NULL, so the distinction could never reach
+     * a caller.
+     */
+    if (nbuckets == 0)
+        return ENOMEM;
+
     /* Reallocate bucket heads if size changed. */
     if (nbuckets != arr->nbuckets) {
         uint32_t *head = (uint32_t *)malloc(nbuckets * sizeof(uint32_t));
@@ -271,6 +319,28 @@ arr_update_incremental(col_arrangement_t *arr, const col_rel_t *rel,
     uint32_t nrows = rel->nrows;
     if (old_nrows >= nrows)
         return 0;
+
+    /*
+     * Both sizes below are nrows * 2, which wraps for nrows >= 0x80000000 --
+     * every row count in the top half of the range.  The chain array is the
+     * dangerous one: the wrapped product is 0, the 16-entry floor rounds it
+     * up, and arr_index_rows writes past a 64-byte allocation.  The
+     * arr_build_full guard does not cover it, because arr_next_pow2(0) is 16
+     * and matches the arrangement's existing bucket count, so the load-factor
+     * test below never diverts to the rebuild.
+     *
+     * This refuses more than the unsafe range, deliberately.  Where nrows is
+     * in [0x80000000, 0xC0000000] and `needed` differs from arr->nbuckets,
+     * the call used to divert to arr_build_full and complete safely, and is
+     * now rejected.  What that costs is a relation of at least 2^31 rows --
+     * some 34 GB of backing store across two columns -- whose success was a
+     * 16-bucket table with 134-million-entry chains.  One test on the row
+     * count, ahead of both products, is worth more than preserving it.
+     *
+     * ENOMEM is reused for the reason given in arr_build_full.
+     */
+    if (nrows > UINT32_MAX / 2u)
+        return ENOMEM;
 
     /* If load factor would exceed 50%, full rebuild needed. */
     uint32_t needed = arr_next_pow2(nrows * 2u);

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -139,10 +139,8 @@ parse_compound_metadata(const char *type_name, wl_intern_t *intern)
                 5) == 0) ty = WIRELOG_TYPE_INT32;
             else if (tlen == 5 && strncmp(tok, "int64",
                 5) == 0) ty = WIRELOG_TYPE_INT64;
-            else if (tlen == 6 && strncmp(tok, "string",
-                6) == 0) ty = WIRELOG_TYPE_STRING;
-            else if (tlen == 6 && strncmp(tok, "symbol",
-                6) == 0) ty = WIRELOG_TYPE_STRING;
+            else if (tlen == 6 && (strncmp(tok, "string", 6) == 0
+                || strncmp(tok, "symbol", 6) == 0)) ty = WIRELOG_TYPE_STRING;
             else {
                 free(functor_name); return result;
             }

--- a/wirelog/ir/stratify.c
+++ b/wirelog/ir/stratify.c
@@ -275,10 +275,30 @@ wl_ir_stratify_scc_detect(const wl_ir_stratify_dep_graph_t *graph)
         goto cleanup_error;
     }
 
-    /* Count outgoing edges per node */
+    /*
+     * Count outgoing edges per node.
+     *
+     * Both endpoints are tested here so that this pass admits exactly the
+     * edges the fill loop below stores.  Testing only `from` here counted an
+     * edge with an out-of-range `to`, reserving an adjacency slot the fill
+     * loop never wrote while adj_start[] still spanned it -- so the traversal
+     * read an indeterminate neighbour index and subscripted with it (#1083).
+     * The two predicates must stay identical.
+     *
+     * Nothing in CI will tell you if they stop being identical.  Before
+     * #1083 this file was in the clang-tidy backlog with an
+     * uninitialized.Assign report pointing straight at the consequence of
+     * this predicate, which makes it easy to assume the analyser backstops
+     * the invariant.  It does not: the allocation change below is what
+     * silences all three diagnostics, and with it in place a re-broken
+     * predicate measures ZERO clang-tidy diagnostics.  The file is on the
+     * ratchet allowlist and would stay green.  tests/test_stratify_scc_bounds.c
+     * is the only thing that catches a recurrence.
+     */
     for (uint32_t e = 0; e < graph->edge_count; e++) {
         uint32_t from = graph->edges[e].from;
-        if (from < n)
+        uint32_t to = graph->edges[e].to;
+        if (from < n && to < n)
             adj_count_arr[from]++;
     }
 
@@ -288,11 +308,38 @@ wl_ir_stratify_scc_detect(const wl_ir_stratify_dep_graph_t *graph)
         adj_start[i + 1] = adj_start[i] + adj_count_arr[i];
 
     uint32_t total_adj = adj_start[n];
-    if (total_adj > 0) {
-        adj = (uint32_t *)malloc(total_adj * sizeof(uint32_t));
-        if (!adj)
-            goto cleanup_error;
-    }
+
+    /*
+     * One slack slot, so the request is never for zero objects: calloc(0, n)
+     * is permitted to return NULL, and with both endpoints tested above
+     * total_adj == 0 is the COMMON case -- it holds for every program whose
+     * IDB relations have no IDB-to-IDB edges -- so a NULL there would send a
+     * routine graph down the error path.  The slack is unconditional rather
+     * than `total_adj ? total_adj : 1` on purpose: a branch on total_adj lets
+     * the static analyser explore a state where the buffer has the concrete
+     * length 1, which it cannot correlate with the counting loop, and it then
+     * reports two false clang-analyzer-security.ArrayBound hits on a file the
+     * ratchet requires to be clean.
+     *
+     * calloc, not malloc, and this is not a mask: after the predicate fix
+     * above no reserved slot is left unwritten, so the zeroes are never read.
+     * They exist to keep tests/test_stratify_scc_bounds.c deterministic.  If
+     * the two predicates ever drift apart again, an unwritten slot reads back
+     * as 0 -- a phantom edge to node 0 that merges components on every single
+     * run -- instead of heap garbage whose value decides what happens next.
+     *
+     * Reverting to malloc does not disarm that test: with the predicate
+     * drifted it still fails 25 runs out of 25, as a SIGSEGV under the
+     * MALLOC_PERTURB_ that `meson test` always sets and as a clean assertion
+     * failure without it.  What malloc costs is the failure MODE, not the
+     * outcome.  calloc is what makes the failure identical on every allocator
+     * and in every heap state, and legible -- a named semantic assertion
+     * rather than a crash whose cause the next reader has to reconstruct.
+     */
+    size_t slots = (size_t)total_adj + 1u;
+    adj = (uint32_t *)calloc(slots, sizeof(uint32_t));
+    if (!adj)
+        goto cleanup_error;
 
     /* Fill adjacency list */
     memset(adj_count_arr, 0, n * sizeof(uint32_t));

--- a/wirelog/ir/stratify.h
+++ b/wirelog/ir/stratify.h
@@ -248,6 +248,15 @@ wl_ir_stratify_dep_graph_free(wl_ir_stratify_dep_graph_t *graph);
  * condensation DAG) receive lower IDs. This directly maps to execution
  * order — stratum 0 has no IDB dependencies and executes first.
  *
+ * Edge bounds: an edge whose @from or @to is >= graph->relation_count is
+ * ignored outright — it contributes to no node's adjacency and to no SCC.
+ * This is a guarantee of THIS function only. It is not a property of
+ * wl_ir_stratify_dep_graph_t, and other readers of graph->edges do not all
+ * bounds-check their endpoints, so it must not be generalised to them.
+ * wl_ir_stratify_dep_graph_build() never emits such an edge; the guarantee
+ * is what makes hand-built graphs (unit tests, future producers) well
+ * defined here.
+ *
  * Returns: (transfer full): SCC result, or NULL on error
  */
 wl_ir_stratify_scc_result_t *


### PR DESCRIPTION
Three 0.60.0 clang-tidy issues, each developed and gated separately, combined for one CI run. Seven commits: a fix and a promotion per unit, plus one shared documentation commit.

The backlog goes from 13 files to 10; the allowlist from 58 to 61. The partition stays exact at 71 translation units.

**Two of the three were real memory-safety defects, not lint cleanup**, and the third was a true positive that was not a defect at all. The distinction is the point of the work, so each unit says which it is.

## #1074 — `columnar/arrangement.c`: two overflows, one of them a heap-corrupting write

`arr_next_pow2` returns **0** rather than saturating: for `n > 0x80000000` the OR-smear fills to `0xFFFFFFFF` and `return n + 1u` wraps. A full 2³² sweep puts `nbuckets == 0` for `nrows ∈ [0x40000001, 0x7FFFFFFF]` **and** `[0xC0000001, 0xFFFFFFFF]` — 2,147,483,646 row counts, about half the 32-bit space. Zero then equals a freshly-zeroed arrangement's own `nbuckets`, so the "size changed" test does not fire, the bucket-head allocation is skipped, and `arr_index_rows` loads `ht_head[hash & ~0u]` through NULL. That is the reported diagnostic, and it is an out-of-bounds **read**.

The investigation found a second defect the diagnostic does not cover. `arr_update_incremental` sizes the chain array as `nrows * 2u` clamped to a 16-entry floor, so `nrows = 0x80000000` wraps the product to 0 and asks for 64 bytes for a two-billion-row relation — an out-of-bounds **write**, reproduced under ASan as `heap-buffer-overflow, WRITE of size 4, 0 bytes after 64-byte region`. The full rebuild is never reached from there, because `arr_next_pow2(0) == 16` matches the existing bucket count.

**The analyzer never sees the second one.** With only the row-count guard removed the file still reports exactly one diagnostic — the same `NonNullParamChecker`. So promotion buys no protection there, and the new test is what covers it. That test is also the more robust of the two: it triggers on a 64-byte `realloc`, while the first case needs a 4 GB `malloc` to reach its dereference and would pass for the wrong reason on a memory-constrained host. The guard whose only protection is a test has the deterministic test.

The two guards compose with no third hole: `arr_update_incremental` cannot be entered with `nbuckets == 0`, because entry requires `indexed_rows > 0`, which requires a prior successful `arr_build_full`, which now requires `nbuckets != 0`. `nbuckets` is therefore a power of two in [16, 2³¹] on every path reaching `& (nbuckets - 1)`.

Two alternatives were rejected on measurement rather than taste. Widening the bucket test to `|| !arr->ht_head` is *substantively* worse — `malloc(0)` returns non-NULL, so the arrangement then indexes a zero-element live heap allocation, and the analyzer says so by relocating the diagnostic to `security.ArrayBound`. Making `arr_next_pow2` saturate is viable but formulation-dependent: constraining the returned value after the smear clears the analyzer, rejecting the input domain does not. That rule is why the guard is written against `nbuckets` and not `nrows`.

## #1083 — `ir/stratify.c`: two passes with disagreeing predicates

Three diagnostics, but **two distinct findings**. The two `NullDereference` reports are genuine false positives, excluded by local guards regardless of any caller. The `uninitialized.Assign` is real: the counting pass admitted an edge on `from < n` alone while the fill pass stored it only on `from < n && to < n`, so an edge with an out-of-range `to` reserved a slot the fill loop never wrote while `adj_start[]` still spanned it. The traversal then used an indeterminate value as an array index — an out-of-bounds read, with out-of-bounds writes conditional on that value. The observed ASan fault is a READ, with the faulting register holding `0xbebebebe`, ASan's own fill byte.

**The gate is satisfied 100% by the wrong half of the patch.** Measured:

| variant | diagnostics |
|---|---|
| base | 3 |
| predicate fix only — the actual bug fix | **3** |
| allocation change only, defect fully intact | **0** |
| full fix | 0 |

So clang-tidy will not catch a recurrence, and `tests/test_stratify_scc_bounds.c` is the only guard. The counting loop now says exactly that, because the pre-fix `uninitialized.Assign` gives a maintainer positive reason to assume otherwise.

The `calloc` is not a mask — after the predicate fix the zeroes are never read. It exists so a future predicate drift fails identically on every allocator: an unwritten slot reads back as 0, a phantom edge to node 0 that merges components every time. This was verified with a pattern-filling `malloc` interposer: at fill value 2 the phantom becomes a self-loop and **the test passes on broken code**; under `calloc` it fails for every fill.

For the same reason the test's out-of-range edge hangs off the **last** node of the chain and never node 0 — on node 0 the phantom is a benign self-loop. The node-0 variant was built independently by two agents and passes on broken code. A comment pins the placement and says why.

## #1082 — `ir/program.c`: a true positive that is not a defect

`bugprone-branch-clone`: two adjacent arms both assigning `WIRELOG_TYPE_STRING`. `string` and `symbol` are two spellings of one slot type and nothing downstream can tell them apart — `wirelog_column_type_t` has no symbol member, the parallel `wl_ir_coltype_t` lattice has none, and `rel->slot_types` has exactly one read site in the tree, feeding consumers that test only `== WIRELOG_TYPE_STRING`. So the arms are merged to state the equivalence once.

Equivalence was proved rather than argued: 8.1M tokens across exhaustive single-byte mutation of all four literals at every position over **all 256 byte values**, two-byte prefix crossings, and random tokens over the full byte range — in exact-size heap buffers with no NUL terminator under ASan/UBSan. Zero mismatches, exactly four accepted tokens.

The accompanying test is a **characterization test and passes before and after**, which the commit says plainly rather than dressing up as TDD; no source-level red is constructible for a semantics-preserving merge. It earns its place for a different reason: no compound slot list naming `string` existed anywhere in `tests/`, `docs/` or `examples/`, so one of the two arms being merged had zero coverage. Mutation-tested both ways — dropping `"string"` fails only the new case; dropping `"symbol"` fails two pre-existing ones.

Promotion here restores protection rather than adding it: the ratchet's own docstring records that this file was clean and regressed, and `f1d2a2c` had previously cleared 30 warnings from it.

## Verification

Each unit passed an independent review plus separate final design and risk gates, each held by a different agent, all echoing the candidate tree they judged. Every commit tree matches its approved tree.

Re-validated on the **combined** branch, because the register conflict resolution is not something any unit's gates saw:

- Full suite **294 total, 282 Ok, 0 Fail, 11 Skipped**. All three new tests pass; the ratchet passes at 61/10.
- Registers verified per file, not by count: each of the three is present in the allowlist and absent from the backlog. This matters because a "take one side" conflict resolution would silently drop a promotion **with no gate firing** — the partition still holds and the ratchet still reports green. Both registers remain `LC_ALL=C`-sorted over their entry lines.
- The source fixes survived the cherry-picks: comment-stripped diffs against `main` show 6, 12 and 4 changed code lines respectively, matching each unit's contribution.

The seventh commit deletes the register sizes from prose in `CLAUDE.md`, `tests/meson.build` and `clang-tidy-supported-majors.txt`. Every one of them said "58" and "13", all became wrong the moment any unit landed, and no per-branch number could have been right. `clang-tidy-backlog.txt`'s own header already argues the point for diagnostic counts; the same applies to file counts, and `ci-pr.yml` derives both at runtime. **`scripts/ci/check-clang-tidy-ratchet.py:33` carries the same stale sentence and is deliberately untouched — PR #1124 is rewriting that file.**

Note for anyone reproducing locally: `sbom_snapshot` fails if you have a `.venv` in the repository root, because `.venv` is not in `.gitignore` and `check-sbom-snapshot.sh` runs `syft dir:"$repo_root"`. Unrelated to this PR and absent in CI.

## Follow-ups, not folded in here

- `wl_columnar_filter_next_pow2` (`filter.c:785-797`) is byte-identical to `arr_next_pow2` modulo `u` suffixes, is non-`static`, and has five callers in `join.c` feeding `nrows * 2` into `calloc` with no zero check. Two more instances sit in files that are already allowlist-clean: `session_hash.c:44` and `util/lockfree_queue.c:97`. `handle_remap.c:52` is the one correct implementation — `size_t`, documented "returns 0 on overflow", caller checks — and is the pattern to mandate.
- `graph_add_edge` (`stratify.c:94`): sole call site, return value ignored, and `walk_ir_tree` returns `void` so it could not propagate anyway. A `realloc` failure silently drops a dependency edge; a dropped NEGATION edge makes an **unstratifiable program accepted as stratifiable**. clang-tidy will never flag it — the function is a file-local static.
- `wl_ir_stratify_program` Step 6 (`stratify.c:611-618`) indexes `scc_id[]` and `strata[]` with neither endpoint bounds-checked, while the validation loop in the same function checks both. This is why #1083's new header contract is scoped to one function and explicitly forbids generalisation.
- `program.c` has seven unchecked `strdup_safe` calls into `column_names[]`, the same class as the #1119 defect in `jpp.c`. The fix shape differs: `:1877` and `:1907` deliberately assign NULL for anonymous positions, so NULL is a load-bearing sentinel and a plain "check and bail" would break them.
- `program.c:1879-1881`'s comment justifies `WL_IR_COLTYPE_UNKNOWN` on a premise that #1037 falsified, which may mean a comparison or join over an inline symbol slot is rejected unnecessarily. Likely a functional gap rather than a stale comment.

Closes #1074
Closes #1082
Closes #1083
