### PR TITLE
clang-tidy: promote columnar merge

### DIFF
--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -64,6 +64,7 @@ wirelog/columnar/handle_remap_apply_side.c
 wirelog/columnar/inline.c
 wirelog/columnar/lftj.c
 wirelog/columnar/mem_ledger.c
+wirelog/columnar/merge.c
 wirelog/columnar/mobius.c
 wirelog/columnar/ops.c
 wirelog/columnar/partition.c

--- a/scripts/ci/clang-tidy-backlog.txt
+++ b/scripts/ci/clang-tidy-backlog.txt
@@ -36,4 +36,3 @@ wirelog/columnar/eval_tdd_queue.c
 wirelog/columnar/expr.c
 wirelog/columnar/join.c
 wirelog/columnar/kfusion.c
-wirelog/columnar/merge.c

--- a/wirelog/columnar/merge.c
+++ b/wirelog/columnar/merge.c
@@ -1481,7 +1481,6 @@ col_op_consolidate_incremental_delta(col_rel_t *rel, uint32_t old_nrows,
             col_rel_row_move(rel, compacted + j, delta_phys + j);
         old_nrows = compacted;
         rel->nrows = compacted + d_unique;
-        max_rows = old_nrows + d_unique;
     }
 
     uint32_t oi = 0, di = 0, out = 0;


### PR DESCRIPTION
Fix the dead-store diagnostic in wirelog/columnar/merge.c and promote the file from the clang-tidy backlog to the sorted allowlist. Validation: clang-tidy ratchet reports 67 clean and 5 backlog files with both alternate configurations, uncrustify PASS, sorted register checks, and git diff --check. Refs #1184.