### PR TITLE
fix(plan): reject recursive aggregates that share an SCC (#1021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,161 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+- **A recursive `min()`/`max()` aggregate may no longer share an SCC with any
+  other relation** (#1021): plan generation refuses the shape. This is a
+  compatibility break -- programs that run today are refused -- and it is
+  deliberate, because in general what those programs answer cannot be
+  predicted from the program. "In general" is precise rather than hedging:
+  there is a class where it can be, and that class is refused too. See "Why
+  the rule is this coarse" below.
+
+  A relation in the same SCC as a recursive aggregate reads that aggregate's
+  *per-iteration* content: it observes each round's per-rule `REDUCE` output
+  before that round's cross-rule domination has run. What it observes is
+  decided by the evaluation strategy rather than by the program, and the two
+  build configurations do not agree on it. For
+
+      Edge(1,2). Edge(2,3). Edge(3,4).
+      Label(x, min(x)) :- Edge(x, y).
+      Label(y, min(y)) :- Edge(x, y).
+      Label(x, min(l)) :- Label(y, l), Edge(y, x).
+      Big(x)           :- Label(x, l), l > 2.
+      Label(x, min(9)) :- Big(x).
+
+  the default build settled every label at 1 and still reported `Big(3)` and
+  `Big(4)` -- two nodes said to carry a label above 2 when no surviving label
+  exceeds 1. (`Label(4,4)` does exist transiently, in an intermediate round;
+  that it is visible to `Big` at all is the defect.) An `ENABLE_K_FUSION=0`
+  build corrupted the aggregate as well,
+  answering `Label(3,2) Label(4,3)`. Two configurations, two different wrong
+  answers, exit status 0 from both.
+
+  The rule as coded is "no other relation of a recursive stratum may read a
+  relation that carries a `REDUCE`". That is the same rule as the SCC one
+  stated above: `wl_ir_stratify` assigns one stratum per SCC, and a
+  multi-relation SCC is strongly connected, so some other relation of it
+  necessarily reads the aggregate directly. Phrasing it as "no other relation
+  may reference R" would understate how much surface this removes.
+
+  Programs that answer correctly today and are refused anyway. Five are
+  known; each was measured in both build configurations, which agree on all
+  five. The mutual recursion
+
+      A(x, min(x)) :- Edge(x, y).      B(x, min(v)) :- A(x, v).
+      A(y, min(y)) :- Edge(x, y).      A(x, min(v)) :- B(y, v), Edge(y, x).
+
+  answers `A` and `B` all-1 over the path above. The bipartite propagation
+
+      L(x, min(x)) :- Edge(x, y).
+      R(y, min(v)) :- L(x, v), Edge(x, y).
+      L(y, min(v)) :- R(x, v), Edge(y, x).
+
+  answers `L(1,1) (2,2) (3,3) (4,4)` and `R(2,1) (3,2) (4,3) (5,4)` over the
+  path `1->2->3->4->5`. And the repro above *without* its self-recursive
+  third rule --
+
+      Label(x, min(x)) :- Edge(x, y).
+      Label(y, min(y)) :- Edge(x, y).
+      Big(x)           :- Label(x, l), l > 2.
+      Label(x, min(9)) :- Big(x).
+
+  -- answers `Label(1,1) (2,2) (3,3) (4,4)` with `Big(3) Big(4)`, which is
+  the least fixpoint, in both configurations. That one is worth reading
+  twice: it is the same SCC shape as the defect, one rule shorter, and it is
+  refused despite being right.
+
+  The fourth is the `max()` analogue of the `A`/`B` pair above, which answers
+  `A` and `B` `(1,1) (2,2) (3,3) (4,4)`. The fifth is the one that matters
+  most, because it is not merely a program that happens to come out right:
+
+      M(x, min(x)) :- Edge(x, _).
+      Root(x)      :- M(x, v).
+      M(x, min(x)) :- Root(x).
+
+  answers `M(1,1) (2,2) (3,3) (4,4)` and `Root(1) (2) (3) (4)` over
+  `1->2->3->4->5`. Here the aggregated value is functionally determined by
+  the group key, so no value is ever dominated away, so a round's content is
+  the fixpoint's content -- configuration-dependence is impossible by
+  construction, not merely absent from the samples anyone ran. For this class
+  the outcome *is* predictable from the program, and the rule refuses it
+  anyway because it reasons about SCC shape and not about functional
+  dependencies. That is the strongest argument that this rule should be
+  narrowed rather than kept, and #1135 carries it as the leading candidate
+  predicate.
+
+  A third shape, `Seen(x) :- Label(x, l).` together with
+  `Label(x, min(9)) :- Seen(x).`, is refused and is **not** in that list: it
+  carries no predicate on the aggregate column at all, and it is still
+  configuration-dependent today, the default build answering `Label` all-1
+  where an `ENABLE_K_FUSION=0` build answers `Label(3,2) Label(4,3)`. It is
+  the clearest evidence that the trouble is not "the consumer reads the
+  aggregate column non-monotonically" but the broader "a same-SCC consumer
+  observes per-iteration content".
+
+  Why the rule is this coarse. The obvious leniency -- readmit a consumer
+  that carries its own `min()`/`max()` -- is unsound, and was measured to be.
+  Over a propagating `a`:
+
+      a(x, min(x)) :- Edge(x, y).
+      a(y, min(y)) :- Edge(x, y).
+      a(x, min(v)) :- a(y, v), Edge(y, x).
+      b(x, min(v)) :- a(x, v), v > 2.
+      a(x, min(9)) :- b(x, v).
+
+  yields `b(3,3)` and `b(4,3)` in both configurations. The last rule is not
+  decoration: it is what puts `b` in `a`'s SCC, and without it `b` sits in a
+  higher stratum, `a` settles to all-1, nothing satisfies `v > 2` and `b` is
+  empty in both builds. Of the two rows, `b(3,3)` is the one that carries the
+  argument -- no final `a` justifies it in either configuration, `a(3)` being
+  1 by default and 2 under `ENABLE_K_FUSION=0`. (`b(4,3)` is unjustified only
+  in the default build; the unfused one leaves `a(4,3)` behind, which does
+  satisfy the guard.) Narrowing the rule is milestone 0.70.0 work and wants a
+  CI job that runs these fixtures under `ENABLE_K_FUSION=0`, so that a
+  narrowing can be shown not to readmit a configuration-dependent shape. The
+  tree already runs an unfused binary in the default `meson test` --
+  `k_fusion_memory_nofusion` (`tests/meson.build`) is built with
+  `-DENABLE_K_FUSION=0` and evaluates a transitive closure at K=2 and K=4 --
+  so the meson pattern for such a job exists and is short to copy. What is
+  missing is that no job runs the *recursive-aggregate* fixtures unfused.
+  Tracked under #1135, which carries both the programs a narrowing must
+  readmit and the ones it must keep refusing; see also
+  `docs/SEMANTICS.md`, "Per-iteration recursive aggregate domination".
+
+  Relations whose rules disagree on the aggregate function are refused too,
+  which is intended rather than overreach. Such a head leaves
+  `wl_plan_relation_t.recursive_agg.has_spec` false and is never
+  canonicalised, yet it still reduces per rule and still gives
+  configuration-dependent output to a same-SCC consumer. The check therefore
+  keys on the `REDUCE` operator rather than on the recorded specification.
+
+  One workaround, verified: break the feedback edge, so the consumer lands in
+  a later stratum. Removing `Label(x, min(9)) :- Big(x).` from the program
+  above does exactly that and yields `Label` all-1 with an empty `Big`,
+  identically in both configurations.
+
+  An earlier draft of this entry, and of the diagnostic, offered a second
+  remedy -- give the consumer its own `min()`/`max()` and no non-monotone
+  read of the aggregate column. It is withdrawn. It is vacuous, because the
+  check inspects neither the consumer's operators nor its filters, so a
+  same-SCC consumer is refused whatever it carries; and it is wrong on its
+  own terms, because `b(x, min(v)) :- a(x, v).` over a propagating `a` with
+  the feedback rule intact answers `b` all-1 by default and
+  `b(1,1) (2,1) (3,2) (4,3)` under `ENABLE_K_FUSION=0`. Whether that class
+  can be readmitted is #1135's question; it was never a workaround.
+
+  The rejection is silent at the default log level: the CLI prints only
+  `Plan generation failed: rc=-1`. Run with `WL_LOG=EVAL:1` to get the
+  diagnostic, which names the relations involved and the workaround.
+  `wl_plan_from_program()` has no error channel of its own, so this entry
+  inherits that gap from #991's
+  rejection rather than widening it; it is now tracked as #1137. It is not
+  covered by #979, which fixed the parse and rule-lowering half and left plan
+  generation alone.
+
+  `wl_plan_stratum_t.is_monotone` is untouched. It has been computed since
+  #1021's first step and still has no consumer; this change neither reads it
+  nor makes it readable.
+
 ### Deprecated
 
 ### Removed

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -154,7 +154,7 @@ not assume symmetric coverage.
 - `CHANGELOG.md` — entry for #718.
 - `stable-release-plan.md` §3, §7 — public-surface and conformance plans.
 
-## Recursive aggregation residue (Status: Implemented for MIN/MAX)
+## Recursive aggregation residue (Status: Implemented for MIN/MAX outside a shared SCC)
 
 Tracked under #692.
 
@@ -203,6 +203,40 @@ from producing semantically correct output at workers in {1, 4, 8, 16}.
   one aggregate.
 - Both checks cover the parser path only. IR built directly through the API
   still reaches the crash.
+- **A recursive MIN/MAX aggregate may not share an SCC with any other
+  relation** (#1021). The heading above says "outside a shared SCC" because
+  of this: MIN/MAX is implemented, but only for an aggregate whose stratum
+  holds it alone. Plan generation refuses the rest.
+
+  The reason is that canonicalization runs at the fixpoint, so a relation in
+  the aggregate's own SCC reads the aggregate's per-iteration content --
+  each round's per-rule REDUCE output, before that round's cross-rule
+  domination. What such a consumer observes is decided by the evaluation
+  strategy rather than by the program, and the two build configurations
+  disagree: the issue's repro answers `Big(3) Big(4)` over labels that all
+  settle at 1 in the default build, and additionally corrupts the aggregate
+  to `Label(3,2) Label(4,3)` under `ENABLE_K_FUSION=0`. This is *not* limited
+  to consumers that read the aggregate column non-monotonically; a consumer
+  with no predicate on that column at all is configuration-dependent for the
+  same reason.
+
+  Stated as an SCC rule rather than as "no other relation may reference the
+  aggregate" because `wl_ir_stratify` assigns one stratum per SCC, so the two
+  are the same rule and the second understates it.
+
+  The check is `validate_recursive_aggregates()` in `wirelog/exec_plan_gen.c`,
+  and it must stay above `rewrite_lftj_chains()` and
+  `rewrite_multiway_delta()`: after those, a fused aggregate relation holds no
+  REDUCE operator to find.
+
+  The rule is coarse and knowingly refuses programs that answer correctly in
+  both build configurations today; the CHANGELOG entry for #1021 names five.
+  One of the five is not merely accidentally correct: when the aggregated
+  value is functionally determined by the group key, no value is ever
+  dominated away, so a round's content is the fixpoint's content and
+  configuration-dependence is impossible by construction. The rule refuses
+  that class anyway, because it reasons about SCC shape rather than about
+  functional dependencies. Narrowing it is Future work, below.
 
 ### References
 
@@ -215,6 +249,66 @@ from producing semantically correct output at workers in {1, 4, 8, 16}.
 - `wirelog/columnar/eval.c` — recursive aggregate canonicalization.
 - `wirelog/ir/program.c` — `convert_rule` multi-aggregate head rejection.
 - `tests/test_recursive_agg_conformance.c` — active columnar harness.
+- Issue #1021 — a recursive MIN/MAX aggregate may not share an SCC with any
+  other relation.
+- `wirelog/exec_plan_gen.c` — `validate_recursive_aggregates`, both passes.
+- `tests/test_recursive_agg_kfusion.c` — the #1021 rejection and its two
+  acceptance controls.
+
+---
+
+## Per-iteration recursive aggregate domination (Status: Future)
+
+Target: milestone 0.70.0. Tracked under #1135. Narrows the #1021 rejection
+above.
+
+### What is deferred
+
+Recursive MIN/MAX canonicalization runs once, at the fixpoint. Moving it into
+per-iteration consolidation (`col_op_consolidate_diff`,
+`wirelog/columnar/diff.c`) would make each round's cross-rule domination
+visible to that round's readers.
+
+That does not by itself make a same-SCC consumer well defined, and this
+section does not claim it would. The observation window has two halves:
+
+- **Intra-round** — a consumer that reads one rule's REDUCE output before a
+  sibling rule of the same head has contributed a dominating value in the
+  same round. Eager domination in consolidation removes this half.
+- **Inter-round** — a consumer that reads a value that a *later* round
+  dominates away. This half survives eager domination, and it is the half
+  the #1021 repro exercises, which is why #1021 is a plan-time rejection
+  rather than a scheduling change.
+
+So the deferred work buys real correctness, but not all of it, and the
+rejection above cannot simply be lifted once it lands.
+
+### Preconditions
+
+- A CI job that runs the recursive-aggregate fixtures under
+  `ENABLE_K_FUSION=0`. Every fixture a narrowing would readmit has to be
+  shown to answer the same in both build configurations, and no job does that
+  today.
+
+  The tree is not starting from nothing here. `k_fusion_memory_nofusion`
+  (`tests/meson.build`) is built with `c_args: ['-DENABLE_K_FUSION=0']` and
+  runs in the default `meson test`, evaluating a transitive closure at K=2
+  and K=4; `bench/meson.build` has a second such target. So the meson pattern
+  for an unfused test binary already exists and is short to copy. What is
+  missing is a target that puts *these* programs through it. (Separately,
+  `scripts/ci/check-clang-tidy-ratchet.py` scans `wirelog/exec_plan_gen.c`
+  under the macro via `ALTERNATE_CONFIGS`, but that is static analysis and
+  runs nothing.)
+- Re-admission fixtures, the programs #1021 refuses that answer correctly in
+  both configurations now, and the counter-fixtures a narrowing must keep
+  refusing. Both sets are written out in #1135.
+
+### Non-goal
+
+`wl_plan_stratum_t.is_monotone` is computed (negation only) and has no
+consumer. It is not a clearance signal for this work: it does not decide
+whether a same-stratum rule reads an aggregate column non-monotonically, and
+#1021 established that non-monotone reads are not the whole hazard anyway.
 
 ---
 

--- a/tests/test_recursive_agg_kfusion.c
+++ b/tests/test_recursive_agg_kfusion.c
@@ -108,6 +108,23 @@
  *       the operand's domain: the last one decides.  See the comment on the
  *       case itself.
  *
+ *   test_same_stratum_consumer_rejected
+ *       Issue #1021's repro, in a fused and an unfused spelling.  A relation
+ *       that reads a recursive min()/max() from inside that aggregate's own
+ *       SCC is refused at plan time.  The fused spelling is what pins the
+ *       check above rewrite_multiway_delta(): after the rewrite the
+ *       aggregate relation holds no REDUCE for a check to find.
+ *
+ *   test_stratified_consumer_control
+ *       The same program with the feedback rule removed, so the consumer
+ *       lands in its own stratum.  Accepted, and its answer pinned, because
+ *       that is the workaround the diagnostic names.
+ *
+ *   test_single_relation_aggregate_control
+ *       A recursive min() alone in its stratum -- CC-min's shape, and
+ *       SSSP-max's.  Accepted, asserted here rather than inferred from the
+ *       conformance harness.
+ *
  * Not covered here, and not silently skipped:
  *
  *   - incremental (--watch) evaluation of a fused aggregate relation.
@@ -115,13 +132,24 @@
  *     by the same K_FUSION hiding, so the insert is dropped before any
  *     aggregate runs.  That is issue #1019.
  *
- *   - a -DENABLE_K_FUSION=0 build as a cross-check oracle.  That build
- *     aborts on this program family; issue #1020.
+ *   - a -DENABLE_K_FUSION=0 build as a cross-check oracle.  This file is
+ *     built once, in whatever configuration the tree is configured with, so
+ *     it cannot compare the two.  It is not that the unfused build refuses
+ *     to run these programs: #1020 is closed and the whole family above runs
+ *     under -DENABLE_K_FUSION=0 without aborting.  It answers some of them
+ *     differently, which is exactly why a second build is worth having, and
+ *     why running these fixtures under ENABLE_K_FUSION=0 is a precondition
+ *     for narrowing #1021's rejection.  No job does that today -- though the
+ *     tree does already build and run an unfused binary,
+ *     k_fusion_memory_nofusion in tests/meson.build, so the pattern to copy
+ *     exists.
  *
- *   - a same-stratum consumer of a relation whose labels are dominated away
- *     at fixpoint can retain rows derived from labels that no longer exist,
- *     which is internally contradictory output.  That is issue #1021 and is
- *     a property of canonicalising at fixpoint rather than per iteration.
+ *   - a same-stratum consumer that is *accepted*.  There is no longer such a
+ *     case to cover: #1021 refuses the shape outright rather than making it
+ *     answer correctly, so what is pinned above is the refusal and the one
+ *     workaround.  Moving the reduction into per-iteration consolidation,
+ *     which would readmit part of the shape, is deferred to milestone
+ *     0.70.0; see docs/SEMANTICS.md.
  */
 
 #include "../wirelog/backend.h"
@@ -799,6 +827,151 @@ test_operand_domain_conflict_is_vetoed(void)
 
 /* ---------------------------------------------------------------------- */
 
+/*
+ * Issue #1021: a recursive min/max aggregate may not share an SCC with any
+ * other relation.
+ *
+ * REPRO_FUSED below is the issue's repro.  Big reads Label from inside
+ * Label's own stratum, so it sees each round's per-rule minimum rather than
+ * the relation's -- and which rounds it sees is decided by the evaluation
+ * strategy, not by the program.  Both builds answer it wrongly and they do
+ * not agree on how: the default build settles every Label at 1 and still
+ * reports Big(3) Big(4), no surviving label exceeding 1, while an
+ * ENABLE_K_FUSION=0 build additionally leaves the aggregate itself at
+ * Label(3,2) Label(4,3).  Plan generation now refuses the shape.
+ *
+ * Both spellings matter, and they are not the file's usual redundant-rule
+ * pair.  REPRO_FUSED carries the self-recursive rule, which together with
+ * the Big feedback takes Label to two delta positions: after
+ * rewrite_multiway_delta() its operator list is exactly {K_FUSION, EXCHANGE}
+ * and no REDUCE is visible in it at all.  REPRO_UNFUSED drops that rule and
+ * keeps the REDUCE operators in place.  A check placed below the rewrites
+ * passes the second and silently ignores the first, which is the shape of
+ * the mistake #975 and #1019 each made once, so the pair is what pins the
+ * check above them.
+ *
+ * Note what REPRO_UNFUSED is not.  It is not a second wrong answer: it
+ * evaluates to Label(1,1) (2,2) (3,3) (4,4) with Big(3) Big(4), the least
+ * fixpoint, identically in both builds.  It is refused all the same, which
+ * is the point -- the rule is keyed on the SCC shape, not on whether a
+ * particular program happens to come out right, because coming out right is
+ * what cannot be predicted from the program.  Asserting rejection of a
+ * spelling that answers correctly is deliberate, and the break is disclosed
+ * in the CHANGELOG entry for #1021 alongside the four other known
+ * over-rejections.
+ *
+ * No worker-count axis here, unlike the cases above.  Rejection happens in
+ * wl_plan_from_program(), before any session exists; running it at four
+ * worker counts would repeat one plan-time decision four times.
+ */
+#define REPRO_SEED                                              \
+        ".decl Edge(x: int64, y: int64)\n"                      \
+        ".decl Label(x: int64, l: int64)\n"                     \
+        ".decl Big(x: int64)\n"                                 \
+        "Edge(1,2). Edge(2,3). Edge(3,4).\n"                    \
+        "Label(x, min(x)) :- Edge(x, y).\n"                     \
+        "Label(y, min(y)) :- Edge(x, y).\n"
+
+#define REPRO_FEEDBACK                                          \
+        "Big(x)           :- Label(x, l), l > 2.\n"             \
+        "Label(x, min(9)) :- Big(x).\n"
+
+#define REPRO_FUSED                                             \
+        REPRO_SEED                                              \
+        "Label(x, min(l)) :- Label(y, l), Edge(y, x).\n"        \
+        REPRO_FEEDBACK
+
+#define REPRO_UNFUSED                                           \
+        REPRO_SEED                                              \
+        REPRO_FEEDBACK
+
+static void
+test_same_stratum_consumer_rejected(void)
+{
+    TEST("a same-stratum consumer of a recursive min(): rejected");
+
+    collect_t c;
+
+    ASSERT(eval_relation_at(REPRO_FUSED, "Label", 1,
+        NO_SYMBOL_COLUMN, &c) != 0,
+        "the fused spelling of the #1021 repro was accepted");
+
+    ASSERT(eval_relation_at(REPRO_UNFUSED, "Label", 1,
+        NO_SYMBOL_COLUMN, &c) != 0,
+        "the unfused spelling of the #1021 repro was accepted");
+    PASS();
+}
+
+/*
+ * The control the rejection has to leave alone, and the workaround the
+ * diagnostic names: drop the rule that feeds Big back into Label, and Big
+ * lands in a stratum of its own above Label's.  This is also the issue's own
+ * expected answer for the repro -- every label reaches 1, so nothing exceeds
+ * 2 and Big is empty -- and both builds already agree on it.
+ *
+ * It is the case that catches a check written over "is there a REDUCE and
+ * more than one relation in the program", or one that keyed on the stratum
+ * rather than on the SCC.
+ */
+#define STRATIFIED_CONTROL                                      \
+        REPRO_SEED                                              \
+        "Label(x, min(l)) :- Label(y, l), Edge(y, x).\n"        \
+        "Big(x)           :- Label(x, l), l > 2.\n"
+
+static void
+test_stratified_consumer_control(void)
+{
+    TEST("a higher-stratum consumer of a recursive min(): accepted");
+
+    static const char *const want_label[] = {
+        "1|1", "2|1", "3|1", "4|1", NULL
+    };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(STRATIFIED_CONTROL, "Label",
+            k_worker_counts[w], NO_SYMBOL_COLUMN, &c) == 0,
+            "the stratified control was rejected");
+        ASSERT(saw_exactly(&c, want_label),
+            "every label must reach the minimum reachable id, which is 1");
+
+        ASSERT(eval_relation_at(STRATIFIED_CONTROL, "Big",
+            k_worker_counts[w], NO_SYMBOL_COLUMN, &c) == 0,
+            "the stratified control was rejected");
+        ASSERT(c.count == 0,
+            "no label exceeds 2, so Big must be empty");
+    }
+    PASS();
+}
+
+/*
+ * CC-min, the shape the rejection most plausibly breaks by accident: a
+ * recursive min() whose stratum holds exactly one relation.  Asserted
+ * explicitly rather than left to the conformance harness, because a check
+ * that refused it would take out `bench/workloads/cc.dl` and
+ * `sssp.dl` with it, and the failure would surface as an unrelated
+ * benchmark regression rather than as this file going red.
+ */
+static void
+test_single_relation_aggregate_control(void)
+{
+    TEST("a recursive min() alone in its stratum: accepted");
+
+    static const char *const want[] = { "1|1", "2|1", "3|1", "4|1", NULL };
+
+    for (size_t w = 0; w < N_WORKER_COUNTS; w++) {
+        collect_t c;
+        ASSERT(eval_relation_at(MIN_BASE, "Label", k_worker_counts[w],
+            NO_SYMBOL_COLUMN, &c) == 0,
+            "a single-relation recursive aggregate stratum was rejected");
+        ASSERT(saw_exactly(&c, want),
+            "CC-min must still answer with the minimum reachable id");
+    }
+    PASS();
+}
+
+/* ---------------------------------------------------------------------- */
+
 int
 main(void)
 {
@@ -815,6 +988,9 @@ main(void)
     test_mixed_min_max_not_canonicalized();
     test_operand_type_is_order_independent();
     test_operand_domain_conflict_is_vetoed();
+    test_same_stratum_consumer_rejected();
+    test_stratified_consumer_control();
+    test_single_relation_aggregate_control();
 
     printf("\n=== %d/%d passed, %d failed ===\n", pass_count, test_count,
         fail_count);

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -168,11 +168,20 @@ col_canonicalize_recursive_aggregates(const wl_plan_stratum_t *sp,
      * any rewrite runs.
      *
      * Timing is unchanged: this is the fixpoint, not per-iteration
-     * consolidation.  A same-stratum consumer can therefore hold rows derived
-     * from labels this reduction then dominates away, leaving output that
-     * contradicts itself.  Moving it into consolidation needs
-     * wl_plan_stratum_t.is_monotone, which is hardcoded false and never
-     * computed -- that is issue #1021, not this one.
+     * consolidation.  A same-stratum consumer would therefore hold rows
+     * derived from labels this reduction then dominates away, output that
+     * contradicts itself.  #1021 settled that by refusing the shape at plan
+     * time -- a recursive min/max aggregate may not share an SCC with any
+     * other relation -- rather than by changing when this runs, so nothing
+     * here had to move.  Moving the reduction into consolidation is still
+     * open and would readmit the intra-round half of the shape; that is
+     * deferred to milestone 0.70.0, see docs/SEMANTICS.md.
+     *
+     * The correction that matters to a reader of the old comment here:
+     * wl_plan_stratum_t.is_monotone is no longer "hardcoded false and never
+     * computed".  wl_plan_from_program() computes it (negation only), and it
+     * still has no consumer, so a true value is not yet a signal anything may
+     * act on.
      */
     for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
         const wl_plan_relation_t *rp = &sp->relations[ri];

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -3402,11 +3402,157 @@ plan_stratum_record_refs(wl_plan_stratum_t *st)
 /* Public API                                                               */
 /* ======================================================================== */
 
+/*
+ * plan_relation_has_reduce - True when @relation still carries a REDUCE
+ * operator of its own.
+ *
+ * Keyed on the operator rather than on wl_plan_relation_t.recursive_agg
+ * deliberately.  recursive_agg records only the reductions that can be
+ * canonicalised -- a head whose rules disagree on the aggregate function
+ * leaves has_spec false -- yet such a relation still reduces per rule, still
+ * has its per-iteration content read by a same-stratum consumer, and still
+ * answers differently in different builds.  The operator is the thing that
+ * exists in every one of those cases.
+ */
+static bool
+plan_relation_has_reduce(const wl_plan_relation_t *relation)
+{
+    for (uint32_t o = 0; o < relation->op_count; o++) {
+        if (relation->ops[o].op == WL_PLAN_OP_REDUCE)
+            return true;
+    }
+    return false;
+}
+
+/*
+ * plan_relation_reads - True when an operator of @relation names @name,
+ * under exactly the predicate plan_stratum_record_refs() records with.
+ */
+static bool
+plan_relation_reads(const wl_plan_relation_t *relation, const char *name)
+{
+    for (uint32_t o = 0; o < relation->op_count; o++) {
+        const char *read = plan_op_referenced_relation(&relation->ops[o]);
+        if (read && strcmp(read, name) == 0)
+            return true;
+    }
+    return false;
+}
+
+/*
+ * validate_recursive_aggregate_consumers - Issue #1021.  A recursive MIN/MAX
+ * aggregate may not share an SCC with any other relation.
+ *
+ * The rule as coded is "no other relation of a recursive stratum may read a
+ * relation that carries a REDUCE".  That is the same rule: wl_ir_stratify
+ * assigns one stratum per SCC (ir/stratify.c, stratum_id[i] = scc_id[i]), and
+ * an SCC with two or more relations is strongly connected, so some other
+ * relation of it necessarily reads the aggregate directly.  State it as the
+ * SCC rule when explaining it -- "no other relation may reference R"
+ * understates how much surface this removes.
+ *
+ * Why the whole shape and not some narrower predicate.  A same-stratum
+ * consumer sees each round's per-rule REDUCE output, before that round's
+ * cross-rule domination has run; what it therefore observes is, in general,
+ * decided by the evaluation strategy rather than by the program.  "In
+ * general" is doing real work in that sentence -- see the last paragraph
+ * below.  The issue's repro
+ * makes that visible twice over -- the default build answers Big(3) Big(4)
+ * over labels that are all 1, and an ENABLE_K_FUSION=0 build corrupts the
+ * aggregate itself as well, so two builds give two different wrong answers.
+ * It is not merely that the consumer reads the aggregate column
+ * non-monotonically: a consumer with no predicate on that column at all
+ * (Seen(x) :- Label(x, l)) is configuration-dependent for the same reason.
+ *
+ * The rule is coarse and knowingly refuses programs that answer correctly
+ * today; the CHANGELOG entry for #1021 names five.  The obvious leniency --
+ * readmit a consumer that carries its own MIN/MAX -- is unsound, and was
+ * measured to be.  Over a propagating a:
+ *
+ *     a(x, min(v)) :- a(y, v), Edge(y, x).
+ *     b(x, min(v)) :- a(x, v), v > 2.
+ *     a(x, min(9)) :- b(x, v).
+ *
+ * yields b(3,3) b(4,3) in both build configurations.  The third rule is
+ * load-bearing: it is what puts b in a's SCC.  Drop it and b is a higher
+ * stratum, a settles to all-1, and b comes out empty in both builds -- so
+ * the shorter spelling of this example proves nothing.  Of the two rows,
+ * b(3,3) is the one no final a justifies in either configuration; b(4,3) is
+ * unjustified only in the default build, the unfused one leaving a(4,3)
+ * behind.
+ *
+ * There is one class where the outcome *is* predictable from the program,
+ * and it is the reason to expect this rule to be narrowed rather than kept.
+ * When the aggregated value is functionally determined by the group key --
+ * `M(x, min(x)) :- Edge(x, _).` with `Root(x) :- M(x, v).` feeding back --
+ * no value is ever dominated away, so a round's content is the fixpoint's
+ * content and configuration-dependence is impossible by construction, not
+ * merely absent from the samples anyone happened to run.  That program is
+ * refused here all the same, because this check reasons about shape and not
+ * about functional dependencies.  Recognising the class is #1135's best
+ * candidate for a narrowing predicate.
+ *
+ * Returns 0 when no stratum has the shape, -1 after logging the first that
+ * does.
+ */
+static int
+validate_recursive_aggregate_consumers(const wl_plan_t *plan)
+{
+    for (uint32_t s = 0; s < plan->stratum_count; s++) {
+        const wl_plan_stratum_t *stratum = &plan->strata[s];
+        if (!stratum->is_recursive || !stratum->relations
+            || stratum->relation_count < 2)
+            continue;
+
+        for (uint32_t r = 0; r < stratum->relation_count; r++) {
+            const wl_plan_relation_t *agg = &stratum->relations[r];
+            if (!plan_relation_has_reduce(agg))
+                continue;
+
+            for (uint32_t c = 0; c < stratum->relation_count; c++) {
+                const wl_plan_relation_t *consumer = &stratum->relations[c];
+                if (c == r || !plan_relation_reads(consumer, agg->name))
+                    continue;
+
+                /* One remedy, not two.  An earlier draft also offered
+                 * "give the consumer its own min/max and no non-monotone
+                 * read of the aggregate column".  That is vacuous for every
+                 * program that can reach this message: the check inspects
+                 * neither the consumer's operators nor its filters, so a
+                 * same-SCC consumer is refused whatever it carries -- the
+                 * advice would have told the reader to do what they already
+                 * do.  It is also wrong on its own terms, because such a
+                 * program is configuration-dependent too: over a
+                 * propagating a, `b(x, min(v)) :- a(x, v).` with the
+                 * feedback rule intact answers b all-1 by default and
+                 * b(3,2) b(4,3) under ENABLE_K_FUSION=0.  Whether that
+                 * class can ever be readmitted is #1135's question, not a
+                 * workaround to hand out here. */
+                WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_ERROR,
+                    "relation '%s' of stratum %u reads recursive aggregate "
+                    "relation '%s' from the same stratum: a recursive "
+                    "min/max aggregate may not share an SCC with any other "
+                    "relation, because a same-SCC consumer observes the "
+                    "aggregate's per-iteration content and what it observes "
+                    "is configuration-dependent.  Break the feedback edge "
+                    "into '%s' so that '%s' lands in a later stratum",
+                    consumer->name, stratum->stratum_id, agg->name,
+                    agg->name, consumer->name);
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
 /* COUNT and SUM are not monotone reducers across a recursive fixpoint.  The
  * plan must reject them before any rewrite can hide the REDUCE operator and
  * otherwise expose a relation whose rows violate its declared functional
  * dependency.  AVG is included defensively; parsed AVG expressions are
- * rejected earlier in translate_ir_node(). */
+ * rejected earlier in translate_ir_node().
+ *
+ * The second pass, validate_recursive_aggregate_consumers(), rejects a
+ * further shape for a related reason (#1021); see the comment on it. */
 static int
 validate_recursive_aggregates(const wl_plan_t *plan)
 {
@@ -3435,7 +3581,8 @@ validate_recursive_aggregates(const wl_plan_t *plan)
             }
         }
     }
-    return 0;
+
+    return validate_recursive_aggregate_consumers(plan);
 }
 
 void
@@ -3914,7 +4061,19 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
 
     /* Reject non-monotone recursive aggregates while the original REDUCE
      * operators are still visible.  Rewrites below may move them into opaque
-     * backend metadata or discard their shape entirely. */
+     * backend metadata or discard their shape entirely.
+     *
+     * Do not move this call below rewrite_lftj_chains() or
+     * rewrite_multiway_delta().  Both passes of the validation key on
+     * WL_PLAN_OP_REDUCE, and after those two rewrites there is no REDUCE left
+     * to key on: the #1021 repro's Label relation is exactly {K_FUSION,
+     * EXCHANGE} at that point, its operators having been moved into
+     * wl_plan_op_k_fusion_t.k_ops[].  A check placed lower down would
+     * silently never fire on precisely the shapes fusion applies to, while
+     * still passing its own tests on the unfused spellings -- which is how
+     * the same mistake got made once in #975 and again in #1019.  It has to
+     * sit here, after plan_stratum_record_refs() above and before the four
+     * rewrites below. */
     if (validate_recursive_aggregates(plan) != 0) {
         wl_plan_free(plan);
         return -1;


### PR DESCRIPTION
**This is a compatibility break, deliberately taken and approved.** Programs that answer correctly today are refused. The reason is that the shape they belong to has no defined answer in general, and the engine currently gives two different wrong ones for it.

## The defect

```
Edge(1,2). Edge(2,3). Edge(3,4).
Label(x, min(x)) :- Edge(x, y).
Label(y, min(y)) :- Edge(x, y).
Label(x, min(l)) :- Label(y, l), Edge(y, x).
Big(x)          :- Label(x, l), l > 2.
Label(x, min(9)) :- Big(x).
```

Default build: every `Label` settles at 1, and `Big(3) Big(4)` are reported anyway — no surviving label exceeds 1. Under `-DENABLE_K_FUSION=0` the aggregate is *also* corrupted, differing at `Label(3,2) Label(4,3)`. **Two configurations, two different wrong answers, exit 0 from both.**

`Label(4,4)` does exist transiently in an intermediate round. That it is visible to `Big` at all is the defect: a relation in the aggregate's own SCC observes each round's per-rule `REDUCE` output, before that round's cross-rule domination has run. What it observes is decided by the evaluation strategy rather than by the program.

## Why the issue's own prescription does not fix it

#1021 proposed computing the aggregate half of `is_monotone` and gating *eager domination* on it. That cannot work here, and establishing why is most of this change's value.

At iteration 1 the settled-so-far minimum for node 3 genuinely **is** 3, so `Big(x) :- Label(x,l), l > 2.` fires on a value that is correct at that moment. No domination schedule prevents that derivation, because nothing dominates it when it happens. `Big(3)` can only disappear by **retraction** — domination emitting a negative delta that propagates through the `Big` rule inside the fixpoint — and `col_canonicalize_recursive_aggregate_relation` rewrites in place and produces no diffs.

The bound is sharper than "timing cannot help": a same-stratum consumer observes each round's outputs *before* that round's domination. Eager domination in consolidation would remove the **intra-round** subset of this bug; the repro is the **inter-round** subset. That deferred work is #1135 (milestone 0.70.0), and landing it will not on its own lift this rejection.

## The fix

A second pass in `validate_recursive_aggregates()`, alongside the COUNT/SUM/AVG rejection `d5aaa5c` added there for #991: **a recursive `min()`/`max()` aggregate may not share an SCC with any other relation.** Same file, same pass, same pre-rewrite timing requirement, same failure mode — #991's is a non-monotone *reducer*, this is a non-monotone *observation*.

The rule is coarse because `stratify.c` maps `stratum_id = scc_id` one-to-one, so any multi-relation SCC necessarily contains a relation that reads the aggregate. The obvious leniency — readmit a consumer carrying its own `min()`/`max()` — is unsound and was measured to be: `b(x, min(v)) :- a(x, v), v > 2.` with a feedback rule yields `b(3,3)` in **both** configurations, unjustified by any final `a` in either.

## Placement is the subtle part, and it is guarded structurally

The call must stay above `rewrite_lftj_chains()` and `rewrite_multiway_delta()`. After those, the repro's `Label` relation is exactly `{K_FUSION, EXCHANGE}` and carries no `REDUCE` to key on — so a check placed lower would **silently never fire on the shapes fusion applies to while still passing on the unfused spellings**, i.e. half the tests green. #975 and #1019 each made this mistake once.

Two reviewers independently moved the call below the rewrites on purpose and confirmed TESTs 7, 8 and 12 fail. Because the new check rides inside #991's already-correctly-placed function, neither can be moved without the other. That is the guard; the comment documents why.

## The compatibility break, disclosed

Five programs are known that answer the least fixpoint identically in both configurations and are now refused. The CHANGELOG names them with their answers: a mutually recursive `A`/`B` `min()` pair, its `max()` analogue, a bipartite `L`/`R` propagation, the repro's own unfused spelling, and a key-determined aggregate.

The last is the interesting one and it forced a correction to the rationale. The original justification was "the consumer reads the aggregate column non-monotonically". That is refuted by `Seen(x) :- Label(x,l).` — no predicate on the aggregate column at all, and configuration-dependent today. So the shipped rationale is broader: any same-SCC consumer observes per-iteration content, and in general what it observes cannot be predicted from the program. **"In general" is precise rather than hedging** — an aggregate functionally determined by its group key dominates nothing away, so its per-iteration content *is* its fixpoint content and configuration-dependence is impossible by construction. That class is refused too, and it is the leading narrowing predicate recorded in #1135.

A sixth was found during final validation — a `max()` aggregate whose feedback edge is syntactically present but semantically dead. It is worth knowing that its correctness is **accidental**: the exact `min()` twin with an equally dead guard diverges between configurations. The dead-feedback class is not uniformly safe, which is this change's own thesis.

## What this does not do

It does not compute `is_monotone` — `5116ab6` already did, and the field remains computed and unread. It does not move domination into consolidation. It does not touch `stratify.c`; forcing an aggregate-column reader into a higher stratum was considered and rejected on measurement, because it makes the bipartite and `Seen` cases *unstratifiable*, over-rejecting at least as much with a worse message.

## Verification

Reviewer plus separate final design and risk gates, each held by a different agent. **The first design gate returned `blocked`** — the diagnostic's first remedy was vacuous for every program that could see it, and pointed at a configuration-dependent shape. It was withdrawn; the surviving remedy was then verified by constructing it for nine refused programs and confirming each is accepted afterwards and answers identically in both builds.

- Full suite **296 total, 285 Ok, 0 Fail, 11 Skipped**, re-run after rebasing onto current `main`.
- Red→green with the **controls immobile**: reverting only `wirelog/exec_plan_gen.c` fails exactly the rejection test; the stratified control and the CC-min control pass in the red build too.
- Not refused, verified: `bench/workloads/cc.dl`, `sssp.dl`, `examples/06-timestamp-lww`, the stratified variant, non-aggregate mutual recursion, and 40 accepted programs total — all identical across both build configurations.
- No `ENABLE_K_FUSION=0` divergence found **outside** the refused class, across 32 in-tree `.dl` programs plus 8 synthetic ones.
- The check is reachable through all four `wl_plan_from_program` callers, cannot crash or leak on any plan the generator can build, and never examines nothing.

## Known gaps, tracked

Rejection is **silent at the default log level** — the CLI prints `Plan generation failed: rc=-1` and `error: execution failed`, exit 1. `WL_LOG=EVAL:1` surfaces the diagnostic, which names the verified workaround. `wl_plan_from_program()` has no error channel; this inherits that from #991's rejection rather than widening it, and it is now **#1137**.

Three stale claims elsewhere in the tree are corrected in the second commit: `columnar/eval.c` said `is_monotone` is "hardcoded false and never computed"; `docs/SEMANTICS.md` said MIN/MAX recursive aggregation is implemented full stop; and `tests/test_recursive_agg_kfusion.c` said an `ENABLE_K_FUSION=0` build aborts on this family per #1020 — #1020 is closed and the family runs unfused without aborting.

Closes #1021
