### PR TITLE
fix(ir): reject later allocation failures

### DIFF
--- a/tests/test_program_oom.c
+++ b/tests/test_program_oom.c
@@ -252,6 +252,11 @@ main(void)
         ".decl right(key: int64)\n"
         ".decl out(key: int64)\n"
         "out(key) :- left(key), right(key).\n";
+    static const char anti_join_source[]
+        = ".decl item(x: int64)\n"
+        ".decl blocked(x: int64)\n"
+        ".decl out(x: int64)\n"
+        "out(x) :- item(x), !blocked(x).\n";
     static const char false_filter_source[]
         = ".decl item(key: int64, payload: pair/2 inline)\n"
         ".decl out(key: int64)\n"
@@ -281,6 +286,9 @@ main(void)
         WIRELOG_IR_SCAN, WL_IR_EXPR_CMP) != 0)
         return 1;
     if (sweep_conversion(join_source, WIRELOG_IR_JOIN,
+        WIRELOG_IR_SCAN, -1) != 0)
+        return 1;
+    if (sweep_conversion(anti_join_source, WIRELOG_IR_ANTIJOIN,
         WIRELOG_IR_SCAN, -1) != 0)
         return 1;
     if (sweep_conversion(false_filter_source, WIRELOG_IR_FILTER,

--- a/tests/test_program_oom.c
+++ b/tests/test_program_oom.c
@@ -1,4 +1,4 @@
-/* Regression coverage for issue #1143. */
+/* Regression coverage for issues #1143 and #1165. */
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -76,9 +76,78 @@ contains_type(const wirelog_ir_node_t *node, wirelog_ir_node_type_t type)
     return false;
 }
 
+static bool
+valid_expr(const wl_ir_expr_t *expr)
+{
+    if (!expr)
+        return false;
+    if (expr->type == WL_IR_EXPR_VAR && !expr->var_name)
+        return false;
+    if (expr->type == WL_IR_EXPR_CONST_STR && !expr->str_value)
+        return false;
+    if (expr->type == WL_IR_EXPR_CMP && expr->child_count != 2)
+        return false;
+    for (uint32_t i = 0; i < expr->child_count; i++) {
+        if (!valid_expr(expr->children[i]))
+            return false;
+    }
+    return true;
+}
+
+static bool
+valid_ir(const wirelog_ir_node_t *node)
+{
+    if (!node)
+        return false;
+    if (node->type == WIRELOG_IR_FILTER
+        && !valid_expr(node->filter_expr))
+        return false;
+    if (node->type == WIRELOG_IR_PROJECT) {
+        if (node->project_count > 0 && !node->project_exprs)
+            return false;
+        for (uint32_t i = 0; i < node->project_count; i++) {
+            if (!valid_expr(node->project_exprs[i]))
+                return false;
+        }
+    }
+    if (node->type == WIRELOG_IR_AGGREGATE) {
+        if (!valid_expr(node->agg_expr))
+            return false;
+        if (node->group_by_count > 0 && !node->group_by_indices)
+            return false;
+    }
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        if (!valid_ir(node->children[i]))
+            return false;
+    }
+    return true;
+}
+
+static bool
+contains_expr_type(const wirelog_ir_node_t *node, wl_ir_expr_type_t type)
+{
+    if (!node)
+        return false;
+    if (node->filter_expr && node->filter_expr->type == type)
+        return true;
+    if (node->project_exprs) {
+        for (uint32_t i = 0; i < node->project_count; i++) {
+            if (node->project_exprs[i] && node->project_exprs[i]->type == type)
+                return true;
+        }
+    }
+    if (node->agg_expr && node->agg_expr->type == type)
+        return true;
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        if (contains_expr_type(node->children[i], type))
+            return true;
+    }
+    return false;
+}
+
 static int
 sweep_conversion(const char *source, wirelog_ir_node_type_t expected_a,
-    wirelog_ir_node_type_t expected_b)
+    wirelog_ir_node_type_t expected_b, int expected_expr_type)
 {
     bool saw_success = false;
     bool saw_injected_failure = false;
@@ -91,15 +160,33 @@ sweep_conversion(const char *source, wirelog_ir_node_type_t expected_a,
         fail_at = attempt;
         allocation_calls = 0;
         int rc = wl_ir_program_convert_rules(program, ast);
-        if (allocation_calls > attempt)
+        bool injected = allocation_calls > attempt;
+        if (injected && rc == 0) {
+            fprintf(stderr,
+                "issue #1165: allocation failure was accepted at %ld\n",
+                attempt);
+            wl_ir_program_free(program);
+            return 1;
+        }
+        if (injected && program->rules[0].ir_root) {
+            fprintf(stderr,
+                "issue #1165: rejected conversion retained an IR root at "
+                "allocation %ld\n", attempt);
+            wl_ir_program_free(program);
+            return 1;
+        }
+        if (injected)
             saw_injected_failure = true;
         fail_at = -1;
         if (rc == 0) {
             wirelog_ir_node_t *root = program->rules[0].ir_root;
-            if (!root || !contains_type(root, expected_a)
-                || !contains_type(root, expected_b)) {
+            if (!root || !valid_ir(root) || !contains_type(root, expected_a)
+                || !contains_type(root, expected_b)
+                || (expected_expr_type >= 0
+                && !contains_expr_type(root,
+                (wl_ir_expr_type_t)expected_expr_type))) {
                 fprintf(stderr,
-                    "issue #1143: incomplete IR accepted at allocation %ld\n",
+                    "issue #1165: incomplete IR accepted at allocation %ld\n",
                     attempt);
                 wl_ir_program_free(program);
                 return 1;
@@ -165,12 +252,54 @@ main(void)
         ".decl right(key: int64)\n"
         ".decl out(key: int64)\n"
         "out(key) :- left(key), right(key).\n";
+    static const char false_filter_source[]
+        = ".decl item(key: int64, payload: pair/2 inline)\n"
+        ".decl out(key: int64)\n"
+        "out(key) :- item(key, wrong(a, b)).\n";
+    static const char explicit_filter_source[]
+        = ".decl item(key: int64)\n"
+        ".decl out(key: int64)\n"
+        "out(key) :- item(key), key > 0.\n";
+    static const char boolean_filter_source[]
+        = ".decl item(value: int64)\n"
+        ".decl out(value: int64)\n"
+        "out(value) :- item(value), False.\n";
+    static const char string_filter_source[]
+        = ".decl item(value: string)\n"
+        ".decl out(value: string)\n"
+        "out(value) :- item(value), contains(value, \"x\").\n";
+    static const char aggregate_source[]
+        = ".decl item(group: int64, value: int64)\n"
+        ".decl out(group: int64, value: int64)\n"
+        "out(group, min(value + 1)) :- item(group, value).\n";
+    static const char projection_source[]
+        = ".decl item(key: int64)\n"
+        ".decl out(key: int64, next: int64)\n"
+        "out(key, key + 1) :- item(key).\n";
 
     if (sweep_conversion(constant_source, WIRELOG_IR_FILTER,
-        WIRELOG_IR_SCAN) != 0)
+        WIRELOG_IR_SCAN, WL_IR_EXPR_CMP) != 0)
         return 1;
     if (sweep_conversion(join_source, WIRELOG_IR_JOIN,
-        WIRELOG_IR_SCAN) != 0)
+        WIRELOG_IR_SCAN, -1) != 0)
+        return 1;
+    if (sweep_conversion(false_filter_source, WIRELOG_IR_FILTER,
+        WIRELOG_IR_SCAN, WL_IR_EXPR_BOOL) != 0)
+        return 1;
+    if (sweep_conversion(explicit_filter_source, WIRELOG_IR_FILTER,
+        WIRELOG_IR_SCAN, WL_IR_EXPR_CMP) != 0)
+        return 1;
+    if (sweep_conversion(boolean_filter_source, WIRELOG_IR_FILTER,
+        WIRELOG_IR_SCAN, WL_IR_EXPR_BOOL) != 0)
+        return 1;
+    if (sweep_conversion(string_filter_source, WIRELOG_IR_FILTER,
+        WIRELOG_IR_SCAN, WL_IR_EXPR_STR_FN) != 0)
+        return 1;
+    if (sweep_conversion(aggregate_source, WIRELOG_IR_AGGREGATE,
+        WIRELOG_IR_SCAN, WL_IR_EXPR_ARITH) != 0)
+        return 1;
+    if (sweep_conversion(projection_source, WIRELOG_IR_PROJECT,
+        WIRELOG_IR_SCAN, WL_IR_EXPR_ARITH) != 0)
         return 1;
     return sweep_compound_metadata();
 }

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -2768,6 +2768,15 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             wirelog_ir_node_t *neg_scan
                 = build_atom_scan(neg_atom, prog, &neg_vars, &neg_vcount);
 
+            if (!neg_scan) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while lowering negated atom '%s' in "
+                    "rule '%s'", neg_atom->name ? neg_atom->name : "?",
+                    head->name ? head->name : "?");
+                free_var_names(neg_vars, neg_vcount);
+                goto conversion_failed;
+            }
+
             /* Safety / range restriction (issue #920): every named variable in
              * a negated atom must also be bound by a positive body atom. A
              * variable that occurs only under negation has an unbounded range,
@@ -2808,39 +2817,47 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                 return NULL;
             }
 
-            if (neg_scan) {
-                wirelog_ir_node_t *aj = wl_ir_node_create(WIRELOG_IR_ANTIJOIN);
-                if (aj) {
-                    if (setup_join_keys(cur_vars, cur_vcount, neg_vars,
-                        neg_vcount, aj) != 0) {
-                        wl_ir_node_free(aj);
-                        wl_ir_node_free(neg_scan);
-                        free_var_names(neg_vars, neg_vcount);
-                        wl_ir_node_free(current);
-                        for (uint32_t s = 0; s < scan_count; s++)
-                            free_var_names(scan_vars[s], scan_vcounts[s]);
-                        if (cur_vars_is_merged)
-                            free_var_names(cur_vars, cur_vcount);
-                        free((void *)scans);
-                        free((void *)scan_vars);
-                        free(scan_vcounts);
-                        return NULL;
-                    }
-                    if (wl_ir_node_add_child(aj, current) != 0) {
-                        wl_ir_node_free(aj);
-                        wl_ir_node_free(neg_scan);
-                    } else if (wl_ir_node_add_child(aj, neg_scan) != 0) {
-                        aj->children[0] = NULL;
-                        aj->child_count = 0;
-                        wl_ir_node_free(aj);
-                        wl_ir_node_free(neg_scan);
-                    } else {
-                        current = aj;
-                    }
-                } else {
-                    wl_ir_node_free(neg_scan);
-                }
+            wirelog_ir_node_t *aj = wl_ir_node_create(WIRELOG_IR_ANTIJOIN);
+            if (!aj) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while creating an anti-join for rule "
+                    "'%s'", head->name ? head->name : "?");
+                wl_ir_node_free(neg_scan);
+                free_var_names(neg_vars, neg_vcount);
+                goto conversion_failed;
             }
+            if (setup_join_keys(cur_vars, cur_vcount, neg_vars, neg_vcount,
+                aj) != 0) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while building anti-join keys for "
+                    "rule '%s'", head->name ? head->name : "?");
+                wl_ir_node_free(aj);
+                wl_ir_node_free(neg_scan);
+                free_var_names(neg_vars, neg_vcount);
+                goto conversion_failed;
+            }
+            if (wl_ir_node_add_child(aj, current) != 0) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while attaching the positive anti-join "
+                    "input for rule '%s'", head->name ? head->name : "?");
+                wl_ir_node_free(aj);
+                wl_ir_node_free(neg_scan);
+                free_var_names(neg_vars, neg_vcount);
+                goto conversion_failed;
+            }
+            if (wl_ir_node_add_child(aj, neg_scan) != 0) {
+                wl_ir_node_free(aj);
+                aj = NULL;
+                wl_ir_node_free(neg_scan);
+                current = NULL;
+                wl_ir_program_set_error(prog,
+                    "allocation failed while attaching the negated anti-join "
+                    "input for rule '%s'", head->name ? head->name : "?");
+                free_var_names(neg_vars, neg_vcount);
+                goto conversion_failed;
+            }
+
+            current = aj;
 
             free_var_names(neg_vars, neg_vcount);
         }

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -1167,8 +1167,13 @@ convert_expr(const wl_parser_ast_node_t *node)
     switch (node->type) {
     case WL_PARSER_AST_NODE_VARIABLE: {
         wl_ir_expr_t *e = wl_ir_expr_create(WL_IR_EXPR_VAR);
-        if (e)
+        if (e) {
             e->var_name = strdup_safe(node->name);
+            if (!e->var_name) {
+                wl_ir_expr_free(e);
+                return NULL;
+            }
+        }
         return e;
     }
     case WL_PARSER_AST_NODE_INTEGER: {
@@ -1179,8 +1184,13 @@ convert_expr(const wl_parser_ast_node_t *node)
     }
     case WL_PARSER_AST_NODE_STRING: {
         wl_ir_expr_t *e = wl_ir_expr_create(WL_IR_EXPR_CONST_STR);
-        if (e)
+        if (e) {
             e->str_value = strdup_safe(node->str_value);
+            if (!e->str_value) {
+                wl_ir_expr_free(e);
+                return NULL;
+            }
+        }
         return e;
     }
     case WL_PARSER_AST_NODE_BINARY_EXPR: {
@@ -1251,12 +1261,12 @@ convert_expr(const wl_parser_ast_node_t *node)
     }
 }
 
-static void
+static bool
 rewrite_expr_vars_to_columns(wl_ir_expr_t *expr, char **vars,
     uint32_t var_count)
 {
     if (!expr)
-        return;
+        return false;
 
     if (expr->type == WL_IR_EXPR_VAR && expr->var_name) {
         for (uint32_t i = 0; i < var_count; i++) {
@@ -1264,17 +1274,20 @@ rewrite_expr_vars_to_columns(wl_ir_expr_t *expr, char **vars,
                 char col[32];
                 snprintf(col, sizeof(col), "col%u", i);
                 char *next = strdup_safe(col);
-                if (next) {
-                    free(expr->var_name);
-                    expr->var_name = next;
-                }
-                return;
+                if (!next)
+                    return false;
+                free(expr->var_name);
+                expr->var_name = next;
+                return true;
             }
         }
     }
 
-    for (uint32_t i = 0; i < expr->child_count; i++)
-        rewrite_expr_vars_to_columns(expr->children[i], vars, var_count);
+    for (uint32_t i = 0; i < expr->child_count; i++) {
+        if (!rewrite_expr_vars_to_columns(expr->children[i], vars, var_count))
+            return false;
+    }
+    return true;
 }
 
 /* ---- Variable Name Tracking Helpers ---- */
@@ -1517,19 +1530,23 @@ static wirelog_ir_node_t *
 wrap_false_filter(wirelog_ir_node_t *child)
 {
     wirelog_ir_node_t *filter = wl_ir_node_create(WIRELOG_IR_FILTER);
-    if (!filter)
-        return child;
+    if (!filter) {
+        wl_ir_node_free(child);
+        return NULL;
+    }
 
     wl_ir_expr_t *expr = wl_ir_expr_create(WL_IR_EXPR_BOOL);
     if (!expr) {
         wl_ir_node_free(filter);
-        return child;
+        wl_ir_node_free(child);
+        return NULL;
     }
     expr->bool_value = false;
     filter->filter_expr = expr;
     if (wl_ir_node_add_child(filter, child) != 0) {
         wl_ir_node_free(filter);
-        return child;
+        wl_ir_node_free(child);
+        return NULL;
     }
     return filter;
 }
@@ -1832,6 +1849,10 @@ build_side_compound_scan(const wl_parser_ast_node_t *compound_arg,
     }
     if (unsupported_nested_pattern)
         result = wrap_false_filter(result);
+    if (!result) {
+        scan = NULL;
+        goto fail;
+    }
 
     *out_var_names = var_names;
     *out_var_count = count;
@@ -2152,6 +2173,7 @@ scan_build_complete:
     if (compound_mismatch)
         result = wrap_false_filter(result);
     if (!result) {
+        scan = NULL;
         free_var_names(var_names, physical_count);
         for (uint32_t i = 0; i < side_binding_count; i++)
             free(side_bindings[i].handle_var);
@@ -2477,6 +2499,9 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
     char ***scan_vars = (char ***)calloc(scan_cap, sizeof(char **));
     uint32_t *scan_vcounts = (uint32_t *)calloc(scan_cap, sizeof(uint32_t));
     if (!scans || !scan_vars || !scan_vcounts) {
+        wl_ir_program_set_error(prog,
+            "allocation failed while preparing rule '%s'",
+            head->name ? head->name : "?");
         free((void *)scans);
         free((void *)scan_vars);
         free(scan_vcounts);
@@ -2495,6 +2520,10 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             scans[scan_count] = build_atom_scan(b, prog,
                     &scan_vars[scan_count], &scan_vcounts[scan_count]);
             if (!scans[scan_count]) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while lowering body atom '%s' in rule "
+                    "'%s'", b->name ? b->name : "?",
+                    head->name ? head->name : "?");
                 WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_ERROR,
                     "convert_rule: build_atom_scan returned NULL for "
                     "body atom index=%u relation=%s",
@@ -2514,6 +2543,9 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
 
     if (!wl_ir_program_push_constant_filters(rule_node, scans, scan_vars,
         scan_vcounts, scan_count)) {
+        wl_ir_program_set_error(prog,
+            "allocation failed while pushing constant filters in rule '%s'",
+            head->name ? head->name : "?");
         for (uint32_t s = 0; s < scan_count; s++) {
             free_var_names(scan_vars[s], scan_vcounts[s]);
             wl_ir_node_free(scans[s]);
@@ -2634,37 +2666,69 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
         // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
         if (b->type == WL_PARSER_AST_NODE_COMPARISON && current) {
             wirelog_ir_node_t *f = wl_ir_node_create(WIRELOG_IR_FILTER);
-            if (!f)
-                continue;
+            if (!f) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while creating an explicit filter in "
+                    "rule '%s'", head->name ? head->name : "?");
+                goto conversion_failed;
+            }
             f->filter_expr = convert_expr(b);
-            if (!f->filter_expr || wl_ir_node_add_child(f, current) != 0) {
+            if (!f->filter_expr) {
                 wl_ir_node_free(f);
+                wl_ir_program_set_error(prog,
+                    "allocation failed while converting an explicit filter "
+                    "in rule '%s'", head->name ? head->name : "?");
+                goto conversion_failed;
+            }
+            if (wl_ir_node_add_child(f, current) != 0) {
+                wl_ir_node_free(f);
+                wl_ir_program_set_error(prog,
+                    "allocation failed while attaching an explicit filter "
+                    "in rule '%s'", head->name ? head->name : "?");
+                goto conversion_failed;
             } else {
                 current = f;
             }
         } else if (b->type == WL_PARSER_AST_NODE_BOOLEAN) {
             if (!b->bool_value && current) {
                 wirelog_ir_node_t *f = wl_ir_node_create(WIRELOG_IR_FILTER);
-                if (!f)
-                    continue;
+                if (!f) {
+                    wl_ir_program_set_error(prog,
+                        "allocation failed while creating a false filter in "
+                        "rule '%s'", head->name ? head->name : "?");
+                    goto conversion_failed;
+                }
                 wl_ir_expr_t *e = wl_ir_expr_create(WL_IR_EXPR_BOOL);
-                if (e)
-                    e->bool_value = false;
-                f->filter_expr = e;
-                if (wl_ir_node_add_child(f, current) != 0)
+                if (!e) {
                     wl_ir_node_free(f);
-                else
+                    goto conversion_failed;
+                }
+                e->bool_value = false;
+                f->filter_expr = e;
+                if (wl_ir_node_add_child(f, current) != 0) {
+                    wl_ir_node_free(f);
+                    goto conversion_failed;
+                } else
                     current = f;
             }
             /* Boolean True -> no-op */
         } else if (b->type == WL_PARSER_AST_NODE_STR_FUNCTION && current) {
             /* Standalone string predicate: contains(x, y), str_prefix(x, y), etc. */
             wirelog_ir_node_t *f = wl_ir_node_create(WIRELOG_IR_FILTER);
-            if (!f)
-                continue;
+            if (!f) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while creating a string filter in "
+                    "rule '%s'", head->name ? head->name : "?");
+                goto conversion_failed;
+            }
             f->filter_expr = convert_expr(b);
-            if (!f->filter_expr || wl_ir_node_add_child(f, current) != 0) {
+            if (!f->filter_expr) {
                 wl_ir_node_free(f);
+                goto conversion_failed;
+            }
+            if (wl_ir_node_add_child(f, current) != 0) {
+                wl_ir_node_free(f);
+                goto conversion_failed;
             } else {
                 current = f;
             }
@@ -2818,8 +2882,25 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
 
             if (agg_node->child_count >= 1) {
                 root->agg_expr = convert_expr(agg_node->children[0]);
-                rewrite_expr_vars_to_columns(root->agg_expr, cur_vars,
-                    cur_vcount);
+                if (!root->agg_expr) {
+                    wl_ir_program_set_error(prog,
+                        "allocation failed while converting an aggregate "
+                        "expression in rule '%s'",
+                        head->name ? head->name : "?");
+                    wl_ir_node_free(root);
+                    root = NULL;
+                    goto conversion_failed;
+                }
+                if (!rewrite_expr_vars_to_columns(root->agg_expr, cur_vars,
+                    cur_vcount)) {
+                    wl_ir_program_set_error(prog,
+                        "allocation failed while rewriting an aggregate "
+                        "expression in rule '%s'",
+                        head->name ? head->name : "?");
+                    wl_ir_node_free(root);
+                    root = NULL;
+                    goto conversion_failed;
+                }
             }
 
             root->column_count = cur_vcount;
@@ -2844,10 +2925,14 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             }
 
             if (!root_names_ok) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while copying aggregate column names "
+                    "in rule '%s'", head->name ? head->name : "?");
                 wl_ir_node_free(root);
                 wl_ir_node_free(current);
                 root = NULL;
                 current = NULL;
+                goto conversion_failed;
             }
 
             if (root)
@@ -2855,6 +2940,15 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             if (root && non_agg_count > 0) {
                 root->group_by_indices
                     = (uint32_t *)calloc(non_agg_count, sizeof(uint32_t));
+                if (!root->group_by_indices) {
+                    wl_ir_program_set_error(prog,
+                        "allocation failed while building aggregate grouping "
+                        "indices in rule '%s'",
+                        head->name ? head->name : "?");
+                    wl_ir_node_free(root);
+                    root = NULL;
+                    goto conversion_failed;
+                }
                 uint32_t gi = 0;
                 for (uint32_t i = 0; i < head->child_count; i++) {
                     if (head->children[i]->type
@@ -2883,6 +2977,9 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                 root = NULL;
             }
         } else {
+            wl_ir_program_set_error(prog,
+                "allocation failed while creating an aggregate root for rule "
+                "'%s'", head->name ? head->name : "?");
             goto conversion_failed;
         }
     } else {
@@ -2899,10 +2996,24 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             if (head->child_count > 0) {
                 root->project_exprs = (wl_ir_expr_t **)calloc(
                     head->child_count, sizeof(wl_ir_expr_t *));
-                if (root->project_exprs) {
-                    for (uint32_t i = 0; i < head->child_count; i++) {
-                        root->project_exprs[i]
-                            = convert_expr(head->children[i]);
+                if (!root->project_exprs) {
+                    wl_ir_program_set_error(prog,
+                        "allocation failed while building project expressions "
+                        "in rule '%s'", head->name ? head->name : "?");
+                    wl_ir_node_free(root);
+                    root = NULL;
+                    goto conversion_failed;
+                }
+                for (uint32_t i = 0; i < head->child_count; i++) {
+                    root->project_exprs[i] = convert_expr(head->children[i]);
+                    if (!root->project_exprs[i]) {
+                        wl_ir_program_set_error(prog,
+                            "allocation failed while converting a project "
+                            "expression in rule '%s'",
+                            head->name ? head->name : "?");
+                        wl_ir_node_free(root);
+                        root = NULL;
+                        goto conversion_failed;
                     }
                 }
             }
@@ -2913,6 +3024,9 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                 root = NULL;
             }
         } else {
+            wl_ir_program_set_error(prog,
+                "allocation failed while creating a project root for rule "
+                "'%s'", head->name ? head->name : "?");
             goto conversion_failed;
         }
     }


### PR DESCRIPTION
Closes #1143
Closes #1165
Closes #1167

This PR contains the complete allocation-failure hardening stack: the original body-atom/IR lowering fix from #1166, later filter/projection/aggregate rejection from #1165, and negated-atom anti-join rejection from #1167.

The branch is based on the reviewed #1166 work and includes the merged #1170 anti-join fix.

Validation:
- meson compile -C build
- meson test -C build program program_oom jpp --print-errorlogs
- meson test -C build --suite abi --print-errorlogs
- meson test -C build --suite asan --print-errorlogs
- uncrustify -c uncrustify.cfg --check wirelog/ir/program.c tests/test_program_oom.c
- git diff --check

Note: the broad local suite had one unrelated SBOM snapshot failure because this environment adds agent-workflows/pyrewire dependencies.