### PR TITLE
fix(ir): reject anti-join allocation failures

### DIFF
--- a/tests/test_program_oom.c
+++ b/tests/test_program_oom.c
@@ -252,6 +252,11 @@ main(void)
         ".decl right(key: int64)\n"
         ".decl out(key: int64)\n"
         "out(key) :- left(key), right(key).\n";
+    static const char anti_join_source[]
+        = ".decl item(x: int64)\n"
+        ".decl blocked(x: int64)\n"
+        ".decl out(x: int64)\n"
+        "out(x) :- item(x), !blocked(x).\n";
     static const char false_filter_source[]
         = ".decl item(key: int64, payload: pair/2 inline)\n"
         ".decl out(key: int64)\n"
@@ -281,6 +286,9 @@ main(void)
         WIRELOG_IR_SCAN, WL_IR_EXPR_CMP) != 0)
         return 1;
     if (sweep_conversion(join_source, WIRELOG_IR_JOIN,
+        WIRELOG_IR_SCAN, -1) != 0)
+        return 1;
+    if (sweep_conversion(anti_join_source, WIRELOG_IR_ANTIJOIN,
         WIRELOG_IR_SCAN, -1) != 0)
         return 1;
     if (sweep_conversion(false_filter_source, WIRELOG_IR_FILTER,

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -2768,6 +2768,15 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
             wirelog_ir_node_t *neg_scan
                 = build_atom_scan(neg_atom, prog, &neg_vars, &neg_vcount);
 
+            if (!neg_scan) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while lowering negated atom '%s' in "
+                    "rule '%s'", neg_atom->name ? neg_atom->name : "?",
+                    head->name ? head->name : "?");
+                free_var_names(neg_vars, neg_vcount);
+                goto conversion_failed;
+            }
+
             /* Safety / range restriction (issue #920): every named variable in
              * a negated atom must also be bound by a positive body atom. A
              * variable that occurs only under negation has an unbounded range,
@@ -2808,39 +2817,47 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
                 return NULL;
             }
 
-            if (neg_scan) {
-                wirelog_ir_node_t *aj = wl_ir_node_create(WIRELOG_IR_ANTIJOIN);
-                if (aj) {
-                    if (setup_join_keys(cur_vars, cur_vcount, neg_vars,
-                        neg_vcount, aj) != 0) {
-                        wl_ir_node_free(aj);
-                        wl_ir_node_free(neg_scan);
-                        free_var_names(neg_vars, neg_vcount);
-                        wl_ir_node_free(current);
-                        for (uint32_t s = 0; s < scan_count; s++)
-                            free_var_names(scan_vars[s], scan_vcounts[s]);
-                        if (cur_vars_is_merged)
-                            free_var_names(cur_vars, cur_vcount);
-                        free((void *)scans);
-                        free((void *)scan_vars);
-                        free(scan_vcounts);
-                        return NULL;
-                    }
-                    if (wl_ir_node_add_child(aj, current) != 0) {
-                        wl_ir_node_free(aj);
-                        wl_ir_node_free(neg_scan);
-                    } else if (wl_ir_node_add_child(aj, neg_scan) != 0) {
-                        aj->children[0] = NULL;
-                        aj->child_count = 0;
-                        wl_ir_node_free(aj);
-                        wl_ir_node_free(neg_scan);
-                    } else {
-                        current = aj;
-                    }
-                } else {
-                    wl_ir_node_free(neg_scan);
-                }
+            wirelog_ir_node_t *aj = wl_ir_node_create(WIRELOG_IR_ANTIJOIN);
+            if (!aj) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while creating an anti-join for rule "
+                    "'%s'", head->name ? head->name : "?");
+                wl_ir_node_free(neg_scan);
+                free_var_names(neg_vars, neg_vcount);
+                goto conversion_failed;
             }
+            if (setup_join_keys(cur_vars, cur_vcount, neg_vars, neg_vcount,
+                aj) != 0) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while building anti-join keys for "
+                    "rule '%s'", head->name ? head->name : "?");
+                wl_ir_node_free(aj);
+                wl_ir_node_free(neg_scan);
+                free_var_names(neg_vars, neg_vcount);
+                goto conversion_failed;
+            }
+            if (wl_ir_node_add_child(aj, current) != 0) {
+                wl_ir_program_set_error(prog,
+                    "allocation failed while attaching the positive anti-join "
+                    "input for rule '%s'", head->name ? head->name : "?");
+                wl_ir_node_free(aj);
+                wl_ir_node_free(neg_scan);
+                free_var_names(neg_vars, neg_vcount);
+                goto conversion_failed;
+            }
+            if (wl_ir_node_add_child(aj, neg_scan) != 0) {
+                wl_ir_node_free(aj);
+                aj = NULL;
+                wl_ir_node_free(neg_scan);
+                current = NULL;
+                wl_ir_program_set_error(prog,
+                    "allocation failed while attaching the negated anti-join "
+                    "input for rule '%s'", head->name ? head->name : "?");
+                free_var_names(neg_vars, neg_vcount);
+                goto conversion_failed;
+            }
+
+            current = aj;
 
             free_var_names(neg_vars, neg_vcount);
         }


### PR DESCRIPTION
Closes #1167

This stacked PR follows #1168 and hardens negated-atom lowering. Allocation failures while building the negated scan, anti-join node/keys, or either child attachment now reject the rule instead of silently weakening it by dropping the negation.

The second child attachment path explicitly releases the already-owned positive child exactly once. The OOM regression fixture covers the anti-join rule across malloc/calloc/realloc fault injection and rejects every injected failure with no retained IR root.

The base is temporarily `issue-1165-ir-oom`; after #1168 merges, retarget this PR to `main` and keep auto-merge enabled.

Validation:
- `meson compile -C build`
- `meson test -C build program program_oom jpp --print-errorlogs`
- `meson test -C build --suite abi --print-errorlogs`
- `meson test -C build --suite asan --print-errorlogs`
- broad `meson test -C build --print-errorlogs` (298/299 executed tests passed; the only failure is the environment SBOM snapshot gaining installed agent-workflows/pyrewire dependencies)
- `uncrustify -c uncrustify.cfg --check wirelog/ir/program.c tests/test_program_oom.c`
- `git diff --check`
