### PR TITLE
fix(ir): reject column name allocation failures

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -106,6 +106,21 @@ test_program_exe = executable(
   dependencies: [threads_dep],
 )
 
+if host_machine.system() == 'linux'
+  test_column_names_oom_exe = executable(
+    'test_column_names_oom',
+    files('test_column_names_oom.c'),
+    parser_src,
+    ir_src,
+    io_src,
+    thread_src,
+    include_directories: [wirelog_inc, wirelog_src_inc],
+    dependencies: [threads_dep],
+    link_args: ['-Wl,--wrap=malloc'],
+    override_options: ['b_lto=false'],
+  )
+endif
+
 test_stratify_exe = executable(
   'test_stratify',
   files('test_stratify.c'),
@@ -147,6 +162,9 @@ test('lexer', test_lexer_exe)
 test('parser', test_parser_exe)
 test('ir', test_ir_exe)
 test('program', test_program_exe)
+if host_machine.system() == 'linux'
+  test('column_names_oom', test_column_names_oom_exe)
+endif
 test('stratify', test_stratify_exe)
 test('stratify_scc_bounds', test_stratify_scc_bounds_exe)
 test('parse_duplicate_decl_no_leak', test_parse_duplicate_decl_no_leak_exe)

--- a/tests/test_column_names_oom.c
+++ b/tests/test_column_names_oom.c
@@ -1,0 +1,181 @@
+/* Regression test for issue #1129. */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../wirelog/ir/ir.h"
+#include "../wirelog/ir/program.h"
+#include "../wirelog/ir/stratify.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/parser/parser.h"
+#include "../wirelog/wirelog-parser.h"
+
+void *__real_malloc(size_t size);
+
+static long fail_at = -1;
+static long malloc_calls;
+
+void *
+__wrap_malloc(size_t size)
+{
+    if (fail_at >= 0 && malloc_calls++ == fail_at)
+        return NULL;
+    return __real_malloc(size);
+}
+
+static wirelog_ir_node_t *
+find_relation(wirelog_ir_node_t *node, const char *name)
+{
+    if (!node)
+        return NULL;
+    if (node->type == WIRELOG_IR_SCAN && node->relation_name
+        && strcmp(node->relation_name, name) == 0)
+        return node;
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        wirelog_ir_node_t *found = find_relation(node->children[i], name);
+        if (found)
+            return found;
+    }
+    return NULL;
+}
+
+static wirelog_ir_node_t *
+find_join(wirelog_ir_node_t *node)
+{
+    if (!node)
+        return NULL;
+    if (node->type == WIRELOG_IR_JOIN && node->join_key_count > 0)
+        return node;
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        wirelog_ir_node_t *found = find_join(node->children[i]);
+        if (found)
+            return found;
+    }
+    return NULL;
+}
+
+static bool
+has_name(const wirelog_ir_node_t *scan, const char *name)
+{
+    if (!scan || !scan->column_names)
+        return false;
+    for (uint32_t i = 0; i < scan->column_count; i++) {
+        if (scan->column_names[i] && strcmp(scan->column_names[i], name) == 0)
+            return true;
+    }
+    return false;
+}
+
+static bool
+plan_has_expected_join(const wl_plan_t *plan)
+{
+    if (!plan)
+        return false;
+    for (uint32_t s = 0; s < plan->stratum_count; s++) {
+        const wl_plan_stratum_t *stratum = &plan->strata[s];
+        for (uint32_t r = 0; r < stratum->relation_count; r++) {
+            const wl_plan_relation_t *relation = &stratum->relations[r];
+            for (uint32_t i = 0; i < relation->op_count; i++) {
+                const wl_plan_op_t *op = &relation->ops[i];
+                if (op->op != WL_PLAN_OP_JOIN || op->key_count != 1
+                    || !op->left_keys || !op->right_keys)
+                    continue;
+                if (strcmp(op->left_keys[0], "col1") == 0
+                    && strcmp(op->right_keys[0], "col0") == 0)
+                    return true;
+            }
+        }
+    }
+    return false;
+}
+
+int
+main(void)
+{
+    static const char source[] =
+        ".decl left(a: int64, y: int64)\n"
+        ".decl right(y: int64, z: int64)\n"
+        ".decl out(a: int64, z: int64)\n"
+        "out(a, z) :- left(a, y), right(y, z).\n";
+    bool saw_success = false;
+
+    /* The fixture is small, but allow room for parser and IR allocations. */
+    for (long attempt = 0; attempt < 512; attempt++) {
+        char parse_error[512] = { 0 };
+        wl_parser_ast_node_t *ast = wl_parser_parse_string(source,
+                parse_error, sizeof(parse_error));
+        if (!ast)
+            return 1;
+        struct wirelog_program *program = wl_ir_program_create();
+        if (!program)
+            return 1;
+        program->ast = ast;
+        if (wl_ir_program_collect_metadata(program, ast) != 0) {
+            wirelog_program_free(program);
+            return 1;
+        }
+
+        fail_at = attempt;
+        malloc_calls = 0;
+        int convert_rc = wl_ir_program_convert_rules(program, ast);
+        fail_at = -1;
+        if (convert_rc != 0) {
+            wirelog_program_free(program);
+            continue; /* A required allocation failed: rejection is valid. */
+        }
+        if (wl_ir_program_merge_unions(program) != 0) {
+            wirelog_program_free(program);
+            return 1;
+        }
+        wl_ir_program_build_schemas(program);
+        if (wl_ir_stratify_program(program) != 0) {
+            wirelog_program_free(program);
+            return 1;
+        }
+        wl_plan_t *plan = NULL;
+        if (wl_plan_from_program(program, &plan) != 0) {
+            wl_plan_free(plan);
+            wirelog_program_free(program);
+            continue; /* unresolved layouts must reject plan generation. */
+        }
+        if (!plan_has_expected_join(plan)) {
+            wl_plan_free(plan);
+            wirelog_program_free(program);
+            fprintf(stderr,
+                "issue #1129: plan accepted an unexpected join layout at %ld\n",
+                attempt);
+            return 1;
+        }
+        wl_plan_free(plan);
+        saw_success = true;
+        wirelog_ir_node_t *out = (wirelog_ir_node_t *)
+            wirelog_program_get_relation_ir(program, "out");
+        wirelog_ir_node_t *join = find_join(out);
+        wirelog_ir_node_t *left = find_relation(out, "left");
+        wirelog_ir_node_t *right = find_relation(out, "right");
+        bool valid = join && join->join_key_count == 1
+            && join->join_left_keys && join->join_right_keys
+            && join->join_left_keys[0]
+            && join->join_right_keys[0]
+            && strcmp(join->join_left_keys[0], "y") == 0
+            && strcmp(join->join_right_keys[0], "y") == 0
+            && has_name(left, "y") && has_name(right, "y");
+        if (!valid) {
+            fprintf(stderr,
+                "issue #1129: partial name allocation was accepted at %ld\n",
+                attempt);
+            wirelog_program_free(program);
+            return 1;
+        }
+        wirelog_program_free(program);
+    }
+
+    fail_at = -1;
+    if (!saw_success) {
+        fprintf(stderr, "issue #1129: OOM sweep never reached a valid parse\n");
+        return 1;
+    }
+    return 0;
+}

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -20,6 +20,8 @@
 #include "wirelog-types.h"
 
 #include <ctype.h>
+#include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1072,8 +1074,15 @@ collect_output_columns(const wirelog_ir_node_t *node, col_ctx_t *out)
         if (col_ctx_alloc(out, node->column_count) != 0)
             return -1;
         for (uint32_t i = 0; i < out->count; i++) {
-            out->names[i]
-                = dup_str(node->column_names ? node->column_names[i] : NULL);
+            const char *name
+                = node->column_names ? node->column_names[i] : NULL;
+            if (name) {
+                out->names[i] = dup_str(name);
+                if (!out->names[i]) {
+                    col_ctx_free(out);
+                    return -1;
+                }
+            }
             out->types[i] = node->column_types ? node->column_types[i]
                                                : WL_IR_COLTYPE_UNKNOWN;
         }
@@ -1108,7 +1117,14 @@ collect_output_columns(const wirelog_ir_node_t *node, col_ctx_t *out)
             for (uint32_t i = 0; i < proj.count; i++) {
                 uint32_t idx = node->project_indices[i];
                 if (idx < left.count) {
-                    proj.names[i] = dup_str(left.names[idx]);
+                    if (left.names[idx]) {
+                        proj.names[i] = dup_str(left.names[idx]);
+                        if (!proj.names[i]) {
+                            col_ctx_free(&proj);
+                            col_ctx_free(&left);
+                            return -1;
+                        }
+                    }
                     proj.types[i] = col_ctx_type_at(&left, idx);
                 }
             }
@@ -1125,10 +1141,14 @@ collect_output_columns(const wirelog_ir_node_t *node, col_ctx_t *out)
         col_ctx_t left, right;
         memset(&left, 0, sizeof(left));
         memset(&right, 0, sizeof(right));
-        if (node->child_count > 0)
-            collect_output_columns(node->children[0], &left);
-        if (node->child_count > 1)
-            collect_output_columns(node->children[1], &right);
+        if (node->child_count == 0
+            || collect_output_columns(node->children[0], &left) != 0
+            || (node->child_count > 1
+            && collect_output_columns(node->children[1], &right) != 0)) {
+            col_ctx_free(&left);
+            col_ctx_free(&right);
+            return -1;
+        }
 
         if (col_ctx_alloc(out, left.count + right.count) != 0) {
             col_ctx_free(&left);
@@ -1164,15 +1184,25 @@ collect_output_columns(const wirelog_ir_node_t *node, col_ctx_t *out)
              * projection would read as untyped. */
             col_ctx_t child;
             memset(&child, 0, sizeof(child));
-            if (node->child_count > 0)
-                collect_output_columns(node->children[0], &child);
+            if (node->child_count == 0
+                || collect_output_columns(node->children[0], &child) != 0) {
+                col_ctx_free(&child);
+                return -1;
+            }
 
             if (col_ctx_alloc(out, node->column_count) != 0) {
                 col_ctx_free(&child);
                 return -1;
             }
             for (uint32_t i = 0; i < out->count; i++) {
-                out->names[i] = dup_str(node->column_names[i]);
+                if (node->column_names[i]) {
+                    out->names[i] = dup_str(node->column_names[i]);
+                    if (!out->names[i]) {
+                        col_ctx_free(out);
+                        col_ctx_free(&child);
+                        return -1;
+                    }
+                }
                 if (node->project_indices && i < node->project_count)
                     out->types[i]
                         = col_ctx_type_at(&child, node->project_indices[i]);
@@ -1253,27 +1283,44 @@ resolve_project_indices(const wirelog_ir_node_t *project_node)
 
 /**
  * Resolve a join key variable name to "colN" format using the child's
- * column layout.  Returns a newly allocated string like "col1".
- * Falls back to "col0" if the name is not found.
+ * column layout.  An explicit, in-range colN is also accepted because some
+ * optimizer passes have already rewritten names to positional form.  An
+ * unknown name is an error; silently selecting col0 changes query semantics.
  */
 static char *
 resolve_key_to_colN(const char *key_name, const wirelog_ir_node_t *child)
 {
     char buf[32];
-    uint32_t idx = 0; /* fallback */
+    if (!key_name || !child)
+        return NULL;
 
-    if (key_name && child) {
-        col_ctx_t ctx;
-        if (collect_output_columns(child, &ctx) == 0) {
-            for (uint32_t c = 0; c < ctx.count; c++) {
-                if (ctx.names[c] && strcmp(ctx.names[c], key_name) == 0) {
-                    idx = c;
-                    break;
-                }
-            }
+    col_ctx_t ctx = { 0 };
+    if (collect_output_columns(child, &ctx) != 0)
+        return NULL;
+
+    uint32_t idx = UINT32_MAX;
+    for (uint32_t c = 0; c < ctx.count; c++) {
+        if (ctx.names[c] && strcmp(ctx.names[c], key_name) == 0) {
+            idx = c;
+            break;
         }
-        col_ctx_free(&ctx);
     }
+
+    if (idx == UINT32_MAX) {
+        const char *digits = key_name;
+        if (strncmp(digits, "col", 3) == 0 && digits[3] != '\0') {
+            char *end = NULL;
+            errno = 0;
+            unsigned long explicit_idx = strtoul(digits + 3, &end, 10);
+            if (errno == 0 && end != digits + 3 && *end == '\0'
+                && explicit_idx <= UINT32_MAX
+                && explicit_idx < ctx.count)
+                idx = (uint32_t)explicit_idx;
+        }
+    }
+    col_ctx_free(&ctx);
+    if (idx == UINT32_MAX)
+        return NULL;
 
     snprintf(buf, sizeof(buf), "col%u", idx);
     return dup_str(buf);
@@ -1537,6 +1584,8 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             node->join_right_keys, node->join_key_count,
             node->child_count > 1 ? node->children[1] : NULL);
         op->key_count = node->join_key_count;
+        if (op->key_count > 0 && (!op->left_keys || !op->right_keys))
+            return -1;
         return 0;
     }
 
@@ -1576,6 +1625,8 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             node->join_right_keys, node->join_key_count,
             node->child_count > 1 ? node->children[1] : NULL);
         op->key_count = node->join_key_count;
+        if (op->key_count > 0 && (!op->left_keys || !op->right_keys))
+            return -1;
         return 0;
     }
 
@@ -1615,6 +1666,8 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
             node->join_right_keys, node->join_key_count,
             node->child_count > 1 ? node->children[1] : NULL);
         op->key_count = node->join_key_count;
+        if (op->key_count > 0 && (!op->left_keys || !op->right_keys))
+            return -1;
         op->project_indices
             = dup_indices(node->project_indices, node->project_count);
         op->project_count = node->project_count;

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -1274,6 +1274,18 @@ free_var_names(char **names, uint32_t count)
     free((void *)names);
 }
 
+/* A NULL source denotes an intentional anonymous slot.  Callers use this
+ * helper only for names that must be present; strdup_safe() returning NULL is
+ * therefore an allocation failure, not an absent variable. */
+static int
+dup_required_name(char **dst, const char *src)
+{
+    if (!dst || !src)
+        return -1;
+    *dst = strdup_safe(src);
+    return *dst ? 0 : -1;
+}
+
 static char **
 merge_var_names(char **left, uint32_t left_count, char **right,
     uint32_t right_count, uint32_t *out_count)
@@ -1287,7 +1299,8 @@ merge_var_names(char **left, uint32_t left_count, char **right,
     }
 
     for (uint32_t i = 0; i < left_count; i++) {
-        merged[i] = left[i] ? strdup_safe(left[i]) : NULL;
+        if (left[i] && dup_required_name(&merged[i], left[i]) != 0)
+            goto fail;
     }
 
     for (uint32_t i = 0; i < right_count; i++) {
@@ -1297,16 +1310,23 @@ merge_var_names(char **left, uint32_t left_count, char **right,
          * needs ~2^32 variable slots, each already backed by a char * in
          * these arrays and by a parsed token upstream. */
         // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
-        merged[left_count + i] = right[i] ? strdup_safe(right[i]) : NULL;
+        if (right[i]
+            && dup_required_name(&merged[left_count + i], right[i]) != 0)
+            goto fail;
     }
 
     *out_count = max_count;
     return merged;
+
+fail:
+    free_var_names(merged, max_count);
+    *out_count = 0;
+    return NULL;
 }
 
 /* ---- Join Key Extraction ---- */
 
-static void
+static int
 setup_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
     uint32_t right_count, wirelog_ir_node_t *join)
 {
@@ -1335,12 +1355,12 @@ setup_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
     }
 
     if (key_count == 0)
-        return;
+        return 0;
 
     join->join_left_keys = (char **)calloc(key_count, sizeof(char *));
     join->join_right_keys = (char **)calloc(key_count, sizeof(char *));
     if (!join->join_left_keys || !join->join_right_keys)
-        return;
+        goto fail;
     join->join_key_count = key_count;
 
     uint32_t k = 0;
@@ -1366,13 +1386,33 @@ setup_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
                  * models each strcmp() call site as an independent opaque
                  * value and so cannot relate the two tallies. */
                 // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
-                join->join_left_keys[k] = strdup_safe(left_vars[i]);
-                join->join_right_keys[k] = strdup_safe(right_vars[j]);
+                if (dup_required_name(&join->join_left_keys[k], left_vars[i])
+                    != 0
+                    || dup_required_name(&join->join_right_keys[k],
+                    right_vars[j]) != 0)
+                    goto fail;
                 k++;
                 break;
             }
         }
     }
+    return 0;
+
+fail:
+    if (join->join_left_keys) {
+        for (uint32_t i = 0; i < key_count; i++)
+            free(join->join_left_keys[i]);
+    }
+    if (join->join_right_keys) {
+        for (uint32_t i = 0; i < key_count; i++)
+            free(join->join_right_keys[i]);
+    }
+    free(join->join_left_keys);
+    free(join->join_right_keys);
+    join->join_left_keys = NULL;
+    join->join_right_keys = NULL;
+    join->join_key_count = 0;
+    return -1;
 }
 
 /* ---- Scan Building with Intra-atom Filters ---- */
@@ -1618,13 +1658,23 @@ concat_var_names_positional(char **left, uint32_t left_count, char **right,
         return NULL;
     }
 
-    for (uint32_t i = 0; i < left_count; i++)
-        merged[i] = strdup_safe(left ? left[i] : NULL);
+    for (uint32_t i = 0; i < left_count; i++) {
+        if (left && left[i]
+            && dup_required_name(&merged[i], left[i]) != 0)
+            goto fail;
+    }
     for (uint32_t i = 0; i < right_count; i++)
-        merged[left_count + i] = strdup_safe(right ? right[i] : NULL);
+        if (right && right[i]
+            && dup_required_name(&merged[left_count + i], right[i]) != 0)
+            goto fail;
 
     *out_count = total;
     return merged;
+
+fail:
+    free_var_names(merged, total);
+    *out_count = 0;
+    return NULL;
 }
 
 static int
@@ -1636,15 +1686,24 @@ set_single_join_key(wirelog_ir_node_t *join, const char *key)
     join->join_left_keys = (char **)calloc(1, sizeof(char *));
     join->join_right_keys = (char **)calloc(1, sizeof(char *));
     if (!join->join_left_keys || !join->join_right_keys)
-        return -1;
+        goto fail;
 
     join->join_key_count = 1;
-    join->join_left_keys[0] = strdup_safe(key);
-    join->join_right_keys[0] = strdup_safe(key);
-    if (!join->join_left_keys[0] || !join->join_right_keys[0])
-        return -1;
+    if (dup_required_name(&join->join_left_keys[0], key) != 0
+        || dup_required_name(&join->join_right_keys[0], key) != 0)
+        goto fail;
 
     return 0;
+
+fail:
+    free(join->join_left_keys ? join->join_left_keys[0] : NULL);
+    free(join->join_right_keys ? join->join_right_keys[0] : NULL);
+    free(join->join_left_keys);
+    free(join->join_right_keys);
+    join->join_left_keys = NULL;
+    join->join_right_keys = NULL;
+    join->join_key_count = 0;
+    return -1;
 }
 
 static wirelog_ir_node_t *
@@ -1664,17 +1723,23 @@ build_side_compound_scan(const wl_parser_ast_node_t *compound_arg,
     if (!side_name)
         return NULL;
 
+    uint32_t count = compound_arg->child_count + 1u;
+    char **var_names = NULL;
     wirelog_ir_node_t *scan = wl_ir_node_create(WIRELOG_IR_SCAN);
     if (!scan) {
         free(side_name);
         return NULL;
     }
     wl_ir_node_set_relation(scan, side_name);
+    if (side_name && !scan->relation_name) {
+        free(side_name);
+        wl_ir_node_free(scan);
+        return NULL;
+    }
     free(side_name);
 
-    uint32_t count = compound_arg->child_count + 1u;
     scan->column_names = (char **)calloc(count, sizeof(char *));
-    char **var_names = (char **)calloc(count, sizeof(char *));
+    var_names = (char **)calloc(count, sizeof(char *));
     /* __compound_<f>_<n> is (handle: int64, arg0..arg{n-1}: int64) -- see
      * docs/COMPOUND_TERMS.md, "Side-relation tier".  The argument columns
      * hold values whose original type the side relation does not record, so
@@ -1689,13 +1754,16 @@ build_side_compound_scan(const wl_parser_ast_node_t *compound_arg,
     scan->column_count = count;
     scan->column_types[0] = WL_IR_COLTYPE_SCALAR;
 
-    scan->column_names[0] = strdup_safe(handle_var);
-    var_names[0] = strdup_safe(handle_var);
+    if (dup_required_name(&scan->column_names[0], handle_var) != 0
+        || dup_required_name(&var_names[0], handle_var) != 0)
+        goto fail;
     for (uint32_t i = 0; i < compound_arg->child_count; i++) {
         const wl_parser_ast_node_t *child = compound_arg->children[i];
         if (child && child->type == WL_PARSER_AST_NODE_VARIABLE) {
-            scan->column_names[i + 1u] = strdup_safe(child->name);
-            var_names[i + 1u] = strdup_safe(child->name);
+            if (dup_required_name(&scan->column_names[i + 1u], child->name)
+                != 0
+                || dup_required_name(&var_names[i + 1u], child->name) != 0)
+                goto fail;
         }
     }
 
@@ -1727,6 +1795,11 @@ build_side_compound_scan(const wl_parser_ast_node_t *compound_arg,
     *out_var_names = var_names;
     *out_var_count = count;
     return result;
+
+fail:
+    free_var_names(var_names, count);
+    wl_ir_node_free(scan);
+    return NULL;
 }
 
 static bool
@@ -1787,6 +1860,12 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
     }
 
     wl_ir_node_set_relation(scan, atom->name);
+    if (atom->name && !scan->relation_name) {
+        wl_ir_node_free(scan);
+        *out_var_names = NULL;
+        *out_var_count = 0;
+        return NULL;
+    }
 
     uint32_t arg_count = atom->child_count;
     wl_ir_relation_info_t *rel_info = find_relation_info(prog, atom->name);
@@ -1856,9 +1935,11 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
         if (arg->type == WL_PARSER_AST_NODE_VARIABLE) {
             // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
             physical_args[phys_idx] = arg;
-            scan->column_names[phys_idx] = strdup_safe(arg->name);
+            if (dup_required_name(&scan->column_names[phys_idx], arg->name)
+                != 0
+                || dup_required_name(&var_names[phys_idx], arg->name) != 0)
+                goto fail_scan_build;
             scan->column_types[phys_idx] = declared_coltype(rel_info, i);
-            var_names[phys_idx] = strdup_safe(arg->name);
             phys_idx++;
         } else if (rel_info && i < rel_info->column_count
             && rel_info->columns[i].compound_kind
@@ -1869,8 +1950,11 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
                 // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
                 physical_args[phys_idx] = child;
                 if (child->type == WL_PARSER_AST_NODE_VARIABLE) {
-                    scan->column_names[phys_idx] = strdup_safe(child->name);
-                    var_names[phys_idx] = strdup_safe(child->name);
+                    if (dup_required_name(&scan->column_names[phys_idx],
+                        child->name) != 0
+                        || dup_required_name(&var_names[phys_idx],
+                        child->name) != 0)
+                        goto fail_scan_build;
                 } else {
                     scan->column_names[phys_idx] = NULL;
                     var_names[phys_idx] = NULL;
@@ -1888,9 +1972,15 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
             char *handle_var = make_side_handle_var(atom, i);
             // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
             physical_args[phys_idx] = arg;
-            if (handle_var) {
-                scan->column_names[phys_idx] = strdup_safe(handle_var);
-                var_names[phys_idx] = strdup_safe(handle_var);
+            if (!handle_var)
+                goto fail_scan_build;
+            if (dup_required_name(&scan->column_names[phys_idx], handle_var)
+                != 0
+                || dup_required_name(&var_names[phys_idx], handle_var) != 0) {
+                free(handle_var);
+                goto fail_scan_build;
+            }
+            {
                 side_bindings[side_binding_count].arg = arg;
                 side_bindings[side_binding_count].handle_var = handle_var;
                 side_binding_count++;
@@ -1908,6 +1998,21 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
             phys_idx++;
         }
     }
+
+    goto scan_build_complete;
+
+fail_scan_build:
+    for (uint32_t i = 0; i < side_binding_count; i++)
+        free(side_bindings[i].handle_var);
+    free(side_bindings);
+    free((void *)physical_args);
+    free_var_names(var_names, physical_count);
+    wl_ir_node_free(scan);
+    *out_var_names = NULL;
+    *out_var_count = 0;
+    return NULL;
+
+scan_build_complete:
 
     wirelog_ir_node_t *result = scan;
 
@@ -2033,6 +2138,7 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
 
     char **result_vars = var_names;
     uint32_t result_vcount = physical_count;
+    bool lowering_failed = false;
 
     for (uint32_t i = 0; i < side_binding_count; i++) {
         char **side_vars = NULL;
@@ -2046,15 +2152,16 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
             wl_ir_node_free(side_scan);
             wl_ir_node_free(join);
             free_var_names(side_vars, side_vcount);
-            result = wrap_false_filter(result);
-            continue;
+            lowering_failed = true;
+            break;
         }
 
         if (wl_ir_node_add_child(join, result) != 0) {
             wl_ir_node_free(join);
             wl_ir_node_free(side_scan);
             free_var_names(side_vars, side_vcount);
-            continue;
+            lowering_failed = true;
+            break;
         }
         if (wl_ir_node_add_child(join, side_scan) != 0) {
             join->children[0] = NULL;
@@ -2062,7 +2169,8 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
             wl_ir_node_free(join);
             wl_ir_node_free(side_scan);
             free_var_names(side_vars, side_vcount);
-            continue;
+            lowering_failed = true;
+            break;
         }
         result = join;
 
@@ -2074,8 +2182,8 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
         if (!combined) {
             result_vars = NULL;
             result_vcount = 0;
-            result = wrap_false_filter(result);
-            continue;
+            lowering_failed = true;
+            break;
         }
         result_vars = combined;
         result_vcount = combined_count;
@@ -2087,6 +2195,13 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
         free(side_bindings[i].handle_var);
     free(side_bindings);
     free((void *)physical_args);
+    if (lowering_failed) {
+        free_var_names(result_vars, result_vcount);
+        wl_ir_node_free(result);
+        *out_var_names = NULL;
+        *out_var_count = 0;
+        return NULL;
+    }
     *out_var_names = result_vars;
     *out_var_count = result_vcount;
     return result;
@@ -2291,6 +2406,14 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                     "convert_rule: build_atom_scan returned NULL for "
                     "body atom index=%u relation=%s",
                     i, b->name ? b->name : "?");
+                for (uint32_t s = 0; s <= scan_count; s++)
+                    free_var_names(scan_vars[s], scan_vcounts[s]);
+                for (uint32_t s = 0; s < scan_count; s++)
+                    wl_ir_node_free(scans[s]);
+                free((void *)scans);
+                free((void *)scan_vars);
+                free(scan_vcounts);
+                return NULL;
             }
             scan_count++;
         }
@@ -2325,8 +2448,21 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                 break;
             }
 
-            setup_join_keys(cur_vars, cur_vcount, scan_vars[i], scan_vcounts[i],
-                join);
+            if (setup_join_keys(cur_vars, cur_vcount, scan_vars[i],
+                scan_vcounts[i], join) != 0) {
+                wl_ir_node_free(join);
+                wl_ir_node_free(current);
+                for (uint32_t j = i; j < scan_count; j++)
+                    wl_ir_node_free(scans[j]);
+                for (uint32_t s = 0; s < scan_count; s++)
+                    free_var_names(scan_vars[s], scan_vcounts[s]);
+                if (cur_vars_is_merged)
+                    free_var_names(cur_vars, cur_vcount);
+                free((void *)scans);
+                free((void *)scan_vars);
+                free(scan_vcounts);
+                return NULL;
+            }
 
             if (wl_ir_node_add_child(join, current) != 0) {
                 wl_ir_node_free(join);
@@ -2350,6 +2486,22 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             uint32_t merged_count;
             char **merged = merge_var_names(cur_vars, cur_vcount, scan_vars[i],
                     scan_vcounts[i], &merged_count);
+            if (!merged && merged_count == 0
+                && cur_vcount + scan_vcounts[i] > 0) {
+                /* join owns both current and scans[i] after the two child
+                 * attachments above. */
+                wl_ir_node_free(join);
+                for (uint32_t j = i + 1; j < scan_count; j++)
+                    wl_ir_node_free(scans[j]);
+                for (uint32_t s = 0; s < scan_count; s++)
+                    free_var_names(scan_vars[s], scan_vcounts[s]);
+                if (cur_vars_is_merged)
+                    free_var_names(cur_vars, cur_vcount);
+                free((void *)scans);
+                free((void *)scan_vars);
+                free(scan_vcounts);
+                return NULL;
+            }
             if (cur_vars_is_merged) {
                 free_var_names(cur_vars, cur_vcount);
             }
@@ -2484,8 +2636,21 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             if (neg_scan) {
                 wirelog_ir_node_t *aj = wl_ir_node_create(WIRELOG_IR_ANTIJOIN);
                 if (aj) {
-                    setup_join_keys(cur_vars, cur_vcount, neg_vars, neg_vcount,
-                        aj);
+                    if (setup_join_keys(cur_vars, cur_vcount, neg_vars,
+                        neg_vcount, aj) != 0) {
+                        wl_ir_node_free(aj);
+                        wl_ir_node_free(neg_scan);
+                        free_var_names(neg_vars, neg_vcount);
+                        wl_ir_node_free(current);
+                        for (uint32_t s = 0; s < scan_count; s++)
+                            free_var_names(scan_vars[s], scan_vcounts[s]);
+                        if (cur_vars_is_merged)
+                            free_var_names(cur_vars, cur_vcount);
+                        free((void *)scans);
+                        free((void *)scan_vars);
+                        free(scan_vcounts);
+                        return NULL;
+                    }
                     if (wl_ir_node_add_child(aj, current) != 0) {
                         wl_ir_node_free(aj);
                         wl_ir_node_free(neg_scan);
@@ -2527,6 +2692,11 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
         root = wl_ir_node_create(WIRELOG_IR_AGGREGATE);
         if (root) {
             wl_ir_node_set_relation(root, head->name);
+            if (head->name && !root->relation_name) {
+                wl_ir_node_free(root);
+                root = NULL;
+                goto conversion_failed;
+            }
             root->agg_fn = agg_node->agg_fn;
             for (uint32_t i = 0; i < head->child_count; i++) {
                 if (head->children[i]->type == WL_PARSER_AST_NODE_AGGREGATE) {
@@ -2542,19 +2712,34 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             }
 
             root->column_count = cur_vcount;
+            bool root_names_ok = true;
             if (cur_vcount > 0) {
                 root->column_names
                     = (char **)calloc(cur_vcount, sizeof(char *));
                 if (root->column_names) {
-                    for (uint32_t j = 0; j < cur_vcount; j++)
-                        root->column_names[j] = strdup_safe(cur_vars[j]);
+                    for (uint32_t j = 0; j < cur_vcount; j++) {
+                        if (cur_vars[j]
+                            && dup_required_name(&root->column_names[j],
+                            cur_vars[j]) != 0) {
+                            root_names_ok = false;
+                            break;
+                        }
+                    }
                 } else {
-                    root->column_count = 0;
+                    root_names_ok = false;
                 }
             }
 
-            root->group_by_count = non_agg_count;
-            if (non_agg_count > 0) {
+            if (!root_names_ok) {
+                wl_ir_node_free(root);
+                wl_ir_node_free(current);
+                root = NULL;
+                current = NULL;
+            }
+
+            if (root)
+                root->group_by_count = non_agg_count;
+            if (root && non_agg_count > 0) {
                 root->group_by_indices
                     = (uint32_t *)calloc(non_agg_count, sizeof(uint32_t));
                 uint32_t gi = 0;
@@ -2589,6 +2774,11 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
         root = wl_ir_node_create(WIRELOG_IR_PROJECT);
         if (root) {
             wl_ir_node_set_relation(root, head->name);
+            if (head->name && !root->relation_name) {
+                wl_ir_node_free(root);
+                root = NULL;
+                goto conversion_failed;
+            }
             root->project_count = head->child_count;
 
             if (head->child_count > 0) {
@@ -2611,6 +2801,15 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
     }
 
     /* ---- Cleanup ---- */
+
+    goto conversion_cleanup;
+
+conversion_failed:
+    wl_ir_node_free(current);
+    current = NULL;
+    root = NULL;
+
+conversion_cleanup:
 
     for (uint32_t i = 0; i < scan_count; i++) {
         free_var_names(scan_vars[i], scan_vcounts[i]);

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -1277,13 +1277,10 @@ free_var_names(char **names, uint32_t count)
 /* A NULL source denotes an intentional anonymous slot.  Callers use this
  * helper only for names that must be present; strdup_safe() returning NULL is
  * therefore an allocation failure, not an absent variable. */
-static int
-dup_required_name(char **dst, const char *src)
+static char *
+dup_required_name(const char *src)
 {
-    if (!dst || !src)
-        return -1;
-    *dst = strdup_safe(src);
-    return *dst ? 0 : -1;
+    return src ? strdup_safe(src) : NULL;
 }
 
 static char **
@@ -1299,8 +1296,11 @@ merge_var_names(char **left, uint32_t left_count, char **right,
     }
 
     for (uint32_t i = 0; i < left_count; i++) {
-        if (left[i] && dup_required_name(&merged[i], left[i]) != 0)
-            goto fail;
+        if (left && left[i]) {
+            merged[i] = dup_required_name(left[i]);
+            if (!merged[i])
+                goto fail;
+        }
     }
 
     for (uint32_t i = 0; i < right_count; i++) {
@@ -1310,9 +1310,13 @@ merge_var_names(char **left, uint32_t left_count, char **right,
          * needs ~2^32 variable slots, each already backed by a char * in
          * these arrays and by a parsed token upstream. */
         // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
-        if (right[i]
-            && dup_required_name(&merged[left_count + i], right[i]) != 0)
-            goto fail;
+        char **slot = &merged[left_count + i];
+        if (right && right[i]) {
+            char *copy = dup_required_name(right[i]);
+            if (!copy)
+                goto fail;
+            memcpy((void *)slot, (const void *)&copy, sizeof(copy));
+        }
     }
 
     *out_count = max_count;
@@ -1386,10 +1390,9 @@ setup_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
                  * models each strcmp() call site as an independent opaque
                  * value and so cannot relate the two tallies. */
                 // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
-                if (dup_required_name(&join->join_left_keys[k], left_vars[i])
-                    != 0
-                    || dup_required_name(&join->join_right_keys[k],
-                    right_vars[j]) != 0)
+                join->join_left_keys[k] = dup_required_name(left_vars[i]);
+                join->join_right_keys[k] = dup_required_name(right_vars[j]);
+                if (!join->join_left_keys[k] || !join->join_right_keys[k])
                     goto fail;
                 k++;
                 break;
@@ -1407,8 +1410,8 @@ fail:
         for (uint32_t i = 0; i < key_count; i++)
             free(join->join_right_keys[i]);
     }
-    free(join->join_left_keys);
-    free(join->join_right_keys);
+    free((void *)join->join_left_keys);
+    free((void *)join->join_right_keys);
     join->join_left_keys = NULL;
     join->join_right_keys = NULL;
     join->join_key_count = 0;
@@ -1651,30 +1654,7 @@ static char **
 concat_var_names_positional(char **left, uint32_t left_count, char **right,
     uint32_t right_count, uint32_t *out_count)
 {
-    uint32_t total = left_count + right_count;
-    char **merged = (char **)calloc(total > 0 ? total : 1, sizeof(char *));
-    if (!merged) {
-        *out_count = 0;
-        return NULL;
-    }
-
-    for (uint32_t i = 0; i < left_count; i++) {
-        if (left && left[i]
-            && dup_required_name(&merged[i], left[i]) != 0)
-            goto fail;
-    }
-    for (uint32_t i = 0; i < right_count; i++)
-        if (right && right[i]
-            && dup_required_name(&merged[left_count + i], right[i]) != 0)
-            goto fail;
-
-    *out_count = total;
-    return merged;
-
-fail:
-    free_var_names(merged, total);
-    *out_count = 0;
-    return NULL;
+    return merge_var_names(left, left_count, right, right_count, out_count);
 }
 
 static int
@@ -1689,8 +1669,9 @@ set_single_join_key(wirelog_ir_node_t *join, const char *key)
         goto fail;
 
     join->join_key_count = 1;
-    if (dup_required_name(&join->join_left_keys[0], key) != 0
-        || dup_required_name(&join->join_right_keys[0], key) != 0)
+    join->join_left_keys[0] = dup_required_name(key);
+    join->join_right_keys[0] = dup_required_name(key);
+    if (!join->join_left_keys[0] || !join->join_right_keys[0])
         goto fail;
 
     return 0;
@@ -1698,8 +1679,8 @@ set_single_join_key(wirelog_ir_node_t *join, const char *key)
 fail:
     free(join->join_left_keys ? join->join_left_keys[0] : NULL);
     free(join->join_right_keys ? join->join_right_keys[0] : NULL);
-    free(join->join_left_keys);
-    free(join->join_right_keys);
+    free((void *)join->join_left_keys);
+    free((void *)join->join_right_keys);
     join->join_left_keys = NULL;
     join->join_right_keys = NULL;
     join->join_key_count = 0;
@@ -1754,15 +1735,16 @@ build_side_compound_scan(const wl_parser_ast_node_t *compound_arg,
     scan->column_count = count;
     scan->column_types[0] = WL_IR_COLTYPE_SCALAR;
 
-    if (dup_required_name(&scan->column_names[0], handle_var) != 0
-        || dup_required_name(&var_names[0], handle_var) != 0)
+    scan->column_names[0] = dup_required_name(handle_var);
+    var_names[0] = dup_required_name(handle_var);
+    if (!scan->column_names[0] || !var_names[0])
         goto fail;
     for (uint32_t i = 0; i < compound_arg->child_count; i++) {
         const wl_parser_ast_node_t *child = compound_arg->children[i];
         if (child && child->type == WL_PARSER_AST_NODE_VARIABLE) {
-            if (dup_required_name(&scan->column_names[i + 1u], child->name)
-                != 0
-                || dup_required_name(&var_names[i + 1u], child->name) != 0)
+            scan->column_names[i + 1u] = dup_required_name(child->name);
+            var_names[i + 1u] = dup_required_name(child->name);
+            if (!scan->column_names[i + 1u] || !var_names[i + 1u])
                 goto fail;
         }
     }
@@ -1935,9 +1917,9 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
         if (arg->type == WL_PARSER_AST_NODE_VARIABLE) {
             // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
             physical_args[phys_idx] = arg;
-            if (dup_required_name(&scan->column_names[phys_idx], arg->name)
-                != 0
-                || dup_required_name(&var_names[phys_idx], arg->name) != 0)
+            scan->column_names[phys_idx] = dup_required_name(arg->name);
+            var_names[phys_idx] = dup_required_name(arg->name);
+            if (!scan->column_names[phys_idx] || !var_names[phys_idx])
                 goto fail_scan_build;
             scan->column_types[phys_idx] = declared_coltype(rel_info, i);
             phys_idx++;
@@ -1950,10 +1932,11 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
                 // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
                 physical_args[phys_idx] = child;
                 if (child->type == WL_PARSER_AST_NODE_VARIABLE) {
-                    if (dup_required_name(&scan->column_names[phys_idx],
-                        child->name) != 0
-                        || dup_required_name(&var_names[phys_idx],
-                        child->name) != 0)
+                    scan->column_names[phys_idx] = dup_required_name(
+                        child->name);
+                    var_names[phys_idx] = dup_required_name(child->name);
+                    if (!scan->column_names[phys_idx]
+                        || !var_names[phys_idx])
                         goto fail_scan_build;
                 } else {
                     scan->column_names[phys_idx] = NULL;
@@ -1974,9 +1957,10 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
             physical_args[phys_idx] = arg;
             if (!handle_var)
                 goto fail_scan_build;
-            if (dup_required_name(&scan->column_names[phys_idx], handle_var)
-                != 0
-                || dup_required_name(&var_names[phys_idx], handle_var) != 0) {
+            scan->column_names[phys_idx] = dup_required_name(handle_var);
+            var_names[phys_idx] = dup_required_name(handle_var);
+            if (!scan->column_names[phys_idx]
+                || !var_names[phys_idx]) {
                 free(handle_var);
                 goto fail_scan_build;
             }
@@ -2718,11 +2702,13 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                     = (char **)calloc(cur_vcount, sizeof(char *));
                 if (root->column_names) {
                     for (uint32_t j = 0; j < cur_vcount; j++) {
-                        if (cur_vars[j]
-                            && dup_required_name(&root->column_names[j],
-                            cur_vars[j]) != 0) {
-                            root_names_ok = false;
-                            break;
+                        if (cur_vars[j]) {
+                            root->column_names[j]
+                                = dup_required_name(cur_vars[j]);
+                            if (!root->column_names[j]) {
+                                root_names_ok = false;
+                                break;
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
Closes #1129

## What changed
- Treat non-NULL variable/handle name duplication failures as IR conversion failures while preserving intentional anonymous inline and wildcard slots.
- Propagate join-name, layout-copy, and plan key resolution failures instead of silently selecting `col0`.
- Add a Linux malloc-failure sweep that verifies both IR names and generated JOIN keys (`col1`/`col0`).

## Validation
- `meson test -C builddir column_names_oom program ir --print-errorlogs`
- `git diff --check`