### PR TITLE
refactor(columnar): extract serial stratum evaluator into eval_serial.c

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -43,6 +43,7 @@ bench_backend_src = files(
   subdir_wirelog / 'columnar/eval_tdd_plan.c',
   subdir_wirelog / 'columnar/eval_plan.c',
   subdir_wirelog / 'columnar/eval_stack.c',
+  subdir_wirelog / 'columnar/eval_serial.c',
   subdir_wirelog / 'columnar/eval.c',
   subdir_wirelog / 'columnar/arrangement.c',
   subdir_wirelog / 'columnar/frontier.c',

--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -246,7 +246,7 @@ from producing semantically correct output at workers in {1, 4, 8, 16}.
   rule heads are validated; rule *bodies* and facts on undeclared relations
   are not.
 - `wirelog/columnar/ops.c` — `col_op_reduce`.
-- `wirelog/columnar/eval.c` — recursive aggregate canonicalization.
+- `wirelog/columnar/eval_serial.c` — recursive aggregate canonicalization.
 - `wirelog/ir/program.c` — `convert_rule` multi-aggregate head rejection.
 - `tests/test_recursive_agg_conformance.c` — active columnar harness.
 - Issue #1021 — a recursive MIN/MAX aggregate may not share an SCC with any

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -302,7 +302,7 @@ once and the surrounding overhead dominates.
 | `ops.c:2420` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
 | `ops.c:2423` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag (see :2410 note) |
 | `ops.c:6750` | `stop` (local) | `atomic_load_explicit` | `relaxed` | Compaction-loop cancel poll |
-| `ops.c:6299` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before the branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:1875`, which resets the TDD counter before `thread_create()` |
+| `ops.c:6299` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before the branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:292`, which resets the TDD counter before `thread_create()` |
 | `ops.c:6771` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
 | `ops.c:6773` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Backpressure poll |
 
@@ -316,7 +316,7 @@ and the wasted work is bounded.
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `eval.c:1875` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
+| `eval.c:292` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
 
 ### 5.6 `wirelog/columnar/session.c` — worker budget snapshot (1 row)
 
@@ -484,7 +484,7 @@ that enforces this is the `sess->coordinator == NULL` predicate:
   guard noted in the surrounding `ops.c:5451-5455` comment block;
   the `coordinator == NULL` conjunct is the load-bearing
   coordinator-only invariant.
-- `wirelog/columnar/eval.c:933-935` (eval-stratum sub-pass tail): the
+- `wirelog/columnar/eval_serial.c:788-791` (eval-stratum sub-pass tail): the
   same gate.
 
 The rotation strategy itself does **not** re-check the predicate
@@ -749,7 +749,7 @@ advisory leg); issue #826 (native TSan SEGV triage);
   gate.
 - `wirelog/columnar/ops.c:5456-5459` — compound-arena gate (K-fusion
   side).
-- `wirelog/columnar/eval.c:933-935` — compound-arena gate (eval-
+- `wirelog/columnar/eval_serial.c:788-791` — compound-arena gate (eval-
   stratum side).
 - `wirelog/columnar/mem_ledger.{h,c}` — accounting atomics + MSVC
   shim.

--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -51,6 +51,7 @@ wirelog/columnar/diff_trace.c
 wirelog/columnar/diff_vtable.c
 wirelog/columnar/eval.c
 wirelog/columnar/eval_dedup.c
+wirelog/columnar/eval_serial.c
 wirelog/columnar/eval_stack.c
 wirelog/columnar/eval_tdd_plan.c
 wirelog/columnar/filter.c

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -973,6 +973,7 @@ backend_src = files(
   '../wirelog/columnar/eval_tdd_plan.c',
   '../wirelog/columnar/eval_plan.c',
   '../wirelog/columnar/eval_stack.c',
+  '../wirelog/columnar/eval_serial.c',
   '../wirelog/columnar/eval.c',
   '../wirelog/columnar/arrangement.c',
   '../wirelog/columnar/frontier.c',

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -33,943 +33,7 @@
         wl_columnar_eval_dedup_set_init_from_rel
 
 /* Relation-plan dispatch is implemented in columnar/eval_plan.c. */
-static col_frontier_t
-col_frontier_compute(const col_rel_t *rel);
-static int
-col_eval_nonrecursive_relation_parallel(const wl_plan_relation_t *rp,
-    wl_col_session_t *coord);
-static int
-col_canonicalize_recursive_aggregates(const wl_plan_stratum_t *sp,
-    wl_col_session_t *sess);
-
-static bool
-col_reduce_output_group_equal(const col_rel_t *rel, uint32_t a, uint32_t b,
-    uint32_t group_by_count, uint32_t aggregate_index)
-{
-    for (uint32_t c = 0; c < group_by_count; c++) {
-        uint32_t out_col = c >= aggregate_index ? c + 1 : c;
-        if (col_rel_get(rel, a, out_col)
-            != col_rel_get(rel, b, out_col))
-            return false;
-    }
-    return true;
-}
-
-typedef struct {
-    uint64_t hash;
-    uint32_t row;
-} col_group_slot_t;
-
-static uint64_t
-col_group_hash(const col_rel_t *rel, uint32_t row, uint32_t group_by_count,
-    uint32_t aggregate_index)
-{
-    uint64_t hash = UINT64_C(1469598103934665603);
-    for (uint32_t c = 0; c < group_by_count; c++) {
-        uint32_t out_col = c >= aggregate_index ? c + 1 : c;
-        hash ^= (uint64_t)col_rel_get(rel, row, out_col);
-        hash *= UINT64_C(1099511628211);
-    }
-    return hash ? hash : 1;
-}
-
-static int
-col_canonicalize_recursive_aggregate_relation(col_rel_t *rel,
-    const wl_plan_agg_spec_t *spec, const wl_intern_t *intern)
-{
-    if (!rel || !spec || !spec->has_spec || rel->nrows < 2)
-        return 0;
-
-    uint32_t gc = spec->group_by_count;
-    uint32_t agg_index = spec->aggregate_index < rel->ncols
-        ? spec->aggregate_index : gc;
-    if (rel->ncols <= gc)
-        return EINVAL;
-
-    uint32_t out = 0;
-    uint32_t map_cap = 1;
-    uint64_t desired = (uint64_t)rel->nrows * 2U;
-    while ((uint64_t)map_cap < desired && map_cap <= UINT32_MAX / 2U)
-        map_cap <<= 1;
-    if ((uint64_t)map_cap < desired)
-        return ENOMEM;
-    col_group_slot_t *groups = (col_group_slot_t *)calloc(map_cap,
-            sizeof(*groups));
-    if (!groups)
-        return ENOMEM;
-    uint32_t map_mask = map_cap - 1;
-    for (uint32_t row = 0; row < rel->nrows; row++) {
-        uint32_t found = UINT32_MAX;
-        uint64_t hash = col_group_hash(rel, row, gc, agg_index);
-        uint32_t slot = (uint32_t)hash & map_mask;
-        while (groups[slot].hash != 0) {
-            uint32_t keep = groups[slot].row;
-            if (groups[slot].hash == hash
-                && col_reduce_output_group_equal(rel, keep, row, gc,
-                agg_index)) {
-                found = keep;
-                break;
-            }
-            slot = (slot + 1) & map_mask;
-        }
-
-        if (found != UINT32_MAX) {
-            int64_t cur = col_rel_get(rel, found, agg_index);
-            int64_t val = col_rel_get(rel, row, agg_index);
-            /* Same comparator as col_op_reduce(): a fixpoint that ordered
-             * lexicographically within an iteration and by intern id across
-             * iterations would be worse than the original bug (#965). */
-            bool better = col_agg_better(spec->fn, spec->operand_type,
-                    intern, val, cur);
-            if (better) {
-                col_rel_set(rel, found, agg_index, val);
-                if (rel->timestamps)
-                    rel->timestamps[found] = rel->timestamps[row];
-            }
-            continue;
-        }
-
-        if (out != row) {
-            for (uint32_t c = 0; c < rel->ncols; c++)
-                col_rel_set(rel, out, c, col_rel_get(rel, row, c));
-            if (rel->timestamps)
-                rel->timestamps[out] = rel->timestamps[row];
-        }
-        groups[slot].hash = hash;
-        groups[slot].row = out;
-        out++;
-    }
-
-    if (out != rel->nrows) {
-        rel->nrows = out;
-        rel->sorted_nrows = out;
-        rel->base_nrows = out;
-        rel->run_count = 0;
-        rel->dedup_count = 0;
-        memset(rel->run_ends, 0, sizeof(rel->run_ends));
-    }
-
-    free(groups);
-
-    return 0;
-}
-
-static int
-col_canonicalize_recursive_aggregates(const wl_plan_stratum_t *sp,
-    wl_col_session_t *sess)
-{
-    /*
-     * Reading the recorded specification rather than looking for a REDUCE in
-     * rp->ops is the whole of #975: rewrite_multiway_delta() replaces a fused
-     * relation's operators with a single K_FUSION and moves the originals into
-     * its opaque_data, so the operator was not there to be found and this ran
-     * on every recursive aggregate relation *except* the ones fusion applies
-     * to.  wl_plan_relation_t.recursive_agg is filled at IR lowering, before
-     * any rewrite runs.
-     *
-     * Timing is unchanged: this is the fixpoint, not per-iteration
-     * consolidation.  A same-stratum consumer would therefore hold rows
-     * derived from labels this reduction then dominates away, output that
-     * contradicts itself.  #1021 settled that by refusing the shape at plan
-     * time -- a recursive min/max aggregate may not share an SCC with any
-     * other relation -- rather than by changing when this runs, so nothing
-     * here had to move.  Moving the reduction into consolidation is still
-     * open and would readmit the intra-round half of the shape; that is
-     * deferred to milestone 0.70.0, see docs/SEMANTICS.md.
-     *
-     * The correction that matters to a reader of the old comment here:
-     * wl_plan_stratum_t.is_monotone is no longer "hardcoded false and never
-     * computed".  wl_plan_from_program() computes it (negation only), and it
-     * still has no consumer, so a true value is not yet a signal anything may
-     * act on.
-     */
-    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-        const wl_plan_relation_t *rp = &sp->relations[ri];
-        if (!rp->recursive_agg.has_spec)
-            continue;
-        col_rel_t *rel = session_find_rel(sess, rp->name);
-        int rc = col_canonicalize_recursive_aggregate_relation(rel,
-                &rp->recursive_agg, sess->intern);
-        if (rc != 0)
-            return rc;
-        col_session_invalidate_arrangements(&sess->base, rp->name);
-    }
-    return 0;
-}
-
-/*
- * col_eval_stratum:
- * Evaluate one stratum, writing results into session relations.
- * Non-recursive strata are evaluated once.
- * Recursive strata use semi-naive fixed-point iteration.
- *
- * Returns 0 on success, non-zero on error.
- */
-int
-col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
-    uint32_t stratum_idx)
-{
-    if (!sp->is_recursive) {
-        /* Issue #914: a non-recursive stratum is always the base case. The
-         * recursive-stratum loop leaves sess->current_iteration > 0 and never
-         * resets it, which would wrongly trigger the base-case EDB VARIABLE
-         * skip (eval.c base-case skip) and drop this stratum's head tuples.
-         * Reset here so it covers both the parallel and sequential paths. */
-        sess->current_iteration = 0;
-
-        /* Non-recursive: evaluate each relation plan once */
-        for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-            const wl_plan_relation_t *rp = &sp->relations[ri];
-            int par_rc = col_eval_nonrecursive_relation_parallel(rp, sess);
-            if (par_rc == 0)
-                continue;
-            if (par_rc != EAGAIN) {
-                if (getenv("WIRELOG_DEBUG_NONREC_TDD"))
-                    fprintf(stderr, "nonrec_tdd failed rel=%s rc=%d\n",
-                        rp->name ? rp->name : "(null)", par_rc);
-                return par_rc;
-            }
-
-            eval_stack_t stack;
-            eval_stack_init(&stack);
-
-            int rc = col_eval_relation_plan(rp, &stack, sess);
-            if (rc != 0) {
-                eval_stack_drain(&stack);
-                return rc;
-            }
-
-            if (stack.top == 0)
-                continue;
-
-            eval_entry_t result = eval_stack_pop(&stack);
-            eval_stack_drain(&stack); /* drain any leftover entries */
-
-            col_rel_t *target = session_find_rel(sess, rp->name);
-            if (!target) {
-                /* First time: create and register the relation */
-                if (result.owned) {
-                    /* Rename the result relation */
-                    free(result.rel->name);
-                    result.rel->name = wl_strdup(rp->name);
-                    if (!result.rel->name) {
-                        col_rel_destroy(result.rel);
-                        return ENOMEM;
-                    }
-                    rc = session_add_rel(sess, result.rel);
-                    if (rc != 0) {
-                        col_rel_destroy(result.rel);
-                        return rc;
-                    }
-                    result.owned = false;
-                } else {
-                    col_rel_t *copy = col_rel_pool_new_like(
-                        sess->delta_pool, rp->name, result.rel);
-                    if (!copy)
-                        return ENOMEM;
-                    rc = col_rel_append_all(copy, result.rel,
-                            sess->eval_arena);
-                    if (rc != 0) {
-                        col_rel_destroy(copy);
-                        return rc;
-                    }
-                    rc = session_add_rel(sess, copy);
-                    if (rc != 0) {
-                        col_rel_destroy(copy);
-                        return rc;
-                    }
-                }
-            } else {
-                /* Append new results to existing relation */
-                rc = col_rel_append_all(target, result.rel, sess->eval_arena);
-                if (result.owned)
-                    col_rel_destroy(result.rel);
-                if (rc != 0)
-                    return rc;
-            }
-        }
-        col_mat_cache_clear(&sess->mat_cache);
-        delta_pool_reset(sess->delta_pool);
-        sess->rotation_ops->rotate_eval_arena(sess);
-
-        /* Non-recursive stratum frontier: record convergence epoch and iteration.
-        * Non-recursive strata always converge at iteration UINT32_MAX (no loop),
-        * so store (outer_epoch, UINT32_MAX) to enable epoch-aware skip on next
-        * incremental call. Always update both fields so same-epoch skip logic
-        * fires correctly when the frontier persists across session_step calls. */
-        sess->frontier_ops->record_stratum_convergence(sess, stratum_idx,
-            sess->outer_epoch, UINT32_MAX);
-
-        /* Issue #317: Report non-recursive convergence to coordinator's
-         * progress tracker.  Non-recursive strata always converge at
-         * UINT32_MAX (no iteration loop), matching the sentinel convention. */
-        if (sess->coordinator) {
-            wl_frontier_progress_record(&sess->coordinator->progress,
-                sess->worker_id, stratum_idx, sess->outer_epoch, UINT32_MAX);
-        }
-
-        /* Non-recursive rule frontiers: mark each rule fully evaluated.
-         * UINT32_MAX sentinel matches stratum frontier convention. */
-        if (sess->plan) {
-            uint32_t rule_base = 0;
-            for (uint32_t si = 0; si < stratum_idx; si++)
-                rule_base += sess->plan->strata[si].relation_count;
-            for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-                uint32_t rule_idx = rule_base + ri;
-                if (rule_idx < MAX_RULES) {
-                    /* Issue #106: Conservative approach - always reset rule frontiers
-                     * for affected strata to (current_epoch, UINT32_MAX) sentinel.
-                     * UINT32_MAX prevents premature skip during re-evaluation. */
-                    sess->frontier_ops->reset_rule_frontier(sess, rule_idx,
-                        sess->outer_epoch);
-                }
-            }
-        }
-
-        return 0;
-    }
-
-    /*
-     * Recursive stratum: semi-naive fixed-point iteration.
-     * Iterate until no new tuples are produced.
-     *
-     * Pre-register empty IDB relations so that VARIABLE ops can find
-     * them on the first iteration (before any tuples are produced).
-     */
-    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-        col_rel_t *existing = session_find_rel(sess, sp->relations[ri].name);
-        if (!existing) {
-            col_rel_t *empty = NULL;
-            int rc = col_rel_alloc(&empty, sp->relations[ri].name);
-            if (rc != 0)
-                return ENOMEM;
-            rc = session_add_rel(sess, empty);
-            if (rc != 0) {
-                col_rel_destroy(empty);
-                return rc;
-            }
-        }
-    }
-
-    /*
-     * Semi-naive fixed-point iteration with delta tracking.
-     * VARIABLE ops prefer "$d$relname" delta relations (rows added in the
-     * previous iteration). JOIN right-side lookups always use the full
-     * relation by name, giving delta (left) x full (right) join semantics.
-     */
-    uint32_t nrels = sp->relation_count;
-    col_rel_t **delta_rels = (col_rel_t **)calloc(nrels, sizeof(col_rel_t *));
-    if (!delta_rels)
-        return ENOMEM;
-
-    /* Allocate snap once before the iteration loop (Issue #367): hoisting
-     * the allocation out of the outer loop eliminates 2 malloc/free calls
-     * per iteration (14K+ iterations for CRDT). */
-    uint32_t *snap = (uint32_t *)malloc(nrels * sizeof(uint32_t));
-    if (!snap) {
-        free((void *)delta_rels);
-        return ENOMEM;
-    }
-
-    /* Sort pre-existing data in each IDB relation before iterating.
-     * Handles the EDB+IDB case: when base facts are pre-loaded into a
-     * relation that also appears as an IDB in a recursive rule, the loaded
-     * facts may be in insertion order (unsorted).
-     * col_op_consolidate_incremental_delta requires rel->data[0..snap) to be
-     * sorted; an unsorted prefix causes the 2-pointer merge to miss duplicates,
-     * producing spurious output rows. */
-    for (uint32_t ri = 0; ri < nrels; ri++) {
-        col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
-        if (r && r->nrows > 1) {
-            col_rel_radix_sort_int64(r);
-        }
-    }
-
-    /* Initialize recursive stratum frontier to UINT32_MAX (not set sentinel)
-     * only on the first evaluation (frontier==0 from calloc). If a prior
-     * col_session_insert_incremental call preserved a real convergence frontier,
-     * keep it so the per-iteration skip condition fires for iterations beyond
-     * the prior convergence point. */
-    sess->frontier_ops->init_stratum(sess, stratum_idx);
-
-    /* Phase 4 (US-4-004): Compute the base global rule index for this stratum.
-     * Rule indices are assigned by enumerating strata in order and relations
-     * within each stratum, matching col_compute_affected_rules convention. */
-    uint32_t rule_id_base = 0;
-    if (sess->plan) {
-        for (uint32_t si = 0;
-            si < stratum_idx && si < sess->plan->stratum_count; si++) {
-            rule_id_base += sess->plan->strata[si].relation_count;
-        }
-    }
-    /* Clamp so rule_id_base + ri never exceeds MAX_RULES - 1 */
-    if (rule_id_base >= MAX_RULES)
-        rule_id_base = MAX_RULES;
-
-    uint32_t iter;
-    col_frontier_t strat_frontier = { 0, 0 };
-    uint32_t final_eff_iter = 0; /* effective sub-pass index at convergence */
-
-    /* Issue #282: Save the session-level diff_operators_active so we can
-     * restore it after the recursive stratum evaluation completes.
-     * Within the iteration loop, we override it per sub-pass. */
-    bool saved_diff_operators_active = sess->diff_operators_active;
-
-    /*
-     * Stride-based semi-naive iteration (Issue #237).
-     * Each outer iteration runs EVAL_STRIDE sub-passes, chaining the delta
-     * from each sub-pass into the next.  Effective recursion depth covered:
-     *   MAX_ITERATIONS * EVAL_STRIDE = 4096 * 8 = 32768
-     * This allows deep-chain workloads (e.g. CRDT) to converge where they
-     * previously hit the MAX_ITERATIONS cap and produced incomplete results.
-     *
-     * When EVAL_STRIDE == 1 the behaviour is identical to the prior single-
-     * pass loop.
-     */
-    for (iter = 0; iter < MAX_ITERATIONS; iter++) {
-        bool outer_any_new = false; /* any sub-pass produced new tuples  */
-        int outer_rc = 0;           /* error propagated from inner loop  */
-        bool stride_all_skipped
-            = true; /* true until a sub-pass actually runs */
-        bool outer_continue_next
-            = false;            /* net-zero/all-empty: retry next outer */
-        bool converged = false; /* fixed point reached                */
-
-        /* snap[] is filled at the start of each sub-pass (nrows grows as new
-         * tuples are appended).  The array is allocated once before this loop
-         * (Issue #367) to avoid per-iteration malloc/free overhead. */
-
-        /* ------------------------------------------------------------------ */
-        /* Inner sub-pass loop: EVAL_STRIDE semi-naive passes per outer iter.  */
-        /* ------------------------------------------------------------------ */
-        for (uint32_t sub = 0; sub < EVAL_STRIDE; sub++) {
-            uint32_t eff_iter = iter * EVAL_STRIDE + sub;
-
-            /* Publish effective iteration so operators can distinguish base case
-             * (eff_iter 0: FORCE_DELTA falls back to full) from delta case
-             * (eff_iter > 0: FORCE_DELTA with absent delta → empty result). */
-            sess->current_iteration = eff_iter;
-
-            /* Issue #282: Enable differential operators for recursive iterations
-             * > 0.  At eff_iter 0, we seed from full EDB relations (base case)
-             * so arrangement reuse is not applicable.  From eff_iter 1 onward,
-             * only the delta is processed (semi-naive), so col_op_join_diff can
-             * build the hash table incrementally: O(D) instead of O(N).
-             * diff_arr_entries persist across sub-passes and are invalidated by
-             * col_session_invalidate_arrangements when the underlying relation
-             * changes (called after consolidation each sub-pass).
-             * The saved value is restored after the recursive stratum completes
-             * so non-recursive strata and the outer session logic are unaffected. */
-            sess->diff_operators_active
-                = sess->diff_enabled && eff_iter > 0;
-
-            /* Iteration skip based on frontier (convergence point of prior
-             * evaluation).  Skip sub-pass when both hold:
-             * 1. Same outer_epoch — frontier is valid for this insertion epoch
-             * 2. eff_iter > frontier.iteration — already processed in this epoch
-             * Once eff_iter exceeds the frontier for sub=0, it also exceeds for
-             * all higher sub values, so the entire outer iteration effectively
-             * continues to the next one. */
-            if (sess->frontier_ops->should_skip_iteration(sess, stratum_idx,
-                eff_iter)) {
-                continue; /* skip this sub-pass */
-            }
-
-            stride_all_skipped = false; /* at least one sub-pass runs */
-
-            /* Clear per-sub-pass delta arrangement cache (sequential eval path).
-             * K-fusion workers manage their own darr caches independently. */
-            col_session_free_delta_arrangements(sess);
-
-            /* Register delta relations from previous sub-pass into session */
-            for (uint32_t ri = 0; ri < nrels; ri++) {
-                if (!delta_rels[ri])
-                    continue;
-                const char *dname = sp->relations[ri].delta_name;
-                session_remove_rel(sess, dname);
-                int rc = session_add_rel(sess, delta_rels[ri]);
-                if (rc != 0)
-                    col_rel_destroy(delta_rels[ri]);
-                delta_rels[ri] = NULL; /* session now owns it */
-            }
-
-            /* Record per-relation row counts (O(1) snapshot — no data copy).
-             * Re-filled each sub-pass because nrows changes after each pass. */
-            for (uint32_t ri = 0; ri < nrels; ri++) {
-                col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
-                snap[ri] = r ? r->nrows : 0; /* O(1) count only, no copy */
-            }
-
-            /* Phase 3D: Frontier skip with multiplicities (US-3D-002).
-             * Skip sub-pass if all delta relations have zero net multiplicity.
-             * When detected, retry with the next outer iteration (same as the
-             * prior single-pass behaviour). */
-            if (eff_iter
-                > 0) { /* only skip from effective iteration 1 onward */
-                bool all_deltas_net_zero = true;
-                for (uint32_t ri = 0; ri < nrels; ri++) {
-                    const char *dname = sp->relations[ri].delta_name;
-                    col_rel_t *delta = session_find_rel(sess, dname);
-                    if (!delta || delta->nrows == 0) {
-                        /* Empty delta: net multiplicity is zero */
-                        continue;
-                    }
-                    /* Compute net multiplicity for this delta relation */
-                    int64_t net_mult = 0;
-                    for (uint32_t row = 0; row < delta->nrows; row++) {
-                        net_mult += delta->timestamps[row].multiplicity;
-                    }
-                    if (net_mult != 0) {
-                        all_deltas_net_zero = false;
-                        break;
-                    }
-                }
-                if (all_deltas_net_zero) {
-                    /* All deltas zero net-multiplicity: skip to next outer iter */
-                    outer_continue_next = true;
-                    break;
-                }
-            }
-
-            /* Stratum-level early exit: if all rules have empty forced deltas,
-             * the sub-pass will produce no new facts. (Issue #81) */
-            if (eff_iter > 0) {
-                bool all_rules_empty = true;
-                for (uint32_t ri = 0; ri < nrels; ri++) {
-                    if (!has_empty_forced_delta(&sp->relations[ri], sess,
-                        eff_iter)) {
-                        all_rules_empty = false;
-                        break;
-                    }
-                }
-                if (all_rules_empty) {
-                    outer_continue_next = true;
-                    break;
-                }
-            }
-
-            /* Single-pass semi-naive evaluation. VARIABLE prefers delta when it
-             * is a strict subset of full (genuine new facts). JOIN propagates
-             * the is_delta flag through results and applies right-delta when
-             * left is full and a strictly-smaller right delta exists. */
-            for (uint32_t ri = 0; ri < nrels; ri++) {
-                const wl_plan_relation_t *rp = &sp->relations[ri];
-
-                /* Issue #106 (US-106-003): Rule-level frontier skip with epoch
-                 * gating.  Skip rule evaluation only when BOTH hold:
-                 * 1. Same outer_epoch (prevents cross-epoch incorrect skips)
-                 * 2. eff_iter > convergence point (already processed in epoch)
-                 * Across epoch boundaries mismatch => always re-eval. */
-                uint32_t rule_id = rule_id_base + ri;
-                if (sess->frontier_ops->should_skip_rule(sess, rule_id,
-                    eff_iter)) {
-                    continue;
-                }
-
-                /* Pre-scan skip: if a FORCE_DELTA op references an empty or
-                 * absent delta (eff_iter > 0), the plan produces 0 rows. */
-                if (has_empty_forced_delta(rp, sess, eff_iter)) {
-                    continue;
-                }
-
-                eval_stack_t stack;
-                eval_stack_init(&stack);
-
-                int rc = col_eval_relation_plan(rp, &stack, sess);
-                if (rc != 0) {
-                    eval_stack_drain(&stack);
-                    outer_rc = rc;
-                    goto stride_error;
-                }
-
-                if (stack.top == 0)
-                    continue;
-
-                eval_entry_t result = eval_stack_pop(&stack);
-                eval_stack_drain(&stack);
-
-                /* Post-eval skip: evaluation produced 0 rows — safety net for
-                 * cases not caught by pre-scan (e.g. filters eliminating all
-                 * rows).
-                 *
-                 * The !result.rel arm is not analyzer appeasement.
-                 * eval_stack_pop() yields {NULL, ...} only for an empty
-                 * stack, and the stack.top == 0 check three lines above has
-                 * already excluded that, so a NULL here would mean a NULL rel
-                 * was pushed.  It is dispositioned as "no result" to match
-                 * that same branch rather than as an error, so one observable
-                 * state does not get two dispositions depending on which
-                 * check saw it first.  (diff.c and join.c return EINVAL on a
-                 * NULL pop because they pop without a prior emptiness check.)
-                 * Otherwise the statements below dereference result.rel:
-                 * ->name on the rename arm, ->ncols on the schema-adoption
-                 * arm.  col_rel_destroy(NULL) is a no-op, so the continue
-                 * leaks nothing. */
-                if (!result.rel || result.rel->nrows == 0) {
-                    if (result.owned)
-                        col_rel_destroy(result.rel);
-                    continue;
-                }
-
-                col_rel_t *target = session_find_rel(sess, rp->name);
-                if (!target) {
-                    col_rel_t *copy;
-                    if (result.owned) {
-                        copy = result.rel;
-                        free(copy->name);
-                        copy->name = wl_strdup(rp->name);
-                        if (!copy->name) {
-                            col_rel_destroy(copy);
-                            outer_rc = ENOMEM;
-                            goto stride_error;
-                        }
-                        result.owned = false;
-                    } else {
-                        copy = col_rel_pool_new_like(
-                            sess->delta_pool, rp->name, result.rel);
-                        if (!copy) {
-                            outer_rc = ENOMEM;
-                            goto stride_error;
-                        }
-                        rc = col_rel_append_all(copy, result.rel,
-                                sess->eval_arena);
-                        if (rc != 0) {
-                            col_rel_destroy(copy);
-                            outer_rc = rc;
-                            goto stride_error;
-                        }
-                    }
-                    rc = session_add_rel(sess, copy);
-                    if (rc != 0) {
-                        col_rel_destroy(copy);
-                        outer_rc = rc;
-                        goto stride_error;
-                    }
-                } else {
-                    /* Adopt schema from result if target is still uninitialised */
-                    if (target->ncols == 0 && result.rel->ncols > 0) {
-                        rc = col_rel_set_schema(
-                            target, result.rel->ncols,
-                            (const char *const *)result.rel->col_names);
-                        if (rc != 0) {
-                            if (result.owned)
-                                col_rel_destroy(result.rel);
-                            outer_rc = rc;
-                            goto stride_error;
-                        }
-                    }
-                    rc = col_rel_append_all(target, result.rel,
-                            sess->eval_arena);
-                    if (result.owned)
-                        col_rel_destroy(result.rel);
-                    if (rc != 0) {
-                        outer_rc = rc;
-                        goto stride_error;
-                    }
-                }
-            }
-
-            /* Remove delta relations from session (evaluation is complete) */
-            for (uint32_t ri = 0; ri < nrels; ri++) {
-                const char *dname = sp->relations[ri].delta_name;
-                session_remove_rel(sess, dname);
-            }
-
-            /* Phase 4: Frontier is computed incrementally as deltas are created
-             * because delta_rels[ri] may be set to NULL in the next sub-pass's
-             * registration loop.  strat_frontier declared before outer loop. */
-
-            /* Consolidate all IDB relations to remove duplicates and compute
-             * delta as a byproduct.  snap[ri] marks the boundary between the
-             * already-sorted prefix and unsorted new rows appended this pass. */
-            bool any_new = false;
-            for (uint32_t ri = 0; ri < nrels; ri++) {
-                col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
-                if (!r || snap[ri] >= r->nrows) {
-                    continue; /* no new rows for this relation */
-                }
-
-                const char *dname = sp->relations[ri].delta_name;
-                col_rel_t *delta = col_rel_pool_new_like(
-                    sess->delta_pool, dname, r);
-                if (!delta) {
-                    outer_rc = ENOMEM;
-                    goto stride_error;
-                }
-
-                /* Consolidate WITH delta output (no separate merge walk) */
-                uint32_t cons_old = snap[ri];
-                uint32_t cons_new = r->nrows - cons_old; /* delta count D */
-                int fast_flag = 0;
-                uint64_t cons_t0 = now_ns();
-                int rc2 = col_op_consolidate_incremental_delta(r, snap[ri],
-                        delta, &fast_flag);
-                uint64_t cons_elapsed = now_ns() - cons_t0;
-                sess->consolidation_ns += cons_elapsed;
-                sess->consolidate_fast_hits += (uint64_t)fast_flag;
-                sess->consolidate_slow_hits += (uint64_t)(1 - fast_flag);
-                /* Invalidate arrangements for this relation (data changed). */
-                col_session_invalidate_arrangements(&sess->base,
-                    sp->relations[ri].name);
-                /* Per-call trace: WL_LOG=CONSOLIDATION:5 (or legacy
-                 * WL_CONSOLIDATION_LOG presence shim). */
-                WL_LOG(WL_LOG_SEC_CONSOLIDATION, WL_LOG_DEBUG,
-                    "eff_iter=%u stratum=%u rel=%s N=%u D=%u "
-                    "time_us=%.1f ratio=%.4f",
-                    eff_iter, stratum_idx, sp->relations[ri].name,
-                    cons_old, cons_new, (double)cons_elapsed / 1000.0,
-                    cons_old > 0 ? (double)cons_new / (double)cons_old
-                                     : 0.0);
-                if (rc2 != 0) {
-                    col_rel_destroy(delta);
-                    outer_rc = rc2;
-                    goto stride_error;
-                }
-
-                if (delta->nrows > 0) {
-                    /* Stamp each new row with its provenance (eff_iter, stratum).
-                     * worker=0 indicates the sequential (non-K-fusion) path. */
-                    delta->timestamps = (col_delta_timestamp_t *)calloc(
-                        delta->nrows, sizeof(col_delta_timestamp_t));
-                    if (!delta->timestamps) {
-                        col_rel_destroy(delta);
-                        outer_rc = ENOMEM;
-                        goto stride_error;
-                    }
-                    for (uint32_t ti = 0; ti < delta->nrows; ti++) {
-                        delta->timestamps[ti].iteration = eff_iter;
-                        delta->timestamps[ti].stratum = stratum_idx;
-                        /* worker left zero: sequential evaluation path */
-                        delta->timestamps[ti].multiplicity = 1;
-                    }
-
-                    /* Phase 4: Enable timestamp tracking on target relation to
-                     * preserve provenance through consolidation.  This enables
-                     * frontier computation to determine convergence. */
-                    if (!r->timestamps && r->capacity > 0) {
-                        r->timestamps = (col_delta_timestamp_t *)calloc(
-                            r->capacity, sizeof(col_delta_timestamp_t));
-                        if (!r->timestamps) {
-                            free(delta->timestamps);
-                            col_rel_destroy(delta);
-                            outer_rc = ENOMEM;
-                            goto stride_error;
-                        }
-                    }
-
-                    delta_rels[ri] = delta;
-                    any_new = true;
-
-                    /* Phase 4: Compute frontier from this delta immediately.
-                     * Must happen before next sub-pass registration sets
-                     * delta_rels[ri]=NULL.
-                     * frontier = MAX eff_iter that produced facts. */
-                    col_frontier_t rel_frontier = col_frontier_compute(delta);
-                    if (rel_frontier.iteration > strat_frontier.iteration
-                        || (rel_frontier.iteration == strat_frontier.iteration
-                        && rel_frontier.stratum > strat_frontier.stratum)) {
-                        strat_frontier = rel_frontier;
-                    }
-                } else {
-                    col_rel_destroy(delta);
-                }
-            }
-
-            /* Issue #176: Per-sub-pass cache eviction for recursive strata.
-             * Materialized join results may live in delta_pool, so release
-             * them before resetting the pool.  Resetting first clears the
-             * pool-owned marker and leaves the cache holding stale pointers.
-             * Use configurable eviction threshold (cache_evict_threshold):
-             * - If 0: clear entire cache each sub-pass (backward compatible)
-             * - If > 0: evict LRU entries when cache exceeds threshold */
-            if (sess->cache_evict_threshold == 0) {
-                col_mat_cache_clear(&sess->mat_cache);
-            } else {
-                col_mat_cache_evict_until(&sess->mat_cache,
-                    sess->cache_evict_threshold);
-            }
-
-            delta_pool_reset(sess->delta_pool);
-            sess->rotation_ops->rotate_eval_arena(sess);
-            /* Issue #560: Advance the compound-arena epoch frontier at the
-             * end of each recursive sub-pass iteration so the
-             * epoch-frontier GC can reclaim handles whose multiplicity
-             * dropped to zero in this iteration.  NULL-guard each link in
-             * the dispatch chain because tests and early lifecycle paths
-             * may operate without a compound arena or rotation strategy.
-             * The compound_arena is borrowed from the coordinator (Issue
-             * #579 / R-5); only the coordinator may mutate it, so
-             * worker-context invocations skip the dispatch. */
-            if (sess->coordinator == NULL
-                && sess->compound_arena && sess->rotation_ops
-                && sess->rotation_ops->gc_epoch_boundary) {
-                sess->rotation_ops->gc_epoch_boundary(sess);
-            }
-            if (!any_new) {
-                /* Fixed point reached: no new tuples in this sub-pass. */
-                converged = true;
-                break;
-            }
-            outer_any_new = true;
-            final_eff_iter = eff_iter;
-            continue; /* next sub-pass */
-
-stride_error:
-            break; /* exit inner loop; outer_rc carries the error */
-        } /* end inner sub-pass loop */
-
-        if (outer_rc != 0) {
-            /* Issue #282: Restore diff_operators_active on error path */
-            sess->diff_operators_active = saved_diff_operators_active;
-            for (uint32_t ri = 0; ri < nrels; ri++) {
-                session_remove_rel(sess, sp->relations[ri].delta_name);
-                if (delta_rels[ri])
-                    col_rel_destroy(delta_rels[ri]);
-            }
-            free(snap);
-            free((void *)delta_rels);
-            return outer_rc;
-        }
-
-        /* Dispatch on why the inner loop exited */
-        if (stride_all_skipped)
-            continue; /* all sub-passes were frontier-skipped: next outer iter */
-        if (outer_continue_next)
-            continue; /* net-zero or all-empty delta: retry next outer iter */
-        if (converged || !outer_any_new)
-            break; /* true convergence */
-    } /* end outer stride loop */
-    /* Issue #282: Restore session-level diff_operators_active.
-     * The per-iteration override above applies only within the recursive
-     * fixed-point loop.  Restoring the saved value ensures subsequent
-     * non-recursive strata and outer session logic see the correct state. */
-    sess->diff_operators_active = saved_diff_operators_active;
-
-    sess->total_iterations = final_eff_iter;
-
-    /* Issue #914: current_iteration is deliberately left at final_eff_iter (> 0)
-     * here. The non-recursive branch of col_eval_stratum is responsible for
-     * resetting it to 0 before its base-case evaluation; do not add a second
-     * reset here (consensus declined that). See the non-recursive branch above. */
-
-    /* Issue #106 (US-106-005): Record per-rule frontier at convergence with epoch.
-     * When stratum converges at effective iteration I, record (outer_epoch, I).
-     * On next incremental snapshot, skip fires when eff_iter > I. */
-    for (uint32_t ri = 0; ri < nrels && rule_id_base + ri < MAX_RULES; ri++) {
-        uint32_t rule_id = rule_id_base + ri;
-        sess->frontier_ops->record_rule_convergence(sess, rule_id,
-            sess->outer_epoch, final_eff_iter);
-    }
-
-    /* Phase 4: Update per-stratum frontier after recursive stratum evaluation.
-     * strat_frontier was computed incrementally via delta timestamps (eff_iter),
-     * so it already holds the effective iteration index at convergence. */
-    if (strat_frontier.iteration != UINT32_MAX) {
-        sess->frontier_ops->record_stratum_convergence(sess, stratum_idx,
-            sess->outer_epoch, strat_frontier.iteration);
-
-        /* Issue #317: Report recursive convergence to coordinator's progress
-         * tracker so col_eval_stratum_multiworker can compute the global
-         * minimum frontier after the workqueue barrier. */
-        if (sess->coordinator) {
-            wl_frontier_progress_record(&sess->coordinator->progress,
-                sess->worker_id, stratum_idx, sess->outer_epoch,
-                strat_frontier.iteration);
-        }
-    }
-
-    int agg_rc = col_canonicalize_recursive_aggregates(sp, sess);
-    if (agg_rc != 0) {
-        for (uint32_t ri = 0; ri < nrels; ri++) {
-            if (delta_rels[ri])
-                col_rel_destroy(delta_rels[ri]);
-        }
-        free(snap);
-        free((void *)delta_rels);
-        return agg_rc;
-    }
-
-    /* Cleanup all delta relations after frontier has been computed */
-    for (uint32_t ri = 0; ri < nrels; ri++) {
-        if (delta_rels[ri])
-            col_rel_destroy(delta_rels[ri]);
-        const char *dname = sp->relations[ri].delta_name;
-        session_remove_rel(sess, dname);
-    }
-    free(snap);
-    free((void *)delta_rels);
-    delta_pool_reset(sess->delta_pool);
-    sess->rotation_ops->rotate_eval_arena(sess);
-    col_mat_cache_clear(&sess->mat_cache);
-
-    return 0;
-}
-static col_frontier_t
-col_frontier_compute(const col_rel_t *rel)
-{
-    col_frontier_t f = { 0, 0 };
-
-    /* Handle NULL or empty relation */
-    if (!rel || rel->nrows == 0 || !rel->timestamps)
-        return f;
-
-    /* Initialize frontier to first row's timestamp */
-    f.iteration = rel->timestamps[0].iteration;
-    f.stratum = rel->timestamps[0].stratum;
-
-    /* Find minimum (iteration, stratum) */
-    for (uint32_t i = 1; i < rel->nrows; i++) {
-        const col_delta_timestamp_t *ts = &rel->timestamps[i];
-        if (ts->iteration < f.iteration
-            || (ts->iteration == f.iteration && ts->stratum < f.stratum)) {
-            f.iteration = ts->iteration;
-            f.stratum = ts->stratum;
-        }
-    }
-
-    return f;
-}
-bool
-stratum_has_preseeded_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess)
-{
-    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-        const char *dname = sp->relations[ri].delta_name;
-        col_rel_t *delta = session_find_rel(sess, dname);
-        if (delta && delta->nrows > 0)
-            return true;
-    }
-    return false;
-}
-
-/*
- * rule_index_to_stratum_index: Map a flat rule index to its stratum index
- *
- * Rules are laid out contiguously across strata in plan order. Stratum 0
- * owns rule indices [0, relation_count_0), stratum 1 owns
- * [relation_count_0, relation_count_0 + relation_count_1), and so on.
- * This function walks the strata, accumulating a running rule offset, and
- * returns the stratum whose window contains rule_id.
- *
- * Issue #107: Selective rule frontier reset uses this mapping to check
- * if a rule's stratum has pre-seeded delta before resetting the rule's frontier.
- *
- * @param plan:    Execution plan containing the strata array.
- * @param rule_id: Flat (zero-based) rule index to look up.
- * @return Stratum index that owns rule_id, or UINT32_MAX if rule_id is
- *         out of range (>= total rule count across all strata).
- */
-uint32_t
-rule_index_to_stratum_index(const wl_plan_t *plan, uint32_t rule_id)
-{
-    uint32_t offset = 0;
-    for (uint32_t si = 0; si < plan->stratum_count; si++) {
-        uint32_t next_offset = offset + plan->strata[si].relation_count;
-        if (rule_id < next_offset)
-            return si;
-        offset = next_offset;
-    }
-    return UINT32_MAX;
-}
+/* Serial stratum evaluation is implemented in columnar/eval_serial.c. */
 
 /* ======================================================================== */
 /* Distributed Stratum Evaluator (Issue #318)                               */
@@ -1142,8 +206,8 @@ nonrec_make_shared_relation_view(const col_rel_t *src, col_rel_t **out)
     return 0;
 }
 
-static int
-col_eval_nonrecursive_relation_parallel(const wl_plan_relation_t *rp,
+int
+wl_columnar_eval_nonrec_relation_parallel(const wl_plan_relation_t *rp,
     wl_col_session_t *coord)
 {
     const char *driver_name = NULL;
@@ -1823,7 +887,7 @@ tdd_seed_global_read_initial_deltas(const wl_plan_stratum_t *sp,
  * tdd_worker_subpass_fn:
  * Execute one sub-pass of the semi-naive iteration on a worker's partition.
  *
- * Mirrors eval.c:392-736 for a single (iter, sub) effective iteration,
+ * Mirrors eval_serial.c:377-721 for a single (iter, sub) effective iteration,
  * operating entirely on the worker's local session.  The coordinator
  * controls the outer iteration loop and convergence detection.
  *
@@ -1870,7 +934,7 @@ tdd_worker_subpass_fn(void *arg)
     uint64_t worker_t0 = now_ns();
 
     /* Issue #282: Enable differential operators from eff_iter 1 onward.
-     * Mirrors eval.c:410-411 / Clarification 3.
+     * Mirrors eval_serial.c:395-396 / Clarification 3.
      * Issue #390: BDX mode forces diff from eff_iter 0 so that K_FUSION
      * evaluates Δr ⋈ r_w (broadcast delta × local partition) instead of
      * r_w ⋈ r_w (incomplete local self-join). */
@@ -1898,11 +962,12 @@ tdd_worker_subpass_fn(void *arg)
             return; \
         } while (0)
 
-    /* Free per-sub-pass delta arrangements (eval.c:429) */
+    /* Free per-sub-pass delta arrangements (eval_serial.c:414) */
     col_session_free_delta_arrangements(sess);
 
-    /* Early-exit: all relation plans have empty FORCE_DELTA (eval.c:486-498).
-    * Worker reports all_empty_delta; coordinator skips to next outer iter. */
+    /* Early-exit: all relation plans have empty FORCE_DELTA
+     * (eval_serial.c:471-483).  Worker reports all_empty_delta;
+     * coordinator skips to next outer iter. */
     if (eff_iter > 0) {
         bool all_empty = true;
         for (uint32_t ri = 0; ri < nrels; ri++) {
@@ -1920,7 +985,7 @@ tdd_worker_subpass_fn(void *arg)
         }
     }
 
-    /* Snapshot nrows before evaluation (eval.c:446-449) */
+    /* Snapshot nrows before evaluation (eval_serial.c:431-434) */
     uint32_t *snap = (uint32_t *)calloc(nrels, sizeof(uint32_t));
     if (!snap) {
         ctx->rc = ENOMEM;
@@ -1936,7 +1001,7 @@ tdd_worker_subpass_fn(void *arg)
 
     bool any_new = false;
 
-    /* Evaluate all relation plans (eval.c:505-604) */
+    /* Evaluate all relation plans (eval_serial.c:490-589) */
     for (uint32_t ri = 0; ri < nrels; ri++) {
         const wl_plan_relation_t *rp = &sp->relations[ri];
 
@@ -2166,7 +1231,7 @@ tdd_worker_subpass_fn(void *arg)
         }
     }
 
-    /* Consolidate + produce deltas (eval.c:621-713).
+    /* Consolidate + produce deltas (eval_serial.c:606-698).
      * Use col_rel_new_like (heap) so deltas survive delta_pool_reset. */
     for (uint32_t ri = 0; ri < nrels; ri++) {
         col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
@@ -2245,7 +1310,7 @@ tdd_worker_subpass_fn(void *arg)
         }
 
         if (delta->nrows > 0) {
-            /* Stamp timestamps (eval.c:668-696) */
+            /* Stamp timestamps (eval_serial.c:653-681) */
             delta->timestamps = (col_delta_timestamp_t *)calloc(
                 delta->nrows, sizeof(col_delta_timestamp_t));
             if (!delta->timestamps) {
@@ -2311,7 +1376,7 @@ tdd_worker_subpass_fn(void *arg)
 
     free(snap);
 
-    /* Reset per-sub-pass allocators and cache (eval.c:716-727) */
+    /* Reset per-sub-pass allocators and cache (eval_serial.c:701-712) */
     delta_pool_reset(sess->delta_pool);
     sess->rotation_ops->rotate_eval_arena(sess);
     if (sess->cache_evict_threshold == 0) {
@@ -2635,7 +1700,7 @@ tdd_sorted_merge_append(col_rel_t *dst, col_rel_t *src)
  * tdd_preregister_idb_on_workers:
  * Pre-register empty IDB relations on each worker session so that
  * VARIABLE ops can find them on the first sub-pass (eff_iter == 0).
- * Mirrors eval.c:291-304.
+ * Mirrors eval_serial.c:276-289.
  */
 static int
 tdd_preregister_idb_on_workers(const wl_plan_stratum_t *sp,
@@ -3552,7 +2617,8 @@ tdd_broadcast_deltas(const wl_plan_stratum_t *sp,
 /*
  * tdd_record_recursive_convergence:
  * After recursive fixed-point convergence, record stratum and per-rule
- * frontiers on the coordinator.  Mirrors eval.c:768-791 for the TDD path.
+ * frontiers on the coordinator.  Mirrors eval_serial.c:753-776 for the
+ * TDD path.
  */
 static void
 tdd_record_recursive_convergence(wl_col_session_t *coord,
@@ -3561,13 +2627,13 @@ tdd_record_recursive_convergence(wl_col_session_t *coord,
 {
     uint32_t nrels = sp->relation_count;
 
-    /* Per-rule frontier (eval.c:771-775) */
+    /* Per-rule frontier (eval_serial.c:756-760) */
     for (uint32_t ri = 0; ri < nrels && rule_id_base + ri < MAX_RULES; ri++) {
         coord->frontier_ops->record_rule_convergence(coord,
             rule_id_base + ri, coord->outer_epoch, final_eff_iter);
     }
 
-    /* Stratum frontier (eval.c:780-782) */
+    /* Stratum frontier (eval_serial.c:765-767) */
     coord->frontier_ops->record_stratum_convergence(coord,
         stratum_idx, coord->outer_epoch, final_eff_iter);
 }
@@ -3576,17 +2642,17 @@ tdd_record_recursive_convergence(wl_col_session_t *coord,
  * tdd_record_nonrecursive_convergence:
  * After non-recursive stratum dispatch, record stratum and per-rule frontiers.
  * Non-recursive strata always converge in one step; uses UINT32_MAX sentinel.
- * Mirrors eval.c:247-279 for the TDD coordinator path.
+ * Mirrors eval_serial.c:232-264 for the TDD coordinator path.
  */
 static void
 tdd_record_nonrecursive_convergence(wl_col_session_t *coord,
     const wl_plan_stratum_t *sp, uint32_t stratum_idx)
 {
-    /* Stratum frontier: UINT32_MAX sentinel (eval.c:252-253) */
+    /* Stratum frontier: UINT32_MAX sentinel (eval_serial.c:237-238) */
     coord->frontier_ops->record_stratum_convergence(coord,
         stratum_idx, coord->outer_epoch, UINT32_MAX);
 
-    /* Per-rule frontiers (eval.c:265-279) */
+    /* Per-rule frontiers (eval_serial.c:250-264) */
     if (coord->plan) {
         uint32_t rule_base = 0;
         for (uint32_t si = 0; si < stratum_idx; si++)
@@ -4593,7 +3659,8 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
     int rc = 0;
     uint64_t tdd_total_t0 = now_ns();
 
-    /* Pre-register empty IDB relations on coordinator (eval.c:291-304) */
+    /* Pre-register empty IDB relations on coordinator
+     * (eval_serial.c:276-289) */
     for (uint32_t ri = 0; ri < nrels; ri++) {
         if (session_find_rel(coord, sp->relations[ri].name))
             continue;
@@ -4755,7 +3822,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         return rc;
     }
 
-    /* Sort pre-existing IDB data on workers (eval.c:324-329) */
+    /* Sort pre-existing IDB data on workers (eval_serial.c:309-314) */
     for (uint32_t w = 0; w < W; w++) {
         for (uint32_t ri = 0; ri < nrels; ri++) {
             col_rel_t *r = session_find_rel(&coord->tdd_workers[w],
@@ -4795,7 +3862,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         }
     }
 
-    /* Phase 4: Frontier Initialization (eval.c:336)
+    /* Phase 4: Frontier Initialization (eval_serial.c:321)
      * Initialize per-stratum frontier tracking for convergence detection.
      * Frontier records the iteration at which each stratum converged
      * (fixed-point reached with no new tuples).
@@ -4993,7 +4060,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         for (uint32_t sub = 0; sub < EVAL_STRIDE; sub++) {
             uint32_t eff_iter = iter * EVAL_STRIDE + sub;
 
-            /* Phase 4: Frontier Skip Optimization (eval.c:420-423) */
+            /* Phase 4: Frontier Skip Optimization (eval_serial.c:405-408) */
             if (coord->frontier_ops->should_skip_iteration(coord,
                 stratum_idx, eff_iter)) {
                 continue;
@@ -5266,7 +4333,8 @@ done:
     coord->total_iterations += final_eff_iter;
 
     if (rc == 0) {
-        /* Record stratum and per-rule frontiers (mirrors eval.c:768-791) */
+        /* Record stratum and per-rule frontiers
+         * (mirrors eval_serial.c:753-776) */
         tdd_record_recursive_convergence(coord, sp, stratum_idx,
             rule_id_base, final_eff_iter);
 
@@ -5280,7 +4348,7 @@ done:
                 if (r && r->nrows > 1)
                     tdd_dedup_rel(r);
             }
-            rc = col_canonicalize_recursive_aggregates(sp, coord);
+            rc = wl_columnar_eval_serial_canonicalize_aggregates(sp, coord);
             coord->tdd_final_merge_ns += now_ns() - merge_t0;
         } else {
             /* Non-BDX: Merge worker IDB into coordinator */
@@ -5296,7 +4364,7 @@ done:
                     if (r && r->nrows > 1)
                         tdd_dedup_rel(r);
                 }
-                rc = col_canonicalize_recursive_aggregates(sp, coord);
+                rc = wl_columnar_eval_serial_canonicalize_aggregates(sp, coord);
             }
             coord->tdd_final_merge_ns += now_ns() - merge_t0;
         }
@@ -5386,7 +4454,8 @@ col_eval_stratum_tdd_nonrecursive(const wl_plan_stratum_t *sp,
         }
     }
 
-    /* Phase 7: Record stratum and per-rule frontiers (mirrors eval.c:247-279) */
+    /* Phase 7: Record stratum and per-rule frontiers
+     * (mirrors eval_serial.c:232-264) */
     if (rc == 0)
         tdd_record_nonrecursive_convergence(coord, sp, stratum_idx);
 

--- a/wirelog/columnar/eval_serial.c
+++ b/wirelog/columnar/eval_serial.c
@@ -1,0 +1,957 @@
+/*
+ * columnar/eval_serial.c - serial stratum evaluator
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ * For commercial licenses, contact: inquiry@cleverplant.com
+ *
+ * Serial (single-threaded) stratum evaluation extracted from
+ * columnar/eval.c.
+ */
+
+#define _GNU_SOURCE
+
+#include "columnar/internal.h"
+#include "wirelog/util/log.h"
+
+#include "../wirelog-internal.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Distributed (TDD) stratum evaluation is implemented in columnar/eval.c. */
+static col_frontier_t
+col_frontier_compute(const col_rel_t *rel);
+
+static bool
+col_reduce_output_group_equal(const col_rel_t *rel, uint32_t a, uint32_t b,
+    uint32_t group_by_count, uint32_t aggregate_index)
+{
+    for (uint32_t c = 0; c < group_by_count; c++) {
+        uint32_t out_col = c >= aggregate_index ? c + 1 : c;
+        if (col_rel_get(rel, a, out_col)
+            != col_rel_get(rel, b, out_col))
+            return false;
+    }
+    return true;
+}
+
+typedef struct {
+    uint64_t hash;
+    uint32_t row;
+} col_group_slot_t;
+
+static uint64_t
+col_group_hash(const col_rel_t *rel, uint32_t row, uint32_t group_by_count,
+    uint32_t aggregate_index)
+{
+    uint64_t hash = UINT64_C(1469598103934665603);
+    for (uint32_t c = 0; c < group_by_count; c++) {
+        uint32_t out_col = c >= aggregate_index ? c + 1 : c;
+        hash ^= (uint64_t)col_rel_get(rel, row, out_col);
+        hash *= UINT64_C(1099511628211);
+    }
+    return hash ? hash : 1;
+}
+
+static int
+col_canonicalize_recursive_aggregate_relation(col_rel_t *rel,
+    const wl_plan_agg_spec_t *spec, const wl_intern_t *intern)
+{
+    if (!rel || !spec || !spec->has_spec || rel->nrows < 2)
+        return 0;
+
+    uint32_t gc = spec->group_by_count;
+    uint32_t agg_index = spec->aggregate_index < rel->ncols
+        ? spec->aggregate_index : gc;
+    if (rel->ncols <= gc)
+        return EINVAL;
+
+    uint32_t out = 0;
+    uint32_t map_cap = 1;
+    uint64_t desired = (uint64_t)rel->nrows * 2U;
+    while ((uint64_t)map_cap < desired && map_cap <= UINT32_MAX / 2U)
+        map_cap <<= 1;
+    if ((uint64_t)map_cap < desired)
+        return ENOMEM;
+    col_group_slot_t *groups = (col_group_slot_t *)calloc(map_cap,
+            sizeof(*groups));
+    if (!groups)
+        return ENOMEM;
+    uint32_t map_mask = map_cap - 1;
+    for (uint32_t row = 0; row < rel->nrows; row++) {
+        uint32_t found = UINT32_MAX;
+        uint64_t hash = col_group_hash(rel, row, gc, agg_index);
+        uint32_t slot = (uint32_t)hash & map_mask;
+        while (groups[slot].hash != 0) {
+            uint32_t keep = groups[slot].row;
+            if (groups[slot].hash == hash
+                && col_reduce_output_group_equal(rel, keep, row, gc,
+                agg_index)) {
+                found = keep;
+                break;
+            }
+            slot = (slot + 1) & map_mask;
+        }
+
+        if (found != UINT32_MAX) {
+            int64_t cur = col_rel_get(rel, found, agg_index);
+            int64_t val = col_rel_get(rel, row, agg_index);
+            /* Same comparator as col_op_reduce(): a fixpoint that ordered
+             * lexicographically within an iteration and by intern id across
+             * iterations would be worse than the original bug (#965). */
+            bool better = col_agg_better(spec->fn, spec->operand_type,
+                    intern, val, cur);
+            if (better) {
+                col_rel_set(rel, found, agg_index, val);
+                if (rel->timestamps)
+                    rel->timestamps[found] = rel->timestamps[row];
+            }
+            continue;
+        }
+
+        if (out != row) {
+            for (uint32_t c = 0; c < rel->ncols; c++)
+                col_rel_set(rel, out, c, col_rel_get(rel, row, c));
+            if (rel->timestamps)
+                rel->timestamps[out] = rel->timestamps[row];
+        }
+        groups[slot].hash = hash;
+        groups[slot].row = out;
+        out++;
+    }
+
+    if (out != rel->nrows) {
+        rel->nrows = out;
+        rel->sorted_nrows = out;
+        rel->base_nrows = out;
+        rel->run_count = 0;
+        rel->dedup_count = 0;
+        memset(rel->run_ends, 0, sizeof(rel->run_ends));
+    }
+
+    free(groups);
+
+    return 0;
+}
+
+int
+wl_columnar_eval_serial_canonicalize_aggregates(const wl_plan_stratum_t *sp,
+    wl_col_session_t *sess)
+{
+    /*
+     * Reading the recorded specification rather than looking for a REDUCE in
+     * rp->ops is the whole of #975: rewrite_multiway_delta() replaces a fused
+     * relation's operators with a single K_FUSION and moves the originals into
+     * its opaque_data, so the operator was not there to be found and this ran
+     * on every recursive aggregate relation *except* the ones fusion applies
+     * to.  wl_plan_relation_t.recursive_agg is filled at IR lowering, before
+     * any rewrite runs.
+     *
+     * Timing is unchanged: this is the fixpoint, not per-iteration
+     * consolidation.  A same-stratum consumer would therefore hold rows
+     * derived from labels this reduction then dominates away, output that
+     * contradicts itself.  #1021 settled that by refusing the shape at plan
+     * time -- a recursive min/max aggregate may not share an SCC with any
+     * other relation -- rather than by changing when this runs, so nothing
+     * here had to move.  Moving the reduction into consolidation is still
+     * open and would readmit the intra-round half of the shape; that is
+     * deferred to milestone 0.70.0, see docs/SEMANTICS.md.
+     *
+     * The correction that matters to a reader of the old comment here:
+     * wl_plan_stratum_t.is_monotone is no longer "hardcoded false and never
+     * computed".  wl_plan_from_program() computes it (negation only), and it
+     * still has no consumer, so a true value is not yet a signal anything may
+     * act on.
+     */
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        const wl_plan_relation_t *rp = &sp->relations[ri];
+        if (!rp->recursive_agg.has_spec)
+            continue;
+        col_rel_t *rel = session_find_rel(sess, rp->name);
+        int rc = col_canonicalize_recursive_aggregate_relation(rel,
+                &rp->recursive_agg, sess->intern);
+        if (rc != 0)
+            return rc;
+        col_session_invalidate_arrangements(&sess->base, rp->name);
+    }
+    return 0;
+}
+
+/*
+ * col_eval_stratum:
+ * Evaluate one stratum, writing results into session relations.
+ * Non-recursive strata are evaluated once.
+ * Recursive strata use semi-naive fixed-point iteration.
+ *
+ * Returns 0 on success, non-zero on error.
+ */
+int
+col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
+    uint32_t stratum_idx)
+{
+    if (!sp->is_recursive) {
+        /* Issue #914: a non-recursive stratum is always the base case. The
+         * recursive-stratum loop leaves sess->current_iteration > 0 and never
+         * resets it, which would wrongly trigger the base-case EDB VARIABLE
+         * skip (eval.c base-case skip) and drop this stratum's head tuples.
+         * Reset here so it covers both the parallel and sequential paths. */
+        sess->current_iteration = 0;
+
+        /* Non-recursive: evaluate each relation plan once */
+        for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+            const wl_plan_relation_t *rp = &sp->relations[ri];
+            int par_rc = wl_columnar_eval_nonrec_relation_parallel(rp, sess);
+            if (par_rc == 0)
+                continue;
+            if (par_rc != EAGAIN) {
+                if (getenv("WIRELOG_DEBUG_NONREC_TDD"))
+                    fprintf(stderr, "nonrec_tdd failed rel=%s rc=%d\n",
+                        rp->name ? rp->name : "(null)", par_rc);
+                return par_rc;
+            }
+
+            eval_stack_t stack;
+            eval_stack_init(&stack);
+
+            int rc = col_eval_relation_plan(rp, &stack, sess);
+            if (rc != 0) {
+                eval_stack_drain(&stack);
+                return rc;
+            }
+
+            if (stack.top == 0)
+                continue;
+
+            eval_entry_t result = eval_stack_pop(&stack);
+            eval_stack_drain(&stack); /* drain any leftover entries */
+
+            col_rel_t *target = session_find_rel(sess, rp->name);
+            if (!target) {
+                /* First time: create and register the relation */
+                if (result.owned) {
+                    /* Rename the result relation */
+                    free(result.rel->name);
+                    result.rel->name = wl_strdup(rp->name);
+                    if (!result.rel->name) {
+                        col_rel_destroy(result.rel);
+                        return ENOMEM;
+                    }
+                    rc = session_add_rel(sess, result.rel);
+                    if (rc != 0) {
+                        col_rel_destroy(result.rel);
+                        return rc;
+                    }
+                    result.owned = false;
+                } else {
+                    col_rel_t *copy = col_rel_pool_new_like(
+                        sess->delta_pool, rp->name, result.rel);
+                    if (!copy)
+                        return ENOMEM;
+                    rc = col_rel_append_all(copy, result.rel,
+                            sess->eval_arena);
+                    if (rc != 0) {
+                        col_rel_destroy(copy);
+                        return rc;
+                    }
+                    rc = session_add_rel(sess, copy);
+                    if (rc != 0) {
+                        col_rel_destroy(copy);
+                        return rc;
+                    }
+                }
+            } else {
+                /* Append new results to existing relation */
+                rc = col_rel_append_all(target, result.rel, sess->eval_arena);
+                if (result.owned)
+                    col_rel_destroy(result.rel);
+                if (rc != 0)
+                    return rc;
+            }
+        }
+        col_mat_cache_clear(&sess->mat_cache);
+        delta_pool_reset(sess->delta_pool);
+        sess->rotation_ops->rotate_eval_arena(sess);
+
+        /* Non-recursive stratum frontier: record convergence epoch and iteration.
+        * Non-recursive strata always converge at iteration UINT32_MAX (no loop),
+        * so store (outer_epoch, UINT32_MAX) to enable epoch-aware skip on next
+        * incremental call. Always update both fields so same-epoch skip logic
+        * fires correctly when the frontier persists across session_step calls. */
+        sess->frontier_ops->record_stratum_convergence(sess, stratum_idx,
+            sess->outer_epoch, UINT32_MAX);
+
+        /* Issue #317: Report non-recursive convergence to coordinator's
+         * progress tracker.  Non-recursive strata always converge at
+         * UINT32_MAX (no iteration loop), matching the sentinel convention. */
+        if (sess->coordinator) {
+            wl_frontier_progress_record(&sess->coordinator->progress,
+                sess->worker_id, stratum_idx, sess->outer_epoch, UINT32_MAX);
+        }
+
+        /* Non-recursive rule frontiers: mark each rule fully evaluated.
+         * UINT32_MAX sentinel matches stratum frontier convention. */
+        if (sess->plan) {
+            uint32_t rule_base = 0;
+            for (uint32_t si = 0; si < stratum_idx; si++)
+                rule_base += sess->plan->strata[si].relation_count;
+            for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+                uint32_t rule_idx = rule_base + ri;
+                if (rule_idx < MAX_RULES) {
+                    /* Issue #106: Conservative approach - always reset rule frontiers
+                     * for affected strata to (current_epoch, UINT32_MAX) sentinel.
+                     * UINT32_MAX prevents premature skip during re-evaluation. */
+                    sess->frontier_ops->reset_rule_frontier(sess, rule_idx,
+                        sess->outer_epoch);
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    /*
+     * Recursive stratum: semi-naive fixed-point iteration.
+     * Iterate until no new tuples are produced.
+     *
+     * Pre-register empty IDB relations so that VARIABLE ops can find
+     * them on the first iteration (before any tuples are produced).
+     */
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        col_rel_t *existing = session_find_rel(sess, sp->relations[ri].name);
+        if (!existing) {
+            col_rel_t *empty = NULL;
+            int rc = col_rel_alloc(&empty, sp->relations[ri].name);
+            if (rc != 0)
+                return ENOMEM;
+            rc = session_add_rel(sess, empty);
+            if (rc != 0) {
+                col_rel_destroy(empty);
+                return rc;
+            }
+        }
+    }
+
+    /*
+     * Semi-naive fixed-point iteration with delta tracking.
+     * VARIABLE ops prefer "$d$relname" delta relations (rows added in the
+     * previous iteration). JOIN right-side lookups always use the full
+     * relation by name, giving delta (left) x full (right) join semantics.
+     */
+    uint32_t nrels = sp->relation_count;
+    col_rel_t **delta_rels = (col_rel_t **)calloc(nrels, sizeof(col_rel_t *));
+    if (!delta_rels)
+        return ENOMEM;
+
+    /* Allocate snap once before the iteration loop (Issue #367): hoisting
+     * the allocation out of the outer loop eliminates 2 malloc/free calls
+     * per iteration (14K+ iterations for CRDT). */
+    uint32_t *snap = (uint32_t *)malloc(nrels * sizeof(uint32_t));
+    if (!snap) {
+        free((void *)delta_rels);
+        return ENOMEM;
+    }
+
+    /* Sort pre-existing data in each IDB relation before iterating.
+     * Handles the EDB+IDB case: when base facts are pre-loaded into a
+     * relation that also appears as an IDB in a recursive rule, the loaded
+     * facts may be in insertion order (unsorted).
+     * col_op_consolidate_incremental_delta requires rel->data[0..snap) to be
+     * sorted; an unsorted prefix causes the 2-pointer merge to miss duplicates,
+     * producing spurious output rows. */
+    for (uint32_t ri = 0; ri < nrels; ri++) {
+        col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
+        if (r && r->nrows > 1) {
+            col_rel_radix_sort_int64(r);
+        }
+    }
+
+    /* Initialize recursive stratum frontier to UINT32_MAX (not set sentinel)
+     * only on the first evaluation (frontier==0 from calloc). If a prior
+     * col_session_insert_incremental call preserved a real convergence frontier,
+     * keep it so the per-iteration skip condition fires for iterations beyond
+     * the prior convergence point. */
+    sess->frontier_ops->init_stratum(sess, stratum_idx);
+
+    /* Phase 4 (US-4-004): Compute the base global rule index for this stratum.
+     * Rule indices are assigned by enumerating strata in order and relations
+     * within each stratum, matching col_compute_affected_rules convention. */
+    uint32_t rule_id_base = 0;
+    if (sess->plan) {
+        for (uint32_t si = 0;
+            si < stratum_idx && si < sess->plan->stratum_count; si++) {
+            rule_id_base += sess->plan->strata[si].relation_count;
+        }
+    }
+    /* Clamp so rule_id_base + ri never exceeds MAX_RULES - 1 */
+    if (rule_id_base >= MAX_RULES)
+        rule_id_base = MAX_RULES;
+
+    uint32_t iter;
+    col_frontier_t strat_frontier = { 0, 0 };
+    uint32_t final_eff_iter = 0; /* effective sub-pass index at convergence */
+
+    /* Issue #282: Save the session-level diff_operators_active so we can
+     * restore it after the recursive stratum evaluation completes.
+     * Within the iteration loop, we override it per sub-pass. */
+    bool saved_diff_operators_active = sess->diff_operators_active;
+
+    /*
+     * Stride-based semi-naive iteration (Issue #237).
+     * Each outer iteration runs EVAL_STRIDE sub-passes, chaining the delta
+     * from each sub-pass into the next.  Effective recursion depth covered:
+     *   MAX_ITERATIONS * EVAL_STRIDE = 4096 * 8 = 32768
+     * This allows deep-chain workloads (e.g. CRDT) to converge where they
+     * previously hit the MAX_ITERATIONS cap and produced incomplete results.
+     *
+     * When EVAL_STRIDE == 1 the behaviour is identical to the prior single-
+     * pass loop.
+     */
+    for (iter = 0; iter < MAX_ITERATIONS; iter++) {
+        bool outer_any_new = false; /* any sub-pass produced new tuples  */
+        int outer_rc = 0;           /* error propagated from inner loop  */
+        bool stride_all_skipped
+            = true; /* true until a sub-pass actually runs */
+        bool outer_continue_next
+            = false;            /* net-zero/all-empty: retry next outer */
+        bool converged = false; /* fixed point reached                */
+
+        /* snap[] is filled at the start of each sub-pass (nrows grows as new
+         * tuples are appended).  The array is allocated once before this loop
+         * (Issue #367) to avoid per-iteration malloc/free overhead. */
+
+        /* ------------------------------------------------------------------ */
+        /* Inner sub-pass loop: EVAL_STRIDE semi-naive passes per outer iter.  */
+        /* ------------------------------------------------------------------ */
+        for (uint32_t sub = 0; sub < EVAL_STRIDE; sub++) {
+            uint32_t eff_iter = iter * EVAL_STRIDE + sub;
+
+            /* Publish effective iteration so operators can distinguish base case
+             * (eff_iter 0: FORCE_DELTA falls back to full) from delta case
+             * (eff_iter > 0: FORCE_DELTA with absent delta → empty result). */
+            sess->current_iteration = eff_iter;
+
+            /* Issue #282: Enable differential operators for recursive iterations
+             * > 0.  At eff_iter 0, we seed from full EDB relations (base case)
+             * so arrangement reuse is not applicable.  From eff_iter 1 onward,
+             * only the delta is processed (semi-naive), so col_op_join_diff can
+             * build the hash table incrementally: O(D) instead of O(N).
+             * diff_arr_entries persist across sub-passes and are invalidated by
+             * col_session_invalidate_arrangements when the underlying relation
+             * changes (called after consolidation each sub-pass).
+             * The saved value is restored after the recursive stratum completes
+             * so non-recursive strata and the outer session logic are unaffected. */
+            sess->diff_operators_active
+                = sess->diff_enabled && eff_iter > 0;
+
+            /* Iteration skip based on frontier (convergence point of prior
+             * evaluation).  Skip sub-pass when both hold:
+             * 1. Same outer_epoch — frontier is valid for this insertion epoch
+             * 2. eff_iter > frontier.iteration — already processed in this epoch
+             * Once eff_iter exceeds the frontier for sub=0, it also exceeds for
+             * all higher sub values, so the entire outer iteration effectively
+             * continues to the next one. */
+            if (sess->frontier_ops->should_skip_iteration(sess, stratum_idx,
+                eff_iter)) {
+                continue; /* skip this sub-pass */
+            }
+
+            stride_all_skipped = false; /* at least one sub-pass runs */
+
+            /* Clear per-sub-pass delta arrangement cache (sequential eval path).
+             * K-fusion workers manage their own darr caches independently. */
+            col_session_free_delta_arrangements(sess);
+
+            /* Register delta relations from previous sub-pass into session */
+            for (uint32_t ri = 0; ri < nrels; ri++) {
+                if (!delta_rels[ri])
+                    continue;
+                const char *dname = sp->relations[ri].delta_name;
+                session_remove_rel(sess, dname);
+                int rc = session_add_rel(sess, delta_rels[ri]);
+                if (rc != 0)
+                    col_rel_destroy(delta_rels[ri]);
+                delta_rels[ri] = NULL; /* session now owns it */
+            }
+
+            /* Record per-relation row counts (O(1) snapshot — no data copy).
+             * Re-filled each sub-pass because nrows changes after each pass. */
+            for (uint32_t ri = 0; ri < nrels; ri++) {
+                col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
+                snap[ri] = r ? r->nrows : 0; /* O(1) count only, no copy */
+            }
+
+            /* Phase 3D: Frontier skip with multiplicities (US-3D-002).
+             * Skip sub-pass if all delta relations have zero net multiplicity.
+             * When detected, retry with the next outer iteration (same as the
+             * prior single-pass behaviour). */
+            if (eff_iter
+                > 0) { /* only skip from effective iteration 1 onward */
+                bool all_deltas_net_zero = true;
+                for (uint32_t ri = 0; ri < nrels; ri++) {
+                    const char *dname = sp->relations[ri].delta_name;
+                    col_rel_t *delta = session_find_rel(sess, dname);
+                    if (!delta || delta->nrows == 0) {
+                        /* Empty delta: net multiplicity is zero */
+                        continue;
+                    }
+                    /* Compute net multiplicity for this delta relation */
+                    int64_t net_mult = 0;
+                    for (uint32_t row = 0; row < delta->nrows; row++) {
+                        net_mult += delta->timestamps[row].multiplicity;
+                    }
+                    if (net_mult != 0) {
+                        all_deltas_net_zero = false;
+                        break;
+                    }
+                }
+                if (all_deltas_net_zero) {
+                    /* All deltas zero net-multiplicity: skip to next outer iter */
+                    outer_continue_next = true;
+                    break;
+                }
+            }
+
+            /* Stratum-level early exit: if all rules have empty forced deltas,
+             * the sub-pass will produce no new facts. (Issue #81) */
+            if (eff_iter > 0) {
+                bool all_rules_empty = true;
+                for (uint32_t ri = 0; ri < nrels; ri++) {
+                    if (!has_empty_forced_delta(&sp->relations[ri], sess,
+                        eff_iter)) {
+                        all_rules_empty = false;
+                        break;
+                    }
+                }
+                if (all_rules_empty) {
+                    outer_continue_next = true;
+                    break;
+                }
+            }
+
+            /* Single-pass semi-naive evaluation. VARIABLE prefers delta when it
+             * is a strict subset of full (genuine new facts). JOIN propagates
+             * the is_delta flag through results and applies right-delta when
+             * left is full and a strictly-smaller right delta exists. */
+            for (uint32_t ri = 0; ri < nrels; ri++) {
+                const wl_plan_relation_t *rp = &sp->relations[ri];
+
+                /* Issue #106 (US-106-003): Rule-level frontier skip with epoch
+                 * gating.  Skip rule evaluation only when BOTH hold:
+                 * 1. Same outer_epoch (prevents cross-epoch incorrect skips)
+                 * 2. eff_iter > convergence point (already processed in epoch)
+                 * Across epoch boundaries mismatch => always re-eval. */
+                uint32_t rule_id = rule_id_base + ri;
+                if (sess->frontier_ops->should_skip_rule(sess, rule_id,
+                    eff_iter)) {
+                    continue;
+                }
+
+                /* Pre-scan skip: if a FORCE_DELTA op references an empty or
+                 * absent delta (eff_iter > 0), the plan produces 0 rows. */
+                if (has_empty_forced_delta(rp, sess, eff_iter)) {
+                    continue;
+                }
+
+                eval_stack_t stack;
+                eval_stack_init(&stack);
+
+                int rc = col_eval_relation_plan(rp, &stack, sess);
+                if (rc != 0) {
+                    eval_stack_drain(&stack);
+                    outer_rc = rc;
+                    goto stride_error;
+                }
+
+                if (stack.top == 0)
+                    continue;
+
+                eval_entry_t result = eval_stack_pop(&stack);
+                eval_stack_drain(&stack);
+
+                /* Post-eval skip: evaluation produced 0 rows — safety net for
+                 * cases not caught by pre-scan (e.g. filters eliminating all
+                 * rows).
+                 *
+                 * The !result.rel arm is not analyzer appeasement.
+                 * eval_stack_pop() yields {NULL, ...} only for an empty
+                 * stack, and the stack.top == 0 check three lines above has
+                 * already excluded that, so a NULL here would mean a NULL rel
+                 * was pushed.  It is dispositioned as "no result" to match
+                 * that same branch rather than as an error, so one observable
+                 * state does not get two dispositions depending on which
+                 * check saw it first.  (diff.c and join.c return EINVAL on a
+                 * NULL pop because they pop without a prior emptiness check.)
+                 * Otherwise the statements below dereference result.rel:
+                 * ->name on the rename arm, ->ncols on the schema-adoption
+                 * arm.  col_rel_destroy(NULL) is a no-op, so the continue
+                 * leaks nothing. */
+                if (!result.rel || result.rel->nrows == 0) {
+                    if (result.owned)
+                        col_rel_destroy(result.rel);
+                    continue;
+                }
+
+                col_rel_t *target = session_find_rel(sess, rp->name);
+                if (!target) {
+                    col_rel_t *copy;
+                    if (result.owned) {
+                        copy = result.rel;
+                        free(copy->name);
+                        copy->name = wl_strdup(rp->name);
+                        if (!copy->name) {
+                            col_rel_destroy(copy);
+                            outer_rc = ENOMEM;
+                            goto stride_error;
+                        }
+                        result.owned = false;
+                    } else {
+                        copy = col_rel_pool_new_like(
+                            sess->delta_pool, rp->name, result.rel);
+                        if (!copy) {
+                            outer_rc = ENOMEM;
+                            goto stride_error;
+                        }
+                        rc = col_rel_append_all(copy, result.rel,
+                                sess->eval_arena);
+                        if (rc != 0) {
+                            col_rel_destroy(copy);
+                            outer_rc = rc;
+                            goto stride_error;
+                        }
+                    }
+                    rc = session_add_rel(sess, copy);
+                    if (rc != 0) {
+                        col_rel_destroy(copy);
+                        outer_rc = rc;
+                        goto stride_error;
+                    }
+                } else {
+                    /* Adopt schema from result if target is still uninitialised */
+                    if (target->ncols == 0 && result.rel->ncols > 0) {
+                        rc = col_rel_set_schema(
+                            target, result.rel->ncols,
+                            (const char *const *)result.rel->col_names);
+                        if (rc != 0) {
+                            if (result.owned)
+                                col_rel_destroy(result.rel);
+                            outer_rc = rc;
+                            goto stride_error;
+                        }
+                    }
+                    rc = col_rel_append_all(target, result.rel,
+                            sess->eval_arena);
+                    if (result.owned)
+                        col_rel_destroy(result.rel);
+                    if (rc != 0) {
+                        outer_rc = rc;
+                        goto stride_error;
+                    }
+                }
+            }
+
+            /* Remove delta relations from session (evaluation is complete) */
+            for (uint32_t ri = 0; ri < nrels; ri++) {
+                const char *dname = sp->relations[ri].delta_name;
+                session_remove_rel(sess, dname);
+            }
+
+            /* Phase 4: Frontier is computed incrementally as deltas are created
+             * because delta_rels[ri] may be set to NULL in the next sub-pass's
+             * registration loop.  strat_frontier declared before outer loop. */
+
+            /* Consolidate all IDB relations to remove duplicates and compute
+             * delta as a byproduct.  snap[ri] marks the boundary between the
+             * already-sorted prefix and unsorted new rows appended this pass. */
+            bool any_new = false;
+            for (uint32_t ri = 0; ri < nrels; ri++) {
+                col_rel_t *r = session_find_rel(sess, sp->relations[ri].name);
+                if (!r || snap[ri] >= r->nrows) {
+                    continue; /* no new rows for this relation */
+                }
+
+                const char *dname = sp->relations[ri].delta_name;
+                col_rel_t *delta = col_rel_pool_new_like(
+                    sess->delta_pool, dname, r);
+                if (!delta) {
+                    outer_rc = ENOMEM;
+                    goto stride_error;
+                }
+
+                /* Consolidate WITH delta output (no separate merge walk) */
+                uint32_t cons_old = snap[ri];
+                uint32_t cons_new = r->nrows - cons_old; /* delta count D */
+                int fast_flag = 0;
+                uint64_t cons_t0 = now_ns();
+                int rc2 = col_op_consolidate_incremental_delta(r, snap[ri],
+                        delta, &fast_flag);
+                uint64_t cons_elapsed = now_ns() - cons_t0;
+                sess->consolidation_ns += cons_elapsed;
+                sess->consolidate_fast_hits += (uint64_t)fast_flag;
+                sess->consolidate_slow_hits += (uint64_t)(1 - fast_flag);
+                /* Invalidate arrangements for this relation (data changed). */
+                col_session_invalidate_arrangements(&sess->base,
+                    sp->relations[ri].name);
+                /* Per-call trace: WL_LOG=CONSOLIDATION:5 (or legacy
+                 * WL_CONSOLIDATION_LOG presence shim). */
+                WL_LOG(WL_LOG_SEC_CONSOLIDATION, WL_LOG_DEBUG,
+                    "eff_iter=%u stratum=%u rel=%s N=%u D=%u "
+                    "time_us=%.1f ratio=%.4f",
+                    eff_iter, stratum_idx, sp->relations[ri].name,
+                    cons_old, cons_new, (double)cons_elapsed / 1000.0,
+                    cons_old > 0 ? (double)cons_new / (double)cons_old
+                                     : 0.0);
+                if (rc2 != 0) {
+                    col_rel_destroy(delta);
+                    outer_rc = rc2;
+                    goto stride_error;
+                }
+
+                if (delta->nrows > 0) {
+                    /* Stamp each new row with its provenance (eff_iter, stratum).
+                     * worker=0 indicates the sequential (non-K-fusion) path. */
+                    delta->timestamps = (col_delta_timestamp_t *)calloc(
+                        delta->nrows, sizeof(col_delta_timestamp_t));
+                    if (!delta->timestamps) {
+                        col_rel_destroy(delta);
+                        outer_rc = ENOMEM;
+                        goto stride_error;
+                    }
+                    for (uint32_t ti = 0; ti < delta->nrows; ti++) {
+                        delta->timestamps[ti].iteration = eff_iter;
+                        delta->timestamps[ti].stratum = stratum_idx;
+                        /* worker left zero: sequential evaluation path */
+                        delta->timestamps[ti].multiplicity = 1;
+                    }
+
+                    /* Phase 4: Enable timestamp tracking on target relation to
+                     * preserve provenance through consolidation.  This enables
+                     * frontier computation to determine convergence. */
+                    if (!r->timestamps && r->capacity > 0) {
+                        r->timestamps = (col_delta_timestamp_t *)calloc(
+                            r->capacity, sizeof(col_delta_timestamp_t));
+                        if (!r->timestamps) {
+                            free(delta->timestamps);
+                            col_rel_destroy(delta);
+                            outer_rc = ENOMEM;
+                            goto stride_error;
+                        }
+                    }
+
+                    delta_rels[ri] = delta;
+                    any_new = true;
+
+                    /* Phase 4: Compute frontier from this delta immediately.
+                     * Must happen before next sub-pass registration sets
+                     * delta_rels[ri]=NULL.
+                     * frontier = MAX eff_iter that produced facts. */
+                    col_frontier_t rel_frontier = col_frontier_compute(delta);
+                    if (rel_frontier.iteration > strat_frontier.iteration
+                        || (rel_frontier.iteration == strat_frontier.iteration
+                        && rel_frontier.stratum > strat_frontier.stratum)) {
+                        strat_frontier = rel_frontier;
+                    }
+                } else {
+                    col_rel_destroy(delta);
+                }
+            }
+
+            /* Issue #176: Per-sub-pass cache eviction for recursive strata.
+             * Materialized join results may live in delta_pool, so release
+             * them before resetting the pool.  Resetting first clears the
+             * pool-owned marker and leaves the cache holding stale pointers.
+             * Use configurable eviction threshold (cache_evict_threshold):
+             * - If 0: clear entire cache each sub-pass (backward compatible)
+             * - If > 0: evict LRU entries when cache exceeds threshold */
+            if (sess->cache_evict_threshold == 0) {
+                col_mat_cache_clear(&sess->mat_cache);
+            } else {
+                col_mat_cache_evict_until(&sess->mat_cache,
+                    sess->cache_evict_threshold);
+            }
+
+            delta_pool_reset(sess->delta_pool);
+            sess->rotation_ops->rotate_eval_arena(sess);
+            /* Issue #560: Advance the compound-arena epoch frontier at the
+             * end of each recursive sub-pass iteration so the
+             * epoch-frontier GC can reclaim handles whose multiplicity
+             * dropped to zero in this iteration.  NULL-guard each link in
+             * the dispatch chain because tests and early lifecycle paths
+             * may operate without a compound arena or rotation strategy.
+             * The compound_arena is borrowed from the coordinator (Issue
+             * #579 / R-5); only the coordinator may mutate it, so
+             * worker-context invocations skip the dispatch. */
+            if (sess->coordinator == NULL
+                && sess->compound_arena && sess->rotation_ops
+                && sess->rotation_ops->gc_epoch_boundary) {
+                sess->rotation_ops->gc_epoch_boundary(sess);
+            }
+            if (!any_new) {
+                /* Fixed point reached: no new tuples in this sub-pass. */
+                converged = true;
+                break;
+            }
+            outer_any_new = true;
+            final_eff_iter = eff_iter;
+            continue; /* next sub-pass */
+
+stride_error:
+            break; /* exit inner loop; outer_rc carries the error */
+        } /* end inner sub-pass loop */
+
+        if (outer_rc != 0) {
+            /* Issue #282: Restore diff_operators_active on error path */
+            sess->diff_operators_active = saved_diff_operators_active;
+            for (uint32_t ri = 0; ri < nrels; ri++) {
+                session_remove_rel(sess, sp->relations[ri].delta_name);
+                if (delta_rels[ri])
+                    col_rel_destroy(delta_rels[ri]);
+            }
+            free(snap);
+            free((void *)delta_rels);
+            return outer_rc;
+        }
+
+        /* Dispatch on why the inner loop exited */
+        if (stride_all_skipped)
+            continue; /* all sub-passes were frontier-skipped: next outer iter */
+        if (outer_continue_next)
+            continue; /* net-zero or all-empty delta: retry next outer iter */
+        if (converged || !outer_any_new)
+            break; /* true convergence */
+    } /* end outer stride loop */
+    /* Issue #282: Restore session-level diff_operators_active.
+     * The per-iteration override above applies only within the recursive
+     * fixed-point loop.  Restoring the saved value ensures subsequent
+     * non-recursive strata and outer session logic see the correct state. */
+    sess->diff_operators_active = saved_diff_operators_active;
+
+    sess->total_iterations = final_eff_iter;
+
+    /* Issue #914: current_iteration is deliberately left at final_eff_iter (> 0)
+     * here. The non-recursive branch of col_eval_stratum is responsible for
+     * resetting it to 0 before its base-case evaluation; do not add a second
+     * reset here (consensus declined that). See the non-recursive branch above. */
+
+    /* Issue #106 (US-106-005): Record per-rule frontier at convergence with epoch.
+     * When stratum converges at effective iteration I, record (outer_epoch, I).
+     * On next incremental snapshot, skip fires when eff_iter > I. */
+    for (uint32_t ri = 0; ri < nrels && rule_id_base + ri < MAX_RULES; ri++) {
+        uint32_t rule_id = rule_id_base + ri;
+        sess->frontier_ops->record_rule_convergence(sess, rule_id,
+            sess->outer_epoch, final_eff_iter);
+    }
+
+    /* Phase 4: Update per-stratum frontier after recursive stratum evaluation.
+     * strat_frontier was computed incrementally via delta timestamps (eff_iter),
+     * so it already holds the effective iteration index at convergence. */
+    if (strat_frontier.iteration != UINT32_MAX) {
+        sess->frontier_ops->record_stratum_convergence(sess, stratum_idx,
+            sess->outer_epoch, strat_frontier.iteration);
+
+        /* Issue #317: Report recursive convergence to coordinator's progress
+         * tracker so col_eval_stratum_multiworker can compute the global
+         * minimum frontier after the workqueue barrier. */
+        if (sess->coordinator) {
+            wl_frontier_progress_record(&sess->coordinator->progress,
+                sess->worker_id, stratum_idx, sess->outer_epoch,
+                strat_frontier.iteration);
+        }
+    }
+
+    int agg_rc = wl_columnar_eval_serial_canonicalize_aggregates(sp, sess);
+    if (agg_rc != 0) {
+        for (uint32_t ri = 0; ri < nrels; ri++) {
+            if (delta_rels[ri])
+                col_rel_destroy(delta_rels[ri]);
+        }
+        free(snap);
+        free((void *)delta_rels);
+        return agg_rc;
+    }
+
+    /* Cleanup all delta relations after frontier has been computed */
+    for (uint32_t ri = 0; ri < nrels; ri++) {
+        if (delta_rels[ri])
+            col_rel_destroy(delta_rels[ri]);
+        const char *dname = sp->relations[ri].delta_name;
+        session_remove_rel(sess, dname);
+    }
+    free(snap);
+    free((void *)delta_rels);
+    delta_pool_reset(sess->delta_pool);
+    sess->rotation_ops->rotate_eval_arena(sess);
+    col_mat_cache_clear(&sess->mat_cache);
+
+    return 0;
+}
+static col_frontier_t
+col_frontier_compute(const col_rel_t *rel)
+{
+    col_frontier_t f = { 0, 0 };
+
+    /* Handle NULL or empty relation */
+    if (!rel || rel->nrows == 0 || !rel->timestamps)
+        return f;
+
+    /* Initialize frontier to first row's timestamp */
+    f.iteration = rel->timestamps[0].iteration;
+    f.stratum = rel->timestamps[0].stratum;
+
+    /* Find minimum (iteration, stratum) */
+    for (uint32_t i = 1; i < rel->nrows; i++) {
+        const col_delta_timestamp_t *ts = &rel->timestamps[i];
+        if (ts->iteration < f.iteration
+            || (ts->iteration == f.iteration && ts->stratum < f.stratum)) {
+            f.iteration = ts->iteration;
+            f.stratum = ts->stratum;
+        }
+    }
+
+    return f;
+}
+bool
+stratum_has_preseeded_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess)
+{
+    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
+        const char *dname = sp->relations[ri].delta_name;
+        col_rel_t *delta = session_find_rel(sess, dname);
+        if (delta && delta->nrows > 0)
+            return true;
+    }
+    return false;
+}
+
+/*
+ * rule_index_to_stratum_index: Map a flat rule index to its stratum index
+ *
+ * Rules are laid out contiguously across strata in plan order. Stratum 0
+ * owns rule indices [0, relation_count_0), stratum 1 owns
+ * [relation_count_0, relation_count_0 + relation_count_1), and so on.
+ * This function walks the strata, accumulating a running rule offset, and
+ * returns the stratum whose window contains rule_id.
+ *
+ * Issue #107: Selective rule frontier reset uses this mapping to check
+ * if a rule's stratum has pre-seeded delta before resetting the rule's frontier.
+ *
+ * @param plan:    Execution plan containing the strata array.
+ * @param rule_id: Flat (zero-based) rule index to look up.
+ * @return Stratum index that owns rule_id, or UINT32_MAX if rule_id is
+ *         out of range (>= total rule count across all strata).
+ */
+uint32_t
+rule_index_to_stratum_index(const wl_plan_t *plan, uint32_t rule_id)
+{
+    uint32_t offset = 0;
+    for (uint32_t si = 0; si < plan->stratum_count; si++) {
+        uint32_t next_offset = offset + plan->strata[si].relation_count;
+        if (rule_id < next_offset)
+            return si;
+        offset = next_offset;
+    }
+    return UINT32_MAX;
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1805,6 +1805,16 @@ stratum_has_preseeded_delta(const wl_plan_stratum_t *sp,
     wl_col_session_t *sess);
 uint32_t
 rule_index_to_stratum_index(const wl_plan_t *plan, uint32_t rule_id);
+/* Defined in columnar/eval_serial.c; also called from the TDD final-merge
+ * path in columnar/eval.c. */
+int
+wl_columnar_eval_serial_canonicalize_aggregates(const wl_plan_stratum_t *sp,
+    wl_col_session_t *sess);
+/* Defined in columnar/eval.c; called from the serial stratum evaluator in
+ * columnar/eval_serial.c. */
+int
+wl_columnar_eval_nonrec_relation_parallel(const wl_plan_relation_t *rp,
+    wl_col_session_t *coord);
 
 /* ======================================================================== */
 /* Relation Partitioning (columnar/partition.c)                             */

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -90,7 +90,7 @@ wirelog_lockfree_queue_src = files('util/lockfree_queue.c', )
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
 wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
-                           'columnar/ops.c', 'columnar/arithmetic.c', 'columnar/expr.c', 'columnar/filter.c', 'columnar/join.c', 'columnar/merge.c', 'columnar/kfusion.c', 'columnar/diff.c', 'columnar/inline.c', 'columnar/eval_dedup.c', 'columnar/eval_delta.c', 'columnar/eval_tdd_queue.c', 'columnar/eval_tdd_plan.c', 'columnar/eval_plan.c', 'columnar/eval_stack.c', 'columnar/eval.c',
+                           'columnar/ops.c', 'columnar/arithmetic.c', 'columnar/expr.c', 'columnar/filter.c', 'columnar/join.c', 'columnar/merge.c', 'columnar/kfusion.c', 'columnar/diff.c', 'columnar/inline.c', 'columnar/eval_dedup.c', 'columnar/eval_delta.c', 'columnar/eval_tdd_queue.c', 'columnar/eval_tdd_plan.c', 'columnar/eval_plan.c', 'columnar/eval_stack.c', 'columnar/eval_serial.c', 'columnar/eval.c',
                            'columnar/arrangement.c', 'columnar/frontier.c', 'columnar/frontier_epoch.c',
                            'columnar/mobius.c', 'columnar/session.c', 'columnar/session_hash.c',
                            'columnar/delta_pool.c', 'columnar/lftj.c',


### PR DESCRIPTION
Extraction #6 of the #1086 series. **This does not close #1086** — see "What this does not do" below.

## What moved

`wirelog/columnar/eval.c:45-972` (928 lines) becomes `wirelog/columnar/eval_serial.c`. The boundary is the one the file already declared for itself: everything above its own `Distributed Stratum Evaluator (Issue #318)` banner. What remains in `eval.c` is now entirely the distributed/TDD evaluator.

| | before | after |
|---|---|---|
| `wirelog/columnar/eval.c` | 5552 | **4621** |
| `wirelog/columnar/eval_serial.c` | — | **957** |

The boundary was chosen by measuring crossings, not by convenience. Exactly **two symbols cross, one in each direction** — the minimum across every candidate boundary examined (the exchange-strategy family costs 11, worker lifecycle 11, the `nonrec_*` block 5). Only those two lose `static`:

- `col_canonicalize_recursive_aggregates` → `wl_columnar_eval_serial_canonicalize_aggregates` (defined in the new file, called from the TDD final-merge path)
- `col_eval_nonrecursive_relation_parallel` → `wl_columnar_eval_nonrec_relation_parallel` (stays in `eval.c`, called from the moved serial evaluator)

Prefixes encode the defining file per `AGENTS.md`. Their intra-file forward declarations are deleted rather than kept: `readability-redundant-declaration` is enabled and `internal.h` is inside `HeaderFilterRegex`, so a surviving duplicate fails the ratchet.

## Evidence the move is verbatim

The moved block differs from base in **exactly 4 lines** — the `static int`→`int` promotion, the definition rename, and the two call-site renames. This was verified mechanically, not asserted:

- ordered line-for-line diff of base `eval.c:45-972` against `eval_serial.c:30-957` → 4 changed lines, nothing else
- ordered diff of the retained side → 4 changed lines plus the declared comment edits, nothing else
- whole-file line-multiset reconciliation of base `eval.c` against `eval.c` + `eval_serial.c` → balances to zero unexplained lines
- comment-stripped comparison (via `cc -fpreprocessed -dD -E -P`) → the code is identical modulo those 4 lines
- `.text` is **208864 bytes, byte-identical to the pre-change value** — LTO absorbed the split entirely

## Reference repointing

The move invalidates every citation of the moved lines. A stale citation here is worse than ordinary comment rot: after the split the old `eval.c:<line>` numbers still resolve, to *unrelated code in the same file*.

Repointed: **22 in-code breadcrumbs** in the retained `eval.c` (offset −15, each of the 44 range endpoints verified against the base file by content identity), plus `docs/SEMANTICS.md:249` and `docs/THREADING.md:487,752`. Five comments were rewrapped because the longer filename pushed them past 80 columns — the retained half now has 8 lines over 80 where base had 9.

**Two doc edits deliberately do not follow the shift arithmetic**, because they were already wrong before this PR and are corrected to the real sites rather than translated into differently-wrong ones:

- `docs/THREADING.md:305,319` cited `eval.c:1875` for the `shared_join_count` store, which was at base `eval.c:1228` → now `eval.c:292`
- `docs/THREADING.md:487,752` cited `eval.c:933-935` for the compound-arena gate, which was at base `eval.c:800-806` → now `eval_serial.c:788-791`

Scope of the repoint is `eval.c` + `docs/`. Six comments elsewhere (`wirelog/ir/program.c:917,2316`, `tests/test_program.c:3287`, `tests/test_worker_arena_borrow.c:367`, `tests/test_symbol_aggregates.c:40`, `tests/test_recursive_agg_kfusion.c:11`) still name `eval.c` as the home of `col_eval_stratum` or the canonicalization; left for a follow-up rather than widening this commit into `ir/` and `tests/`. `CHANGELOG.md:1642,1645` cite moved lines and are deliberately untouched — rewriting a shipped release note would falsify the record.

## No test added

Deliberate. This is a verbatim relocation plus two promotions, and everything the new boundary exposes is pinned mechanically rather than behaviourally: a divergent prototype is a compile error, a duplicate definition a link error, an accidental export is caught by `--suite abi`, lost inlining by `check-text-size.sh`. The existing suite is the regression test, and its SKIP set is unchanged so nothing silently stopped covering the moved code.

One residual, disclosed rather than papered over: `-Wmissing-prototypes` is not in the build flags, so the definition/declaration agreement rests on the include. That is the standing convention for every `wl_columnar_*` symbol in the tree, not something this split introduces.

## Validation

| check | result |
|---|---|
| `ninja -C build` | clean, zero warnings |
| `WIRELOG_TIDY_REQUIRED=1 meson test --suite tidy` | 4/4 OK — ratchet **64 clean / 8 backlog** (was 63) |
| full `meson test -C build` | **287 Ok / 0 Fail / 12 Skipped**, SKIP set identical to baseline |
| `check-text-size.sh` | PASS, `.text` 208864 — unchanged |
| `check-abi-symbols.sh` | 78 exported symbols unchanged; neither promoted symbol reaches the dynamic table |
| `check-threading-doc.sh` | OK, 44 sites / 44 rows |
| `uncrustify --check` | PASS on all three C/H files |
| `libwirelog.so` | +80 bytes, all metadata |

The clang-tidy result is the one worth noting: the issue's own planning comment warned that `eval.c`'s cleanliness is partly an artifact of its size, and that code moved verbatim out of it has previously arrived **dirty** in the smaller TU. This extraction arrived clean and went straight onto the allowlist — no code fix, no `NOLINT`, backlog untouched.

## What this does not do

`eval.c` is still **4621 lines** and is not yet the "small orchestration layer" #1086 asks for. This PR satisfies the issue's per-extraction criteria and none of its terminal one. The residue is coherent — purely the distributed/TDD evaluator — which positions the next extraction (worker lifecycle, or the delta-exchange family) well, but those crossing counts must be re-measured against the reduced file rather than reused.

Two follow-ups worth filing: the six out-of-`eval.c` breadcrumbs above, and 15 stale `ops.c:<line>` citations in `docs/THREADING.md` left by the earlier `ops.c` split (`ops.c` is only 809 lines).

Refs #1086
