### PR TITLE
ci: resolve threading audit citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1496,14 +1496,14 @@ All notable changes to wirelog are documented in this file.
   per-test, not as a numeric ratio, so future additions on
   either side cannot silently regress parity.  Result at this
   commit: 15 paired + 14 annotated = 29 easy tests covered.
-- **`scripts/ci/check-threading-doc.sh`** (#734): static gate
+- **`scripts/ci/check-threading-doc.sh`** (#734, #1173): static gate
   registered as `meson test --suite abi:threading_doc` that counts
-  `atomic_*` call sites in `wirelog/` production sources and asserts
-  the count matches the number of audit-table rows in
-  `docs/THREADING.md` §5.  Drift in either direction (atomic_* added
-  in code without a doc row, or doc row removed without code change)
-  fails the gate with a clear diagnostic pointing at the section to
-  update.
+  `atomic_*` call sites in `wirelog/` production sources, resolves every
+  `docs/THREADING.md` §5 audit row to a unique logical source line, and
+  checks its documented operation. Drift in either direction (atomic_*
+  added in code without a doc row, doc row removed without code change,
+  or a citation moved under a different basename/line) fails the gate with
+  a diagnostic naming the stale row and remediation.
 - **Compile-only smoke test for `WIRELOG_DEPRECATED_SINCE`** (#782):
   `tests/standalone/test_standalone_wirelog_deprecated_macro.c`
   annotates a static probe function with

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -228,7 +228,7 @@ These exist so struct fields can be declared portably; the audit in
 
 Every `atomic_*` call site in `wirelog/` production sources. Counted
 mechanically by `scripts/ci/check-threading-doc.sh`; row count must
-match the script's count (currently **43**).
+match the script's count (currently **44**).
 
 Format: `file:line` | field | operation | order | justification.
 
@@ -290,21 +290,26 @@ atomic APIs (`atomic_load`/`atomic_store`); they default to
 `memory_order_seq_cst`, which is acceptable here because init runs
 once and the surrounding overhead dominates.
 
-### 5.4 `wirelog/columnar/ops.c` — K-fusion cancel/budget (11 rows)
+### 5.4 `wirelog/columnar/join.c` — keyed-join cancel/budget (10 rows)
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `ops.c:2194` | `ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Tuple-budget accumulator across K-fusion workers; counter only |
-| `ops.c:2387` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll; eventual visibility is acceptable for cooperative cancel |
-| `ops.c:2395` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll |
-| `ops.c:2405` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
-| `ops.c:2410` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag — best-effort signal, **not a synchronization point**; readers may observe the previous value for a bounded period |
-| `ops.c:2420` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
-| `ops.c:2423` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag (see :2410 note) |
-| `ops.c:6750` | `stop` (local) | `atomic_load_explicit` | `relaxed` | Compaction-loop cancel poll |
-| `ops.c:6299` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before the branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:292`, which resets the TDD counter before `thread_create()` |
-| `ops.c:6771` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
-| `ops.c:6773` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Backpressure poll |
+| `join.c:137` | `sess->join_output_shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Tuple-budget accumulator across keyed-join workers; counter only |
+| `join.c:355` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll; eventual visibility is acceptable for cooperative cancel |
+| `join.c:363` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll |
+| `join.c:373` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
+| `join.c:378` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag — best-effort signal, **not a synchronization point**; readers may observe the previous value for a bounded period |
+| `join.c:388` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
+| `join.c:391` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag (see :378 note) |
+| `join.c:1958` | `stop` (local) | `atomic_load_explicit` | `relaxed` | Compaction-loop cancel poll |
+| `join.c:1979` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
+| `join.c:1981` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
+
+### 5.5 `wirelog/columnar/kfusion.c` — K-fusion shared counter (1 row)
+
+| `file:line` | Field | Op | Order | Justification |
+|---|---|---|---|---|
+| `kfusion.c:663` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:292`, which resets the TDD counter before `thread_create()` |
 
 The `stop` flag's `memory_order_relaxed` store is deliberate:
 cancellation is **cooperative**, not preemptive. A worker may observe
@@ -312,19 +317,19 @@ the previous value for up to one cache-line propagation interval; that
 is acceptable because each worker re-polls before every tuple batch
 and the wasted work is bounded.
 
-### 5.5 `wirelog/columnar/eval.c` — shared counter (1 row)
+### 5.6 `wirelog/columnar/eval.c` — shared counter (1 row)
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
 | `eval.c:292` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
 
-### 5.6 `wirelog/columnar/session.c` — worker budget snapshot (1 row)
+### 5.7 `wirelog/columnar/session.c` — worker budget snapshot (1 row)
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `session.c:1484` | per-worker view of `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Worker session reads coordinator's budget snapshot; advisory, no edge required |
+| `session.c:1499` | per-worker view of `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Worker session reads coordinator's budget snapshot; advisory, no edge required |
 
-### 5.7 `wirelog/intern.c` — shared symbol table (3 rows)
+### 5.8 `wirelog/intern.c` — shared symbol table (3 rows)
 
 The intern table is shared, unsynchronized, by every parallel worker
 (Issue #958). Writers (`wl_intern_put`, `wl_intern_get`) serialize on
@@ -340,15 +345,17 @@ named in the justification.
 | `intern.c:84` | `intern->count` | `atomic_load_explicit` | `relaxed` | `WL_INTERN_LOAD_RELAXED`, used by `wl_intern_put`, `intern_resize` and `wl_intern_free`. The writer holds `intern->lock` (or, in `free`, has exclusive access), so no edge is needed |
 | `intern.c:86` | `intern->count` | `atomic_store_explicit` | `release` | `WL_INTERN_STORE_RELEASE`, used by `wl_intern_put` after the string and its segment pointer are written. Publishing the count first would let a lock-free reader dereference an unwritten slot |
 
-### 5.8 Total
+### 5.9 Total
 
-22 + 4 + 2 + 10 + 1 + 1 + 3 = **43 atomic call sites**.
+22 + 4 + 2 + 10 + 1 + 1 + 1 + 3 = **44 atomic call sites**.
 
 `scripts/ci/check-threading-doc.sh` extracts the same count from
-`grep -rE '\batomic_(load|store|fetch_add|fetch_sub|compare_exchange|exchange|init|thread_fence)(_explicit)?\s*\(' wirelog/ --include='*.c' --include='*.h'`
+`grep -rE '(^|[^[:alnum:]_])atomic_(load|store|fetch_add|fetch_sub|fetch_or|fetch_and|fetch_xor|compare_exchange_weak|compare_exchange_strong|exchange|init|thread_fence)(_explicit)?[[:space:]]*\(' wirelog/ --include='*.c' --include='*.h'`
 minus the MSVC shim definitions in `mem_ledger.h:46-81` and
-`lockfree_queue.c:22-37`, and compares against the row count in
-this section. A mismatch fails `meson test --suite abi:threading_doc`.
+`lockfree_queue.c:22-37`. It also resolves each audit row to a unique
+source file and logical (backslash-continued) line, checks the documented
+operation, and compares the resolved-row count with the source count. A
+mismatch or stale citation fails `meson test --suite abi:threading_doc`.
 
 ---
 
@@ -412,7 +419,7 @@ emits a non-fused chain.
 #define WL_KFUSION_MIN_PARALLEL_K 4
 ```
 
-At the dispatch site (`ops.c:5498-5513`), the runtime picks between
+At the dispatch site (`kfusion.c:609-623`), the runtime picks between
 parallel and serial K-fusion:
 
 ```c
@@ -440,7 +447,7 @@ So:
 The serial-vs-parallel cutover at K = 4 was set empirically. Below
 that threshold the workqueue dispatch overhead and the per-worker
 session allocation (`COL_SESSION(sess)->kfusion_alloc_ns` profiled
-at `ops.c:5522`) exceed the saved tuple work for the CRDT and
+at `kfusion.c:633`) exceed the saved tuple work for the CRDT and
 DDISASM workloads measured in the v0.40 perf gate
 (`tests/test_crdt_perf_gate.c`, `bench/bench_flowlog.c`). The
 `ops.c:17-19` comment block records the measurement summary:
@@ -472,7 +479,7 @@ Workers are forbidden to advance the arena's epoch counter or to
 free its memory; only the coordinator may do so. The live invariant
 that enforces this is the `sess->coordinator == NULL` predicate:
 
-- `wirelog/columnar/ops.c:5456-5460` (K-fusion path):
+- `wirelog/columnar/kfusion.c:561-569` (K-fusion path):
   ```c
   if (sess->coordinator == NULL
       && sess->compound_arena && sess->rotation_ops
@@ -481,7 +488,7 @@ that enforces this is the `sess->coordinator == NULL` predicate:
   }
   ```
   The `sess->compound_arena` conjunct is the defensive NULL-pointer
-  guard noted in the surrounding `ops.c:5451-5455` comment block;
+  guard noted in the surrounding `kfusion.c:555-565` comment block;
   the `coordinator == NULL` conjunct is the load-bearing
   coordinator-only invariant.
 - `wirelog/columnar/eval_serial.c:788-791` (eval-stratum sub-pass tail): the
@@ -745,9 +752,9 @@ advisory leg); issue #826 (native TSan SEGV triage);
   `posix`).
 - `wirelog/columnar/ops.c:17-22` — `WL_KFUSION_MIN_PARALLEL_K` plus
   the rationale comment block citing the DDISASM K = 3 measurement.
-- `wirelog/columnar/ops.c:5498-5513` — K-fusion parallel-dispatch
+- `wirelog/columnar/kfusion.c:609-623` — K-fusion parallel-dispatch
   gate.
-- `wirelog/columnar/ops.c:5456-5459` — compound-arena gate (K-fusion
+- `wirelog/columnar/kfusion.c:561-569` — compound-arena gate (K-fusion
   side).
 - `wirelog/columnar/eval_serial.c:788-791` — compound-arena gate (eval-
   stratum side).

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -12,16 +12,19 @@
 # pattern-matched as: `| \`file:line\` | ...`.
 #
 # Exit codes:
-#   0 - row count in doc matches site count in code.
+#   0 - row count and every cited source location match the code.
 #   1 - mismatch (atomic_* added or removed; doc needs an audit
-#       refresh) or other hard failure.
+#       refresh), an unresolved citation, or other hard failure.
 #
 # Intended to register under `meson test --suite abi:threading_doc`.
 
 set -euo pipefail
 
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
 script_dir="$(cd "$(dirname "$0")" && pwd)"
-repo_root="$(cd "$script_dir/../.." && pwd)"
+repo_root="${WIRELOG_THREADING_DOC_ROOT:-$(cd "$script_dir/../.." && pwd)}"
 doc="$repo_root/docs/THREADING.md"
 
 if [ ! -f "$doc" ]; then
@@ -36,7 +39,7 @@ fi
 # definitions are at lines 22-37 and 47-57; the actual atomic_*
 # tokens are inside the macro bodies and are the contract sites we
 # do want to count as "atomic operations on the SPSC ring").
-sites=$(grep -rEn '\batomic_(load|store|fetch_add|fetch_sub|fetch_or|fetch_and|fetch_xor|compare_exchange_weak|compare_exchange_strong|exchange|init|thread_fence)(_explicit)?\s*\(' \
+sites=$(grep -rEn '(^|[^[:alnum:]_])atomic_(load|store|fetch_add|fetch_sub|fetch_or|fetch_and|fetch_xor|compare_exchange_weak|compare_exchange_strong|exchange|init|thread_fence)(_explicit)?[[:space:]]*\(' \
         "$repo_root/wirelog" \
         --include='*.c' --include='*.h' \
     | grep -v '#define atomic_' \
@@ -50,21 +53,210 @@ sites=$(grep -rEn '\batomic_(load|store|fetch_add|fetch_sub|fetch_or|fetch_and|f
 # with a backtick.
 rows=$(grep -cE '^\| `[A-Za-z_./-]+:[0-9]+`' "$doc" || true)
 
+# Return success only when the cited physical line and its backslash
+# continuations contain an atomic_* call. Status 2 means the line is past EOF.
+logical_line_has_atomic() {
+    local source=$1
+    local line=$2
+    local operation=$3
+    awk -v wanted="$line" -v operation="$operation" '
+        NR == wanted {
+            logical = $0
+            while (logical ~ /\\$/ && getline > 0)
+                logical = logical "\n" $0
+            found = logical ~ ("(^|[^[:alnum:]_])" operation "[[:space:]]*\\(")
+            seen = 1
+            exit
+        }
+        END {
+            if (!seen)
+                exit 2
+            if (!found)
+                exit 1
+        }
+    ' "$source"
+}
+
+atomic_token_line() {
+    local source=$1
+    local line=$2
+    local operation=$3
+    awk -v wanted="$line" -v operation="$operation" '
+        NR == wanted {
+            physical = NR
+            while (1) {
+                if ($0 ~ ("(^|[^[:alnum:]_])" operation "[[:space:]]*\\(")) {
+                    print physical
+                    found = 1
+                    exit
+                }
+                if ($0 !~ /\\$/ || getline <= 0)
+                    exit
+                physical++
+            }
+        }
+        END {
+            if (!found)
+                exit 1
+        }
+    ' "$source"
+}
+
+# Resolve basename references used by the audit table. The document predates
+# repo-relative citations, so candidates are selected by the cited logical
+# line; a tie fails loudly rather than depending on `find` ordering.
+resolve_source() {
+    local reference=$1
+    local operation=$2
+    local basename=${reference%%:*}
+    local line=${reference##*:}
+    local -a candidates
+    local -a matches=()
+    local candidate
+    candidates=()
+    while IFS= read -r candidate; do
+        candidates+=("$candidate")
+    done < <(find "$repo_root/wirelog" -type f -name "$basename" -print | sort)
+    if [ "${#candidates[@]}" -eq 0 ]; then
+        echo "check-threading-doc: FAIL: $reference has no matching source; fix the audit row to name an existing wirelog file" >&2
+        return 1
+    fi
+    for candidate in "${candidates[@]}"; do
+        if logical_line_has_atomic "$candidate" "$line" "$operation"; then
+            matches+=("$candidate")
+        fi
+    done
+    if [ "${#matches[@]}" -eq 1 ]; then
+        printf '%s\n' "${matches[0]}"
+        return 0
+    fi
+    if [ "${#matches[@]}" -eq 0 ]; then
+        echo "check-threading-doc: FAIL: $reference does not contain $operation on its logical line; fix the file:line or operation citation" >&2
+    else
+        printf 'check-threading-doc: FAIL: %s is ambiguous; matching candidates:\n' "$reference" >&2
+        printf '  %s\n' "${matches[@]}" >&2
+        echo "  Fix the audit row to use a uniquely identifying file:line citation." >&2
+    fi
+    return 1
+}
+
+# Check the complete logical preprocessor line, not only its first physical
+# line. The intern.c audit deliberately cites macro definitions whose
+# atomic_* token is on the continuation line.
+check_citation() {
+    local reference=$1
+    local operation=$2
+    local source
+    source=$(resolve_source "$reference" "$operation") || return 1
+    return 0
+}
+
+# Validate every audit-table citation after the count check. Keep the first
+# cell deliberately narrow so prose references elsewhere do not become rows.
+validated_rows=0
+while IFS=$'\t' read -r reference operation; do
+    if [[ ! "$operation" =~ ^atomic_[A-Za-z0-9_]+$ ]]; then
+        echo "check-threading-doc: FAIL: $reference has invalid operation '$operation'; fix the audit row" >&2
+        exit 1
+    fi
+    check_citation "$reference" "$operation" || exit 1
+    validated_rows=$((validated_rows + 1))
+done < <(sed -nE 's/^\| `([A-Za-z_./-]+:[0-9]+)` \| [^|]* \| `([^`]*)` \|.*/\1\t\2/p' "$doc")
+
+if [ "$validated_rows" -ne "$rows" ]; then
+    echo "check-threading-doc: FAIL: $rows audit rows found but only $validated_rows rows have a valid citation shape" >&2
+    exit 1
+fi
+
 if [ "$sites" -ne "$rows" ]; then
     echo "check-threading-doc: FAIL:" >&2
     echo "  atomic_* call sites in wirelog/: $sites" >&2
     echo "  audit table rows in $doc: $rows" >&2
     echo "" >&2
-    echo "Drift detected.  Either:" >&2
-    echo "  (a) the audit table is stale -- update docs/THREADING.md §5" >&2
-    echo "      with a new row for the added atomic_* call site, or" >&2
-    echo "  (b) an atomic_* call site was removed -- delete the matching" >&2
-    echo "      row from §5." >&2
-    echo "" >&2
-    echo "Re-run after fixing.  See docs/THREADING.md §5 for the row" >&2
-    echo "format and the per-site justification convention." >&2
+    echo "Drift detected. Either update docs/THREADING.md §5 to add or remove the matching row." >&2
     exit 1
 fi
 
-echo "check-threading-doc: OK; $sites atomic_* call sites match $rows audit rows in docs/THREADING.md"
+# Compare the normalized source-site inventory with the audit references. The
+# count check alone cannot detect a duplicated row that hides an omitted site.
+source_sites="$tmp_dir/source-sites"
+audit_sites="$tmp_dir/audit-sites"
+grep -rEn '(^|[^[:alnum:]_])atomic_(load|store|fetch_add|fetch_sub|fetch_or|fetch_and|fetch_xor|compare_exchange_weak|compare_exchange_strong|exchange|init|thread_fence)(_explicit)?[[:space:]]*\(' \
+        "$repo_root/wirelog" \
+        --include='*.c' --include='*.h' \
+    | grep -v '#define atomic_' \
+    | grep -v '#define WL_ATOMIC' \
+    | awk -F: '{print $1 ":" $2}' \
+    | while IFS=: read -r source line; do
+        file=$source
+        file=${file##*/}
+        printf '%s:%s\n' "$file" "$line"
+    done \
+    | sort > "$source_sites"
+while IFS=$'\t' read -r reference operation; do
+    source=$(resolve_source "$reference" "$operation") || exit 1
+    token_line=$(atomic_token_line "$source" "${reference##*:}" "$operation") || exit 1
+    file=${source##*/}
+    printf '%s:%s\n' "$file" "$token_line"
+done < <(sed -nE 's/^\| `([A-Za-z_./-]+:[0-9]+)` \| [^|]* \| `([^`]*)` \|.*/\1\t\2/p' "$doc") \
+    | sort > "$audit_sites"
+if ! cmp -s "$source_sites" "$audit_sites"; then
+    echo "check-threading-doc: FAIL: audit citations do not cover the exact atomic-site inventory" >&2
+    echo "  source-only or duplicate audit entries:" >&2
+    comm -3 "$source_sites" "$audit_sites" >&2
+    exit 1
+fi
+
+# Validate line and range references in prose as well as audit rows. Ranges
+# are bounds checks only; the operation-specific check above remains the
+# authoritative validation for table rows.
+resolve_reference_source() {
+    local basename=$1
+    local start=$2
+    local end=$3
+    local -a candidates=()
+    local -a matches=()
+    local candidate line_count
+    if [[ "$basename" == wirelog/* ]]; then
+        candidates=("$repo_root/$basename")
+    else
+        while IFS= read -r candidate; do
+            candidates+=("$candidate")
+        done < <(find "$repo_root/wirelog" -type f -name "$basename" -print | sort)
+    fi
+    for candidate in "${candidates[@]}"; do
+        [ -f "$candidate" ] || continue
+        line_count=$(wc -l < "$candidate")
+        if [ "$start" -ge 1 ] && [ "$end" -ge "$start" ] && [ "$end" -le "$line_count" ]; then
+            matches+=("$candidate")
+        fi
+    done
+    [ "${#matches[@]}" -eq 1 ]
+}
+
+while IFS= read -r citation; do
+    citation=${citation#\`}
+    citation=${citation%\`}
+    basename=${citation%%:*}
+    locations=${citation#*:}
+    IFS=',' read -ra location_list <<< "$locations"
+    for location in "${location_list[@]}"; do
+        if [[ "$location" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+            start=${BASH_REMATCH[1]}
+            end=${BASH_REMATCH[2]}
+        elif [[ "$location" =~ ^[0-9]+$ ]]; then
+            start=$location
+            end=$location
+        else
+            echo "check-threading-doc: FAIL: malformed prose citation '$citation'" >&2
+            exit 1
+        fi
+        if ! resolve_reference_source "$basename" "$start" "$end"; then
+            echo "check-threading-doc: FAIL: prose citation '$basename:$location' does not resolve to an in-range source" >&2
+            exit 1
+        fi
+    done
+done < <(grep -oE '`[A-Za-z0-9_./-]+\.(c|h):[0-9]+([,-][0-9]+)*`' "$doc" || true)
+
+echo "check-threading-doc: OK; $sites atomic_* call sites and $rows resolved audit rows match in docs/THREADING.md"
 exit 0

--- a/scripts/ci/test-threading-doc.sh
+++ b/scripts/ci/test-threading-doc.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Focused regression tests for check-threading-doc.sh.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+checker="$script_dir/check-threading-doc.sh"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+make_fixture() {
+    rm -rf "$fixture"
+    mkdir -p "$fixture/wirelog/columnar" "$fixture/docs"
+}
+
+run_checker() {
+    WIRELOG_THREADING_DOC_ROOT="$fixture" "$checker"
+}
+
+replace_doc() {
+    local old=$1
+    local new=$2
+    sed "s#$old#$new#" "$fixture/docs/THREADING.md" > "$fixture/docs/THREADING.md.tmp"
+    mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"
+}
+
+delete_doc_lines() {
+    local pattern=$1
+    sed "/$pattern/d" "$fixture/docs/THREADING.md" > "$fixture/docs/THREADING.md.tmp"
+    mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"
+}
+
+expect_failure() {
+    local label=$1
+    shift
+    if "$@" >"$fixture/stdout" 2>"$fixture/stderr"; then
+        echo "test-threading-doc: FAIL: $label unexpectedly passed" >&2
+        cat "$fixture/stderr" >&2
+        exit 1
+    fi
+    grep -F "$label" "$fixture/stderr" >/dev/null || {
+        echo "test-threading-doc: FAIL: diagnostic for $label missing" >&2
+        cat "$fixture/stderr" >&2
+        exit 1
+    }
+}
+
+# A unique basename resolves and a backslash-continued macro is accepted.
+make_fixture
+printf '%s\n' 'atomic_load_explicit(&value, memory_order_relaxed);' 'not an atomic site' > "$fixture/wirelog/foo.c"
+printf '%s\n' '#define LOAD(p) \' '    atomic_load_explicit((p), memory_order_acquire)' > "$fixture/wirelog/intern.c"
+printf '%s\n' 'int session(void) {' '    atomic_store_explicit(&value, 1, memory_order_relaxed);' '}' > "$fixture/wirelog/columnar/session.c"
+printf '%s\n' '/* duplicate basename must not be selected */' > "$fixture/wirelog/session.c"
+cat > "$fixture/docs/THREADING.md" <<'EOF'
+| `foo.c:1` | value | `atomic_load_explicit` | relaxed | test |
+| `intern.c:1` | value | `atomic_load_explicit` | acquire | test |
+| `session.c:2` | value | `atomic_store_explicit` | relaxed | test |
+EOF
+run_checker >/dev/null
+
+# A duplicate valid row cannot hide an omitted source site: exact inventory
+# comparison must catch it even when counts still match.
+replace_doc 'intern.c:1' 'foo.c:1'
+expect_failure 'audit citations do not cover the exact atomic-site inventory' run_checker
+replace_doc 'foo.c:1` | value | `atomic_load_explicit` | acquire' 'intern.c:1` | value | `atomic_load_explicit` | acquire'
+
+# The documented operation must match the cited source operation.
+replace_doc 'atomic_load_explicit` | relaxed' 'atomic_store_explicit` | relaxed'
+expect_failure 'foo.c:1 does not contain atomic_store_explicit' run_checker
+replace_doc 'atomic_store_explicit` | relaxed' 'atomic_load_explicit` | relaxed'
+replace_doc 'atomic_load_explicit` | relaxed' 'not_atomic` | relaxed'
+expect_failure 'foo.c:1 has invalid operation' run_checker
+replace_doc 'not_atomic` | relaxed' 'atomic_load_explicit` | relaxed'
+replace_doc 'session.c:2.*atomic_load_explicit' 'session.c:2` | value | `atomic_store_explicit'
+
+# An existing file with a non-atomic cited line is rejected.
+replace_doc 'foo.c:1' 'foo.c:2'
+expect_failure 'foo.c:2 does not contain atomic_load_explicit' run_checker
+
+# The ambiguity rule reports both candidates instead of picking one.
+replace_doc 'foo.c:2' 'foo.c:1'
+mkdir -p "$fixture/wirelog/extra"
+printf '%s\n' 'atomic_load_explicit(&value, memory_order_relaxed);' > "$fixture/wirelog/extra/foo.c"
+expect_failure 'foo.c:1 is ambiguous' run_checker
+
+# Out-of-range citations name the offending row and source.
+rm "$fixture/wirelog/foo.c"
+printf '%s\n' 'atomic_load_explicit(&value, memory_order_relaxed);' > "$fixture/wirelog/foo.c"
+rm "$fixture/wirelog/extra/foo.c"
+replace_doc 'foo.c:1' 'foo.c:99'
+expect_failure 'foo.c:99 does not contain atomic_load_explicit' run_checker
+
+# A basename with no source candidate reports the row and remediation.
+replace_doc 'foo.c:99' 'missing.c:1'
+expect_failure 'missing.c:1 has no matching source' run_checker
+
+# The original count backstop remains active.
+delete_doc_lines '`missing.c:1`'
+expect_failure 'atomic_* call sites in wirelog/' run_checker
+
+echo 'test-threading-doc: OK'

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -726,12 +726,15 @@ if sh.found()
        suite: 'abi')
 endif
 
-# Issue #734: docs/THREADING.md atomics audit row count must match
-# the count of atomic_* call sites in wirelog/ production sources.
-# Static text scan; no build-tree input required.
+# Issue #734/#1173: docs/THREADING.md atomics audit rows must resolve to
+# logical atomic_* source lines, and the count must match production sources.
+# Static shell checks; no build-tree input required.
 if sh.found()
   test('threading_doc', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-threading-doc.sh'],
+       suite: 'abi')
+  test('threading_doc_selftest', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-threading-doc.sh'],
        suite: 'abi')
 endif
 


### PR DESCRIPTION
## Summary
- repoint stale #1172 threading audit citations, including the session worker site and extracted join/K-fusion sites
- validate every audit row by unique source/line, exact atomic operation, logical macro continuation, and exact source inventory
- add portable fixture self-tests and register them in the ABI suite

Closes #1172
Closes #1173

## Validation
- `scripts/ci/check-threading-doc.sh`
- `scripts/ci/test-threading-doc.sh`
- `meson test -C build-1173 --suite abi --print-errorlogs` (35/35)
- `git diff --check`