### PR TITLE
release: add deterministic source artifacts

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  attestations: write
 
 env:
   EXPECTED_SHA: ${{ github.sha }}
@@ -186,3 +188,40 @@ jobs:
           for result in "${statuses[@]}"; do
             test "$result" = success
           done
+
+  release-artifacts:
+    name: Tag / source artifacts and provenance
+    if: ${{ needs.release-verification.result == 'success' }}
+    needs: [release-verification]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ env.TAG_REF }}
+          fetch-depth: 0
+      - name: Verify tagged commit
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+      - name: Install checksum tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y b3sum
+      - name: Build deterministic source archive
+        run: scripts/release/make-tarball.sh dist "$TAG_REF"
+      - name: Attest source archive provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/wirelog-*.tar.gz
+      - name: Download provenance attestation bundle
+        run: |
+          (cd dist && gh attestation download "wirelog-"*.tar.gz \
+            --repo "$GITHUB_REPOSITORY" --limit 1)
+          attestation=$(find dist -maxdepth 1 -type f -name 'sha256*.jsonl' -print -quit)
+          test -n "$attestation"
+          mv "$attestation" "dist/wirelog-${TAG_REF#v}.intoto.jsonl"
+      - name: Upload source archive, checksums, and attestation
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-artifacts-${{ github.ref_name }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 35

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -232,6 +232,15 @@ When cutting a release tag:
    after the at-tag gate succeeds (publisher wiring is #1152): tarball +
    checksums + SBOM + ABI manifest + provenance file.
 
+   The repository-side deterministic archive and checksum recipe is
+   `scripts/release/make-tarball.sh <output-dir>`. It uses the tagged
+   `git archive` tree and `gzip -n`, then emits SHA256 and BLAKE3 files.
+   Downstream consumers can run
+   `scripts/release/verify-release.sh <tarball>` for checksum verification.
+   When the signed inputs are available, pass `--tag`, `--signature
+   <file> --certificate <file>`, and `--attestation <file>` to perform the
+   corresponding GPG, Sigstore blob, and GitHub provenance checks as well.
+
 ### Perf-suite graph gate
 
 The `sub_ms_graph_perf_gate` entry in `--suite perf` covers the Reach,

--- a/sbom/snapshot.txt
+++ b/sbom/snapshot.txt
@@ -1,6 +1,7 @@
 ./.github/workflows/lint-main.yml@UNKNOWN:NOASSERTION
 ./.github/workflows/lint-pr.yml@UNKNOWN:NOASSERTION
 ./.github/workflows/tier1-sanitizers.yml@UNKNOWN:NOASSERTION
+actions/attest-build-provenance@v2:NOASSERTION
 actions/cache@v4:NOASSERTION
 actions/cache@v5:NOASSERTION
 actions/cache@v5:NOASSERTION

--- a/scripts/release/make-tarball.sh
+++ b/scripts/release/make-tarball.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build the deterministic source archive and its public checksums.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+out_dir=${1:-"$repo_root/dist"}
+ref=${2:-HEAD}
+commit=$(git -C "$repo_root" rev-parse --verify "$ref^{commit}")
+version=$(git -C "$repo_root" show "$commit:meson.build" \
+  | sed -n "s/^  version: '\([^']*\)'.*/\1/p" | head -1)
+version=${version%%-*}
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "invalid project version: $version" >&2
+  exit 1
+}
+command -v sha256sum >/dev/null || { echo 'sha256sum is required' >&2; exit 1; }
+command -v b3sum >/dev/null || { echo 'b3sum is required' >&2; exit 1; }
+
+mkdir -p "$out_dir"
+archive="$out_dir/wirelog-$version.tar.gz"
+prefix="wirelog-$version/"
+
+# git-archive uses the explicitly supplied tag/ref tree and preserves only tracked source;
+# gzip -n removes wall-clock metadata so repeated builds are byte-identical.
+git -C "$repo_root" archive --format=tar --prefix="$prefix" "$commit" \
+  | gzip -n -9 > "$archive"
+(cd "$(dirname "$archive")" && sha256sum "$(basename "$archive")" > "$(basename "$archive").sha256")
+(cd "$(dirname "$archive")" && b3sum "$(basename "$archive")" > "$(basename "$archive").blake3")
+
+printf '%s\n' "$archive" "$archive.sha256" "$archive.blake3"

--- a/scripts/release/verify-release.sh
+++ b/scripts/release/verify-release.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Verify a release archive and its published checksums.
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 ARCHIVE [ARCHIVE.sha256] [ARCHIVE.blake3] [--tag TAG] [--signature FILE --certificate FILE] [--attestation FILE --repo OWNER/REPO]" >&2
+  exit 2
+}
+[[ $# -ge 1 ]] || usage
+archive=$1
+shift
+sha_file="$archive.sha256"
+b3_file="$archive.blake3"
+if [[ $# -gt 0 && "$1" != --* ]]; then sha_file=$1; shift; fi
+if [[ $# -gt 0 && "$1" != --* ]]; then b3_file=$1; shift; fi
+tag=''
+signature=''
+certificate=''
+attestation=''
+repository='semantic-reasoning/wirelog'
+identity_regexp='https://github.com/semantic-reasoning/wirelog/.github/workflows/'
+oidc_issuer='https://token.actions.githubusercontent.com'
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      [[ $# -ge 2 ]] || usage
+      tag=$2
+      shift 2
+      ;;
+    --signature)
+      [[ $# -ge 2 ]] || usage
+      signature=$2
+      shift 2
+      ;;
+    --certificate)
+      [[ $# -ge 2 ]] || usage
+      certificate=$2
+      shift 2
+      ;;
+    --attestation)
+      [[ $# -ge 2 ]] || usage
+      attestation=$2
+      shift 2
+      ;;
+    --repo)
+      [[ $# -ge 2 ]] || usage
+      repository=$2
+      shift 2
+      ;;
+    --identity-regexp)
+      [[ $# -ge 2 ]] || usage
+      identity_regexp=$2
+      shift 2
+      ;;
+    --oidc-issuer)
+      [[ $# -ge 2 ]] || usage
+      oidc_issuer=$2
+      shift 2
+      ;;
+    *) usage ;;
+  esac
+done
+[[ -f "$archive" && -f "$sha_file" && -f "$b3_file" ]] || {
+  echo 'archive and both checksum files are required' >&2
+  exit 1
+}
+
+command -v b3sum >/dev/null || { echo 'b3sum is required' >&2; exit 1; }
+archive_dir=$(cd "$(dirname "$archive")" && pwd)
+archive_name=$(basename "$archive")
+for manifest in "$sha_file" "$b3_file"; do
+  manifest_name=$(awk 'NF { print $2; exit }' "$manifest")
+  test "$manifest_name" = "$archive_name" || {
+    echo "checksum manifest does not name $archive_name: $manifest_name" >&2
+    exit 1
+  }
+done
+expected_sha=$(awk 'NF { print $1; exit }' "$sha_file")
+expected_b3=$(awk 'NF { print $1; exit }' "$b3_file")
+actual_sha=$(sha256sum "$archive" | awk '{print $1}')
+actual_b3=$(b3sum "$archive" | awk '{print $1}')
+test "$expected_sha" = "$actual_sha" || { echo "SHA256 mismatch for $archive" >&2; exit 1; }
+test "$expected_b3" = "$actual_b3" || { echo "BLAKE3 mismatch for $archive" >&2; exit 1; }
+
+echo "verified checksums for $archive"
+if [[ -n "$tag" ]]; then
+  git verify-tag "$tag"
+  tag_commit=$(git rev-parse --verify "$tag^{commit}")
+  archive_commit=$(gzip -dc "$archive" | git get-tar-commit-id)
+  test "$tag_commit" = "$archive_commit" || {
+    echo "tag $tag does not identify the archive source commit" >&2
+    exit 1
+  }
+  echo "verified annotated tag $tag"
+fi
+if [[ -n "$signature" || -n "$certificate" ]]; then
+  [[ -n "$signature" && -n "$certificate" ]] || {
+    echo '--signature and --certificate must be supplied together' >&2
+    exit 2
+  }
+  command -v cosign >/dev/null || { echo 'cosign is required for signature verification' >&2; exit 1; }
+  cosign verify-blob \
+    --certificate "$certificate" \
+    --certificate-identity-regexp "$identity_regexp" \
+    --certificate-oidc-issuer "$oidc_issuer" \
+    --signature "$signature" "$archive"
+  echo "verified Sigstore signature for $archive"
+fi
+if [[ -n "$attestation" ]]; then
+  command -v gh >/dev/null || { echo 'gh is required for attestation verification' >&2; exit 1; }
+  gh attestation verify "$archive" \
+    --repo "$repository" \
+    --bundle "$attestation" \
+    --predicate-type https://slsa.dev/provenance/v1 \
+    --cert-identity-regex "$identity_regexp" \
+    --cert-oidc-issuer "$oidc_issuer"
+  echo "verified SLSA provenance attestation $attestation"
+fi
+if [[ -z "$tag" && -z "$signature" && -z "$attestation" ]]; then
+  echo 'checksum verification complete; signed inputs were not supplied'
+fi


### PR DESCRIPTION
Closes #751

Adds the at-tag source artifact pipeline: deterministic git archive tarball, SHA256/BLAKE3 manifests, GitHub provenance JSONL download/upload, and downstream verification for checksums, signed tags, Sigstore blobs, and provenance bundles.

Validation: bash syntax, deterministic byte-identical archives, checksum verification including external manifests, actionlint, and diff checks.