### PR TITLE
fix(columnar): resolve the internal.h:414 ArrayBound diagnostic in both reaching TUs

### DIFF
--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -63,6 +63,7 @@ wirelog/columnar/handle_remap_apply_side.c
 wirelog/columnar/inline.c
 wirelog/columnar/lftj.c
 wirelog/columnar/mem_ledger.c
+wirelog/columnar/mobius.c
 wirelog/columnar/ops.c
 wirelog/columnar/partition.c
 wirelog/columnar/progress.c

--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -51,6 +51,7 @@ wirelog/columnar/diff_trace.c
 wirelog/columnar/diff_vtable.c
 wirelog/columnar/eval.c
 wirelog/columnar/eval_dedup.c
+wirelog/columnar/eval_delta.c
 wirelog/columnar/eval_serial.c
 wirelog/columnar/eval_stack.c
 wirelog/columnar/eval_tdd_plan.c

--- a/scripts/ci/clang-tidy-backlog.txt
+++ b/scripts/ci/clang-tidy-backlog.txt
@@ -38,4 +38,3 @@ wirelog/columnar/expr.c
 wirelog/columnar/join.c
 wirelog/columnar/kfusion.c
 wirelog/columnar/merge.c
-wirelog/columnar/mobius.c

--- a/scripts/ci/clang-tidy-backlog.txt
+++ b/scripts/ci/clang-tidy-backlog.txt
@@ -31,7 +31,6 @@
 #
 # wirelog/ir/program.c is the reason this issue exists: it was clean, and
 # regressed to bugprone-branch-clone after f1d2a2c with nothing failing.
-wirelog/columnar/eval_delta.c
 wirelog/columnar/eval_plan.c
 wirelog/columnar/eval_tdd_queue.c
 wirelog/columnar/expr.c

--- a/tests/test_mobius_delta_formula.c
+++ b/tests/test_mobius_delta_formula.c
@@ -441,6 +441,126 @@ test_wide_relation_delta(void)
 /* ----------------------------------------------------------------
  * main
  * ---------------------------------------------------------------- */
+/* ================================================================
+ * Test 6 (Issue #1076): an out_delta carrying rows is rejected
+ *
+ * The append path grows out_delta only when nrows >= capacity, to
+ * capacity ? capacity * 2 : 16 -- which can still be <= nrows.  An
+ * out_delta handed over with nrows already past its buffer therefore
+ * writes off the end: ASan reports a heap-buffer-overflow WRITE at
+ * internal.h:414 reached from mobius.c.
+ *
+ * capacity and columns are left at 0/NULL so the pre-fix grow path
+ * allocates 16 rows and the write at index 8 lands in bounds; before the
+ * fix this case returns 0 and fails the assertion cleanly instead of
+ * corrupting the heap.
+ * ================================================================ */
+static void
+test_non_empty_out_delta_rejected(void)
+{
+    TEST("col_compute_delta_mobius rejects an out_delta with rows (#1076)");
+
+    col_rel_t *prev = test_rel_alloc(1);
+    col_rel_t *curr = test_rel_alloc(1);
+    col_rel_t *out = test_rel_alloc(1);
+    ASSERT(prev && curr && out, "test_rel_alloc failed");
+
+    int64_t row[] = { 42 };
+    ASSERT(test_rel_append_row_mult(curr, row, 1) == 0, "append curr row");
+
+    out->nrows = 8;
+
+    int rc = col_compute_delta_mobius(prev, curr, out);
+
+    ASSERT(rc == EINVAL, "returns EINVAL for an out_delta with nrows != 0");
+    ASSERT(out->nrows == 8, "out_delta is left untouched on rejection");
+
+    test_rel_free(prev);
+    test_rel_free(curr);
+    test_rel_free(out);
+    PASS();
+}
+
+/* ================================================================
+ * Test 7 (Issue #1076): an out_delta whose arity disagrees is rejected
+ *
+ * out_delta->ncols is overwritten by this function, but ncols is also the
+ * length bound for col_names, merge_columns and retract_backup_columns,
+ * which it does not touch.  Widening it silently desyncs those from what
+ * the caller allocated: col_rel_free_contents() then walks col_names to
+ * the new, larger ncols and reads past the allocation (ASan:
+ * heap-buffer-overflow READ, followed by free() on garbage pointers).
+ *
+ * The relation here is pristine in nrows/capacity/columns -- the check
+ * added for shapes A and C does not catch it -- but carries one column
+ * against three-column inputs.
+ * ================================================================ */
+static void
+test_arity_mismatch_out_delta_rejected(void)
+{
+    TEST("col_compute_delta_mobius rejects a wrong-arity out_delta (#1076)");
+
+    col_rel_t *prev = test_rel_alloc(3);
+    col_rel_t *curr = test_rel_alloc(3);
+    col_rel_t *out = test_rel_alloc(1); /* pristine, but one column */
+    ASSERT(prev && curr && out, "test_rel_alloc failed");
+
+    int64_t row[] = { 1, 2, 3 };
+    ASSERT(test_rel_append_row_mult(curr, row, 1) == 0, "append curr row");
+
+    int rc = col_compute_delta_mobius(prev, curr, out);
+
+    ASSERT(rc == EINVAL, "returns EINVAL when out_delta->ncols != input ncols");
+    ASSERT(out->ncols == 1, "out_delta->ncols is not overwritten on rejection");
+
+    test_rel_free(prev);
+    test_rel_free(curr);
+    test_rel_free(out);
+    PASS();
+}
+
+/* ================================================================
+ * Test 8 (Issue #1076): an out_delta with a lying capacity is rejected
+ *
+ * This is the case the documented contract did not cover: nrows == 0 is
+ * satisfied, so the old precondition was met.  The arity matches too, so
+ * the check added for Test 7 does not see it either -- what is wrong is
+ * that capacity claims four rows while the buffers hold one, and
+ * timestamps is NULL.  Because nrows < capacity the append path skips
+ * the grow that would have allocated timestamps, so the first append
+ * writes out_delta->timestamps[0] through a NULL pointer.
+ *
+ * This case is what pins the capacity/columns half of the precondition:
+ * remove only those clauses and this is the sole test that fails.
+ * ================================================================ */
+static void
+test_lying_capacity_out_delta_rejected(void)
+{
+    TEST("col_compute_delta_mobius rejects a lying capacity (#1076)");
+
+    col_rel_t *prev = test_rel_alloc(1);
+    col_rel_t *curr = test_rel_alloc(1);
+    col_rel_t *out = test_rel_alloc(1);
+    ASSERT(prev && curr && out, "test_rel_alloc failed");
+
+    int64_t row[] = { 7 };
+    ASSERT(test_rel_append_row_mult(curr, row, 1) == 0, "append curr row");
+
+    /* nrows stays 0 and ncols matches: only capacity/columns are wrong. */
+    out->capacity = 4;
+    out->columns = col_columns_alloc(1, 1);
+    ASSERT(out->columns != NULL, "col_columns_alloc failed");
+
+    int rc = col_compute_delta_mobius(prev, curr, out);
+
+    ASSERT(rc == EINVAL, "returns EINVAL for an out_delta with capacity != 0");
+
+    test_rel_free(prev);
+    test_rel_free(curr);
+    test_rel_free(out);
+    PASS();
+}
+
 int
 main(void)
 {
@@ -463,6 +583,9 @@ main(void)
     test_new_key_appears();
     test_key_vanishes();
     test_wide_relation_delta();
+    test_non_empty_out_delta_rejected();
+    test_arity_mismatch_out_delta_rejected();
+    test_lying_capacity_out_delta_rejected();
 
     printf("\n=== Results: %d passed, %d failed (of %d) ===\n", pass_count,
         fail_count, test_count);

--- a/tests/test_mobius_join_weighted.c
+++ b/tests/test_mobius_join_weighted.c
@@ -442,6 +442,91 @@ test_wide_relation_join(void)
 /* ----------------------------------------------------------------
  * main
  * ---------------------------------------------------------------- */
+/* ================================================================
+ * Test 5 (Issue #1076): a non-pristine dst is rejected
+ *
+ * col_op_join_weighted() overwrites dst->ncols and then appends at
+ * dst->nrows through dst->columns[0..ocols).  A dst that already carries
+ * rows, or whose columns array is narrower than ocols, overflows both --
+ * ASan reports a heap-buffer-overflow WRITE at internal.h:414 reached
+ * from mobius.c.  The documented ncols==0 precondition does not bound
+ * nrows, capacity or columns, so the function now requires the whole
+ * relation pristine.
+ *
+ * dst here is left with capacity==0 and columns==NULL deliberately: the
+ * pre-fix grow path then allocates 16 rows and the write at index 8 lands
+ * in bounds, so before the fix this case returns 0 and fails the
+ * assertion cleanly rather than corrupting the heap.
+ * ================================================================ */
+static void
+test_non_pristine_dst_rejected(void)
+{
+    TEST("col_op_join_weighted rejects a dst carrying rows (#1076)");
+
+    col_rel_t *lhs = test_rel_alloc(1);
+    col_rel_t *rhs = test_rel_alloc(1);
+    col_rel_t *dst = test_rel_alloc(0);
+    ASSERT(lhs && rhs && dst, "test_rel_alloc failed");
+
+    int64_t lrow[] = { 1 };
+    int64_t rrow[] = { 1 };
+    ASSERT(test_rel_append_row_mult(lhs, lrow, 2) == 0, "append lhs row");
+    ASSERT(test_rel_append_row_mult(rhs, rrow, 3) == 0, "append rhs row");
+
+    dst->nrows = 8;
+
+    int rc = col_op_join_weighted(lhs, rhs, 0, dst);
+
+    ASSERT(rc == EINVAL, "returns EINVAL for a dst with nrows != 0");
+    ASSERT(dst->nrows == 8, "dst is left untouched on rejection");
+
+    test_rel_free(lhs);
+    test_rel_free(rhs);
+    test_rel_free(dst);
+    PASS();
+}
+
+/* ================================================================
+ * Test 6 (Issue #1076): a dst of the wrong arity is rejected
+ *
+ * This pins the ncols clause of the precondition specifically.  The other
+ * three clauses do not see this shape: dst is pristine in nrows, capacity
+ * and columns.  What is wrong is that dst carries three columns while the
+ * join produces two, and col_op_join_weighted() overwrites dst->ncols
+ * without resizing col_names, merge_columns or retract_backup_columns --
+ * which ncols also bounds.  Widening desyncs them and
+ * col_rel_free_contents() then frees past the allocation.
+ *
+ * Here ncols narrows (3 -> 2), which leaks rather than overflows, so the
+ * pre-fix run returns 0 and fails the assertion cleanly with no memory
+ * error.  The widening direction is the one that corrupts.
+ * ================================================================ */
+static void
+test_wrong_arity_dst_rejected(void)
+{
+    TEST("col_op_join_weighted rejects a dst of the wrong arity (#1076)");
+
+    col_rel_t *lhs = test_rel_alloc(1);
+    col_rel_t *rhs = test_rel_alloc(1);
+    col_rel_t *dst = test_rel_alloc(3); /* join produces 2 columns */
+    ASSERT(lhs && rhs && dst, "test_rel_alloc failed");
+
+    int64_t lrow[] = { 1 };
+    int64_t rrow[] = { 1 };
+    ASSERT(test_rel_append_row_mult(lhs, lrow, 2) == 0, "append lhs row");
+    ASSERT(test_rel_append_row_mult(rhs, rrow, 3) == 0, "append rhs row");
+
+    int rc = col_op_join_weighted(lhs, rhs, 0, dst);
+
+    ASSERT(rc == EINVAL, "returns EINVAL for a dst with ncols != 0");
+    ASSERT(dst->ncols == 3, "dst->ncols is not overwritten on rejection");
+
+    test_rel_free(lhs);
+    test_rel_free(rhs);
+    test_rel_free(dst);
+    PASS();
+}
+
 int
 main(void)
 {
@@ -462,6 +547,8 @@ main(void)
     test_multiple_keys_different_mults();
     test_output_multiplicity_is_product();
     test_wide_relation_join();
+    test_non_pristine_dst_rejected();
+    test_wrong_arity_dst_rejected();
 
     printf("\n=== Results: %d passed, %d failed (of %d) ===\n", pass_count,
         fail_count, test_count);

--- a/wirelog/columnar/eval_delta.c
+++ b/wirelog/columnar/eval_delta.c
@@ -488,6 +488,18 @@ cleanup:
                 uint32_t nr = prev_nrows[i];
                 r->columns = col_columns_alloc(nc, nr > 0 ? nr : 1);
                 if (r->columns) {
+                    /* Issue #1076: the buffer above is nc wide, and
+                     * col_rel_row_copy_in() bounds its loop by r->ncols.
+                     * Every other geometry field is restored below;
+                     * ncols has to be restored here because the copy
+                     * loop reads it.  nc == r->ncols on every reachable
+                     * path today -- ncols is fixed at construction, and
+                     * the only post-construction writer reachable from
+                     * evaluation is col_rel_set_schema(), which is a
+                     * no-op once non-zero -- so this makes the
+                     * invariant a property of this block rather than of
+                     * the whole call graph. */
+                    r->ncols = nc;
                     for (uint32_t row = 0; row < nr; row++) {
                         const int64_t *rowp
                             = prev_data[i] + (size_t)row * nc;

--- a/wirelog/columnar/mobius.c
+++ b/wirelog/columnar/mobius.c
@@ -28,7 +28,9 @@
  *
  * Output layout: all lhs columns followed by all rhs columns (key column
  * is duplicated; callers may project as needed).  dst->ncols is initialised
- * by this function; dst must be caller-allocated with ncols==0 on entry.
+ * by this function; dst must be caller-allocated and pristine on entry
+ * (ncols==0, nrows==0, capacity==0, columns==NULL), and is rejected with
+ * EINVAL otherwise (Issue #1076).
  *
  * Returns 0 on success, non-zero (ENOMEM / EINVAL) on error.
  */
@@ -39,6 +41,15 @@ col_op_join_weighted(const col_rel_t *lhs, const col_rel_t *rhs,
     if (!lhs || !rhs || !dst)
         return EINVAL;
     if (key_col >= lhs->ncols || key_col >= rhs->ncols)
+        return EINVAL;
+    /* Issue #1076: dst->ncols is overwritten below, and the append path
+     * indexes dst->columns[0..ocols) at dst->nrows.  A dst that already
+     * carries rows, or whose columns array is narrower than ocols,
+     * overflows both (ASan: heap-buffer-overflow WRITE at
+     * internal.h:414).  ncols==0 alone does not bound nrows, capacity or
+     * columns, so require the whole relation pristine. */
+    if (dst->ncols != 0 || dst->nrows != 0 || dst->capacity != 0 ||
+        dst->columns != NULL)
         return EINVAL;
 
     uint32_t ocols = lhs->ncols + rhs->ncols;
@@ -136,7 +147,11 @@ col_op_join_weighted(const col_rel_t *lhs, const col_rel_t *rhs,
  *   - key in both:       delta_mult = curr_mult - prev_mult (skipped if 0)
  *
  * Both input relations must have timestamps != NULL.
- * out_delta must be caller-allocated, empty (nrows==0) on entry.
+ * out_delta must be caller-allocated and carry no data on entry
+ * (nrows==0, capacity==0, columns==NULL), and its ncols must be either 0
+ * or already equal to the input arity, because this function overwrites
+ * ncols without resizing the arrays it also bounds.  Rejected with EINVAL
+ * otherwise (Issue #1076).
  *
  * Returns 0 on success, EINVAL on bad arguments, ENOMEM on allocation failure.
  */
@@ -149,6 +164,23 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
     if (prev_collection->ncols == 0 || curr_collection->ncols == 0)
         return EINVAL;
     if (prev_collection->ncols != curr_collection->ncols)
+        return EINVAL;
+    /* Issue #1076: see col_op_join_weighted.  "empty (nrows==0)" alone is
+     * not sufficient -- an out_delta with nrows==0 but a pre-allocated
+     * columns array narrower than ncols still overruns it on the first
+     * append.  ncols itself is overwritten below, so it is deliberately
+     * not required to be zero: every caller passes a typed relation. */
+    if (out_delta->nrows != 0 || out_delta->capacity != 0 ||
+        out_delta->columns != NULL)
+        return EINVAL;
+    /* Issue #1076: ncols is overwritten below, and it is also the length
+     * bound for col_names, merge_columns and retract_backup_columns, which
+     * this function does not touch.  Silently widening it would desync
+     * those from what the caller allocated and corrupt the heap in
+     * col_rel_free_contents().  A typed out_delta must therefore already
+     * match the input arity; ncols == 0 (untyped) stays allowed. */
+    if (out_delta->ncols != 0 &&
+        out_delta->ncols != prev_collection->ncols)
         return EINVAL;
 
     uint32_t ncols = prev_collection->ncols;


### PR DESCRIPTION
Closes #1076.

## The issue reports one diagnostic; it is two unrelated defects

`clang-analyzer-security.ArrayBound` fires at `wirelog/columnar/internal.h:414`, inside the shared `static inline col_rel_row_copy_in()`. CSA attributes to the inline *body*, not to the path, so two translation units reporting the same coordinates were assumed to be one finding. They are not, and they have opposite verdicts:

| via | verdict | final note |
|---|---|---|
| `mobius.c` | **true positive**, ASan-confirmed | `...while it holds only a single 'long' element` — a column buffer, `row` vs `capacity` |
| `eval_delta.c` | **false positive** | `...while it holds only a single 'long *' element` — the columns array, `ncols` vs allocation width |

Two commits, deliberately not one: opposite verdicts, opposite risk profiles, and a revert of either must not drag the other.

## Why nobody noticed

`internal.h` is a header, so it appears in neither clang-tidy register. The only two TUs that reach the helper — `eval_delta.c` and `mobius.c` — were both on `clang-tidy-backlog.txt`, which the ratchet skips. The gate was green at 64 clean / 8 backlog with a live memory-safety diagnostic behind it.

Both files are now on the allowlist. **66 clean / 6 backlog.**

## Commit 1 — `mobius.c`, a real heap overflow

`col_op_join_weighted()` and `col_compute_delta_mobius()` overwrite their output relation's `ncols` and then append at `nrows` through `columns[0..ncols)`, without checking what they were handed. Three shapes overflow, all reproduced under ASan:

- an output carrying rows past its buffer — heap-buffer-overflow **WRITE**, both functions;
- an output whose `columns` array is narrower than the result — **READ**. This one satisfies the documented `nrows == 0` contract and overflows anyway, which is why the new precondition is stricter than the old documented one.

The `col_op_join_weighted` twin was **masked** from clang-tidy: CSA dedups by bug-type-and-location, so fixing only what was reported would have left a demonstrated overflow in the same file.

Review then found a fourth shape that the pristine check still allowed: `ncols` also bounds `col_names`, `col_shared`, `merge_columns` and `retract_backup_columns`, none of which these functions resize. Silently widening it desyncs them and `col_rel_free_contents()` frees past the allocation — a failure in teardown, not in `col_rel_row_copy_in()`. Also ASan-PoC'd, also now rejected.

The two preconditions differ deliberately: the join demands `ncols == 0`, which every caller satisfies; the delta cannot, because all six of its callers pass a typed `out_delta`.

**These functions have no production callers.** They are pending-integration code awaiting the `WL_PLAN_OP_JOIN_WEIGHTED` / `WL_PLAN_OP_REDUCE_WEIGHTED` opcodes (`eval_plan.c:51`), exercised only by four test binaries. Nothing is being corrupted in a shipped build today; the preconditions become the contract integration has to meet.

For the same reason, do not read the unchanged `.text` as "the checks are free": LTO drops both symbols from `libwirelog.so` entirely, so the size gate gives no signal on this change at all.

## Commit 2 — `eval_delta.c`, a false positive on an unenforced invariant

The error-recovery restore in `col_stratum_step_with_delta()` reallocates `r->columns` with `prev_ncols[i]` columns, then calls a helper whose loop is bounded by `r->ncols`. It restores `nrows`, `capacity`, `sorted_nrows`, `run_count` and `run_ends[0]` — every geometry field except the one the copy loop reads. Now it restores `ncols` too.

The diagnostic is a false positive: CSA re-derives `r` from `session_find_rel()` after the opaque `col_eval_stratum()` call, and `session_find_rel` lives in another TU with no cross-TU analysis, so `r->ncols` becomes a fresh unconstrained symbol.

**Unreachability rests on a static audit, not a proof**, and the commit says so. The argument that survived three independent re-derivations is structural rather than a call-site count: the capture step nulls `r->columns` but never removes `r` from the session, so `r` stays installed and every `session_add_rel()` inside a `session_find_rel() == NULL` branch is unreachable by construction; reaching the replace branch needs a `session_remove_rel()` first, and every remove — like the handful of unguarded adds — is on a `$d$`/`$r$`-prefixed name, which the lexer makes impossible for a plan relation.

The line is justified as making the block self-consistent, **not** as a guard: if the divergence were reachable it would be insufficient on its own, for the same four-array reason found in commit 1.

## Testing

Commit 1 adds five cases across two already-registered binaries; commit 2 adds none.

Every clause *group* is pinned — deleting the join's `ncols` clause, the join's pristine clauses, the delta's pristine clauses, or the delta's arity clause each makes exactly one case fail and leaves the rest passing. Three individual conditions within those groups are not separately pinned, because a shorter condition in the same group catches the shapes tested. Four cases assert cleanly; the lying-capacity case crashes rather than asserting when its clauses are removed, and is ordered last so the legible failures print first.

Commit 2 can have no behavioural test — the store writes the value already present on every reachable path, so any such test passes identically before and after. Its regression pin is the promotion itself, and the RED was observed deliberately in that order: promote first, watch `clang_tidy_ratchet` fail on verbatim `internal.h:414:9 ... [clang-analyzer-security.ArrayBound]`, then fix.

## Validation

| check | result |
|---|---|
| `meson test -C build` | **288 Ok / 0 Fail / 12 Skipped** — identical to baseline |
| `WIRELOG_TIDY_REQUIRED=1 meson test --suite tidy` | 4/4 OK, ratchet **66 clean / 6 backlog** (was 64/8) |
| `check-text-size.sh` | PASS, `.text` 210298 |
| `uncrustify --check` | PASS on all changed C files |
| ASan + LSan on the changed binaries | clean, no leaks |

`internal.h` is byte-untouched across both commits, no `NOLINT` is added anywhere, `.clang-tidy` and `llvm-22.nolint-counts.txt` are unchanged — so "without weakening unrelated checks" holds by construction.

`merge.c` was also scanned, being the only remaining backlog file that calls the helper: one unrelated `deadcode.DeadStores`, nothing at `internal.h:414`. **No TU in `libwirelog.so` produces this diagnostic any more.**

## Not addressed

- Neither precondition constrains the output's `timestamps` pointer. Pre-existing; this change strictly narrows the accepted input set.
- The `rc != 0` restore branch in `cleanup:` is unexercised — nothing makes evaluation fail. The tree's `--wrap` allocation-injection harnesses exist but are pointed at the IR and parser layers.
- `col_idb_consolidate()` adopts another relation's columns array without an arity check, on the same call path. Different defect, needs its own reachability work; follow-up issue to come.
- `merge.c` is one `deadcode.DeadStores` from promotable. Separate unit, deliberately not ridden along here.
