### PR TITLE
columnar: reject preallocated Mobius timestamps

### DIFF
--- a/tests/test_mobius_delta_formula.c
+++ b/tests/test_mobius_delta_formula.c
@@ -561,6 +561,45 @@ test_lying_capacity_out_delta_rejected(void)
     PASS();
 }
 
+/* ================================================================
+ * Test 9 (Issue #1182): an out_delta with timestamps is rejected
+ *
+ * timestamps is an owned output buffer.  Allowing it with capacity==0 would
+ * pass it to realloc() during the first append, even though the caller has
+ * not given the delta computation ownership of that allocation.
+ * ================================================================ */
+static void
+test_timestamps_out_delta_rejected(void)
+{
+    TEST(
+        "col_compute_delta_mobius rejects an out_delta with timestamps (#1182)");
+
+    col_rel_t *prev = test_rel_alloc(1);
+    col_rel_t *curr = test_rel_alloc(1);
+    col_rel_t *out = test_rel_alloc(1);
+    ASSERT(prev && curr && out, "test_rel_alloc failed");
+
+    int64_t row[] = { 42 };
+    ASSERT(test_rel_append_row_mult(curr, row, 1) == 0, "append curr row");
+
+    out->timestamps = (col_delta_timestamp_t *)malloc(
+        sizeof(*out->timestamps));
+    ASSERT(out->timestamps != NULL, "timestamp allocation failed");
+
+    int rc = col_compute_delta_mobius(prev, curr, out);
+
+    ASSERT(rc == EINVAL, "returns EINVAL for an out_delta with timestamps");
+    ASSERT(out->ncols == 1 && out->nrows == 0 && out->capacity == 0,
+        "out_delta shape is left untouched");
+    ASSERT(out->columns == NULL, "out_delta columns is left untouched");
+    ASSERT(out->timestamps != NULL, "out_delta timestamps is left untouched");
+
+    test_rel_free(prev);
+    test_rel_free(curr);
+    test_rel_free(out);
+    PASS();
+}
+
 int
 main(void)
 {
@@ -586,6 +625,7 @@ main(void)
     test_non_empty_out_delta_rejected();
     test_arity_mismatch_out_delta_rejected();
     test_lying_capacity_out_delta_rejected();
+    test_timestamps_out_delta_rejected();
 
     printf("\n=== Results: %d passed, %d failed (of %d) ===\n", pass_count,
         fail_count, test_count);

--- a/tests/test_mobius_join_weighted.c
+++ b/tests/test_mobius_join_weighted.c
@@ -527,6 +527,46 @@ test_wrong_arity_dst_rejected(void)
     PASS();
 }
 
+/* ================================================================
+ * Test 7 (Issue #1182): a dst with timestamps is rejected
+ *
+ * timestamps is an owned output buffer.  Allowing it with capacity==0 would
+ * pass it to realloc() during the first append, even though the caller has
+ * not given the join ownership of that allocation.
+ * ================================================================ */
+static void
+test_timestamps_dst_rejected(void)
+{
+    TEST("col_op_join_weighted rejects a dst with timestamps (#1182)");
+
+    col_rel_t *lhs = test_rel_alloc(1);
+    col_rel_t *rhs = test_rel_alloc(1);
+    col_rel_t *dst = test_rel_alloc(0);
+    ASSERT(lhs && rhs && dst, "test_rel_alloc failed");
+
+    int64_t lrow[] = { 1 };
+    int64_t rrow[] = { 1 };
+    ASSERT(test_rel_append_row_mult(lhs, lrow, 2) == 0, "append lhs row");
+    ASSERT(test_rel_append_row_mult(rhs, rrow, 3) == 0, "append rhs row");
+
+    dst->timestamps = (col_delta_timestamp_t *)malloc(
+        sizeof(*dst->timestamps));
+    ASSERT(dst->timestamps != NULL, "timestamp allocation failed");
+
+    int rc = col_op_join_weighted(lhs, rhs, 0, dst);
+
+    ASSERT(rc == EINVAL, "returns EINVAL for a dst with timestamps");
+    ASSERT(dst->ncols == 0 && dst->nrows == 0 && dst->capacity == 0,
+        "dst shape is left untouched");
+    ASSERT(dst->columns == NULL, "dst columns is left untouched");
+    ASSERT(dst->timestamps != NULL, "dst timestamps is left untouched");
+
+    test_rel_free(lhs);
+    test_rel_free(rhs);
+    test_rel_free(dst);
+    PASS();
+}
+
 int
 main(void)
 {
@@ -549,6 +589,7 @@ main(void)
     test_wide_relation_join();
     test_non_pristine_dst_rejected();
     test_wrong_arity_dst_rejected();
+    test_timestamps_dst_rejected();
 
     printf("\n=== Results: %d passed, %d failed (of %d) ===\n", pass_count,
         fail_count, test_count);

--- a/wirelog/columnar/mobius.c
+++ b/wirelog/columnar/mobius.c
@@ -29,8 +29,8 @@
  * Output layout: all lhs columns followed by all rhs columns (key column
  * is duplicated; callers may project as needed).  dst->ncols is initialised
  * by this function; dst must be caller-allocated and pristine on entry
- * (ncols==0, nrows==0, capacity==0, columns==NULL), and is rejected with
- * EINVAL otherwise (Issue #1076).
+ * (ncols==0, nrows==0, capacity==0, columns==NULL, timestamps==NULL), and
+ * is rejected with EINVAL otherwise (Issues #1076, #1182).
  *
  * Returns 0 on success, non-zero (ENOMEM / EINVAL) on error.
  */
@@ -49,7 +49,7 @@ col_op_join_weighted(const col_rel_t *lhs, const col_rel_t *rhs,
      * internal.h:414).  ncols==0 alone does not bound nrows, capacity or
      * columns, so require the whole relation pristine. */
     if (dst->ncols != 0 || dst->nrows != 0 || dst->capacity != 0 ||
-        dst->columns != NULL)
+        dst->columns != NULL || dst->timestamps != NULL)
         return EINVAL;
 
     uint32_t ocols = lhs->ncols + rhs->ncols;
@@ -148,10 +148,10 @@ col_op_join_weighted(const col_rel_t *lhs, const col_rel_t *rhs,
  *
  * Both input relations must have timestamps != NULL.
  * out_delta must be caller-allocated and carry no data on entry
- * (nrows==0, capacity==0, columns==NULL), and its ncols must be either 0
- * or already equal to the input arity, because this function overwrites
- * ncols without resizing the arrays it also bounds.  Rejected with EINVAL
- * otherwise (Issue #1076).
+ * (nrows==0, capacity==0, columns==NULL, timestamps==NULL), and its ncols
+ * must be either 0 or already equal to the input arity, because this function
+ * overwrites ncols without resizing the arrays it also bounds.  Rejected with
+ * EINVAL otherwise (Issues #1076, #1182).
  *
  * Returns 0 on success, EINVAL on bad arguments, ENOMEM on allocation failure.
  */
@@ -171,7 +171,7 @@ col_compute_delta_mobius(const col_rel_t *prev_collection,
      * append.  ncols itself is overwritten below, so it is deliberately
      * not required to be zero: every caller passes a typed relation. */
     if (out_delta->nrows != 0 || out_delta->capacity != 0 ||
-        out_delta->columns != NULL)
+        out_delta->columns != NULL || out_delta->timestamps != NULL)
         return EINVAL;
     /* Issue #1076: ncols is overwritten below, and it is also the length
      * bound for col_names, merge_columns and retract_backup_columns, which


### PR DESCRIPTION
Closes #1182

## Summary
- reject non-NULL output timestamps before either Mobius operator mutates output state
- document timestamps as part of the pristine-output contract
- add one grow-path regression test per operator

## Validation
- focused Mobius tests: 2/2 pass
- tidy suite: 4/4 pass
- full Meson suite: 290 passed, 0 failed, 12 skipped
- mutation checks: removing each new guard makes its corresponding regression fail
- reviewer: PASS