### PR TITLE
ci: pin DOOP dataset revision

### DIFF
--- a/bench/data/doop/download.sh
+++ b/bench/data/doop/download.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 # Download DOOP (zxing) benchmark dataset
 # Source: FlowLog VLDB 2026 artifact (mirrored on HuggingFace).
+# The dataset revision is immutable; keep it aligned with the archive and
+# extracted-file manifests recorded in scripts/release/downstream-matrix-oracles.tsv.
 # The original host (pages.cs.wisc.edu/~m0riarty) is no longer available.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-URL="${DOOP_ZXING_URL:-https://huggingface.co/datasets/NemoYuu/flowlog_benchmark/resolve/main/dataset/csv/zxing.zip}"
+URL="${DOOP_ZXING_URL:-https://huggingface.co/datasets/NemoYuu/flowlog_benchmark/resolve/da9e91b3ff75d94604f57ba2b21ef3aa97e241ec/dataset/csv/zxing.zip}"
 EXPECTED_SHA256="${DOOP_ZXING_SHA256:-154593343fefd18306d4098ba9f6286947b134b56ebcf83d8e8eae368d5867e7}"
 TMPZIP="/tmp/zxing_doop_$$.zip"
 TMPDIR="/tmp/zxing_doop_$$"

--- a/docs/DOWNSTREAM_MATRIX.md
+++ b/docs/DOWNSTREAM_MATRIX.md
@@ -30,6 +30,14 @@ zxing archive and `bench/data/doop/download.sh` rejects any archive other than
 SHA256
 `154593343fefd18306d4098ba9f6286947b134b56ebcf83d8e8eae368d5867e7`.
 
+The DOOP archive URL is pinned to Hugging Face dataset revision
+`da9e91b3ff75d94604f57ba2b21ef3aa97e241ec`. Its `zxing.zip` blob is 72,025,076
+bytes with ETag/SHA256
+`154593343fefd18306d4098ba9f6286947b134b56ebcf83d8e8eae368d5867e7`; the
+extracted `.facts` manifest is recorded in the oracle file. The download
+script still permits an explicit `DOOP_ZXING_URL` override for controlled
+fixtures, but the default is immutable.
+
 The pinned W=1 oracle is:
 
 The correctness matrix uses one serial run per workload (`workers=1`,

--- a/scripts/ci/test-downstream-matrix.sh
+++ b/scripts/ci/test-downstream-matrix.sh
@@ -46,6 +46,7 @@ test "$actual" = "$expected"
 grep -Fq '154593343fefd18306d4098ba9f6286947b134b56ebcf83d8e8eae368d5867e7' "$oracle"
 grep -Fq 'MATRIX_REPEAT=1' "$runner"
 grep -Fq -- '--repeat "$MATRIX_REPEAT"' "$runner"
+grep -Fq 'flowlog_benchmark/resolve/da9e91b3ff75d94604f57ba2b21ef3aa97e241ec/' "$download"
 
 negative_fixture=$(mktemp)
 negative_log=$(mktemp)


### PR DESCRIPTION
Pin the default DOOP zxing download to Hugging Face revision da9e91b3ff75d94604f57ba2b21ef3aa97e241ec, document the archive identity, preserve the existing archive/file manifest checksums, and assert the immutable revision in the downstream contract test. This closes the repository-side provenance portion of issue 1163. The isolated wirelog-ga runner execution and retained end-to-end evidence remain the operational release step tracked by issues 1156 and 1163. Validation: curl HEAD verification, bash -n, test-downstream-matrix.sh, git diff --check. Refs #1163.