### PR TITLE
ci: verify tier-1 sanitizers on v1 tags

### DIFF
--- a/.github/workflows/tier1-sanitizers-tag.yml
+++ b/.github/workflows/tier1-sanitizers-tag.yml
@@ -1,0 +1,16 @@
+name: Tier-1 Sanitizers (tag)
+
+on:
+  push:
+    tags:
+      - 'v1.*'
+
+permissions:
+  contents: read
+
+jobs:
+  sanitizer-verification:
+    uses: ./.github/workflows/tier1-sanitizers.yml
+    with:
+      ref: ${{ github.ref_name }}
+      expected_sha: ${{ github.sha }}

--- a/.github/workflows/tier1-sanitizers.yml
+++ b/.github/workflows/tier1-sanitizers.yml
@@ -87,15 +87,27 @@ jobs:
 
   tsan:
     name: TSan / ${{ matrix.compiler }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - compiler: gcc
             cc: gcc
+            runs_on: ubuntu-latest
+            platform: linux
           - compiler: clang
             cc: clang
+            runs_on: ubuntu-latest
+            platform: linux
+          - compiler: arm64-gcc
+            cc: gcc
+            runs_on: ubuntu-24.04-arm
+            platform: linux
+          - compiler: apple-clang
+            cc: clang
+            runs_on: macos-latest
+            platform: macos
 
     steps:
       - name: Checkout exact tag commit
@@ -116,10 +128,14 @@ jobs:
 
       - name: Install TSan dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev
-          if [ "${{ matrix.compiler }}" = "clang" ]; then
-            sudo apt-get install -y clang
+          if [ "${{ matrix.platform }}" = "linux" ]; then
+            sudo apt-get update
+            sudo apt-get install -y meson ninja-build libmbedtls-dev
+            if [ "${{ matrix.compiler }}" = "clang" ]; then
+              sudo apt-get install -y clang
+            fi
+          else
+            brew install meson ninja mbedtls
           fi
 
       - name: Configure TSan

--- a/.github/workflows/tier1-sanitizers.yml
+++ b/.github/workflows/tier1-sanitizers.yml
@@ -1,0 +1,136 @@
+name: Tier-1 Sanitizers
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Exact tag or commit to verify.
+        required: true
+        type: string
+      expected_sha:
+        description: Commit SHA that the caller resolved for ref.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  asan-ubsan:
+    name: ASan/UBSan / ${{ matrix.os }} / ${{ matrix.compiler }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            compiler: gcc
+            cc: gcc
+          - os: ubuntu-latest
+            compiler: clang
+            cc: clang
+          - os: ubuntu-24.04-arm
+            compiler: gcc
+            cc: gcc
+          - os: macos-latest
+            compiler: apple-clang
+            cc: clang
+
+    steps:
+      - name: Checkout exact tag commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Verify checkout identity
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          test "$actual_sha" = "$EXPECTED_SHA"
+          echo "verified $actual_sha"
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build abigail-tools
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            sudo apt-get install -y clang
+          fi
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install meson ninja
+
+      - name: Configure ASan/UBSan
+        run: >
+          meson setup builddir-san
+          -Db_sanitize=address,undefined
+          -Db_lundef=false
+          -Dtests=true
+          --buildtype=debug
+        env:
+          CC: ${{ matrix.cc }}
+
+      - name: Build ASan/UBSan
+        run: meson compile -C builddir-san
+
+      - name: Test ASan/UBSan
+        run: meson test -C builddir-san --print-errorlogs
+        env:
+          ASAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1
+          UBSAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1
+
+  msan-fuzz:
+    name: MSan fuzz smoke / clang
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact tag commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Verify checkout identity
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          test "$actual_sha" = "$EXPECTED_SHA"
+          echo "verified $actual_sha"
+
+      - name: Install MSan fuzz dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang meson ninja-build
+
+      - name: Configure MSan fuzz build
+        env:
+          CC: clang
+        run: >
+          meson setup builddir-msan
+          -Denable_fuzz=true
+          -Db_sanitize=memory
+          -Db_lundef=false
+          -Dtests=true
+          --buildtype=debug
+
+      - name: Build MSan fuzz targets
+        run: |
+          meson compile -C builddir-msan \
+            parser_fuzz csv_reader_fuzz intern_fuzz compound_arena_fuzz
+
+      - name: Run MSan fuzz smoke tests
+        run: |
+          meson test -C builddir-msan \
+            parser_fuzz_smoke csv_reader_fuzz_smoke \
+            intern_fuzz_smoke compound_arena_fuzz_smoke \
+            --print-errorlogs
+        env:
+          MSAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1:exit_code=86

--- a/.github/workflows/tier1-sanitizers.yml
+++ b/.github/workflows/tier1-sanitizers.yml
@@ -85,6 +85,62 @@ jobs:
           ASAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1
           UBSAN_OPTIONS: abort_on_error=1:halt_on_error=1:print_stacktrace=1
 
+  tsan:
+    name: TSan / ${{ matrix.compiler }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - compiler: gcc
+            cc: gcc
+          - compiler: clang
+            cc: clang
+
+    steps:
+      - name: Checkout exact tag commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Verify checkout identity
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          test "$actual_sha" = "$EXPECTED_SHA"
+          echo "verified $actual_sha"
+
+      - name: Install TSan dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build libmbedtls-dev
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            sudo apt-get install -y clang
+          fi
+
+      - name: Configure TSan
+        run: |
+          meson setup builddir-tsan \
+            -Db_sanitize=thread \
+            -Db_lundef=false \
+            -Dthreads=posix \
+            -Dtests=true \
+            --buildtype=debug
+        env:
+          CC: ${{ matrix.cc }}
+
+      - name: Build TSan
+        run: meson compile -C builddir-tsan
+
+      - name: Test TSan
+        run: meson test -C builddir-tsan --print-errorlogs
+        env:
+          TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
+
   msan-fuzz:
     name: MSan fuzz smoke / clang
     runs-on: ubuntu-latest

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -209,7 +209,8 @@ When cutting a release tag:
    The [Tier-1 Sanitizers (tag) workflow](../.github/workflows/tier1-sanitizers-tag.yml)
    re-runs the sanitizer matrix on the tagged commit. It verifies the
    ASan/UBSan Linux GCC, Linux Clang, Linux ARM64 GCC, and macOS Apple
-   Clang legs plus the Linux GCC/Clang TSan legs and MSan
+   Clang legs plus the Linux GCC/Clang, Linux ARM64 GCC, and macOS Apple
+   Clang TSan legs and MSan
    parser/CSV/intern/compound-arena fuzz smoke targets required by #693.
    The `release-tag.yml` workflow (#749 B19,
    when shipped) will call this reusable workflow as part of the full

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -209,8 +209,9 @@ When cutting a release tag:
    The [Tier-1 Sanitizers (tag) workflow](../.github/workflows/tier1-sanitizers-tag.yml)
    re-runs the sanitizer matrix on the tagged commit. It verifies the
    ASan/UBSan Linux GCC, Linux Clang, Linux ARM64 GCC, and macOS Apple
-   Clang legs plus the MSan parser/CSV/intern/compound-arena fuzz smoke
-   targets required by #693. The `release-tag.yml` workflow (#749 B19,
+   Clang legs plus the Linux GCC/Clang TSan legs and MSan
+   parser/CSV/intern/compound-arena fuzz smoke targets required by #693.
+   The `release-tag.yml` workflow (#749 B19,
    when shipped) will call this reusable workflow as part of the full
    tagged-commit gate and block artifact publication on failure. It also produces the
    verification artefacts (signed tarball, checksums, SBOM, ABI

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -206,8 +206,13 @@ When cutting a release tag:
    git tag -s vX.Y.Z -m "wirelog X.Y.Z"
    git push origin vX.Y.Z
    ```
-   The `release-tag.yml` workflow (#749 B19, when shipped) re-runs
-   the full CI matrix on the tagged commit and produces the
+   The [Tier-1 Sanitizers (tag) workflow](../.github/workflows/tier1-sanitizers-tag.yml)
+   re-runs the sanitizer matrix on the tagged commit. It verifies the
+   ASan/UBSan Linux GCC, Linux Clang, Linux ARM64 GCC, and macOS Apple
+   Clang legs plus the MSan parser/CSV/intern/compound-arena fuzz smoke
+   targets required by #693. The `release-tag.yml` workflow (#749 B19,
+   when shipped) will call this reusable workflow as part of the full
+   tagged-commit gate and block artifact publication on failure. It also produces the
    verification artefacts (signed tarball, checksums, SBOM, ABI
    manifest, SLSA provenance attestation).
 5. **Author the GitHub Release**:

--- a/sbom/snapshot.txt
+++ b/sbom/snapshot.txt
@@ -1,5 +1,6 @@
 ./.github/workflows/lint-main.yml@UNKNOWN:NOASSERTION
 ./.github/workflows/lint-pr.yml@UNKNOWN:NOASSERTION
+./.github/workflows/tier1-sanitizers.yml@UNKNOWN:NOASSERTION
 actions/cache@v4:NOASSERTION
 actions/cache@v5:NOASSERTION
 actions/cache@v5:NOASSERTION
@@ -9,6 +10,7 @@ actions/cache@v5:NOASSERTION
 actions/cache@v5:NOASSERTION
 actions/checkout@v4.2.2:NOASSERTION
 actions/checkout@v4.2.2:NOASSERTION
+actions/checkout@v5:NOASSERTION
 actions/checkout@v5:NOASSERTION
 actions/checkout@v5:NOASSERTION
 actions/checkout@v5:NOASSERTION
@@ -55,6 +57,7 @@ actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
+agent-workflows@2.1.0:Apache-2.0
 codecov/codecov-action@v6:NOASSERTION
 docker/login-action@v4.2.0:NOASSERTION
 docker/setup-buildx-action@v4.0.0:NOASSERTION
@@ -68,6 +71,7 @@ mymindstorm/setup-emsdk@v14:NOASSERTION
 nanoarrow@0.8.0.9000:Apache
 nttld/setup-ndk@v1:NOASSERTION
 ossf/scorecard-action@v2.3.1:NOASSERTION
+pyrewire@1.0.4:Apache-2.0 OR GPL-3.0-or-later
 r-lib/actions/check-r-package@v2:NOASSERTION
 r-lib/actions/setup-pandoc@v2:NOASSERTION
 r-lib/actions/setup-pandoc@v2:NOASSERTION

--- a/sbom/snapshot.txt
+++ b/sbom/snapshot.txt
@@ -57,7 +57,6 @@ actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
 actions/upload-artifact@v7:NOASSERTION
-agent-workflows@2.1.0:Apache-2.0
 codecov/codecov-action@v6:NOASSERTION
 docker/login-action@v4.2.0:NOASSERTION
 docker/setup-buildx-action@v4.0.0:NOASSERTION
@@ -71,7 +70,6 @@ mymindstorm/setup-emsdk@v14:NOASSERTION
 nanoarrow@0.8.0.9000:Apache
 nttld/setup-ndk@v1:NOASSERTION
 ossf/scorecard-action@v2.3.1:NOASSERTION
-pyrewire@1.0.4:Apache-2.0 OR GPL-3.0-or-later
 r-lib/actions/check-r-package@v2:NOASSERTION
 r-lib/actions/setup-pandoc@v2:NOASSERTION
 r-lib/actions/setup-pandoc@v2:NOASSERTION


### PR DESCRIPTION
Closes #693

## Summary
- add reusable tagged-commit ASan/UBSan verification for Linux GCC, Linux Clang, Linux ARM64 GCC, and macOS Apple Clang
- add MSan smoke coverage for parser, CSV reader, intern, and compound arena fuzz targets
- verify every checkout matches the tag-resolved commit SHA
- document the boundary with the full release-tag workflow tracked by #749

## Validation
- actionlint on both new workflows
- Clang MemorySanitizer configure/build
- all four MSan fuzz smoke tests passed locally
- git diff --check

Unrelated dirty worktree files were excluded.