### PR TITLE
release: add v0.30 upgrade matrix

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -161,6 +161,34 @@ jobs:
           meson compile -C build-mbedtls
           meson test -C build-mbedtls cryptographic_hashes --print-errorlogs
 
+  upgrade:
+    name: Tag / 0.30.0 upgrade matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ env.TAG_REF }}
+          fetch-depth: 0
+      - name: Verify tagged candidate and baseline tag
+        run: |
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+          git rev-parse --verify 'v0.30.0^{commit}'
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y meson ninja-build
+      - name: Run synthetic consumer upgrade matrix
+        env:
+          UPGRADE_MATRIX_LOG_DIR: upgrade-evidence
+        run: scripts/upgrade/run-upgrade-matrix.sh --old-ref v0.30.0 --candidate-ref "$TAG_REF"
+      - name: Upload upgrade evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: upgrade-matrix-${{ github.ref_name }}
+          path: upgrade-evidence/
+          if-no-files-found: error
+          retention-days: 35
+
   sanitizers:
     name: Tag / Tier-1 sanitizers
     # Meson has no separate asan/tsan suite: the reusable workflow runs the
@@ -175,7 +203,7 @@ jobs:
   release-verification:
     name: Tag / release verification gate
     if: ${{ always() }}
-    needs: [default, abi, perf, fuzz, mbedtls, sanitizers]
+    needs: [default, abi, perf, fuzz, mbedtls, sanitizers, upgrade]
     runs-on: ubuntu-latest
     steps:
       - name: Require every tagged verification job
@@ -184,7 +212,7 @@ jobs:
         run: |
           echo "verification results: $RESULTS"
           IFS=',' read -ra statuses <<< "$RESULTS"
-          test "${#statuses[@]}" -eq 6
+          test "${#statuses[@]}" -eq 7
           for result in "${statuses[@]}"; do
             test "$result" = success
           done

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  attestations: write
 
 env:
   EXPECTED_SHA: ${{ github.sha }}
@@ -186,3 +188,40 @@ jobs:
           for result in "${statuses[@]}"; do
             test "$result" = success
           done
+
+  release-artifacts:
+    name: Tag / source artifacts and provenance
+    if: ${{ needs.release-verification.result == 'success' }}
+    needs: [release-verification]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ env.TAG_REF }}
+          fetch-depth: 0
+      - name: Verify tagged commit
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+      - name: Install checksum tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y b3sum
+      - name: Build deterministic source archive
+        run: scripts/release/make-tarball.sh dist "$TAG_REF"
+      - name: Attest source archive provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: dist/wirelog-*.tar.gz
+      - name: Download provenance attestation bundle
+        run: |
+          (cd dist && gh attestation download "wirelog-"*.tar.gz \
+            --repo "$GITHUB_REPOSITORY" --limit 1)
+          attestation=$(find dist -maxdepth 1 -type f -name 'sha256*.jsonl' -print -quit)
+          test -n "$attestation"
+          mv "$attestation" "dist/wirelog-${TAG_REF#v}.intoto.jsonl"
+      - name: Upload source archive, checksums, and attestation
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-artifacts-${{ github.ref_name }}
+          path: dist/
+          if-no-files-found: error
+          retention-days: 35

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -232,6 +232,15 @@ When cutting a release tag:
    after the at-tag gate succeeds (publisher wiring is #1152): tarball +
    checksums + SBOM + ABI manifest + provenance file.
 
+   The repository-side deterministic archive and checksum recipe is
+   `scripts/release/make-tarball.sh <output-dir>`. It uses the tagged
+   `git archive` tree and `gzip -n`, then emits SHA256 and BLAKE3 files.
+   Downstream consumers can run
+   `scripts/release/verify-release.sh <tarball>` for checksum verification.
+   When the signed inputs are available, pass `--tag`, `--signature
+   <file> --certificate <file>`, and `--attestation <file>` to perform the
+   corresponding GPG, Sigstore blob, and GitHub provenance checks as well.
+
 ### Perf-suite graph gate
 
 The `sub_ms_graph_perf_gate` entry in `--suite perf` covers the Reach,

--- a/docs/UPGRADE_MATRIX.md
+++ b/docs/UPGRADE_MATRIX.md
@@ -1,0 +1,33 @@
+# 0.30.0 → 1.0 upgrade matrix
+
+The release-tag workflow runs `scripts/upgrade/run-upgrade-matrix.sh` before
+the aggregate release gate. It extracts the exact `v0.30.0` commit and the
+candidate tag into isolated trees, builds both with Meson, and compiles three
+representative consumers against each installed header/library set.
+
+The matrix deliberately keeps legacy and migrated source files separate where
+the public migration requires a rename:
+
+| Consumer | v0.30.0 source | Candidate source | Contract |
+| --- | --- | --- | --- |
+| easy | `tests/upgrade/easy/legacy.c` (`wl_easy_*`) | `tests/upgrade/easy/migrated.c` (`wirelog_easy_*`) | identical sorted `reach` tuples |
+| session | `tests/upgrade/session/legacy.c` (legacy easy facade) | `tests/upgrade/session/migrated.c` (`wirelog_session_*`) | identical sorted `reach` tuples |
+| executor | `tests/upgrade/executor/consumer.c` | same source | candidate runs; v0.30.0 is `EXPECTED_UNSUPPORTED` |
+
+The candidate is tested from its checked-out git tree because the release
+tarball is created from that same tree only after the verification gate. This
+avoids a dependency cycle while preserving the source-tree identity of the
+artifact. The runner pins both commit IDs, uses isolated temporary prefixes,
+sets runtime library search paths, and stores compiler/output evidence in
+`UPGRADE_MATRIX_LOG_DIR` when supplied.
+
+The six full downstream workload rebuilds requested by #752 are not implied by
+this synthetic matrix. They require a provisioned runner, pinned datasets,
+and workload-specific tuple/iteration oracles; that work is tracked in #1156.
+
+The executor row is also not a compatibility pass: v0.30.0 declares the
+executor/result functions but does not export their implementations. The
+runner records the exact missing-symbol inventory and linker diagnostic in
+`executor-status.json` and `executor-old-link.log`; the compatibility policy
+and the decision whether a shim is required are tracked in #1157. #752 stays
+open until that policy is resolved.

--- a/sbom/snapshot.txt
+++ b/sbom/snapshot.txt
@@ -1,6 +1,7 @@
 ./.github/workflows/lint-main.yml@UNKNOWN:NOASSERTION
 ./.github/workflows/lint-pr.yml@UNKNOWN:NOASSERTION
 ./.github/workflows/tier1-sanitizers.yml@UNKNOWN:NOASSERTION
+actions/attest-build-provenance@v2:NOASSERTION
 actions/cache@v4:NOASSERTION
 actions/cache@v5:NOASSERTION
 actions/cache@v5:NOASSERTION

--- a/scripts/release/make-tarball.sh
+++ b/scripts/release/make-tarball.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build the deterministic source archive and its public checksums.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+out_dir=${1:-"$repo_root/dist"}
+ref=${2:-HEAD}
+commit=$(git -C "$repo_root" rev-parse --verify "$ref^{commit}")
+version=$(git -C "$repo_root" show "$commit:meson.build" \
+  | sed -n "s/^  version: '\([^']*\)'.*/\1/p" | head -1)
+version=${version%%-*}
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "invalid project version: $version" >&2
+  exit 1
+}
+command -v sha256sum >/dev/null || { echo 'sha256sum is required' >&2; exit 1; }
+command -v b3sum >/dev/null || { echo 'b3sum is required' >&2; exit 1; }
+
+mkdir -p "$out_dir"
+archive="$out_dir/wirelog-$version.tar.gz"
+prefix="wirelog-$version/"
+
+# git-archive uses the explicitly supplied tag/ref tree and preserves only tracked source;
+# gzip -n removes wall-clock metadata so repeated builds are byte-identical.
+git -C "$repo_root" archive --format=tar --prefix="$prefix" "$commit" \
+  | gzip -n -9 > "$archive"
+(cd "$(dirname "$archive")" && sha256sum "$(basename "$archive")" > "$(basename "$archive").sha256")
+(cd "$(dirname "$archive")" && b3sum "$(basename "$archive")" > "$(basename "$archive").blake3")
+
+printf '%s\n' "$archive" "$archive.sha256" "$archive.blake3"

--- a/scripts/release/verify-release.sh
+++ b/scripts/release/verify-release.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Verify a release archive and its published checksums.
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 ARCHIVE [ARCHIVE.sha256] [ARCHIVE.blake3] [--tag TAG] [--signature FILE --certificate FILE] [--attestation FILE --repo OWNER/REPO]" >&2
+  exit 2
+}
+[[ $# -ge 1 ]] || usage
+archive=$1
+shift
+sha_file="$archive.sha256"
+b3_file="$archive.blake3"
+if [[ $# -gt 0 && "$1" != --* ]]; then sha_file=$1; shift; fi
+if [[ $# -gt 0 && "$1" != --* ]]; then b3_file=$1; shift; fi
+tag=''
+signature=''
+certificate=''
+attestation=''
+repository='semantic-reasoning/wirelog'
+identity_regexp='https://github.com/semantic-reasoning/wirelog/.github/workflows/'
+oidc_issuer='https://token.actions.githubusercontent.com'
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      [[ $# -ge 2 ]] || usage
+      tag=$2
+      shift 2
+      ;;
+    --signature)
+      [[ $# -ge 2 ]] || usage
+      signature=$2
+      shift 2
+      ;;
+    --certificate)
+      [[ $# -ge 2 ]] || usage
+      certificate=$2
+      shift 2
+      ;;
+    --attestation)
+      [[ $# -ge 2 ]] || usage
+      attestation=$2
+      shift 2
+      ;;
+    --repo)
+      [[ $# -ge 2 ]] || usage
+      repository=$2
+      shift 2
+      ;;
+    --identity-regexp)
+      [[ $# -ge 2 ]] || usage
+      identity_regexp=$2
+      shift 2
+      ;;
+    --oidc-issuer)
+      [[ $# -ge 2 ]] || usage
+      oidc_issuer=$2
+      shift 2
+      ;;
+    *) usage ;;
+  esac
+done
+[[ -f "$archive" && -f "$sha_file" && -f "$b3_file" ]] || {
+  echo 'archive and both checksum files are required' >&2
+  exit 1
+}
+
+command -v b3sum >/dev/null || { echo 'b3sum is required' >&2; exit 1; }
+archive_dir=$(cd "$(dirname "$archive")" && pwd)
+archive_name=$(basename "$archive")
+for manifest in "$sha_file" "$b3_file"; do
+  manifest_name=$(awk 'NF { print $2; exit }' "$manifest")
+  test "$manifest_name" = "$archive_name" || {
+    echo "checksum manifest does not name $archive_name: $manifest_name" >&2
+    exit 1
+  }
+done
+expected_sha=$(awk 'NF { print $1; exit }' "$sha_file")
+expected_b3=$(awk 'NF { print $1; exit }' "$b3_file")
+actual_sha=$(sha256sum "$archive" | awk '{print $1}')
+actual_b3=$(b3sum "$archive" | awk '{print $1}')
+test "$expected_sha" = "$actual_sha" || { echo "SHA256 mismatch for $archive" >&2; exit 1; }
+test "$expected_b3" = "$actual_b3" || { echo "BLAKE3 mismatch for $archive" >&2; exit 1; }
+
+echo "verified checksums for $archive"
+if [[ -n "$tag" ]]; then
+  git verify-tag "$tag"
+  tag_commit=$(git rev-parse --verify "$tag^{commit}")
+  archive_commit=$(gzip -dc "$archive" | git get-tar-commit-id)
+  test "$tag_commit" = "$archive_commit" || {
+    echo "tag $tag does not identify the archive source commit" >&2
+    exit 1
+  }
+  echo "verified annotated tag $tag"
+fi
+if [[ -n "$signature" || -n "$certificate" ]]; then
+  [[ -n "$signature" && -n "$certificate" ]] || {
+    echo '--signature and --certificate must be supplied together' >&2
+    exit 2
+  }
+  command -v cosign >/dev/null || { echo 'cosign is required for signature verification' >&2; exit 1; }
+  cosign verify-blob \
+    --certificate "$certificate" \
+    --certificate-identity-regexp "$identity_regexp" \
+    --certificate-oidc-issuer "$oidc_issuer" \
+    --signature "$signature" "$archive"
+  echo "verified Sigstore signature for $archive"
+fi
+if [[ -n "$attestation" ]]; then
+  command -v gh >/dev/null || { echo 'gh is required for attestation verification' >&2; exit 1; }
+  gh attestation verify "$archive" \
+    --repo "$repository" \
+    --bundle "$attestation" \
+    --predicate-type https://slsa.dev/provenance/v1 \
+    --cert-identity-regex "$identity_regexp" \
+    --cert-oidc-issuer "$oidc_issuer"
+  echo "verified SLSA provenance attestation $attestation"
+fi
+if [[ -z "$tag" && -z "$signature" && -z "$attestation" ]]; then
+  echo 'checksum verification complete; signed inputs were not supplied'
+fi

--- a/scripts/upgrade/run-upgrade-matrix.sh
+++ b/scripts/upgrade/run-upgrade-matrix.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+usage: run-upgrade-matrix.sh [--old-ref REF] [--candidate-ref REF]
+
+REF must resolve to a commit in the current repository. The candidate is
+tested from its checked-out git tree; the release archive is created from the
+same tree after this gate passes.
+EOF
+}
+
+old_ref=v0.30.0
+candidate_ref=HEAD
+while (($#)); do
+    case "$1" in
+        --old-ref) old_ref=${2:?missing value for --old-ref}; shift 2 ;;
+        --candidate-ref) candidate_ref=${2:?missing value for --candidate-ref}; shift 2 ;;
+        -h|--help) usage >&2; exit 0 ;;
+        *) usage; exit 2 ;;
+    esac
+done
+
+root=$(git rev-parse --show-toplevel)
+old_commit=$(git rev-parse --verify "${old_ref}^{commit}")
+candidate_commit=$(git rev-parse --verify "${candidate_ref}^{commit}")
+[[ -n "$old_commit" && -n "$candidate_commit" ]] || {
+    echo 'upgrade matrix: refs must resolve to commits' >&2
+    exit 2
+}
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-upgrade.XXXXXX")
+log_dir=${UPGRADE_MATRIX_LOG_DIR:-$tmp/evidence}
+mkdir -p "$log_dir"
+trap 'rm -rf "$tmp"' EXIT
+
+extract() {
+    local commit=$1 destination=$2
+    mkdir -p "$destination"
+    git archive --format=tar "$commit" | tar -xf - -C "$destination"
+}
+
+build_tree() {
+    local source=$1 name=$2 prefix="$tmp/prefix-$2" build="$tmp/build-$2"
+    meson setup "$build" "$source" --buildtype=release -Dtests=false \
+        -Dprefix="$prefix" >"$log_dir/$name-configure.log" 2>&1
+    meson compile -C "$build" >"$log_dir/$name-build.log" 2>&1
+    meson install -C "$build" >"$log_dir/$name-install.log" 2>&1
+    local lib
+    lib=$(find -L "$prefix" \( -name 'libwirelog.so' -o -name 'libwirelog.dylib' \) -print -quit)
+    [[ -n "$lib" ]] || {
+        echo "upgrade matrix: installed libwirelog not found for $name" >&2
+        exit 1
+    }
+    printf '%s\n' "$prefix|$(dirname "$lib")"
+}
+
+compile_and_run() {
+    local label=$1 prefix=$2 libdir=$3 source=$4 program=$5 output=$6
+    local exe="$tmp/$label"
+    "${CC:-cc}" -std=c11 -Wall -Wextra -Werror -I"$prefix/include" \
+        "$source" -L"$libdir" -lwirelog -Wl,-rpath,"$libdir" -o "$exe" \
+        >"$log_dir/$label-compile.log" 2>&1
+    "$exe" "$program" >"$output"
+    [[ -s "$output" ]] || {
+        echo "upgrade matrix: $label produced no output" >&2
+        exit 1
+    }
+}
+
+old_source=$tmp/old
+candidate_source=$tmp/candidate
+extract "$old_commit" "$old_source"
+extract "$candidate_commit" "$candidate_source"
+old_install=$(build_tree "$old_source" old)
+candidate_install=$(build_tree "$candidate_source" candidate)
+old_prefix=${old_install%%|*}
+old_libdir=${old_install#*|}
+candidate_prefix=${candidate_install%%|*}
+candidate_libdir=${candidate_install#*|}
+
+run_case() {
+    local name=$1 old_program=$2 candidate_program=$3 old_consumer=$4 candidate_consumer=$5
+    local old_out="$log_dir/$name-old.out" candidate_out="$log_dir/$name-candidate.out"
+    compile_and_run "$name-old" "$old_prefix" "$old_libdir" \
+        "$old_consumer" "$old_program" "$old_out"
+    compile_and_run "$name-candidate" "$candidate_prefix" "$candidate_libdir" \
+        "$candidate_consumer" "$candidate_program" "$candidate_out"
+    cmp -s "$old_out" "$candidate_out" || {
+        echo "upgrade matrix: $name output mismatch" >&2
+        diff -u "$old_out" "$candidate_out" >&2 || true
+        exit 1
+    }
+    printf 'PASS %s (%s -> %s)\n' "$name" "$old_commit" "$candidate_commit"
+}
+
+run_executor_case() {
+    local program=$1 consumer=$2 probe=$3 old_lib candidate_out old_lib_symbols
+    candidate_out="$log_dir/executor-candidate.out"
+    compile_and_run executor-candidate "$candidate_prefix" "$candidate_libdir" \
+        "$consumer" "$program" "$candidate_out"
+
+    old_lib=$(find -L "$old_libdir" -maxdepth 1 -name 'libwirelog.so' -print -quit)
+    [[ -n "$old_lib" ]] || { echo 'upgrade matrix: old library missing' >&2; exit 1; }
+    old_lib_symbols="$log_dir/executor-old-exported-symbols.txt"
+    nm -D --defined-only "$old_lib" >"$old_lib_symbols"
+    local symbol
+    for symbol in \
+        wirelog_executor_create wirelog_executor_free \
+        wirelog_load_facts_from_csv wirelog_evaluate \
+        wirelog_result_get_relation wirelog_result_relation_cardinality \
+        wirelog_result_write_csv wirelog_result_free; do
+        if grep -Eq "[[:space:]]${symbol}$" "$old_lib_symbols"; then
+            echo "upgrade matrix: v0.30.0 unexpectedly exports $symbol" >&2
+            exit 1
+        fi
+    done
+
+    local old_obj="$tmp/executor-old-probe.o" old_exe="$tmp/executor-old.so"
+    local old_compile_log="$log_dir/executor-old-probe-compile.log"
+    local old_link_log="$log_dir/executor-old-link.log"
+    "${CC:-cc}" -std=c11 -Wall -Wextra -Werror -I"$old_prefix/include" \
+        -c "$probe" -o "$old_obj" >"$old_compile_log" 2>&1
+    if "${CC:-cc}" -shared "$old_obj" -L"$old_libdir" -lwirelog \
+        -Wl,--no-undefined -Wl,-z,defs -Wl,-rpath,"$old_libdir" -o "$old_exe" \
+        >"$old_link_log" 2>&1; then
+        echo 'upgrade matrix: v0.30.0 executor unexpectedly linked' >&2
+        exit 1
+    fi
+    for symbol in \
+        wirelog_executor_create wirelog_executor_free \
+        wirelog_load_facts_from_csv wirelog_evaluate \
+        wirelog_result_get_relation wirelog_result_relation_cardinality \
+        wirelog_result_write_csv wirelog_result_free; do
+        grep -Fq "$symbol" "$old_link_log" || {
+            echo "upgrade matrix: expected missing-symbol diagnostic absent: $symbol" >&2
+            exit 1
+        }
+    done
+    [[ "$(cat "$candidate_out")" == 'reach-count 3' ]] || {
+        echo 'upgrade matrix: candidate executor output changed' >&2
+        exit 1
+    }
+    local linker_digest
+    linker_digest=$(sha256sum "$old_link_log" | awk '{print $1}')
+    printf '{"status":"EXPECTED_UNSUPPORTED","old_commit":"%s","candidate_commit":"%s","missing_symbols":["wirelog_executor_create","wirelog_executor_free","wirelog_load_facts_from_csv","wirelog_evaluate","wirelog_result_get_relation","wirelog_result_relation_cardinality","wirelog_result_write_csv","wirelog_result_free"],"candidate_output":"reach-count 3","linker_diagnostic_file":"executor-old-link.log","linker_diagnostic_sha256":"%s"}\n' \
+        "$old_commit" "$candidate_commit" "$linker_digest" >"$log_dir/executor-status.json"
+    printf 'EXPECTED_UNSUPPORTED executor (v0.30.0 declarations are not exported; candidate passed)\n'
+}
+
+run_case easy \
+    "$root/tests/upgrade/easy/program.dl" \
+    "$root/tests/upgrade/easy/program.dl" \
+    "$root/tests/upgrade/easy/legacy.c" \
+    "$root/tests/upgrade/easy/migrated.c"
+run_case session \
+    "$root/tests/upgrade/session/program.dl" \
+    "$root/tests/upgrade/session/program.dl" \
+    "$root/tests/upgrade/session/legacy.c" \
+    "$root/tests/upgrade/session/migrated.c"
+run_executor_case \
+    "$root/tests/upgrade/executor/program.dl" \
+    "$root/tests/upgrade/executor/consumer.c" \
+    "$root/tests/upgrade/executor/link-probe.c"
+
+printf 'Upgrade matrix passed: old=%s candidate=%s\n' "$old_commit" "$candidate_commit"

--- a/tests/upgrade/easy/legacy.c
+++ b/tests/upgrade/easy/legacy.c
@@ -1,0 +1,78 @@
+#include <wirelog/wl_easy.h>
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct row { int64_t x, y; };
+struct rows { struct row values[8]; uint32_t count; };
+
+static void collect(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    struct rows *rows = user_data;
+    if (relation && strcmp(relation, "reach") == 0 && ncols == 2
+        && diff > 0 && rows->count < 8) {
+        rows->values[rows->count].x = row[0];
+        rows->values[rows->count++].y = row[1];
+    }
+}
+
+static int compare_rows(const void *left, const void *right)
+{
+    const struct row *a = left;
+    const struct row *b = right;
+    if (a->x != b->x)
+        return a->x < b->x ? -1 : 1;
+    return (a->y > b->y) - (a->y < b->y);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+        return 2;
+    FILE *file = fopen(argv[1], "rb");
+    if (!file)
+        return 3;
+    fseek(file, 0, SEEK_END);
+    long size = ftell(file);
+    rewind(file);
+    char *source = malloc((size_t)size + 1);
+    if (!source || fread(source, 1, (size_t)size, file) != (size_t)size) {
+        fclose(file);
+        free(source);
+        return 4;
+    }
+    fclose(file);
+    source[size] = '\0';
+
+    wl_easy_session_t *session = NULL;
+    if (wl_easy_open(source, &session) != WIRELOG_OK || !session) {
+        free(source);
+        return 5;
+    }
+    struct rows rows = {0};
+    if (wl_easy_set_delta_cb(session, collect, &rows) != WIRELOG_OK) {
+        wl_easy_close(session);
+        free(source);
+        return 6;
+    }
+    int64_t first[] = {1, 2};
+    int64_t second[] = {2, 3};
+    if (wl_easy_insert(session, "edge", first, 2) != WIRELOG_OK
+        || wl_easy_insert(session, "edge", second, 2) != WIRELOG_OK
+        || wl_easy_step(session) != WIRELOG_OK) {
+        wl_easy_close(session);
+        free(source);
+        return 6;
+    }
+    /* The callback count is intentionally reset per process; sort before emit. */
+    qsort(rows.values, rows.count, sizeof(rows.values[0]), compare_rows);
+    for (uint32_t i = 0; i < rows.count; i++)
+        printf("reach %" PRId64 " %" PRId64 "\n",
+            rows.values[i].x, rows.values[i].y);
+    wl_easy_close(session);
+    free(source);
+    return 0;
+}

--- a/tests/upgrade/easy/migrated.c
+++ b/tests/upgrade/easy/migrated.c
@@ -1,0 +1,77 @@
+#include <wirelog/wirelog-easy.h>
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct row { int64_t x, y; };
+struct rows { struct row values[8]; uint32_t count; };
+
+static void collect(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    struct rows *rows = user_data;
+    if (relation && strcmp(relation, "reach") == 0 && ncols == 2
+        && diff > 0 && rows->count < 8) {
+        rows->values[rows->count].x = row[0];
+        rows->values[rows->count++].y = row[1];
+    }
+}
+
+static int compare_rows(const void *left, const void *right)
+{
+    const struct row *a = left;
+    const struct row *b = right;
+    if (a->x != b->x)
+        return a->x < b->x ? -1 : 1;
+    return (a->y > b->y) - (a->y < b->y);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+        return 2;
+    FILE *file = fopen(argv[1], "rb");
+    if (!file)
+        return 3;
+    fseek(file, 0, SEEK_END);
+    long size = ftell(file);
+    rewind(file);
+    char *source = malloc((size_t)size + 1);
+    if (!source || fread(source, 1, (size_t)size, file) != (size_t)size) {
+        fclose(file);
+        free(source);
+        return 4;
+    }
+    fclose(file);
+    source[size] = '\0';
+
+    wirelog_easy_session_t *session = NULL;
+    if (wirelog_easy_open(source, &session) != WIRELOG_OK || !session) {
+        free(source);
+        return 5;
+    }
+    struct rows rows = {0};
+    if (wirelog_easy_set_delta_cb(session, collect, &rows) != WIRELOG_OK) {
+        wirelog_easy_close(session);
+        free(source);
+        return 6;
+    }
+    int64_t first[] = {1, 2};
+    int64_t second[] = {2, 3};
+    if (wirelog_easy_insert(session, "edge", first, 2) != WIRELOG_OK
+        || wirelog_easy_insert(session, "edge", second, 2) != WIRELOG_OK
+        || wirelog_easy_step(session) != WIRELOG_OK) {
+        wirelog_easy_close(session);
+        free(source);
+        return 6;
+    }
+    qsort(rows.values, rows.count, sizeof(rows.values[0]), compare_rows);
+    for (uint32_t i = 0; i < rows.count; i++)
+        printf("reach %" PRId64 " %" PRId64 "\n",
+            rows.values[i].x, rows.values[i].y);
+    wirelog_easy_close(session);
+    free(source);
+    return 0;
+}

--- a/tests/upgrade/easy/program.dl
+++ b/tests/upgrade/easy/program.dl
@@ -1,0 +1,7 @@
+.decl edge(x: int64, y: int64)
+.decl reach(x: int64, y: int64)
+.output reach
+edge(1, 2).
+edge(2, 3).
+reach(X, Y) :- edge(X, Y).
+reach(X, Y) :- edge(X, Z), reach(Z, Y).

--- a/tests/upgrade/executor/consumer.c
+++ b/tests/upgrade/executor/consumer.c
@@ -1,0 +1,46 @@
+#include <wirelog/wirelog.h>
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+        return 2;
+    FILE *file = fopen(argv[1], "rb");
+    if (!file)
+        return 3;
+    fseek(file, 0, SEEK_END);
+    long size = ftell(file);
+    rewind(file);
+    char *source = malloc((size_t)size + 1);
+    if (!source || fread(source, 1, (size_t)size, file) != (size_t)size) {
+        fclose(file);
+        free(source);
+        return 4;
+    }
+    fclose(file);
+    source[size] = '\0';
+    wirelog_error_t error = WIRELOG_ERR_UNKNOWN;
+    wirelog_program_t *program = wirelog_parse_string(source, &error);
+    wirelog_executor_t *executor = program
+        ? wirelog_executor_create(program, &error) : NULL;
+    wirelog_result_t *result = executor ? wirelog_evaluate(executor, &error)
+                                        : NULL;
+    uint64_t rows = result ? wirelog_result_relation_cardinality(result,
+            "reach") : 0;
+    if (!result || error != WIRELOG_OK || rows != 3) {
+        wirelog_result_free(result);
+        wirelog_executor_free(executor);
+        wirelog_program_free(program);
+        free(source);
+        return 5;
+    }
+    printf("reach-count %" PRIu64 "\n", rows);
+    wirelog_result_free(result);
+    wirelog_executor_free(executor);
+    wirelog_program_free(program);
+    free(source);
+    return 0;
+}

--- a/tests/upgrade/executor/link-probe.c
+++ b/tests/upgrade/executor/link-probe.c
@@ -1,0 +1,15 @@
+#include <wirelog/wirelog.h>
+
+int main(void)
+{
+    wirelog_error_t error = WIRELOG_ERR_UNKNOWN;
+    wirelog_executor_t *executor = wirelog_executor_create(NULL, &error);
+    (void)wirelog_load_facts_from_csv(executor, NULL, NULL, &error);
+    (void)wirelog_evaluate(executor, &error);
+    (void)wirelog_result_get_relation(NULL, NULL);
+    (void)wirelog_result_relation_cardinality(NULL, NULL);
+    (void)wirelog_result_write_csv(NULL, NULL, NULL, &error);
+    wirelog_result_free(NULL);
+    wirelog_executor_free(executor);
+    return 0;
+}

--- a/tests/upgrade/executor/program.dl
+++ b/tests/upgrade/executor/program.dl
@@ -1,0 +1,7 @@
+.decl edge(x: int64, y: int64)
+.decl reach(x: int64, y: int64)
+.output reach
+edge(1, 2).
+edge(2, 3).
+reach(X, Y) :- edge(X, Y).
+reach(X, Y) :- edge(X, Z), reach(Z, Y).

--- a/tests/upgrade/session/legacy.c
+++ b/tests/upgrade/session/legacy.c
@@ -1,0 +1,1 @@
+#include "../easy/legacy.c"

--- a/tests/upgrade/session/migrated.c
+++ b/tests/upgrade/session/migrated.c
@@ -1,0 +1,84 @@
+#include <wirelog/wirelog-advanced.h>
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct row { int64_t x, y; };
+struct rows { struct row values[8]; uint32_t count; };
+
+static void collect(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    struct rows *rows = user_data;
+    if (relation && strcmp(relation, "reach") == 0 && ncols == 2
+        && diff > 0 && rows->count < 8) {
+        rows->values[rows->count].x = row[0];
+        rows->values[rows->count++].y = row[1];
+    }
+}
+
+static int compare_rows(const void *left, const void *right)
+{
+    const struct row *a = left;
+    const struct row *b = right;
+    if (a->x != b->x)
+        return a->x < b->x ? -1 : 1;
+    return (a->y > b->y) - (a->y < b->y);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+        return 2;
+    FILE *file = fopen(argv[1], "rb");
+    if (!file)
+        return 3;
+    fseek(file, 0, SEEK_END);
+    long size = ftell(file);
+    rewind(file);
+    char *source = malloc((size_t)size + 1);
+    if (!source || fread(source, 1, (size_t)size, file) != (size_t)size) {
+        fclose(file);
+        free(source);
+        return 4;
+    }
+    fclose(file);
+    source[size] = '\0';
+    wirelog_error_t error = WIRELOG_ERR_UNKNOWN;
+    wirelog_program_t *program = wirelog_parse_string(source, &error);
+    wirelog_session_t *session = NULL;
+    if (!program || !wirelog_optimize(program, &error)
+        || wirelog_session_create(program, WIRELOG_BACKEND_DEFAULT, 0,
+        &session) != WIRELOG_OK) {
+        wirelog_program_free(program);
+        free(source);
+        return 5;
+    }
+    struct rows rows = {0};
+    if (wirelog_session_set_delta_cb(session, collect, &rows) != WIRELOG_OK) {
+        wirelog_session_destroy(session);
+        wirelog_program_free(program);
+        free(source);
+        return 6;
+    }
+    int64_t first[] = {1, 2};
+    int64_t second[] = {2, 3};
+    if (wirelog_session_insert(session, "edge", first, 1, 2) != WIRELOG_OK
+        || wirelog_session_insert(session, "edge", second, 1, 2) != WIRELOG_OK
+        || wirelog_session_step(session) != WIRELOG_OK) {
+        wirelog_session_destroy(session);
+        wirelog_program_free(program);
+        free(source);
+        return 6;
+    }
+    qsort(rows.values, rows.count, sizeof(rows.values[0]), compare_rows);
+    for (uint32_t i = 0; i < rows.count; i++)
+        printf("reach %" PRId64 " %" PRId64 "\n",
+            rows.values[i].x, rows.values[i].y);
+    wirelog_session_destroy(session);
+    wirelog_program_free(program);
+    free(source);
+    return 0;
+}

--- a/tests/upgrade/session/program.dl
+++ b/tests/upgrade/session/program.dl
@@ -1,0 +1,7 @@
+.decl edge(x: int64, y: int64)
+.decl reach(x: int64, y: int64)
+.output reach
+edge(1, 2).
+edge(2, 3).
+reach(X, Y) :- edge(X, Y).
+reach(X, Y) :- edge(X, Z), reach(Z, Y).


### PR DESCRIPTION
## Summary

- Add isolated v0.30.0-to-tag synthetic consumer matrix for easy/session APIs.
- Add candidate executor runtime check and strict `EXPECTED_UNSUPPORTED` evidence for the declaration-only v0.30.0 executor surface.
- Make the matrix a required seventh release-tag verification job.
- Document the candidate-tree model and compatibility boundary.

## Validation

- `scripts/upgrade/run-upgrade-matrix.sh --old-ref v0.30.0 --candidate-ref HEAD`
  - easy: PASS
  - session: PASS
  - executor: EXPECTED_UNSUPPORTED with all eight missing symbols and diagnostic SHA-256
- `bash -n scripts/upgrade/run-upgrade-matrix.sh`
- `actionlint .github/workflows/release-tag.yml`
- `git diff --check`

## Follow-ups

- #1156 tracks the provisioned runner and six full downstream workload smoke matrix.
- #1157 tracks the maintainer decision and ABI/header policy for the historical executor API defect.
- #752 remains open until those acceptance criteria are resolved.

Refs #752, #1156, #1157.