### PR TITLE
Clear the clang-tidy backlog for eval.c and jpp.c (#1075, #1085)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **Partial NULL guard in the columnar evaluator's post-eval skip** (#1075):
+  two sites in `wirelog/columnar/eval.c` tested
+  `result.rel && result.rel->nrows == 0`. A NULL `result.rel` short-circuits
+  that condition, so it fell straight through to statements that dereference
+  it -- `result.rel->name` on the rename arm, `result.rel->ncols` on the
+  schema-adoption arm and, in the TDD worker subpass, `col_rel_new_like()`,
+  which reads `src->ncols` with no NULL check of its own. Both guards now
+  test `!result.rel || result.rel->nrows == 0` and disposition a NULL as "no
+  result", the same disposition the `stack.top == 0` branch three lines above
+  already gives an empty stack. `col_rel_destroy(NULL)` is a no-op, so the
+  skip path leaks nothing.
+
+  Not reachable today: `eval_stack_pop()` yields a NULL relation only for an
+  empty stack, which that `stack.top == 0` check already excludes, and no
+  in-tree caller pushes a NULL relation. The change closes the guard against
+  a future push path rather than a live crash, and no regression test can
+  reach it without editing library code.
+
 - **Out-of-range dependency-graph edges no longer corrupt SCC detection**
   (#1083): `wl_ir_stratify_scc_detect()` builds its adjacency list in two
   passes that disagreed with each other. The counting pass reserved a slot

--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -85,6 +85,7 @@ wirelog/parser/ast.c
 wirelog/parser/lexer.c
 wirelog/parser/parser.c
 wirelog/passes/fusion.c
+wirelog/passes/jpp.c
 wirelog/passes/magic_sets.c
 wirelog/passes/sip.c
 wirelog/passes/subsumption.c

--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -49,6 +49,7 @@ wirelog/columnar/diff_arrangement.c
 wirelog/columnar/diff_bridge.c
 wirelog/columnar/diff_trace.c
 wirelog/columnar/diff_vtable.c
+wirelog/columnar/eval.c
 wirelog/columnar/eval_dedup.c
 wirelog/columnar/eval_stack.c
 wirelog/columnar/eval_tdd_plan.c

--- a/scripts/ci/clang-tidy-backlog.txt
+++ b/scripts/ci/clang-tidy-backlog.txt
@@ -31,7 +31,6 @@
 #
 # wirelog/ir/program.c is the reason this issue exists: it was clean, and
 # regressed to bugprone-branch-clone after f1d2a2c with nothing failing.
-wirelog/columnar/eval.c
 wirelog/columnar/eval_delta.c
 wirelog/columnar/eval_plan.c
 wirelog/columnar/eval_tdd_queue.c

--- a/scripts/ci/clang-tidy-backlog.txt
+++ b/scripts/ci/clang-tidy-backlog.txt
@@ -39,4 +39,3 @@ wirelog/columnar/join.c
 wirelog/columnar/kfusion.c
 wirelog/columnar/merge.c
 wirelog/columnar/mobius.c
-wirelog/passes/jpp.c

--- a/scripts/ci/clang-tidy-baselines/llvm-22.nolint-counts.txt
+++ b/scripts/ci/clang-tidy-baselines/llvm-22.nolint-counts.txt
@@ -4,3 +4,4 @@
 wirelog/columnar/partition.c 1
 wirelog/io/csv_reader.c 1
 wirelog/ir/program.c 9
+wirelog/passes/jpp.c 7

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -1752,6 +1752,152 @@ test_jpp_nullary_chain(void)
 }
 
 static void
+test_jpp_keyed_chain_zero_calloc(void)
+{
+    TEST("jpp #1085: zero-size calloc watch over a chain that HAS join keys");
+
+    /*
+     * Companion to test_jpp_nullary_chain() above, and the reason it is not
+     * redundant with it.
+     *
+     * That test arms jpp_zero_calloc_watch over `o(1) :- a(), b(), e().`,
+     * where every atom is nullary.  On that fixture:
+     *
+     *   - count_shared_vars() returns 0, so jpp_build_join_keys() takes its
+     *     `key_count == 0` early return and NEVER REACHES its calloc.  The
+     *     watch has never once observed that allocation.
+     *   - merge_vars() is only ever reached with na + nb == 0, so the watch
+     *     observes exactly one leg of its sizing and no other.
+     *
+     * So the nullary fixture pins the clamp-removal guarantee for the case
+     * it was written for, and nothing else.  Describing it as cover for
+     * "jpp.c never asks calloc for zero elements" overstates it: the two
+     * allocations that the #1085 re-sizing actually touched were both
+     * outside its reach.  This fixture puts them inside it.
+     *
+     *   o(z) :- a(x), c(y, z), b(x, y).
+     *
+     * Three properties, all load-bearing:
+     *
+     *   - It REORDERS.  greedy_order() always seeds with scans[0] and here
+     *     prefers b (shares x) over c (shares nothing), so the order becomes
+     *     a, b, c and optimize_chain() actually calls rebuild_chain().
+     *     Without a reorder rebuild_chain() is skipped entirely and the
+     *     watch would be as vacuous as it is on the nullary fixture --
+     *     which is why joins_reordered is asserted below rather than merely
+     *     observed.
+     *   - Its first scan has exactly ONE column, so rebuild_chain()'s first
+     *     jpp_build_join_keys() call runs with left_count == 1.  That is
+     *     what gives the watch teeth against the new left_count sizing:
+     *     mis-sizing it by one element asks calloc for zero and is counted
+     *     here, where on any wider fixture it would merely under-allocate
+     *     by one and go unnoticed.
+     *   - It shares a variable at every step, so key_count > 0 and the
+     *     calloc is reached at all.
+     *
+     * What this fixture does NOT cover, stated plainly rather than implied.
+     * merge_vars() is reached here with na + nb > 0, so this exercises the
+     * ordinary leg of that sizing but cannot observe the `+ 1` AS WIDTH.
+     * Nothing can: instrumented over this suite, 845 merge_vars() calls of
+     * which 843 have na + nb > 0, the minimum of (na + nb) - n is 1.  The
+     * merged count never reaches the bound, because every real call merges
+     * an accumulator with a scan sharing at least one variable, so at least
+     * one element is always spare even before the `+ 1`.  The extra element
+     * is therefore never written and no input can press against it.
+     *
+     * The `+ 1` is still guarded, just not here and not as a width: it is
+     * what keeps the request away from zero, and removing it is caught by
+     * test_jpp_nullary_chain() above, which then counts two zero-element
+     * requests.  Mutating it to na + nb - 1 is caught there too, by
+     * underflow.  So the sizing has cover for the property it was chosen
+     * for; what has no cover, and needs none, is the spare element.
+     */
+    wirelog_error_t err;
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl a(x: int32)\n"
+            ".decl b(x: int32, y: int32)\n"
+            ".decl c(y: int32, z: int32)\n"
+            ".decl o(z: int32)\n"
+            "o(z) :- a(x), c(y, z), b(x, y).\n",
+            &err);
+
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wl_jpp_stats_t stats = { 0, 0, 0 };
+#ifdef __linux__
+    jpp_zero_calloc_watch_begin();
+#endif
+    int rc = wl_jpp_apply(prog, &stats);
+#ifdef __linux__
+    unsigned long zero_callocs = jpp_zero_calloc_watch_end();
+#endif
+    if (rc != 0) {
+        FAIL("expected 0");
+        wirelog_program_free(prog);
+        return;
+    }
+
+#ifdef __linux__
+    if (zero_callocs != 0) {
+        char zbuf[160];
+        snprintf(zbuf, sizeof(zbuf),
+            "%lu calloc request(s) for zero elements; calloc(0, n) may "
+            "return NULL and would be misread as OOM",
+            zero_callocs);
+        FAIL(zbuf);
+        wirelog_program_free(prog);
+        return;
+    }
+#endif
+
+    /*
+     * Anti-vacuity: the watch above proves nothing unless the pass really
+     * walked the allocating paths.  A reorder means rebuild_chain() ran,
+     * and keys on every JOIN mean jpp_build_join_keys() got past its
+     * key_count == 0 early return each time.
+     */
+    if (stats.chains_examined != 1 || stats.joins_reordered != 1) {
+        char buf[160];
+        snprintf(buf, sizeof(buf),
+            "expected chains=1 reordered=1 (the watch is vacuous without a "
+            "rebuild), got chains=%u reordered=%u",
+            stats.chains_examined, stats.joins_reordered);
+        FAIL(buf);
+        wirelog_program_free(prog);
+        return;
+    }
+
+    wirelog_ir_node_t *ir = find_relation_ir(prog, "o");
+    wirelog_ir_node_t *root = ir ? find_join_root(ir) : NULL;
+    if (!root || root->type != WIRELOG_IR_JOIN) {
+        FAIL("expected JOIN at the root of the chain");
+        wirelog_program_free(prog);
+        return;
+    }
+
+    wirelog_ir_node_t *n = root;
+    while (n && n->type == WIRELOG_IR_JOIN) {
+        if (n->join_key_count == 0) {
+            FAIL("found a JOIN with no keys; the key builder was never "
+                "reached past its early return");
+            wirelog_program_free(prog);
+            return;
+        }
+        n = n->child_count > 0 ? n->children[0] : NULL;
+        /* insert_projections() may have spliced a PROJECT between two JOIN
+         * levels; the chain continues below it. */
+        while (n && n->type == WIRELOG_IR_PROJECT && n->child_count > 0)
+            n = n->children[0];
+    }
+
+    wirelog_program_free(prog);
+    PASS();
+}
+
+static void
 test_jpp_plan_unchanged_narrow(void)
 {
     TEST("jpp: narrow 3-atom plan (order and projection count) unchanged");
@@ -2617,6 +2763,7 @@ main(void)
     test_jpp_wide_two_atom_noop();
     test_jpp_wide_head_antijoin_key();
     test_jpp_nullary_chain();
+    test_jpp_keyed_chain_zero_calloc();
     test_jpp_plan_unchanged_narrow();
 
     /* Allocation-failure sweeps (issue #1111) */

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -258,8 +258,9 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                         sess->delta_pool, rp->name, result.rel);
                     if (!copy)
                         return ENOMEM;
-                    if ((rc = col_rel_append_all(copy, result.rel,
-                        sess->eval_arena)) != 0) {
+                    rc = col_rel_append_all(copy, result.rel,
+                            sess->eval_arena);
+                    if (rc != 0) {
                         col_rel_destroy(copy);
                         return rc;
                     }
@@ -580,8 +581,22 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
 
                 /* Post-eval skip: evaluation produced 0 rows — safety net for
                  * cases not caught by pre-scan (e.g. filters eliminating all
-                 * rows). */
-                if (result.rel && result.rel->nrows == 0) {
+                 * rows).
+                 *
+                 * The !result.rel arm is not analyzer appeasement.
+                 * eval_stack_pop() yields {NULL, ...} only for an empty
+                 * stack, and the stack.top == 0 check three lines above has
+                 * already excluded that, so a NULL here would mean a NULL rel
+                 * was pushed.  It is dispositioned as "no result" to match
+                 * that same branch rather than as an error, so one observable
+                 * state does not get two dispositions depending on which
+                 * check saw it first.  (diff.c and join.c return EINVAL on a
+                 * NULL pop because they pop without a prior emptiness check.)
+                 * Otherwise the statements below dereference result.rel:
+                 * ->name on the rename arm, ->ncols on the schema-adoption
+                 * arm.  col_rel_destroy(NULL) is a no-op, so the continue
+                 * leaks nothing. */
+                if (!result.rel || result.rel->nrows == 0) {
                     if (result.owned)
                         col_rel_destroy(result.rel);
                     continue;
@@ -607,8 +622,9 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                             outer_rc = ENOMEM;
                             goto stride_error;
                         }
-                        if ((rc = col_rel_append_all(copy, result.rel,
-                            sess->eval_arena)) != 0) {
+                        rc = col_rel_append_all(copy, result.rel,
+                                sess->eval_arena);
+                        if (rc != 0) {
                             col_rel_destroy(copy);
                             outer_rc = rc;
                             goto stride_error;
@@ -1810,7 +1826,6 @@ tdd_seed_global_read_initial_deltas(const wl_plan_stratum_t *sp,
  *      exchange; deltas are heap-allocated (col_rel_new_like) so they
  *      remain valid across delta_pool_reset.
  */
-static void tdd_dedup_rel(col_rel_t *r);
 static int bdx_hash_diff(col_rel_t *delta, const col_rel_t *base);
 static int tdd_hashset_diff(col_rel_t *delta, const col_rel_t *base);
 static int
@@ -1944,7 +1959,22 @@ tdd_worker_subpass_fn(void *arg)
         eval_entry_t result = eval_stack_pop(&stack);
         eval_stack_drain(&stack);
 
-        if (result.rel && result.rel->nrows == 0) {
+        /* Post-eval skip: evaluation produced 0 rows.
+         *
+         * The !result.rel arm is not analyzer appeasement.  eval_stack_pop()
+         * yields {NULL, ...} only for an empty stack, and the stack.top == 0
+         * check three lines above has already excluded that, so a NULL here
+         * would mean a NULL rel was pushed.  It is dispositioned as "no
+         * result" to match that same branch rather than as an error, so one
+         * observable state does not get two dispositions depending on which
+         * check saw it first.  (diff.c and join.c return EINVAL on a NULL
+         * pop because they pop without a prior emptiness check.)
+         *
+         * Three dereferences follow otherwise: col_rel_new_like() below
+         * reads src->ncols unguarded, which clang-tidy cannot see because it
+         * is cross-TU, and ->name / ->ncols on the non-outbound path.
+         * col_rel_destroy(NULL) is a no-op, so the continue leaks nothing. */
+        if (!result.rel || result.rel->nrows == 0) {
             if (result.owned)
                 col_rel_destroy(result.rel);
             continue;
@@ -2428,7 +2458,7 @@ tdd_dedup_rel(col_rel_t *r)
             free(ht);
             free(keep);
             col_rel_radix_sort_int64(r);
-            sorted = true; /* fall through to sorted dedup below */
+            /* Fall through to the sorted dedup below. */
         } else {
             memset(ht, 0xFF, cap * sizeof(uint32_t)); /* 0xFF = UINT32_MAX */
             memset(keep, 0, nrows);
@@ -2625,8 +2655,6 @@ tdd_preregister_idb_on_workers(const wl_plan_stratum_t *sp,
 /* Forward declaration — defined below tdd_exchange_deltas. */
 static int tdd_broadcast_deltas(const wl_plan_stratum_t *sp,
     wl_col_session_t *coord, col_eval_tdd_worker_ctx_t *ctxs, uint32_t W);
-static void tdd_dedup_rel(col_rel_t *r);
-static int bdx_hash_diff(col_rel_t *delta, const col_rel_t *base);
 
 /*
  * tdd_broadcast_relation_delta:
@@ -3173,7 +3201,7 @@ tdd_init_workers_hybrid(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
         const char *edb_name_found = NULL;
         for (uint32_t r = 0; r < nrels; r++) {
             col_rel_t *rel = coord->rels[r];
-            if (!rel || !rel->name)
+            if (!rel)
                 continue;
             /* IDB: appears in sp->relations */
             for (uint32_t ri = 0; ri < sp->relation_count; ri++) {

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -238,8 +238,58 @@ jpp_build_join_keys(char **left_vars, uint32_t left_count, char **right_vars,
     if (key_count == 0)
         return true;
 
-    char **left = (char **)calloc(key_count, sizeof(char *));
-    char **right = (char **)calloc(key_count, sizeof(char *));
+    /*
+     * Size both arrays from left_count, not from key_count.
+     *
+     * key_count is the exact answer, and count_shared_vars() computed it
+     * with a walk that is character-identical to the fill loop below, over
+     * the same left_vars, right_vars, left_count and right_count -- nothing
+     * mutates any of them in between -- so k reaches exactly key_count.
+     * Sizing from left_count instead makes the bound STRUCTURAL: the fill
+     * loop iterates left_vars[0 .. left_count) and appends at most one key
+     * per iteration, so k < left_count at every store no matter what the
+     * two walks agree on.  That is a property of the loop a reader can see
+     * in one place, and it does not depend on re-deriving an equality
+     * through a second traversal.  left_count >= key_count >= 1 here (a
+     * non-zero key_count needs at least one non-NULL left variable), so
+     * this never asks calloc for zero elements either.
+     *
+     * The arrays are therefore allocated LONGER than out->count whenever a
+     * left variable is unshared or NULL.  A DUPLICATED left variable is not
+     * a source of slack: count_shared_vars() counts it and the fill loop
+     * stores it, so it consumes a slot and yields a duplicate key entry.
+     *
+     * The slack is not negligible, and the honest worst case is large.
+     * Measured across the FULL test suite it peaks at 199 spare pointers
+     * per array -- left_count == 200 against key_count == 1, from the
+     * recursive 3-atom self-join over 200 columns in
+     * tests/test_wide_relation.c, where the accumulator carries every
+     * column and the atoms share a single variable.  The 32- and 33-column
+     * widths of that same shape give 31 and 32.  Within tests/test_jpp.c
+     * alone it peaks at three, which is why the figure has to be quoted
+     * against the whole suite and not the pass's own tests.
+     *
+     * That is wasted space, not a leak or a hazard.  The spare elements
+     * stay NULL from calloc, the array is released by the same free()
+     * under either sizing, and nothing truncates: out->count is k either
+     * way, and every consumer of a JOIN's key arrays iterates
+     * [0, join_key_count) -- free_join_keys() and jpp_free_staged_keys()
+     * in this file, wl_ir_node_free() and the IR printer in ir/ir.c, the
+     * key copy in passes/sip.c, and the three resolution loops in
+     * exec_plan_gen.c, which take the array and the count as a pair.  The
+     * ir/ir.c pair is the one a reader is least likely to think to check;
+     * both walk join_key_count, never the allocation.
+     *
+     * This does leave jpp-produced JOIN nodes as the only ones whose key
+     * arrays are longer than join_key_count: ir/program.c's
+     * setup_join_keys() and passes/magic_sets.c both calloc(key_count) and
+     * set join_key_count = key_count.  Nothing appends to these arrays in
+     * place, so the asymmetry is unobservable today; anything that ever
+     * wanted to would have to carry the capacity, which only this builder
+     * knows.
+     */
+    char **left = (char **)calloc(left_count, sizeof(char *));
+    char **right = (char **)calloc(left_count, sizeof(char *));
     if (!left || !right) {
         free((void *)left);
         free((void *)right);
@@ -292,20 +342,28 @@ static char **
 merge_vars(char **a, uint32_t na, char **b, uint32_t nb, uint32_t *out_count)
 {
     /*
-     * Upper bound on merged size, clamped to at least one element.
+     * Upper bound on merged size, plus one element that is never written.
      *
      * na + nb == 0 is reachable and legitimate: `.decl p()` is legal and
      * leaves column_count == 0, so an all-nullary chain merges two empty
      * sets.  C permits calloc(0, n) to return NULL and a caller cannot tell
      * that apart from OOM, which would decline the reorder for a chain that
-     * is perfectly optimizable.  scan_columns_total() above clamps for
-     * exactly this reason; the clamp is safe here for the same reason it is
-     * safe there -- every write into merged[] is bounded by na + nb, so a
-     * zero-total merge performs no writes at all.
+     * is perfectly optimizable.  The `+ 1` is what keeps this allocation
+     * away from zero, and it does so BY CONSTRUCTION rather than by a
+     * `cap > 0 ? cap : 1` clamp at the call: there is no zero-size leg left
+     * to get wrong, and no conditional for a reader to check.  The cost is
+     * one pointer per merge.
+     *
+     * The width is more than sufficient for the writes: the first loop
+     * stores na elements and the second at most nb, so n <= na + nb <
+     * merged_cap on every path.  It cannot wrap.  na and nb count the
+     * elements of `char *` arrays that already exist, so each is at most
+     * SIZE_MAX / sizeof(char *) and the sum plus one stays well inside
+     * size_t on every target -- the addition is performed in size_t, both
+     * operands having been widened before it.
      */
-    size_t merged_cap = (size_t)na + (size_t)nb;
-    char **merged
-        = (char **)calloc(merged_cap > 0 ? merged_cap : 1, sizeof(char *));
+    size_t merged_cap = (size_t)na + (size_t)nb + 1u;
+    char **merged = (char **)calloc(merged_cap, sizeof(char *));
     if (!merged) {
         *out_count = 0;
         return NULL;
@@ -882,6 +940,51 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
      * one alias per scan column in the chain.  needed[] is sized separately
      * -- it holds the head variables as well, so its bound adds
      * head_var_count on top of this. */
+    /*
+     * Six stores into acc[] and phys_names[], and one into needed[], carry
+     * NOLINTs for clang-analyzer-security.ArrayBound below.  All seven are
+     * analyzer limitations rather than real bounds; the proof lives here,
+     * once, so that the suppressions themselves can stay bare.
+     *
+     * total_cols is scan_columns_total(): the sum of the scan_vars() counts
+     * over every entry of scans[].  Call a "chain column" one column of one
+     * of those scans; there are exactly total_cols of them.
+     *
+     *   - acc[] has total_cols elements.  It is filled to scans[0]'s column
+     *     count, then acc_count is incremented once per column of a later
+     *     scan not already present, and is otherwise only ever reset
+     *     DOWNWARD, by the PROJECT rewrite.  Every increment consumes a
+     *     distinct chain column that no earlier increment consumed, so at
+     *     each store the index acc_count is at most the number of chain
+     *     columns already consumed -- leaving at least the one being stored
+     *     -- hence acc_count < total_cols.
+     *   - phys_names[] has total_cols elements.  phys_count is incremented
+     *     once per column of scans[0], scans[1] and each later scans[i + 2],
+     *     and is reset to acc_count (itself <= total_cols) whenever a
+     *     PROJECT shrinks the layout.  Each increment likewise consumes a
+     *     distinct chain column, so phys_count < total_cols at each store.
+     *   - needed[] has head_var_count + total_cols elements.  needed_count
+     *     is incremented at most once per head variable and at most once per
+     *     chain column, each behind a var_in_set() duplicate check, so
+     *     needed_count < needed_cap at each store.
+     *
+     * The counts are uint32_t and total_cols is size_t, so "count <=
+     * total_cols" is a complete argument only together with total_cols <=
+     * UINT32_MAX.  That holds: total_cols is a sum of uint32_t column_count
+     * values over nscan scans, and a chain totalling more than UINT32_MAX
+     * columns could not have been built at all -- phys_names[] alone would
+     * be one allocation of that many pointers.
+     *
+     * The analyzer reports these because it does not inline
+     * scan_columns_total(): a total accumulated over a loop is outside the
+     * constraint manager's reach, so it explores paths on which total_cols
+     * is unrelated to the per-scan counts (total_cols == 1 against a scan of
+     * many columns).  Two stronger experiments confirm that diagnosis rather
+     * than a mere size budget -- inlining the entire summation loop into
+     * this function by hand, giving the analyzer maximal visibility, and
+     * deleting the WL_LOG from the helper to rule out "the helper is too big
+     * to inline".  Both still report the same seven sites.
+     */
     size_t total_cols;
     if (!scan_columns_total(scans, nscan, &total_cols)) {
         free((void *)scans);
@@ -901,6 +1004,7 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
         return 0;
     }
     for (uint32_t i = 0; i < acc_count; i++)
+        // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
         acc[i] = acc_vars[i];
 
     /* Merge scan[1] */
@@ -911,6 +1015,7 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
             if (!svars[j])
                 continue;
             if (!var_in_set(svars[j], acc, acc_count))
+                // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
                 acc[acc_count++] = svars[j];
         }
     }
@@ -934,10 +1039,12 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
         uint32_t s0c;
         char **s0v = scan_vars(scans[0], &s0c);
         for (uint32_t j = 0; j < s0c; j++)
+            // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
             phys_names[phys_count++] = s0v[j];
         uint32_t s1c;
         char **s1v = scan_vars(scans[1], &s1c);
         for (uint32_t j = 0; j < s1c; j++)
+            // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
             phys_names[phys_count++] = s1v[j];
     }
 
@@ -985,6 +1092,7 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
             char **svars = scan_vars(scans[s], &scount);
             for (uint32_t j = 0; j < scount; j++) {
                 if (svars[j] && !var_in_set(svars[j], needed, needed_count))
+                    // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
                     needed[needed_count++] = svars[j];
             }
         }
@@ -1007,6 +1115,53 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
                     = (char **)calloc(live_count, sizeof(char *));
                 if (proj->project_indices && proj->column_names) {
                     proj->column_count = live_count;
+                    /*
+                     * The store into proj->project_indices[] below carries
+                     * an eighth NOLINT, and it is PRE-EMPTIVE: the site does
+                     * not fire at the analyzer's default max-inlinable-size
+                     * of 100 CFG blocks, at which insert_projections() is
+                     * too large to inline into its caller.  Raise that
+                     * threshold to 140 and the reported set for this file
+                     * does not drift, it FLIPS: the seven sites above all
+                     * disappear and this one appears alone in their place.
+                     *
+                     * insert_projections() sits only ~31-40 blocks above the
+                     * default, and the direction of risk is SHRINKING it --
+                     * extracting a helper is the ordinary refactor here.
+                     * Such a refactor would take this file from
+                     * suppressed-clean to RED at a site nothing had flagged.
+                     *
+                     * Other stores in this file are latent too, and none of
+                     * them is suppressed.  greedy_order()'s two acc[] writes
+                     * and rebuild_chain()'s children[0] assignments sit
+                     * OUTSIDE insert_projections(), so no refactor of the
+                     * kind above can surface them.
+                     *
+                     * That argument does not reach the PROJECT rewrite lower
+                     * in this same function -- acc[new_acc++] and the
+                     * phys_names[] refill that follows it are inside
+                     * insert_projections() -- so for those two the reason is
+                     * different, and it is empirical rather than
+                     * structural: neither is reported at 100, at 140 or at
+                     * 200, whereas the store below is reported at 140 and at
+                     * 200.  Both are safe by the bounds already established
+                     * above -- new_acc only trails v across the same
+                     * [0, acc_count) walk, and the refill writes exactly
+                     * acc_count entries into an array of total_cols.
+                     * Suppressing a site that no measured configuration
+                     * reports would spend a baseline slot and buy nothing.
+                     *
+                     * The invariant is the same identical-predicate shape as
+                     * jpp_build_join_keys(): project_indices[] and
+                     * column_names[] both have live_count elements, and p is
+                     * incremented once per v in [0, acc_count) satisfying
+                     * `acc[v] && var_in_set(acc[v], needed, needed_count)`
+                     * -- character-identical to the predicate the live_count
+                     * loop just counted with, over the same acc[], needed[]
+                     * and needed_count, none of which is mutated in between.
+                     * So p reaches exactly live_count, and every store is at
+                     * an index p < live_count.
+                     */
                     uint32_t p = 0;
                     for (uint32_t v = 0; v < acc_count; v++) {
                         if (acc[v]
@@ -1024,6 +1179,7 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
                                     break;
                                 }
                             }
+                            // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
                             proj->project_indices[p] = phys_idx;
                             proj->column_names[p] = strdup_safe(acc[v]);
                             if (!proj->column_names[p]) {
@@ -1133,8 +1289,10 @@ next_level:
             uint32_t scount;
             char **svars = scan_vars(scans[i + 2], &scount);
             for (uint32_t j = 0; j < scount; j++) {
+                // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
                 phys_names[phys_count++] = svars[j];
                 if (svars[j] && !var_in_set(svars[j], acc, acc_count))
+                    // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
                     acc[acc_count++] = svars[j];
             }
         }


### PR DESCRIPTION
Clears the clang-tidy backlog for the two largest remaining entries and promotes both files to the allowlist. `wirelog/columnar/eval.c` (#1075, 11 diagnostics) and `wirelog/passes/jpp.c` (#1085, 10 diagnostics).

They are bundled because they are the only two units editing `clang-tidy-allowlist.txt` and `clang-tidy-backlog.txt`, so landing them separately would conflict on the registers.

## Commits

| | |
|---|---|
| `fix(columnar):` | eval.c — the four repair kinds behind #1075 |
| `chore(ci):` | promote eval.c |
| `refactor(jpp):` | jpp.c — repairs A/B plus eight suppressions |
| `chore(ci):` | promote jpp.c |

Each unit is split fix-then-promote so both halves are individually green: backlog files are never analysed, so the fix commit leaves the partition intact, and the promotion then flips a file that is already clean. The reverse order is red and breaks bisect.

## #1075 — `wirelog/columnar/eval.c`

Two post-eval skips read `if (result.rel && result.rel->nrows == 0)`. A NULL `result.rel` short-circuits that test and falls through to statements that dereference it — including `col_rel_new_like()`, which reads `src->ncols` with no check of its own, in another TU where clang-tidy cannot see it. Both guards now test `!result.rel || ...`.

Not reachable today and not testable: `eval_stack_pop()` yields `{NULL, ...}` only for an empty stack, which the `stack.top == 0` check above already excludes, and both functions are `static`. Rather than manufacture a test that only passes against a mutated library, the disposition is recorded in a comment at each site.

Also: two assignments hoisted out of `if` conditions, three redundant declarations and one dead store deleted, and a `|| !rel->name` guard removed to clear a `NonNullParamChecker` finding. That removal is the one behavioural-looking edit, and it is provably crash-neutral — the next loop over the same array is unconditionally reached and `strcmp`s `rel->name` with no guard at all, so any relation that would fault at the removed check faults some 37 lines later regardless. Independently, a NULL-named relation cannot enter a coordinator session: `session_add_rel()` dereferences `r->name` on every insertion.

## #1085 — `wirelog/passes/jpp.c`

All ten diagnostics are `clang-analyzer-security.ArrayBound`, and all ten are analyzer limitations. Three are repaired structurally rather than suppressed: `merge_vars()` now sizes `na + nb + 1` unconditionally, deleting the ternary the analyzer split on while preserving 3152079's "never ask calloc for zero" guarantee by construction; and `jpp_build_join_keys()` sizes both key arrays from `left_count`, which also turns out to be required rather than convenient, since duplicated left variables can push `key_count` above `right_count`.

The remaining seven get `NOLINTNEXTLINE` with the invariants written out, following the precedent in `ir/program.c`.

**An eighth suppression is added pre-emptively, and the NOLINT baseline records 7.** The reported set for this file does not drift with the path budget — it flips wholesale on whether `insert_projections()` is inlined, governed by `max-inlinable-size`. Bisected exactly: seven sites at ≤137, and at ≥138 those seven vanish while `proj->project_indices[p]` appears alone. `insert_projections()` is 138 CFG blocks, 38 above the default threshold, and the direction of risk is *shrinking* it — the five most recent commits on this branch are helper extractions. Without the eighth NOLINT an ordinary refactor takes this file from green to RED at a site nothing had ever flagged; verified by building that variant.

The baseline records 7 because the ratchet tracks what fires, not what is written. Recording 8 would grant this one file a permanent slot of headroom in which a genuine future suppression lands silently — the exact regression the baseline exists to catch. Verified directly against `check_nolint_baseline`: observed 8 → FAIL, observed 1 (the flipped configuration) → NOTICE, exit 0.

## Verification

The merged state — which neither branch's own CI exercises — was built and checked directly:

```
check-clang-tidy-ratchet: OK; 63 file(s) clean, 8 in backlog, 2 alternate configuration(s) checked
  exit 0, stderr empty (no NOTICE)
check-clang-tidy-backlog-monotonic: OK
meson test: Ok 285 / Fail 0 / Skipped 11
```

Registers partition the 71 `libwirelog.so` TUs exactly (63 + 8), both `LC_ALL=C`-sorted, no duplicates. Each unit was additionally validated on its own branch under `-Db_sanitize=address,undefined` with zero sanitizer reports, and `uncrustify --check` and editorconfig-checker v3.0.3 pass on every changed file.

## Found but not fixed

- #1139 — the left-spine depth walk disagrees with `collect_scans()` on a bushy JOIN tree, so a leaf is silently dropped from the pass's view. Not memory safety.
- #1140 — `eval.c`'s `full ? full : NULL` is a no-op that reads like a NULL guard, passed to a constructor that dereferences its template unconditionally on every path.

Closes #1075
Closes #1085
