### PR TITLE
release: formalize unsupported v0.30 executor policy

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -208,6 +208,7 @@ not a claim of external validation.
 | Numerical fail-closed overflow and recursive aggregation canonicalization | See the `0.41 -> 0.43` section.  No 0.30 public API rename is needed, but callers may observe fail-closed errors or canonicalized recursive aggregate results. |
 | Security/export posture | No source migration needed when using the default build.  `mbedTLS=disabled` remains the default; see `docs/SECURITY_MODEL.md` before enabling crypto built-ins. |
 | Fuzz, SBOM, security policy, and release gates | No source migration needed for library consumers.  These are release-process and maintainer-tooling changes unless your downstream packaging pipeline adopts them. |
+| v0.30.0 executor facade (#1157) | **Unsupported in 1.0; no compatibility shim is provided.** Rebuild executor consumers against the current public API and migrate to the supported session/easy facade as appropriate. The release matrix records the historical link failure as `EXPECTED_UNSUPPORTED`, not as a compatibility pass. |
 
 ### Advanced session API is public via wirelog-advanced.h (#717)
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -420,6 +420,8 @@ changes that policy.
 - #750 — GPG + cosign-keyless signing pipeline.
 - #751 — tarball + SHA256 + BLAKE3 + provenance attestation.
 - #752 — GA release-facing deferrals/readiness follow-up in release process docs.
+- #1157 — resolved executor policy: v0.30.0 executor compatibility is unsupported;
+  the release maintainer owns the decision and no compatibility shim is shipped.
 - #753 — GA PSIRT/CVE-intake policy and 1.x support-window declaration.
 - #1144 — operational verification of the PSIRT mailbox, CVE assignment path,
   and published GPG key.

--- a/docs/UPGRADE_MATRIX.md
+++ b/docs/UPGRADE_MATRIX.md
@@ -25,9 +25,20 @@ The six full downstream workload rebuilds requested by #752 are not implied by
 this synthetic matrix. They require a provisioned runner, pinned datasets,
 and workload-specific tuple/iteration oracles; that work is tracked in #1156.
 
-The executor row is also not a compatibility pass: v0.30.0 declares the
-executor/result functions but does not export their implementations. The
-runner records the exact missing-symbol inventory and linker diagnostic in
-`executor-status.json` and `executor-old-link.log`; the compatibility policy
-and the decision whether a shim is required are tracked in #1157. #752 stays
-open until that policy is resolved.
+The executor row is deliberately not a compatibility pass. The v0.30.0
+executor/result API is unsupported and no compatibility shim is promised for
+the 1.0 migration. The runner derives the executor/result declaration
+inventory from the selected public header, verifies that none is exported by
+the v0.30.0 library, and requires the old consumer to fail at link time with
+every missing-symbol diagnostic. It records the inventory in
+`executor-abi.tsv`, the exact missing-symbol result in `executor-status.json`,
+and the linker diagnostic in `executor-old-link.log`. The candidate consumer
+must still compile, link, run, and produce its expected output.
+
+This is the resolved policy for #1157: consumers using the v0.30.0 executor
+facade must migrate to the 1.0 API; the historical v0.30.0 executor artifact
+is not a supported compatibility target. #752 remains open for the separate
+downstream workload evidence tracked in #1156.
+
+The executor ABI comparison is a Linux release-gate check. It uses `nm -D`,
+GNU linker diagnostics, and `sha256sum`; it is not a cross-platform ABI claim.

--- a/scripts/ci/check-executor-abi.sh
+++ b/scripts/ci/check-executor-abi.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# check-executor-abi.sh - verify the deliberate v0.30.0 executor break.
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+usage: check-executor-abi.sh <public-header> <shared-library> <report> [symbols-file]
+
+The v0.30.0 executor policy is EXPECTED_UNSUPPORTED: every executor/result
+function declared by the selected public header must be absent from the
+selected shared library. The report is a stable, machine-readable TSV file.
+EOF
+}
+
+(($# == 3 || $# == 4)) || { usage; exit 2; }
+header=$1
+library=$2
+report=$3
+symbols_file=${4:-}
+[[ -r "$header" && -r "$library" ]] || {
+    echo 'executor ABI check: header and library must be readable' >&2
+    exit 2
+}
+command -v nm >/dev/null 2>&1 || {
+    echo 'executor ABI check: nm is required' >&2
+    exit 2
+}
+
+# The API sections are deliberately bounded: utility/parser names mentioned in
+# comments must not become part of the executor compatibility contract.
+declared=$(
+    awk '
+        /Executor API/ { in_executor = 1; next }
+        /Result API/ { in_result = 1 }
+        /Utility API/ { in_executor = 0; in_result = 0 }
+        (in_executor || in_result) { print }
+    ' "$header" |
+    grep -oE 'wirelog_(executor_[A-Za-z0-9_]+|load_facts_from_csv|evaluate|result_[A-Za-z0-9_]+)\(' |
+    sed 's/($//' | LC_ALL=C sort -u
+)
+[[ -n "$declared" ]] || {
+    echo 'executor ABI check: no executor/result declarations found' >&2
+    exit 1
+}
+
+exported=$(nm -D --defined-only "$library" |
+    awk '{
+        name = $NF
+        sub(/@@?.*$/, "", name)
+        if (name ~ /^wirelog_(executor_|load_facts_from_csv$|evaluate$|result_)/)
+            print name
+    }' |
+    LC_ALL=C sort -u)
+
+unexpected=$(comm -12 <(printf '%s\n' "$declared") <(printf '%s\n' "$exported"))
+if [[ -n "$unexpected" ]]; then
+    echo 'executor ABI check: unsupported baseline unexpectedly exports executor symbols:' >&2
+    printf '  %s\n' $unexpected >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$report")"
+{
+    printf 'status\tEXPECTED_UNSUPPORTED\n'
+    printf 'declared\t%s\n' "$(tr '\n' ',' <<<"$declared" | sed 's/,$//')"
+    printf 'exported\t%s\n' "$(tr '\n' ',' <<<"$exported" | sed 's/,$//')"
+    printf 'missing\t%s\n' "$(tr '\n' ',' <<<"$declared" | sed 's/,$//')"
+} >"$report"
+
+if [[ -n "$symbols_file" ]]; then
+    mkdir -p "$(dirname "$symbols_file")"
+    printf '%s\n' "$declared" >"$symbols_file"
+fi
+printf 'EXPECTED_UNSUPPORTED: %s declarations absent from %s\n' \
+    "$(wc -l <<<"$declared")" "$library"

--- a/scripts/ci/validate-executor-status.sh
+++ b/scripts/ci/validate-executor-status.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# validate-executor-status.sh - validate the accepted unsupported result.
+set -euo pipefail
+
+(($# == 7)) || {
+    echo 'usage: validate-executor-status.sh STATUS LINK_LOG OLD_COMMIT CANDIDATE_COMMIT CANDIDATE_OUTPUT SYMBOLS ABI_REPORT' >&2
+    exit 2
+}
+status=$1
+link_log=$2
+old_commit=$3
+candidate_commit=$4
+candidate_output=$5
+symbols=$6
+abi_report=$7
+[[ -s "$status" && -s "$link_log" && -s "$candidate_output" && -s "$symbols" && -s "$abi_report" ]] || {
+    echo 'executor status: evidence file is missing or empty' >&2
+    exit 1
+}
+grep -Fq '"status":"EXPECTED_UNSUPPORTED"' "$status"
+grep -Fq "\"old_commit\":\"$old_commit\"" "$status"
+grep -Fq "\"candidate_commit\":\"$candidate_commit\"" "$status"
+grep -Fq '"candidate_output":"reach-count 3"' "$status"
+declared_csv=$(paste -sd, "$symbols")
+grep -Fq $'declared\t'"$declared_csv" "$abi_report"
+grep -Fq $'missing\t'"$declared_csv" "$abi_report"
+missing_json=$(paste -sd, <(sed 's/^/"/; s/$/"/' "$symbols"))
+grep -Fq '"missing_symbols":['"$missing_json"']' "$status"
+digest=$(sha256sum "$link_log" | awk '{print $1}')
+grep -Fq "\"linker_diagnostic_sha256\":\"$digest\"" "$status"
+[[ "$(cat "$candidate_output")" == 'reach-count 3' ]] || {
+    echo 'executor status: candidate output mismatch' >&2
+    exit 1
+}
+while IFS= read -r symbol; do
+    [[ -n "$symbol" ]] || continue
+    grep -Fq "\"$symbol\"" "$status" || {
+        echo "executor status: symbol missing from JSON: $symbol" >&2
+        exit 1
+    }
+    grep -Fq "$symbol" "$link_log" || {
+        echo "executor status: symbol missing from linker diagnostic: $symbol" >&2
+        exit 1
+    }
+done <"$symbols"

--- a/scripts/upgrade/run-upgrade-matrix.sh
+++ b/scripts/upgrade/run-upgrade-matrix.sh
@@ -32,6 +32,10 @@ candidate_commit=$(git rev-parse --verify "${candidate_ref}^{commit}")
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-upgrade.XXXXXX")
 log_dir=${UPGRADE_MATRIX_LOG_DIR:-$tmp/evidence}
+if [[ -e "$log_dir" && -n "$(find "$log_dir" -mindepth 1 -print -quit 2>/dev/null)" ]]; then
+    echo "upgrade matrix: evidence directory must be empty: $log_dir" >&2
+    exit 2
+fi
 mkdir -p "$log_dir"
 trap 'rm -rf "$tmp"' EXIT
 
@@ -105,17 +109,12 @@ run_executor_case() {
     [[ -n "$old_lib" ]] || { echo 'upgrade matrix: old library missing' >&2; exit 1; }
     old_lib_symbols="$log_dir/executor-old-exported-symbols.txt"
     nm -D --defined-only "$old_lib" >"$old_lib_symbols"
-    local symbol
-    for symbol in \
-        wirelog_executor_create wirelog_executor_free \
-        wirelog_load_facts_from_csv wirelog_evaluate \
-        wirelog_result_get_relation wirelog_result_relation_cardinality \
-        wirelog_result_write_csv wirelog_result_free; do
-        if grep -Eq "[[:space:]]${symbol}$" "$old_lib_symbols"; then
-            echo "upgrade matrix: v0.30.0 unexpectedly exports $symbol" >&2
-            exit 1
-        fi
-    done
+    local abi_report="$log_dir/executor-abi.tsv"
+    local declared_symbols="$tmp/executor-declared-symbols.txt"
+    "$root/scripts/ci/check-executor-abi.sh" \
+        "$old_prefix/include/wirelog/wirelog.h" "$old_lib" \
+        "$abi_report" "$declared_symbols"
+    mapfile -t executor_symbols <"$declared_symbols"
 
     local old_obj="$tmp/executor-old-probe.o" old_exe="$tmp/executor-old.so"
     local old_compile_log="$log_dir/executor-old-probe-compile.log"
@@ -128,11 +127,7 @@ run_executor_case() {
         echo 'upgrade matrix: v0.30.0 executor unexpectedly linked' >&2
         exit 1
     fi
-    for symbol in \
-        wirelog_executor_create wirelog_executor_free \
-        wirelog_load_facts_from_csv wirelog_evaluate \
-        wirelog_result_get_relation wirelog_result_relation_cardinality \
-        wirelog_result_write_csv wirelog_result_free; do
+    for symbol in "${executor_symbols[@]}"; do
         grep -Fq "$symbol" "$old_link_log" || {
             echo "upgrade matrix: expected missing-symbol diagnostic absent: $symbol" >&2
             exit 1
@@ -144,24 +139,28 @@ run_executor_case() {
     }
     local linker_digest
     linker_digest=$(sha256sum "$old_link_log" | awk '{print $1}')
-    printf '{"status":"EXPECTED_UNSUPPORTED","old_commit":"%s","candidate_commit":"%s","missing_symbols":["wirelog_executor_create","wirelog_executor_free","wirelog_load_facts_from_csv","wirelog_evaluate","wirelog_result_get_relation","wirelog_result_relation_cardinality","wirelog_result_write_csv","wirelog_result_free"],"candidate_output":"reach-count 3","linker_diagnostic_file":"executor-old-link.log","linker_diagnostic_sha256":"%s"}\n' \
-        "$old_commit" "$candidate_commit" "$linker_digest" >"$log_dir/executor-status.json"
+    missing_json=$(printf '"%s",' "${executor_symbols[@]}" | sed 's/,$//')
+    printf '{"status":"EXPECTED_UNSUPPORTED","old_commit":"%s","candidate_commit":"%s","missing_symbols":[%s],"candidate_output":"reach-count 3","linker_diagnostic_file":"executor-old-link.log","linker_diagnostic_sha256":"%s"}\n' \
+        "$old_commit" "$candidate_commit" "$missing_json" "$linker_digest" >"$log_dir/executor-status.json"
+    "$root/scripts/ci/validate-executor-status.sh" \
+        "$log_dir/executor-status.json" "$old_link_log" \
+        "$old_commit" "$candidate_commit" "$candidate_out" "$declared_symbols" "$abi_report"
     printf 'EXPECTED_UNSUPPORTED executor (v0.30.0 declarations are not exported; candidate passed)\n'
 }
 
 run_case easy \
-    "$root/tests/upgrade/easy/program.dl" \
-    "$root/tests/upgrade/easy/program.dl" \
-    "$root/tests/upgrade/easy/legacy.c" \
-    "$root/tests/upgrade/easy/migrated.c"
+    "$candidate_source/tests/upgrade/easy/program.dl" \
+    "$candidate_source/tests/upgrade/easy/program.dl" \
+    "$candidate_source/tests/upgrade/easy/legacy.c" \
+    "$candidate_source/tests/upgrade/easy/migrated.c"
 run_case session \
-    "$root/tests/upgrade/session/program.dl" \
-    "$root/tests/upgrade/session/program.dl" \
-    "$root/tests/upgrade/session/legacy.c" \
-    "$root/tests/upgrade/session/migrated.c"
+    "$candidate_source/tests/upgrade/session/program.dl" \
+    "$candidate_source/tests/upgrade/session/program.dl" \
+    "$candidate_source/tests/upgrade/session/legacy.c" \
+    "$candidate_source/tests/upgrade/session/migrated.c"
 run_executor_case \
-    "$root/tests/upgrade/executor/program.dl" \
-    "$root/tests/upgrade/executor/consumer.c" \
-    "$root/tests/upgrade/executor/link-probe.c"
+    "$candidate_source/tests/upgrade/executor/program.dl" \
+    "$candidate_source/tests/upgrade/executor/consumer.c" \
+    "$candidate_source/tests/upgrade/executor/link-probe.c"
 
 printf 'Upgrade matrix passed: old=%s candidate=%s\n' "$old_commit" "$candidate_commit"

--- a/tests/upgrade/executor/link-probe.c
+++ b/tests/upgrade/executor/link-probe.c
@@ -1,10 +1,12 @@
 #include <wirelog/wirelog.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
     wirelog_error_t error = WIRELOG_ERR_UNKNOWN;
-    wirelog_executor_t *executor = wirelog_executor_create(NULL, &error);
-    (void)wirelog_load_facts_from_csv(executor, NULL, NULL, &error);
+    wirelog_program_t *program = (wirelog_program_t *)(void *)argv;
+    wirelog_executor_t *executor = wirelog_executor_create(program, &error);
+    (void)argc;
+    (void)wirelog_load_facts_from_csv(executor, argv[0], argv[0], &error);
     (void)wirelog_evaluate(executor, &error);
     (void)wirelog_result_get_relation(NULL, NULL);
     (void)wirelog_result_relation_cardinality(NULL, NULL);


### PR DESCRIPTION
## Summary
- resolve #1157 by declaring the v0.30.0 executor facade unsupported for the 1.0 migration
- add header-derived executor ABI inventory and strict `EXPECTED_UNSUPPORTED` evidence validation
- update upgrade and migration/release documentation; no compatibility shim is introduced

## Validation
- `scripts/upgrade/run-upgrade-matrix.sh --old-ref v0.30.0 --candidate-ref HEAD`
- `meson test -C build-1157 --suite abi --print-errorlogs` (34/34)
- shell syntax and `git diff --check`

Closes #1157
