### PR TITLE
fix(columnar): reject NULL relation templates and guard the base-case skip (#1140)

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2139,6 +2139,24 @@ test_affected_rules_exe = executable(
 test('affected_rules', test_affected_rules_exe)
 
 # ============================================================================
+# Issue #1140: Base-Case Skip NULL Template
+# ============================================================================
+
+test_base_skip_null_template_exe = executable(
+  'test_base_skip_null_template',
+  files('test_base_skip_null_template.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('base_skip_null_template', test_base_skip_null_template_exe)
+
+# ============================================================================
 # Phase 4: Per-Stratum Frontier Integration Tests (US-4-005)
 # ============================================================================
 

--- a/tests/test_base_skip_null_template.c
+++ b/tests/test_base_skip_null_template.c
@@ -1,0 +1,144 @@
+/*
+ * test_base_skip_null_template.c - Issue #1140 regression test
+ *
+ * col_eval_relation_plan()'s Issue #361/#367 base-case-EDB skip looks the
+ * base relation up with session_find_rel() and, before this fix, passed the
+ * result straight to col_rel_pool_new_like() behind the expression
+ * "full ? full : NULL" -- a no-op that reads like a NULL guard but yields
+ * "full" in both arms.  A miss therefore reached a constructor that
+ * dereferences its template.
+ *
+ * The lookup misses whenever the op's relation was never inserted into the
+ * session.  This test builds that state directly: a one-op VARIABLE plan on
+ * a relation that is not in plan->edb_relations, evaluated at iteration 1.
+ * No Datalog program is known to reach it -- the invariant that keeps it
+ * unreachable is accidental, resting on col_op_variable() returning ENOENT
+ * at iteration 0 in another translation unit -- so the call site is pinned
+ * here instead.
+ *
+ * Expected: the skip is abandoned and the op takes the normal path, which
+ * reports ENOENT for the missing relation.  Before the fix this returned
+ * ENOMEM (after Issue #1140's constructor hardening) or segfaulted (before
+ * it).
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/exec_plan.h"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name)                       \
+        do {                                 \
+            printf("  [TEST] %-60s ", name); \
+            fflush(stdout);                  \
+        } while (0)
+#define PASS              \
+        do {                  \
+            printf("PASS\n"); \
+            tests_passed++;   \
+        } while (0)
+#define FAIL(msg)                  \
+        do {                           \
+            printf("FAIL: %s\n", msg); \
+            tests_failed++;            \
+        } while (0)
+
+/*
+ * Evaluate a single-op VARIABLE plan whose relation is absent from the
+ * session, at iteration 1, with no delta present.  Those are exactly the
+ * conditions that enter the base-case skip and then miss the lookup:
+ *
+ *   - op is WL_PLAN_OP_VARIABLE with delta_mode WL_DELTA_AUTO
+ *   - current_iteration > 0
+ *   - the next op is not a JOIN (there is no next op)
+ *   - "$d$ghost" is absent, so the delta guard passes
+ *   - "ghost" is not any JOIN's right_relation
+ *   - "ghost" itself is absent, because plan.edb_count is 0
+ */
+static void
+test_base_skip_missing_relation_reports_enoent(void)
+{
+    TEST("base-case skip: missing relation reports ENOENT, does not fault");
+
+    wl_plan_op_t op;
+    memset(&op, 0, sizeof(op));
+    op.op = WL_PLAN_OP_VARIABLE;
+    op.relation_name = "ghost";
+    op.delta_mode = WL_DELTA_AUTO;
+
+    wl_plan_relation_t rel;
+    memset(&rel, 0, sizeof(rel));
+    rel.name = "idb";
+    rel.ops = &op;
+    rel.op_count = 1;
+
+    wl_plan_stratum_t stratum;
+    memset(&stratum, 0, sizeof(stratum));
+    stratum.stratum_id = 0;
+    stratum.is_recursive = false;
+    stratum.relations = &rel;
+    stratum.relation_count = 1;
+
+    wl_plan_t plan;
+    memset(&plan, 0, sizeof(plan));
+    plan.strata = &stratum;
+    plan.stratum_count = 1;
+    /* plan.edb_count stays 0: nothing pre-registers "ghost". */
+
+    wl_session_t *sess = NULL;
+    const wl_compute_backend_t *backend = wl_backend_columnar();
+    if (backend->session_create(&plan, 1, &sess) != 0 || !sess) {
+        FAIL("session_create failed");
+        return;
+    }
+
+    wl_col_session_t *cs = COL_SESSION(sess);
+    cs->current_iteration = 1;
+
+    eval_stack_t stack;
+    eval_stack_init(&stack);
+    int rc = col_eval_relation_plan(&rel, &stack, cs);
+    /* The abandoned optimization must not have pushed a $base_skip
+     * relation: the op takes the normal path and fails before pushing. */
+    bool pushed_nothing = (stack.top == 0);
+    eval_stack_drain(&stack);
+    backend->session_destroy(sess);
+
+    if (rc == ENOENT && pushed_nothing)
+        PASS;
+    else if (rc == ENOENT)
+        FAIL("ENOENT but something was left on the eval stack");
+    else if (rc == ENOMEM)
+        FAIL("got ENOMEM: the skip still built an empty relation from a "
+            "missing template");
+    else {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "unexpected rc=%d (%s)", rc, strerror(rc));
+        FAIL(buf);
+    }
+}
+
+int
+main(void)
+{
+    printf("\n=== Base-Case Skip NULL Template Tests (Issue #1140) ===\n\n");
+
+    test_base_skip_missing_relation_reports_enoent();
+
+    printf("\n=== Results: %d/%d passed ===\n\n", tests_passed,
+        tests_passed + tests_failed);
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/tests/test_partition.c
+++ b/tests/test_partition.c
@@ -1345,6 +1345,93 @@ test_exchange_graph_mismatch_falls_back_both_sides(void)
     return 0;
 }
 
+/*
+ * test_new_like_rejects_null_template:
+ * Issue #1140: col_rel_new_like() dereferences its src template
+ * unconditionally (src->ncols). A caller that obtained the template from a
+ * lookup which can miss therefore faults instead of seeing an allocation
+ * failure it already checks for. Rejecting NULL makes the existing
+ * "if (!result)" checks at every call site sufficient.
+ */
+static int
+test_new_like_rejects_null_template(void)
+{
+    TEST("col_rel_new_like rejects a NULL template");
+
+    if (col_rel_new_like("clone", NULL) != NULL) {
+        FAIL("expected NULL for a NULL src");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+/*
+ * test_pool_new_like_rejects_null_template_no_pool:
+ * Issue #1140: the rejection sits above the !pool branch, so it holds when
+ * no pool is supplied. This pins that the malloc fallback is never entered
+ * with a NULL template -- not that the fallback rejects one itself.
+ */
+static int
+test_pool_new_like_rejects_null_template_no_pool(void)
+{
+    TEST("col_rel_pool_new_like(NULL pool) rejects a NULL template");
+
+    if (col_rel_pool_new_like(NULL, "clone", NULL) != NULL) {
+        FAIL("expected NULL for a NULL like");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+/*
+ * test_pool_new_like_rejects_null_template_keeps_slot:
+ * Issue #1140: the NULL-template rejection must happen before the pool slot
+ * is taken, otherwise every rejected call burns a slot. Asserts the
+ * rejection and pool->slot_used on both sides of it -- the return value
+ * alone cannot witness a burned slot (see the inline comment below).
+ */
+static int
+test_pool_new_like_rejects_null_template_keeps_slot(void)
+{
+    TEST("col_rel_pool_new_like rejects NULL template without taking a slot");
+
+    delta_pool_t *pool = delta_pool_create(4, sizeof(col_rel_t), 64 * 1024);
+    if (!pool) {
+        FAIL("delta_pool_create");
+        return 1;
+    }
+    col_rel_t *src = col_rel_new_auto("src", 2);
+    if (!src) {
+        FAIL("alloc");
+        delta_pool_destroy(pool);
+        return 1;
+    }
+
+    /* slot_used is asserted directly: a burned slot is not observable
+     * through the return value, because an exhausted pool still falls back
+     * to col_rel_new_like() and returns a valid relation. */
+    int ok = (col_rel_pool_new_like(pool, "clone", NULL) == NULL)
+        && (pool->slot_used == 0);
+
+    col_rel_t *good = col_rel_pool_new_like(pool, "good", src);
+    if (!good || good->ncols != 2 || pool->slot_used != 1)
+        ok = 0;
+
+    if (good)
+        col_rel_destroy(good);
+    col_rel_destroy(src);
+    delta_pool_destroy(pool);
+
+    if (!ok) {
+        FAIL("NULL template not rejected, or the pool lost a slot");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
 /* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
@@ -1378,6 +1465,11 @@ main(void)
     test_exchange_w1_noop();
     test_col_rel_new_like_inherits_graph_flag();
     test_exchange_graph_mismatch_falls_back_both_sides();
+
+    /* Issue #1140: NULL template rejection in the *_like constructors */
+    test_new_like_rejects_null_template();
+    test_pool_new_like_rejects_null_template_no_pool();
+    test_pool_new_like_rejects_null_template_keeps_slot();
 
     printf("\nPassed: %d/%d\n", tests_passed, tests_run);
     printf("Failed: %d/%d\n", tests_failed, tests_run);

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1979,10 +1979,11 @@ tdd_worker_subpass_fn(void *arg)
          * check saw it first.  (diff.c and join.c return EINVAL on a NULL
          * pop because they pop without a prior emptiness check.)
          *
-         * Three dereferences follow otherwise: col_rel_new_like() below
-         * reads src->ncols unguarded, which clang-tidy cannot see because it
-         * is cross-TU, and ->name / ->ncols on the non-outbound path.
-         * col_rel_destroy(NULL) is a no-op, so the continue leaks nothing. */
+         * Two dereferences follow otherwise: ->name / ->ncols on the
+         * non-outbound path.  col_rel_new_like() below no longer needs one:
+         * since Issue #1140 it rejects a NULL src and returns NULL, which
+         * its caller already checks.  col_rel_destroy(NULL) is a no-op, so
+         * the continue leaks nothing. */
         if (!result.rel || result.rel->nrows == 0) {
             if (result.owned)
                 col_rel_destroy(result.rel);

--- a/wirelog/columnar/eval_plan.c
+++ b/wirelog/columnar/eval_plan.c
@@ -99,14 +99,30 @@ col_eval_relation_plan(const wl_plan_relation_t *rplan, eval_stack_t *stack,
                      * requires. Skipping MAP would leave the wrong ncols
                      * on the stack. */
                     col_rel_t *full = session_find_rel(sess, op->relation_name);
+                    /* Issue #1140: the lookup can miss -- session_find_rel()
+                     * returns NULL for a relation that was never inserted.
+                     * Abandon the optimization rather than build $base_skip
+                     * from a template that is not there: falling through to
+                     * col_op_variable() gives the missing relation its normal
+                     * ENOENT disposition, so one state does not get two
+                     * answers depending on which check saw it first.  The
+                     * previous "full ? full : NULL" argument guarded nothing
+                     * -- both arms yield full. */
+                    if (!full)
+                        goto normal_eval;
                     col_rel_t *empty = col_rel_pool_new_like(
-                        sess->delta_pool, "$base_skip", full ? full : NULL);
-                    if (!empty) {
-                        rc = ENOMEM; break;
-                    }
+                        sess->delta_pool, "$base_skip", full);
+                    /* Issue #1140: these exits return rather than break.  A
+                     * break here leaves the for loop, not a switch, and the
+                     * function then falls through to "return 0" -- reporting
+                     * success with nothing pushed on the stack, which the
+                     * caller reads as a rule that produced no rows. */
+                    if (!empty)
+                        return ENOMEM;
                     rc = eval_stack_push(stack, empty, true);
                     if (rc != 0) {
-                        col_rel_destroy(empty); break;
+                        col_rel_destroy(empty);
+                        return rc;
                     }
                     continue;
                 }

--- a/wirelog/columnar/filter.c
+++ b/wirelog/columnar/filter.c
@@ -870,7 +870,9 @@ fill_filtered_rel(const uint8_t *buf, uint32_t bsz, col_rel_t *rel,
  * Apply a serialized filter expression to a relation, returning a new
  * pool-allocated relation containing only the passing rows.
  * The returned relation is owned by pool and freed when the pool resets.
- * Returns NULL on allocation failure.
+ * Returns NULL on allocation failure, and (Issue #1140) also when rel is
+ * NULL, since col_rel_pool_new_like() now rejects a NULL template instead
+ * of dereferencing it.
  */
 col_rel_t *
 wl_columnar_filter_apply_right_filter(const wl_plan_expr_buffer_t *fexpr,
@@ -914,7 +916,9 @@ wl_columnar_filter_fnv1a_hash(const uint8_t *buf, uint32_t len)
  *
  * If the source grew, the stale entry is rebuilt in-place.  If no entry
  * exists, one is created.  On any allocation failure the function returns
- * NULL (caller handles ENOMEM).
+ * NULL (caller handles ENOMEM).  Unlike the uncached variant, @rel must be
+ * non-NULL: it is dereferenced here before any constructor sees it, so the
+ * Issue #1140 rejection in col_rel_pool_new_like() does not cover it.
  *
  * The returned pointer is valid until the cache entry is evicted (i.e., until
  * source_nrows changes or the session is destroyed).  Callers that hold it

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -850,10 +850,17 @@ col_rel_new_auto(const char *name, uint32_t ncols)
     return r;
 }
 
-/* Helper: create owned relation copying col_names from src. */
+/* Helper: create owned relation copying col_names from src.
+ *
+ * Issue #1140: a NULL src is rejected rather than dereferenced.  Several
+ * callers obtain their template from a lookup that can miss and check only
+ * the returned relation, so failing here is what makes that check
+ * sufficient. */
 col_rel_t *
 col_rel_new_like(const char *name, const col_rel_t *src)
 {
+    if (!src)
+        return NULL;
     col_rel_t *r = NULL;
     if (col_rel_alloc(&r, name) != 0)
         return NULL;
@@ -892,6 +899,10 @@ col_rel_t *
 col_rel_pool_new_like(delta_pool_t *pool, const char *name,
     const col_rel_t *like)
 {
+    /* Issue #1140: reject before delta_pool_alloc_slot() so a rejected call
+     * does not burn a pool slot. */
+    if (!like)
+        return NULL;
     if (!pool)
         return col_rel_new_like(name, like); /* Fallback to malloc */
     col_rel_t *r = (col_rel_t *)delta_pool_alloc_slot(pool);


### PR DESCRIPTION
Closes #1140.

## What the issue reported

`col_eval_relation_plan()`'s Issue #361/#367 base-case-EDB skip passed a
possibly-NULL relation to `col_rel_pool_new_like()` as `full ? full : NULL` —
an expression that reads like a NULL guard but yields `full` in both arms.
The constructor dereferences its template unconditionally, so a lookup miss
was a NULL dereference rather than the allocation failure the site's
`if (!empty)` check was written for.

The statement had moved since the issue was filed: it now lives in
`wirelog/columnar/eval_plan.c`, not `eval.c`, following the #1086 split.

## Reachability

No end-to-end Datalog reproducer was found, and the PR does not claim one.
`wirelog/ir/program.c` never registers rule *body* atoms as relations, so a
body atom with no `.decl`, no facts and no producing rule is absent from the
session — the miss is possible in principle. What keeps it unreachable is
that `col_op_variable()` returns `ENOENT` at iteration 0 and aborts
evaluation before iteration 1 can run the skip. That invariant lives in
another translation unit and is stated nowhere, so the call site is pinned
directly by a unit test instead.

## Commit 1 — reject a NULL template in the `*_like` constructors

`col_rel_new_like()` read `src->ncols` and `col_rel_pool_new_like()` read
`like->ncols` with no check. Both now return NULL for a NULL template, which
is what makes the existing `if (!result)` check at every call site
sufficient. The pool constructor rejects before `delta_pool_alloc_slot()`, so
a rejected call does not burn a slot, and before the `!pool` branch, so the
malloc fallback is never entered with a NULL template either.

Every call site of the two constructors was audited: all check the returned
pointer and none passes a NULL template today, so this is behaviour-preserving.
`wl_columnar_filter_apply_right_filter()` is the one that takes its relation
from an external caller unchecked; its doc block now records the NULL return.
The cached variant dereferences `rel->nrows` before any constructor sees it,
so the rejection does not cover it — its non-NULL precondition is documented
rather than enforced, since both of its callers pass an already-resolved
relation.

A comment in `eval.c` documenting an unguarded cross-TU `src->ncols`
dereference is no longer true and is corrected.

## Commit 2 — guard the base-case skip, and a second defect it exposed

The skip is now abandoned when the lookup misses: the op falls through to the
normal path, where `col_op_variable()` gives a missing relation its usual
`ENOENT`, so one state keeps one disposition.

Writing the regression test RED-first exposed a second defect at the same
site. The test asserted `ENOENT`, expected `ENOMEM` as its RED signal, and
observed **`rc = 0`**. The two exits below the constructor call used `break`,
but the enclosing construct there is the operator `for` loop, not a switch —
the switch does not open until after the `normal_eval` label. Breaking out of
the loop skipped the loop tail's `if (rc != 0) return rc;` and fell through to
the function's trailing `return 0`, so the site reported **success with
nothing pushed on the eval stack**, which callers read as a rule that produced
no rows. Both exits now `return`.

So the premise of the issue — and of the `if (!empty)` check it points at —
that this site reported allocation failure was itself false. Under the
K-Fusion entry points the old `break` surfaced as `EINVAL` from the caller's
empty-stack check rather than silently; the true code now propagates there
too. Those entries pass a fused branch's op list, which narrows the
`used_in_join` scan and makes the skip fire more often, so the guard matters
more on that path, not less.

## Tests

- `tests/test_partition.c`: three cases covering the malloc constructor, the
  pool constructor with no pool, and the pool constructor with a real pool.
  The last asserts `pool->slot_used` on both sides of the rejection, because
  the return value cannot witness a burned slot — an exhausted pool still
  falls back to `col_rel_new_like()` and returns a valid relation. Verified by
  mutation: moving the guard below `delta_pool_alloc_slot()` makes it fail.
  Before commit 1 these cases segfault rather than fail an assertion.
- `tests/test_base_skip_null_template.c` (new): drives `col_eval_relation_plan()`
  directly with a one-op VARIABLE plan on a relation absent from the session at
  iteration 1, and asserts `ENOENT` with an empty eval stack.

`meson test -C build` → **287 Ok, 0 Fail, 11 Skipped**. `--suite tidy` → 4/4 OK
(`relation.c`, `eval.c` and `filter.c` are all on the clang-tidy allowlist).

## Known gap

The `break`→`return` fix is pinned by no test. The new test discriminates only
the missing-relation guard; the remaining exit needs an injectable allocation
failure, and the tree has no fault-injection harness. Stated in the commit
message rather than implied to be covered.

## Out of scope

`wirelog/ir/program.c` not registering undeclared body atoms — closing that
hole would change user-visible program validation and deserves its own issue.

https://claude.ai/code/session_01XXFR28bZDJWBSH1xfugfNh