### PR TITLE
ir: validate stratification edge endpoints

### DIFF
--- a/tests/test_stratify_scc_bounds.c
+++ b/tests/test_stratify_scc_bounds.c
@@ -160,6 +160,102 @@ test_scc_out_of_range_from_yields_empty_adjacency(void)
     PASS();
 }
 
+static void
+test_step6_marks_only_valid_self_loops(void)
+{
+    TEST("stratify: Step 6 ignores malformed self-loop endpoints");
+
+    wl_ir_stratify_dep_edge_t edges[] = {
+        { 0, 0, WL_IR_STRATIFY_DEP_POSITIVE },
+        { 1, 1, WL_IR_STRATIFY_DEP_AGGREGATION },
+        { 9, 9, WL_IR_STRATIFY_DEP_POSITIVE },
+        { 0, 9, WL_IR_STRATIFY_DEP_POSITIVE },
+        { 9, 0, WL_IR_STRATIFY_DEP_AGGREGATION },
+    };
+    wl_ir_stratify_dep_graph_t graph = {
+        .relation_count = 2,
+        .edges = edges,
+        .edge_count = sizeof(edges) / sizeof(edges[0]),
+        .edge_capacity = sizeof(edges) / sizeof(edges[0]),
+    };
+    uint32_t scc_ids[] = { 0, 1 };
+    wl_ir_stratify_scc_result_t scc = {
+        .scc_id = scc_ids,
+        .scc_count = 2,
+    };
+    wirelog_stratum_t strata[2] = { 0 };
+
+    wl_ir_stratify_mark_recursive_strata(&graph, &scc, strata, 2);
+
+    if (!strata[0].is_recursive || !strata[1].is_recursive) {
+        FAIL("valid positive and aggregation self-loops were not marked");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_step6_ignores_out_of_range_scc_id(void)
+{
+    TEST("stratify: Step 6 ignores an out-of-range SCC ID");
+
+    wl_ir_stratify_dep_edge_t edges[] = {
+        { 0, 0, WL_IR_STRATIFY_DEP_POSITIVE },
+    };
+    wl_ir_stratify_dep_graph_t graph = {
+        .relation_count = 1,
+        .edges = edges,
+        .edge_count = 1,
+        .edge_capacity = 1,
+    };
+    uint32_t scc_ids[] = { 9 };
+    wl_ir_stratify_scc_result_t scc = {
+        .scc_id = scc_ids,
+        .scc_count = 1,
+    };
+    wirelog_stratum_t strata[2] = { 0 };
+
+    wl_ir_stratify_mark_recursive_strata(&graph, &scc, strata, 2);
+
+    if (strata[0].is_recursive || strata[1].is_recursive) {
+        FAIL("out-of-range SCC ID marked a stratum");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_step6_ignores_out_of_range_edge(void)
+{
+    TEST("stratify: Step 6 ignores an out-of-range self-loop");
+
+    wl_ir_stratify_dep_edge_t edge = {
+        9, 9, WL_IR_STRATIFY_DEP_POSITIVE,
+    };
+    wl_ir_stratify_dep_graph_t graph = {
+        .relation_count = 2,
+        .edges = &edge,
+        .edge_count = 1,
+        .edge_capacity = 1,
+    };
+    /* The extra sentinel makes the pre-fix unchecked read deterministic. */
+    uint32_t scc_ids[10] = { 0, 1 };
+    scc_ids[9] = 1;
+    wl_ir_stratify_scc_result_t scc = {
+        .scc_id = scc_ids,
+        .scc_count = 2,
+    };
+    wirelog_stratum_t strata[2] = { 0 };
+
+    wl_ir_stratify_mark_recursive_strata(&graph, &scc, strata, 2);
+
+    if (strata[0].is_recursive || strata[1].is_recursive) {
+        FAIL("out-of-range edge marked a stratum");
+        return;
+    }
+    PASS();
+}
+
 /* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
@@ -171,6 +267,9 @@ main(void)
 
     test_scc_out_of_range_to_is_ignored();
     test_scc_out_of_range_from_yields_empty_adjacency();
+    test_step6_marks_only_valid_self_loops();
+    test_step6_ignores_out_of_range_scc_id();
+    test_step6_ignores_out_of_range_edge();
 
     printf("\n=== Results: %d passed, %d failed, %d total ===\n\n",
         tests_passed, tests_failed, tests_run);

--- a/wirelog/ir/stratify.c
+++ b/wirelog/ir/stratify.c
@@ -491,6 +491,45 @@ wl_ir_stratify_scc_free(wl_ir_stratify_scc_result_t *result)
 /* Stratification Pipeline                                                  */
 /* ======================================================================== */
 
+void
+wl_ir_stratify_mark_recursive_strata(
+    const wl_ir_stratify_dep_graph_t *graph,
+    const wl_ir_stratify_scc_result_t *scc, wirelog_stratum_t *strata,
+    uint32_t num_strata)
+{
+    if (!graph || !scc || !scc->scc_id || !strata)
+        return;
+
+    uint32_t *scc_size = (uint32_t *)calloc(num_strata, sizeof(uint32_t));
+    if (!scc_size)
+        return;
+
+    for (uint32_t i = 0; i < graph->relation_count; i++) {
+        uint32_t s = scc->scc_id[i];
+        if (s < num_strata)
+            scc_size[s]++;
+    }
+
+    for (uint32_t s = 0; s < num_strata; s++)
+        strata[s].is_recursive = (scc_size[s] > 1);
+
+    for (uint32_t e = 0; e < graph->edge_count; e++) {
+        const wl_ir_stratify_dep_edge_t *edge = &graph->edges[e];
+        if (edge->from >= graph->relation_count
+            || edge->to >= graph->relation_count)
+            continue;
+        if (edge->from == edge->to
+            && (edge->type == WL_IR_STRATIFY_DEP_POSITIVE
+            || edge->type == WL_IR_STRATIFY_DEP_AGGREGATION)) {
+            uint32_t s = scc->scc_id[edge->from];
+            if (s < num_strata)
+                strata[s].is_recursive = true;
+        }
+    }
+
+    free(scc_size);
+}
+
 int
 wl_ir_stratify_program(struct wirelog_program *program)
 {
@@ -674,34 +713,9 @@ wl_ir_stratify_program(struct wirelog_program *program)
     for (uint32_t s = 0; s < num_strata; s++)
         program->strata[s].rule_count = rules_per_stratum[s];
 
-    /* Step 6: Detect recursive strata.
-       A stratum is recursive if its SCC contains >1 node (mutual recursion)
-       or if any edge within the SCC is a self-loop (self-recursion). */
-    {
-        /* Count nodes per SCC */
-        uint32_t *scc_size = (uint32_t *)calloc(num_strata, sizeof(uint32_t));
-        if (scc_size) {
-            for (uint32_t i = 0; i < graph->relation_count; i++)
-                scc_size[scc->scc_id[i]]++;
-
-            for (uint32_t s = 0; s < num_strata; s++)
-                program->strata[s].is_recursive = (scc_size[s] > 1);
-
-            /* Also check self-loops (self-recursion in singleton SCC).
-               Both positive and aggregation edges indicate recursion;
-               e.g. dist(y, min(d+w)) :- dist(x, d), wedge(x, y, w). */
-            for (uint32_t e = 0; e < graph->edge_count; e++) {
-                if (graph->edges[e].from == graph->edges[e].to
-                    && (graph->edges[e].type == WL_IR_STRATIFY_DEP_POSITIVE
-                    || graph->edges[e].type
-                    == WL_IR_STRATIFY_DEP_AGGREGATION)) {
-                    uint32_t s = scc->scc_id[graph->edges[e].from];
-                    program->strata[s].is_recursive = true;
-                }
-            }
-            free(scc_size);
-        }
-    }
+    /* Step 6: Detect recursive strata. */
+    wl_ir_stratify_mark_recursive_strata(graph, scc, program->strata,
+        num_strata);
 
     program->is_stratified = true;
 

--- a/wirelog/ir/stratify.h
+++ b/wirelog/ir/stratify.h
@@ -295,6 +295,22 @@ void
 wl_ir_stratify_scc_free(wl_ir_stratify_scc_result_t *result);
 
 /**
+ * wl_ir_stratify_mark_recursive_strata:
+ * @graph: Dependency graph whose edges are inspected
+ * @scc: SCC result for @graph
+ * @strata: Strata array to mark
+ * @num_strata: Number of entries in @strata
+ *
+ * Mark strata recursive for multi-node SCCs and valid positive or aggregation
+ * self-loops. Malformed edge endpoints and out-of-range SCC IDs are ignored.
+ */
+void
+wl_ir_stratify_mark_recursive_strata(
+    const wl_ir_stratify_dep_graph_t *graph,
+    const wl_ir_stratify_scc_result_t *scc, wirelog_stratum_t *strata,
+    uint32_t num_strata);
+
+/**
  * wl_ir_stratify_program:
  * @program: Program to stratify (modified in place)
  *


### PR DESCRIPTION
Closes #1128

## Summary
- extract Step 6 recursive-stratum marking into an internal helper
- ignore out-of-range edge endpoints and SCC IDs before indexing
- cover valid positive/aggregation self-loops and malformed edges

## Validation
- focused stratify tests: 2/2 pass
- tidy suite: 4/4 pass
- full Meson suite: 290 passed, 0 failed, 12 skipped
- mutation check: removing endpoint guards makes the regression fail
- reviewer: PASS