### PR TITLE
docs: define PSIRT intake and 1.x support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,9 +389,19 @@ external-consumer audit.
 - [docs/ERROR_MODEL.md](docs/ERROR_MODEL.md) -- error reporting, logging safety, fork/signal constraints, and restart handoff
 - [CONTRIBUTING.md](CONTRIBUTING.md) -- development workflow, CI/CD, PR requirements
 - [SECURITY.md](SECURITY.md) -- vulnerability disclosure
+- [docs/SUPPORT_POLICY.md](docs/SUPPORT_POLICY.md) -- supported-version lifecycle and 1.x support window
 - [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) -- threat model, mbedTLS license stack, and export-control self-classification
 - [CLA.md](CLA.md) -- Contributor License Agreement (required for dual licensing)
 - API: [`wirelog/wirelog-easy.h`](wirelog/wirelog-easy.h) (simple) | [`wirelog/wirelog-advanced.h`](wirelog/wirelog-advanced.h) (advanced)
+
+### Supported versions
+
+| Version line | Status |
+|---|---|
+| Pre-1.0 `main` | Security fixes on `main` during development |
+| Maintained `1.x` | Supported through the lifecycle in [`docs/SUPPORT_POLICY.md`](docs/SUPPORT_POLICY.md) |
+| Older `1.x` after EOL | Upgrade recommended; no routine backport promise |
+| 0.x tags and unsupported branches | Not supported |
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,23 +2,21 @@
 
 ## Supported Versions
 
-wirelog is still pre-1.0. Security fixes are currently made on `main`; release
-branch backports begin with supported 1.x release lines.
-
-Full GA PSIRT/CVE-intake activation and the explicit 1.x support-window
-declaration are deferred and tracked by #753. Until that lands, the pre-1.0
-policy in this file remains unchanged.
+The canonical 1.x lifecycle policy is [docs/SUPPORT_POLICY.md](docs/SUPPORT_POLICY.md).
+This table is the security-response summary; it does not create a separate
+support promise.
 
 | Version line | Security support |
 | --- | --- |
 | `main` / current pre-1.0 development | Supported for security fixes on `main` |
-| Current supported 1.x line, when available | Supported |
-| Older supported 1.x lines, when explicitly announced | Backports considered under the policy below |
+| Maintained `1.x` line | Security fixes and applicable CVE backports under the support policy |
+| Older `1.x` line after its EOL | Not supported; upgrade and advisory guidance only |
 | Unmaintained 0.x release tags and unsupported old branches | Not supported |
 
 ## Reporting Vulnerabilities
 
-Please report suspected vulnerabilities privately by email:
+Please report suspected vulnerabilities privately by email to the PSIRT intake
+contact:
 
 **inquiry@cleverplant.com**
 
@@ -29,6 +27,20 @@ available.
 We aim to acknowledge vulnerability reports within a few business days. The
 acknowledgment target is not a guarantee of a fix timeline; investigation,
 coordination, and release timing depend on the issue and affected versions.
+
+Our response targets are:
+
+- acknowledge receipt within **3 business days**;
+- complete an initial severity/impact triage within **7 calendar days**;
+- provide an update at least every **14 calendar days** while an active report
+  is being investigated; and
+- target coordinated disclosure within **90 calendar days** of a confirmed
+  report, unless the reporter and maintainers agree to another date or an
+  active exploit requires an accelerated advisory.
+
+These are service targets, not guarantees. We may disclose earlier when users
+need an urgent mitigation, and we will not disclose sensitive details before a
+fix or mitigation is available unless required by law or an imminent threat.
 
 Commercial licensing, general support, feature requests, and ordinary bug
 reports are separate from vulnerability intake, even if they use the same
@@ -61,13 +73,16 @@ subject so we can route the report.
 
 ## CVE and Advisory Process
 
-After triage, we will classify the report, identify affected versions and build
+After triage, we classify the report, identify affected versions and build
 configurations, and prepare a fix or mitigation when warranted.
 
-For confirmed vulnerabilities with user impact, we will coordinate disclosure
-and request CVE assignment when warranted. The project does not claim CNA
-status. Advisory content may include affected versions, severity, impact,
-mitigations, fixed versions, and reporter credit when requested and appropriate.
+For a confirmed vulnerability that warrants a CVE, an authorized maintainer
+requests an ID through the applicable MITRE CVE request process or a GitHub
+CNA relationship available to the project. wirelog does **not** claim CNA
+status. The CVE ID is recorded in the advisory together with affected
+versions, severity, mitigations, fixed versions, and reporter credit when
+requested and appropriate. We do not invent or reserve a CVE number before it
+is assigned.
 
 ## Severity Rubric
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,10 +24,6 @@ Do not report security vulnerabilities through public GitHub issues,
 discussions, or pull requests. Public reports can expose users before a fix is
 available.
 
-We aim to acknowledge vulnerability reports within a few business days. The
-acknowledgment target is not a guarantee of a fix timeline; investigation,
-coordination, and release timing depend on the issue and affected versions.
-
 Our response targets are:
 
 - acknowledge receipt within **3 business days**;
@@ -37,6 +33,11 @@ Our response targets are:
 - target coordinated disclosure within **90 calendar days** of a confirmed
   report, unless the reporter and maintainers agree to another date or an
   active exploit requires an accelerated advisory.
+
+The fix or mitigation target is to provide a usable resolution by the
+coordinated-disclosure target where practical. If that is not possible, the
+maintainers will explain the reason and publish the next target in the
+14-calendar-day status update cycle.
 
 These are service targets, not guarantees. We may disclose earlier when users
 need an urgent mitigation, and we will not disclose sensitive details before a

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -378,7 +378,12 @@ changes that policy.
   `docs/SECURITY_MODEL.md` — see #715 (subprojects pin
   verification) and the per-release checklist tracked under
   v1.0.0 GA.
-- CVE intake / PSIRT activation per #698 B11.
+- Confirm the PSIRT contact and disclosure procedure in
+  [`SECURITY.md`](../SECURITY.md), including the advisory/CVE ID when one is
+  assigned.
+- Confirm the supported-version and EOL state in
+  [`docs/SUPPORT_POLICY.md`](SUPPORT_POLICY.md); record any 1.x backport
+  decision in the release notes.
 - Subprojects pin SHA256 verification at release time.
 
 ---
@@ -395,6 +400,8 @@ changes that policy.
 - #750 — GPG + cosign-keyless signing pipeline.
 - #751 — tarball + SHA256 + BLAKE3 + provenance attestation.
 - #752 — GA release-facing deferrals/readiness follow-up in release process docs.
-- #753 — GA PSIRT/CVE-intake activation and 1.x support-window declaration deferral.
+- #753 — GA PSIRT/CVE-intake policy and 1.x support-window declaration.
+- #1144 — operational verification of the PSIRT mailbox, CVE assignment path,
+  and published GPG key.
 - #744 — SBOM automation (SPDX + CycloneDX).
 - `stable-release-plan.md` §12.8 — GA exit conditions.

--- a/docs/SUPPORT_POLICY.md
+++ b/docs/SUPPORT_POLICY.md
@@ -1,0 +1,51 @@
+# wirelog Support Policy
+
+This is the canonical lifecycle policy for supported wirelog versions. It
+defines the support promise referenced by [`SECURITY.md`](../SECURITY.md) and
+the version summary in [`README.md`](../README.md).
+
+## Current status
+
+wirelog is currently pre-1.0. Security fixes are made on `main`. The 1.x
+window below begins when `1.0.0` is declared GA; it does not imply that a GA
+date has already been announced.
+
+## 1.x support window
+
+The maintained 1.x line is supported until the later of:
+
+1. 18 months after the `1.0.0` GA date; or
+2. 12 months after the `2.0.0` GA date, once `2.0.0` exists.
+
+If `2.0.0` has not shipped, the first condition remains the applicable
+minimum. The end of the window is the EOL date for the maintained 1.x line;
+the project will announce that date with the relevant release notice.
+
+There is no separate LTS designation for `1.0.x` at this time. A future LTS
+designation must name its maintenance line, end date, and backport scope in a
+release announcement and in this document.
+
+## What supported means
+
+During the support window, the maintained 1.x line receives:
+
+- fixes for confirmed security vulnerabilities and applicable CVE backports;
+- critical correctness, crash, and data-loss fixes when they can be applied
+  safely; and
+- documentation or build fixes needed to consume supported releases.
+
+New features are not added to a maintained 1.x line. A fix that cannot be
+backported safely is handled through an advisory with the affected versions,
+mitigation, and supported upgrade path.
+
+Only the maintained 1.x line is promised routine backports. Older 1.x lines
+may receive a security backport when the maintainer judges it safe and
+necessary, but they are not supported after their announced EOL. Unmaintained
+0.x tags and old branches receive no routine fixes.
+
+## End of life
+
+After EOL, users should upgrade to the current supported release. Security
+reports for an EOL line are still triaged, but the normal response is an
+advisory and an upgrade or mitigation recommendation rather than a guaranteed
+backport.

--- a/scripts/ci/check-support-policy.py
+++ b/scripts/ci/check-support-policy.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Validate the documented PSIRT and supported-version policy."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+
+def fail(message: str) -> None:
+    print(f"check-support-policy: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read(root: pathlib.Path, name: str) -> str:
+    path = root / name
+    if not path.is_file():
+        fail(f"missing {name}")
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> None:
+    root = pathlib.Path(__file__).resolve().parents[2]
+    security = read(root, "SECURITY.md")
+    readme = read(root, "README.md")
+    policy = read(root, "docs/SUPPORT_POLICY.md")
+    release = read(root, "docs/RELEASE_PROCESS.md")
+
+    required = {
+        "SECURITY.md": (
+            security,
+            "inquiry@cleverplant.com",
+            "3 business days",
+            "7 calendar days",
+            "14 calendar days",
+            "90 calendar days",
+            "fix or mitigation target",
+            "docs/SUPPORT_POLICY.md",
+            "CVE",
+        ),
+        "README.md": (readme, "Supported versions", "docs/SUPPORT_POLICY.md"),
+        "docs/SUPPORT_POLICY.md": (
+            policy,
+            "18 months",
+            "12 months",
+            "no separate LTS designation",
+            "What supported means",
+            "End of life",
+        ),
+        "docs/RELEASE_PROCESS.md": (
+            release,
+            "docs/SUPPORT_POLICY.md",
+            "#753",
+            "#1144",
+        ),
+    }
+    for name, (text, *needles) in required.items():
+        for needle in needles:
+            if needle not in text:
+                fail(f"{name}: missing required text {needle!r}")
+
+    if "#753" in security and "deferred" in security.lower():
+        fail("SECURITY.md still describes #753 as deferred")
+
+    for source in (root / "SECURITY.md", root / "README.md", root / "docs/RELEASE_PROCESS.md", root / "docs/SUPPORT_POLICY.md"):
+        text = source.read_text(encoding="utf-8")
+        for target in re.findall(r"\]\(([^)#]+)(?:#[^)]+)?\)", text):
+            if "://" in target:
+                continue
+            target_path = (source.parent / target).resolve()
+            if not target_path.is_file():
+                fail(f"{source.relative_to(root)}: broken link {target!r}")
+
+    print("check-support-policy: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -631,6 +631,12 @@ test('public_header_surface', py3,
             meson.project_source_root()],
      suite: 'abi')
 
+# Issue #753: PSIRT response targets and the supported-version policy must
+# remain present and internally linked. Static text scan; no build-tree input.
+test('support_policy', py3,
+     args: [meson.project_source_root() / 'scripts/ci/check-support-policy.py'],
+     suite: 'abi')
+
 # Issue #761: backstop CI lint preventing wl_*/WL_* prefixes from leaking
 # back onto public installed headers after the v0.40 API audit closes its
 # sibling rename issues (#762 / #756 / #757 / #758 / #759 / #760).


### PR DESCRIPTION
Closes #753

## Summary
- document PSIRT contact, response targets, fix/mitigation window, and CVE/advisory handling
- add canonical 1.x support-window and EOL policy
- link supported versions from README and release process
- track live operational verification in #1144

## Validation
- focused policy-content check
- git diff --check
- meson test -C build --print-errorlogs (284 passed, 11 skipped; existing SBOM snapshot mismatch for agent-workflows/pyrewire dependencies)

Unrelated dirty worktree files were excluded.