### PR TITLE
docs: repoint stale evaluator comments

### DIFF
--- a/tests/test_program.c
+++ b/tests/test_program.c
@@ -3284,7 +3284,7 @@ test_fact_arity_mismatch_maps_to_parse_error(void)
  * col_rel_append_all() (columnar/relation.c) copies dst->ncols columns from
  * it, unclamped against src->ncols -- ASAN reports
  * "heap-buffer-overflow READ of size 8" in col_rel_append_all under
- * col_eval_stratum() (columnar/eval.c), exit 139.  Outside a recursive
+ * col_eval_stratum() (columnar/eval_serial.c), exit 139.  Outside a recursive
  * stratum it is a silent wrong answer instead.
  *
  * The predicate compares PHYSICAL width, not logical, and that is the whole

--- a/tests/test_recursive_agg_kfusion.c
+++ b/tests/test_recursive_agg_kfusion.c
@@ -8,7 +8,7 @@
  *
  * A recursive relation whose head carries min()/max() is reduced twice: once
  * per rule by col_op_reduce(), and once over the whole relation at fixpoint
- * by the recursive-aggregate canonicalisation in columnar/eval.c.  Only the
+ * by the recursive-aggregate canonicalisation in columnar/eval_serial.c.  Only the
  * second one can see across rules, so only it can turn the union of each
  * rule's partial minimum into the relation's minimum.
  *

--- a/tests/test_symbol_aggregates.c
+++ b/tests/test_symbol_aggregates.c
@@ -37,7 +37,7 @@
  *   test_recursive_min_workers / test_recursive_max_workers
  *       The same property through the recursive fixpoint, at W = 1, 4, 8
  *       and 16.  A second reducer -- the recursive-aggregate
- *       canonicalisation in columnar/eval.c -- runs only on this path and
+ *       canonicalisation in columnar/eval_serial.c -- runs only on this path and
  *       flipped independently of col_op_reduce().
  *
  *   test_join_chain_aggregate
@@ -357,7 +357,7 @@ test_max_lexicographic(void)
  * Connected-component labelling over symbols.  {"zz","aa","mm"} form one
  * component and {"pp","bb"} another, so the answer is the lexicographic
  * minimum (or maximum) of each component -- propagated through the
- * recursive rule, which is what makes the eval.c canonicalisation run.
+ * recursive rule, which is what makes the eval_serial.c canonicalisation run.
  */
 #define CC_EDGES                                     \
         ".decl E(x: symbol, y: symbol)\n"            \

--- a/tests/test_worker_arena_borrow.c
+++ b/tests/test_worker_arena_borrow.c
@@ -318,7 +318,7 @@ test_worker_skips_gc_epoch_boundary_dispatch(void)
 
     /* Regression for the TSan data race that surfaced once workers
      * started borrowing the coordinator's compound_arena (Issue #579 /
-     * R-5).  The dispatch sites at ops.c (col_op_k_fusion entry) and
+     * R-5).  The dispatch sites at columnar/kfusion.c (col_op_k_fusion entry) and
      * eval.c (recursive sub-pass tail) advance arena->current_epoch,
      * which is a write on a pointer that workers share with the
      * coordinator.  The gate predicate must therefore reject worker
@@ -363,7 +363,7 @@ test_worker_skips_gc_epoch_boundary_dispatch(void)
         return 1;
     }
 
-    /* The gate predicate that ops.c:col_op_k_fusion and
+    /* The gate predicate that columnar/kfusion.c:col_op_k_fusion and
      * eval_serial.c:col_eval_stratum apply before dispatching
      * gc_epoch_boundary.  Mirroring it here pins the invariant: any
      * future relaxation of the worker check at either call site will

--- a/tests/test_worker_arena_borrow.c
+++ b/tests/test_worker_arena_borrow.c
@@ -364,7 +364,7 @@ test_worker_skips_gc_epoch_boundary_dispatch(void)
     }
 
     /* The gate predicate that ops.c:col_op_k_fusion and
-     * eval.c:col_eval_stratum apply before dispatching
+     * eval_serial.c:col_eval_stratum apply before dispatching
      * gc_epoch_boundary.  Mirroring it here pins the invariant: any
      * future relaxation of the worker check at either call site will
      * trip this assertion. */

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -564,7 +564,7 @@ col_rel_binary_search_row(const col_rel_t *rel, uint32_t lo, uint32_t hi,
  * string, the comparison is therefore over the strings.
  *
  * There are two reducers -- col_op_reduce() in ops.c and the recursive
- * canonicalisation in eval.c -- and they must agree.  Two copies could
+ * canonicalisation in eval_serial.c -- and they must agree.  Two copies could
  * drift into a fixpoint that is lexicographic within an iteration and
  * id-ordered across iterations, which is worse than the original bug, so
  * both call this.

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -930,7 +930,7 @@ validate_fact_arities(struct wirelog_program *program,
  *   cc(y, min(c)) :- cc(x, c, d), edge(x, y).   -> SIGSEGV (exit 139)
  *
  * ASAN reports "heap-buffer-overflow READ of size 8" in col_rel_append_all()
- * under col_eval_stratum() (columnar/eval.c).  Issue #973 rejects the
+ * under col_eval_stratum() (columnar/eval_serial.c).  Issue #973 rejects the
  * multi-aggregate spelling of the same crash; this is the single-aggregate
  * one, which that check cannot see because nothing about its aggregate count
  * is wrong.
@@ -2444,7 +2444,7 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
      * tuple narrower than the .decl.  col_op_reduce() (columnar/ops.c) then
      * sizes its output region as group_by_count + 1 while col_rel_append_all()
      * (columnar/relation.c) copies dst->ncols columns from it, unclamped -- an
-     * out-of-bounds read under col_eval_stratum() (columnar/eval.c):
+     * out-of-bounds read under col_eval_stratum() (columnar/eval_serial.c):
      *   .decl cc(n:int64, lo:int64, hi:int64)
      *   cc(y, min(c), max(c)) :- cc(x, c, d), edge(x, y).   -> SIGSEGV
      *


### PR DESCRIPTION
## Summary
- Repoint eight stale `eval.c` ownership comments to `eval_serial.c` after #1169.
- Repoint the two stale `ops.c` ownership comments for `col_op_k_fusion` to `columnar/kfusion.c` (stacked #1176).
- Preserve legitimate distributed-evaluator/provenance references.
- Comment-only change across the six parent files plus the stacked worker comment update.

## Validation
- `git diff --check`
- `uncrustify --check` on all affected C/C-header files
- Semantic stale-ownership scan for evaluator and k-fusion ownership claims

Closes #1171
Closes #1176
Related: #1169 #1178