### PR TITLE
docs: correct k-fusion ownership comment

### DIFF
--- a/wirelog/columnar/eval_plan.c
+++ b/wirelog/columnar/eval_plan.c
@@ -227,7 +227,7 @@ retraction_rel_name(const char *rel, char *buf, size_t sz)
  *     per-rule pre-scan in its relation loop.
  * The other two are not blinded, because they pass an inner operator list
  * that still carries the FORCE_DELTA ops the rewrite hid:
- *   - col_op_k_fusion_serial() and col_op_k_fusion() (columnar/ops.c)
+ *   - col_op_k_fusion_serial() and col_op_k_fusion() (columnar/kfusion.c)
  *     evaluate meta->k_ops[d] directly.
  * Call sites are named by function on purpose: line numbers drift.
  *


### PR DESCRIPTION
## Summary
- Repoint the stale `col_op_k_fusion` ownership comment from `columnar/ops.c` to `columnar/kfusion.c`.
- Comment-only change in `wirelog/columnar/eval_plan.c`.

## Validation
- `git diff --check`
- `uncrustify --check -c uncrustify.cfg wirelog/columnar/eval_plan.c`

Closes #1178
Related: #1176 #1171