### PR TITLE
fix: reject non-monotone recursive aggregates

### DIFF
--- a/scripts/ci/clang-tidy-baselines/llvm-22.nolint-counts.txt
+++ b/scripts/ci/clang-tidy-baselines/llvm-22.nolint-counts.txt
@@ -3,3 +3,4 @@
 # Missing keys are treated as zero; increases fail the ratchet.
 wirelog/columnar/partition.c 1
 wirelog/io/csv_reader.c 1
+wirelog/ir/program.c 9

--- a/tests/test_recursive_agg_kfusion.c
+++ b/tests/test_recursive_agg_kfusion.c
@@ -571,11 +571,9 @@ test_group_by_two_columns(void)
 /* ---------------------------------------------------------------------- */
 
 /*
- * count() is not an ordering aggregate: there is no sense in which one of a
- * group's counts dominates the others, so the canonicalisation refuses any
- * relation whose REDUCE is not MIN or MAX and leaves every row standing.
- * Both spellings of the program are asserted -- fused and not -- because the
- * refusal has to survive the rewrite that hid the REDUCE.
+ * count() is not monotone across a recursive fixpoint.  It is rejected before
+ * either spelling reaches canonicalisation, including the fused form whose
+ * REDUCE operators would otherwise be hidden by the rewrite.
  */
 #define COUNT_BASE                                                      \
         ".decl Edge(x: int64, y: int64)\n"                              \
@@ -586,35 +584,52 @@ test_group_by_two_columns(void)
         "Label(x, count(l)) :- Label(y, l), Edge(y, x).\n"
 
 static void
-test_count_not_canonicalized(void)
+test_count_rejected(void)
 {
-    TEST("count(): groups keep every value, fused and unfused");
+    TEST("recursive count(): rejected before fusion");
 
     static const char *unfused = COUNT_BASE;
     static const char *fused = COUNT_BASE
         "Label(x, count(l)) :- Label(y, l), Label(y, m), Edge(y, x).\n";
-    /* Groups 3 and 4 hold more than one count.  Canonicalising this relation
-     * would keep one row per group, which is what the assertion detects. */
-    static const char *const want_unfused[] = {
-        "1|1", "2|1", "3|1", "3|2", "4|1", "4|2", NULL
-    };
-    static const char *const want_fused[] = {
-        "1|1", "2|1", "3|1", "3|2", "4|1", "4|2", "4|4", NULL
-    };
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(unfused, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) != 0,
+            "unfused recursive count() was accepted");
+
+        ASSERT(eval_relation_at(fused, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) != 0,
+            "fused recursive count() was accepted");
+    }
+    PASS();
+}
+
+#define SUM_BASE                                                       \
+        ".decl Edge(x: int64, y: int64)\n"                       \
+        ".decl Label(x: int64, l: int64)\n"                      \
+        "Edge(1,3). Edge(2,3). Edge(3,4).\n"                     \
+        "Label(x, sum(y)) :- Edge(x, y).\n"                      \
+        "Label(y, sum(x)) :- Edge(x, y).\n"                      \
+        "Label(x, sum(l)) :- Label(y, l), Edge(y, x).\n"
+
+static void
+test_sum_rejected(void)
+{
+    TEST("recursive sum(): rejected before fusion");
+
+    static const char *unfused = SUM_BASE;
+    static const char *fused = SUM_BASE
+        "Label(x, sum(l)) :- Label(y, l), Label(y, m), Edge(y, x).\n";
 
     for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
         collect_t c;
         ASSERT(eval_relation_at(unfused, "Label", k_worker_counts[w],
-            NO_SYMBOL_COLUMN, &c) == 0,
-            "evaluation failed");
-        ASSERT(saw_exactly(&c, want_unfused),
-            "unfused count() relation was reduced");
+            NO_SYMBOL_COLUMN, &c) != 0,
+            "unfused recursive sum() was accepted");
 
         ASSERT(eval_relation_at(fused, "Label", k_worker_counts[w],
-            NO_SYMBOL_COLUMN, &c) == 0,
-            "evaluation failed");
-        ASSERT(saw_exactly(&c, want_fused),
-            "fused count() relation was reduced");
+            NO_SYMBOL_COLUMN, &c) != 0,
+            "fused recursive sum() was accepted");
     }
     PASS();
 }
@@ -795,7 +810,8 @@ main(void)
     test_cross_rule_fusion();
     test_single_idb_atom_control();
     test_group_by_two_columns();
-    test_count_not_canonicalized();
+    test_count_rejected();
+    test_sum_rejected();
     test_mixed_min_max_not_canonicalized();
     test_operand_type_is_order_independent();
     test_operand_domain_conflict_is_vetoed();

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -3349,6 +3349,42 @@ plan_stratum_record_refs(wl_plan_stratum_t *st)
 /* Public API                                                               */
 /* ======================================================================== */
 
+/* COUNT and SUM are not monotone reducers across a recursive fixpoint.  The
+ * plan must reject them before any rewrite can hide the REDUCE operator and
+ * otherwise expose a relation whose rows violate its declared functional
+ * dependency.  AVG is included defensively; parsed AVG expressions are
+ * rejected earlier in translate_ir_node(). */
+static int
+validate_recursive_aggregates(const wl_plan_t *plan)
+{
+    for (uint32_t s = 0; s < plan->stratum_count; s++) {
+        const wl_plan_stratum_t *stratum = &plan->strata[s];
+        if (!stratum->is_recursive || !stratum->relations)
+            continue;
+
+        for (uint32_t r = 0; r < stratum->relation_count; r++) {
+            const wl_plan_relation_t *relation = &stratum->relations[r];
+            for (uint32_t o = 0; o < relation->op_count; o++) {
+                const wl_plan_op_t *op = &relation->ops[o];
+                if (op->op != WL_PLAN_OP_REDUCE
+                    || (op->agg_fn != WIRELOG_AGG_COUNT
+                    && op->agg_fn != WIRELOG_AGG_SUM
+                    && op->agg_fn != WIRELOG_AGG_AVG))
+                    continue;
+
+                WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_ERROR,
+                    "recursive aggregate '%s' is not supported in "
+                    "relation '%s' of stratum %u: count, sum and average "
+                    "are non-monotone across fixpoint iteration",
+                    wirelog_agg_fn_str(op->agg_fn), relation->name,
+                    stratum->stratum_id);
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
 void
 wl_plan_free(wl_plan_t *plan)
 {
@@ -3821,6 +3857,14 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
             wl_plan_free(plan);
             return -1;
         }
+    }
+
+    /* Reject non-monotone recursive aggregates while the original REDUCE
+     * operators are still visible.  Rewrites below may move them into opaque
+     * backend metadata or discard their shape entirely. */
+    if (validate_recursive_aggregates(plan) != 0) {
+        wl_plan_free(plan);
+        return -1;
     }
 
     /* Rewrite K-atom recursive rules for complete semi-naive evaluation.


### PR DESCRIPTION
Closes #991

Recursive SUM and COUNT aggregates are non-monotone across fixpoint iteration and can produce multiple contradictory rows per group. Reject them during plan generation after stratification but before plan rewrites can hide REDUCE operators.

Changes:
- reject recursive SUM/COUNT (and defensively AVG) with an evaluator diagnostic
- preserve existing AVG lowering rejection, recursive MIN/MAX, and non-recursive aggregates
- update K-fusion regression coverage for fused and unfused recursive COUNT/SUM
- record the existing LLVM 22 NOLINT suppression baseline exposed by the hardened ratchet

Validation:
- full build passed
- full Meson suite: 295 tests passed; existing environment-dependent perf skips remain
- focused recursive aggregate, average rejection, conformance, and clang-tidy tests passed
