### PR TITLE
fix: reject next_pow2 overflow at callers

### DIFF
--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -295,15 +295,15 @@ once and the surrounding overhead dominates.
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
 | `join.c:151` | `sess->join_output_shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Tuple-budget accumulator across keyed-join workers; counter only |
-| `join.c:355` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll; eventual visibility is acceptable for cooperative cancel |
-| `join.c:363` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll |
-| `join.c:373` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
-| `join.c:378` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag — best-effort signal, **not a synchronization point**; readers may observe the previous value for a bounded period |
-| `join.c:388` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
-| `join.c:391` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag (see :378 note) |
-| `join.c:1958` | `stop` (local) | `atomic_load_explicit` | `relaxed` | Compaction-loop cancel poll |
-| `join.c:1979` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
-| `join.c:1981` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
+| `join.c:369` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll; eventual visibility is acceptable for cooperative cancel |
+| `join.c:377` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll |
+| `join.c:387` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
+| `join.c:392` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag — best-effort signal, **not a synchronization point**; readers may observe the previous value for a bounded period |
+| `join.c:402` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
+| `join.c:405` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag (see :392 note) |
+| `join.c:2010` | `stop` (local) | `atomic_load_explicit` | `relaxed` | Compaction-loop cancel poll |
+| `join.c:2031` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
+| `join.c:2033` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
 
 ### 5.5 `wirelog/columnar/kfusion.c` — K-fusion shared counter (1 row)
 

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -294,7 +294,7 @@ once and the surrounding overhead dominates.
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `join.c:137` | `sess->join_output_shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Tuple-budget accumulator across keyed-join workers; counter only |
+| `join.c:151` | `sess->join_output_shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Tuple-budget accumulator across keyed-join workers; counter only |
 | `join.c:355` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll; eventual visibility is acceptable for cooperative cancel |
 | `join.c:363` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll |
 | `join.c:373` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |

--- a/tests/test_join_overflow.c
+++ b/tests/test_join_overflow.c
@@ -188,6 +188,23 @@ test_keyed_join_overflow(void)
 }
 
 static int
+test_filter_next_pow2_overflow_contract(void)
+{
+    TEST("filter next_pow2 returns zero only on overflow");
+
+    if (wl_columnar_filter_next_pow2(15) != 16
+        || wl_columnar_filter_next_pow2(16) != 16
+        || wl_columnar_filter_next_pow2(0x80000000u) != 0x80000000u
+        || wl_columnar_filter_next_pow2(0x80000001u) != 0
+        || wl_columnar_filter_next_pow2(UINT32_MAX) != 0) {
+        FAIL("unexpected next_pow2 boundary result");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
 test_unary_join_overflow(void)
 {
     TEST("unary join overflow returns EOVERFLOW");
@@ -255,6 +272,7 @@ main(void)
     printf("=== test_join_overflow ===\n");
 
     test_keyed_join_overflow();
+    test_filter_next_pow2_overflow_contract();
     test_unary_join_overflow();
     test_diff_join_overflow();
     test_k_fusion_worker_limit_overflow();

--- a/tests/test_lockfree_queue.c
+++ b/tests/test_lockfree_queue.c
@@ -97,6 +97,17 @@ test_create_destroy(void)
     PASS();
 }
 
+static void
+test_capacity_overflow_rejected(void)
+{
+    TEST("capacity overflow is rejected before allocation");
+
+    wl_mpsc_queue_t *q = wl_mpsc_queue_create(1, UINT32_MAX);
+    ASSERT(q == NULL, "overflowing capacity must return NULL");
+
+    PASS();
+}
+
 /* ----------------------------------------------------------------
  * Test 2: single producer enqueue/dequeue correctness
  * ---------------------------------------------------------------- */
@@ -436,6 +447,7 @@ main(void)
     printf("=== lockfree_queue tests ===\n\n");
 
     test_create_destroy();
+    test_capacity_overflow_rejected();
     test_single_producer();
     test_rel_idx_field();
     test_new_fields();

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -11,6 +11,7 @@
  */
 
 #include "../wirelog/backend.h"
+#include "../wirelog/columnar/internal.h"
 #include "../wirelog/exec_plan_gen.h"
 #include "../wirelog/passes/fusion.h"
 #include "../wirelog/passes/jpp.h"
@@ -20,6 +21,8 @@
 #include "../wirelog/wirelog.h"
 
 #include <stdio.h>
+#include <errno.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -43,22 +46,40 @@ static int tests_passed = 0;
 static int tests_failed = 0;
 
 #define TEST(name)                            \
-    do {                                      \
-        tests_run++;                          \
-        printf("  [%d] %s", tests_run, name); \
-    } while (0)
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
 
 #define PASS()                 \
-    do {                       \
-        tests_passed++;        \
-        printf(" ... PASS\n"); \
-    } while (0)
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
 
 #define FAIL(msg)                         \
-    do {                                  \
-        tests_failed++;                   \
-        printf(" ... FAIL: %s\n", (msg)); \
-    } while (0)
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
+
+static void
+test_session_hash_overflow_rejected(void)
+{
+    TEST("session hash rejects overflowing relation counts");
+
+    wl_col_session_t sess = { 0 };
+    sess.nrels = UINT32_MAX / 2u + 2u;
+
+    int rc = session_rel_build_hash(&sess);
+
+    if (rc != ENOMEM || sess.rel_hash_nbuckets != 0
+        || sess.rel_hash_head != NULL) {
+        FAIL("overflowing relation count changed hash state");
+        return;
+    }
+    PASS();
+}
 
 /* ======================================================================== */
 /* Delta Collector                                                          */
@@ -77,7 +98,7 @@ typedef struct {
 
 static void
 collect_delta(const char *relation, const int64_t *row, uint32_t ncols,
-              int32_t diff, void *user_data)
+    int32_t diff, void *user_data)
 {
     delta_collector_t *c = (delta_collector_t *)user_data;
     if (c->count >= MAX_DELTAS)
@@ -104,7 +125,7 @@ typedef struct {
 
 static void
 collect_tuple(const char *relation, const int64_t *row, uint32_t ncols,
-              void *user_data)
+    void *user_data)
 {
     tuple_collector_t *c = (tuple_collector_t *)user_data;
     if (c->count >= MAX_DELTAS)
@@ -134,7 +155,7 @@ count_deltas(const delta_collector_t *c, const char *relation, int32_t diff)
 
 static bool
 has_delta(const delta_collector_t *c, const char *relation,
-          const int64_t *expected, uint32_t ncols, int32_t diff)
+    const int64_t *expected, uint32_t ncols, int32_t diff)
 {
     for (int i = 0; i < c->count; i++) {
         if (strcmp(c->relations[i], relation) != 0)
@@ -156,7 +177,7 @@ has_delta(const delta_collector_t *c, const char *relation,
 
 static bool
 has_tuple(const tuple_collector_t *c, const char *relation,
-          const int64_t *expected, uint32_t ncols)
+    const int64_t *expected, uint32_t ncols)
 {
     for (int i = 0; i < c->count; i++) {
         if (strcmp(c->relations[i], relation) != 0)
@@ -211,8 +232,8 @@ static void
 test_session_create_destroy_impl(const wl_compute_backend_t *backend)
 {
     wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
-                                ".decl r(x: int32)\n"
-                                "r(x) :- a(x).\n");
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return;
@@ -254,8 +275,8 @@ test_session_create_multi_worker_rejected(void)
     TEST("session: multi-worker accepted");
 
     wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
-                                ".decl r(x: int32)\n"
-                                "r(x) :- a(x).\n");
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return;
@@ -285,9 +306,9 @@ test_session_step_initial_delta(void)
     TEST("session: initial step produces diff=+1 deltas");
 
     wl_plan_t *ffi = build_plan(".decl a(x: int32, y: int32)\n"
-                                ".decl b(y: int32, z: int32)\n"
-                                ".decl r(x: int32, y: int32, z: int32)\n"
-                                "r(x, y, z) :- a(x, y), b(y, z).\n");
+            ".decl b(y: int32, z: int32)\n"
+            ".decl r(x: int32, y: int32, z: int32)\n"
+            "r(x, y, z) :- a(x, y), b(y, z).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return;
@@ -338,8 +359,8 @@ test_session_step_initial_delta(void)
     if (!has_delta(&deltas, "r", expected, 3, +1)) {
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "expected r(1,2,3) diff=+1, got %d deltas total",
-                 deltas.count);
+            "expected r(1,2,3) diff=+1, got %d deltas total",
+            deltas.count);
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -349,7 +370,7 @@ test_session_step_initial_delta(void)
     if (count_deltas(&deltas, "r", +1) != 1) {
         char msg[128];
         snprintf(msg, sizeof(msg), "expected exactly 1 positive delta, got %d",
-                 count_deltas(&deltas, "r", +1));
+            count_deltas(&deltas, "r", +1));
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -372,9 +393,9 @@ test_session_step_incremental_delta(void)
     TEST("session: incremental step produces only new deltas");
 
     wl_plan_t *ffi = build_plan(".decl a(x: int32, y: int32)\n"
-                                ".decl b(y: int32, z: int32)\n"
-                                ".decl r(x: int32, y: int32, z: int32)\n"
-                                "r(x, y, z) :- a(x, y), b(y, z).\n");
+            ".decl b(y: int32, z: int32)\n"
+            ".decl r(x: int32, y: int32, z: int32)\n"
+            "r(x, y, z) :- a(x, y), b(y, z).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return;
@@ -426,8 +447,8 @@ test_session_step_incremental_delta(void)
     if (!has_delta(&deltas, "r", expected, 3, +1)) {
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "expected r(1,4,5) diff=+1, got %d deltas total",
-                 deltas.count);
+            "expected r(1,4,5) diff=+1, got %d deltas total",
+            deltas.count);
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -437,7 +458,7 @@ test_session_step_incremental_delta(void)
     if (count_deltas(&deltas, "r", +1) != 1) {
         char msg[128];
         snprintf(msg, sizeof(msg), "expected exactly 1 positive delta, got %d",
-                 count_deltas(&deltas, "r", +1));
+            count_deltas(&deltas, "r", +1));
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -458,8 +479,8 @@ test_session_step_no_change(void)
     TEST("session: step with no changes produces no deltas");
 
     wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
-                                ".decl r(x: int32)\n"
-                                "r(x) :- a(x).\n");
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return;
@@ -528,8 +549,8 @@ test_session_remove_single_delta(void)
     TEST("session: remove tuple produces diff=-1 delta");
 
     wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
-                                ".decl r(x: int32)\n"
-                                "r(x) :- a(x).\n");
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return;
@@ -589,7 +610,7 @@ test_session_remove_single_delta(void)
     if (!has_delta(&deltas, "r", expected, 1, -1)) {
         char msg[128];
         snprintf(msg, sizeof(msg), "expected r(1) diff=-1, got %d total deltas",
-                 deltas.count);
+            deltas.count);
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -599,7 +620,7 @@ test_session_remove_single_delta(void)
     if (count_deltas(&deltas, "r", -1) != 1) {
         char msg[128];
         snprintf(msg, sizeof(msg), "expected exactly 1 retraction, got %d",
-                 count_deltas(&deltas, "r", -1));
+            count_deltas(&deltas, "r", -1));
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -623,8 +644,8 @@ test_session_remove_nonexistent(void)
     TEST("session: remove non-existent tuple is no-op");
 
     wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
-                                ".decl r(x: int32)\n"
-                                "r(x) :- a(x).\n");
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return;
@@ -664,8 +685,8 @@ test_session_snapshot_empty(void)
     TEST("session: snapshot of empty session returns 0 tuples");
 
     wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
-                                ".decl r(x: int32)\n"
-                                "r(x) :- a(x).\n");
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return;
@@ -717,9 +738,9 @@ test_session_snapshot_after_insert(void)
     TEST("session: snapshot reflects current derived state");
 
     wl_plan_t *ffi = build_plan(".decl a(x: int32, y: int32)\n"
-                                ".decl b(y: int32, z: int32)\n"
-                                ".decl r(x: int32, y: int32, z: int32)\n"
-                                "r(x, y, z) :- a(x, y), b(y, z).\n");
+            ".decl b(y: int32, z: int32)\n"
+            ".decl r(x: int32, y: int32, z: int32)\n"
+            "r(x, y, z) :- a(x, y), b(y, z).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return;
@@ -763,8 +784,8 @@ test_session_snapshot_after_insert(void)
     if (!has_tuple(&tuples, "r", expected, 3)) {
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "expected r(1,2,3) in snapshot, got %d tuples total",
-                 tuples.count);
+            "expected r(1,2,3) in snapshot, got %d tuples total",
+            tuples.count);
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -774,7 +795,7 @@ test_session_snapshot_after_insert(void)
     if (tuples.count != 1) {
         char msg[64];
         snprintf(msg, sizeof(msg), "expected exactly 1 tuple, got %d",
-                 tuples.count);
+            tuples.count);
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -796,8 +817,8 @@ test_session_duplicate_insert(void)
     TEST("session: duplicate insert produces single positive delta");
 
     wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
-                                ".decl r(x: int32)\n"
-                                "r(x) :- a(x).\n");
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return;
@@ -832,7 +853,7 @@ test_session_duplicate_insert(void)
     if (!has_delta(&deltas, "r", expected, 1, +1)) {
         char msg[128];
         snprintf(msg, sizeof(msg), "expected r(5) diff=+1, got %d deltas total",
-                 deltas.count);
+            deltas.count);
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -842,8 +863,8 @@ test_session_duplicate_insert(void)
     if (count_deltas(&deltas, "r", +1) != 1) {
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "expected exactly 1 positive delta (set semantics), got %d",
-                 count_deltas(&deltas, "r", +1));
+            "expected exactly 1 positive delta (set semantics), got %d",
+            count_deltas(&deltas, "r", +1));
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -867,11 +888,11 @@ test_session_tc_insert(void)
     /* Program:
        tc(X, Y) :- edge(X, Y).
        tc(X, Z) :- edge(X, Y), tc(Y, Z).
-    */
+     */
     wl_plan_t *ffi = build_plan(".decl edge(x: int32, y: int32)\n"
-                                ".decl tc(x: int32, y: int32)\n"
-                                "tc(X, Y) :- edge(X, Y).\n"
-                                "tc(X, Z) :- edge(X, Y), tc(Y, Z).\n");
+            ".decl tc(x: int32, y: int32)\n"
+            "tc(X, Y) :- edge(X, Y).\n"
+            "tc(X, Z) :- edge(X, Y), tc(Y, Z).\n");
 
     if (!ffi) {
         FAIL("failed to parse TC program");
@@ -937,7 +958,7 @@ test_session_tc_insert(void)
     if (new_tc_count != 3) {
         char msg[128];
         snprintf(msg, sizeof(msg), "expected 3 new TC deltas, got %d",
-                 new_tc_count);
+            new_tc_count);
         wl_session_destroy(session);
         wl_plan_free(ffi);
         FAIL(msg);
@@ -967,6 +988,7 @@ main(void)
 {
     printf("test_session: persistent columnar session delta tests\n");
 
+    test_session_hash_overflow_rejected();
     test_session_create_destroy();
     test_session_create_destroy_columnar();
     test_session_create_multi_worker_rejected();
@@ -987,6 +1009,6 @@ main(void)
     /* test_session_tc_insert(); */
 
     printf("\n  %d tests: %d passed, %d failed\n", tests_run, tests_passed,
-           tests_failed);
+        tests_failed);
     return tests_failed > 0 ? 1 : 0;
 }

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -200,7 +200,8 @@ arr_key_cols_valid(const col_rel_t *rel, const uint32_t *key_cols,
  * smear fills to 0xFFFFFFFF and `n + 1u` wraps.  Callers must reject that
  * themselves; both in this file do, below.  The byte-identical
  * wl_columnar_filter_next_pow2 in filter.c has the same return and more
- * callers.  See follow-up issue (next_pow2 family).
+ * callers.  See follow-up issue #1192 for the remaining queue-capacity
+ * arithmetic paths.
  */
 static uint32_t
 arr_next_pow2(uint32_t n)

--- a/wirelog/columnar/filter.c
+++ b/wirelog/columnar/filter.c
@@ -782,11 +782,15 @@ wl_columnar_filter_op(const wl_plan_op_t *op, eval_stack_t *stack,
 
 /* --- Hash join helpers --------------------------------------------------- */
 
+/* Returns 0 when the requested power of two cannot be represented. */
+
 uint32_t
 wl_columnar_filter_next_pow2(uint32_t n)
 {
     if (n < 16)
         return 16;
+    if (n > UINT32_MAX / 2u + 1u)
+        return 0;
     n--;
     n |= n >> 1;
     n |= n >> 2;

--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -63,6 +63,20 @@ col_op_resolve_key(const col_rel_t *rel, const char *name, const char *side,
     return 0;
 }
 
+/* Return a valid hash bucket count, rejecting representational overflow. */
+static int
+col_join_bucket_count(uint32_t nrows, uint32_t *out)
+{
+    if (!out || nrows > UINT32_MAX / 2u)
+        return ENOMEM;
+    uint32_t count = wl_columnar_filter_next_pow2(
+        nrows > 0 ? nrows * 2u : 1u);
+    if (count == 0)
+        return ENOMEM;
+    *out = count;
+    return 0;
+}
+
 #define WL_JOIN_PAR_MIN_LEFT_ROWS_DEFAULT 4096u
 
 static uint32_t
@@ -956,8 +970,18 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
         uint32_t probe_kcol = right_is_unary ? lk[0] : rk[0];
 
         /* Build hash set from the unary relation's single column. */
-        uint32_t nbuckets = wl_columnar_filter_next_pow2(build->nrows >
-                0 ? build->nrows * 2 : 1);
+        uint32_t nbuckets;
+        if (col_join_bucket_count(build->nrows, &nbuckets) != 0) {
+            free(tmp);
+            col_rel_destroy(out);
+            free(lk);
+            free(rk);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
+            if (left_e.owned)
+                col_rel_destroy(left);
+            return ENOMEM;
+        }
         uint32_t *ht_head = (uint32_t *)calloc(nbuckets, sizeof(uint32_t));
         uint32_t *ht_next = (uint32_t *)malloc(
             (build->nrows > 0 ? build->nrows : 1) * sizeof(uint32_t));
@@ -1090,8 +1114,17 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
 
         if (!arr) {
             /* Ephemeral hash table (delta path or arrangement unavailable). */
-            nbuckets_ep = wl_columnar_filter_next_pow2(right->nrows >
-                    0 ? right->nrows * 2 : 1);
+            if (col_join_bucket_count(right->nrows, &nbuckets_ep) != 0) {
+                free(tmp);
+                col_rel_destroy(out);
+                free(lk);
+                free(rk);
+                if (right_filtered)
+                    col_rel_destroy(right_filtered);
+                if (left_e.owned)
+                    col_rel_destroy(left);
+                return ENOMEM;
+            }
             ht_head_ep = (uint32_t *)calloc(nbuckets_ep, sizeof(uint32_t));
             ht_next_ep = (uint32_t *)malloc(
                 (right->nrows > 0 ? right->nrows : 1) * sizeof(uint32_t));
@@ -1347,8 +1380,17 @@ wl_columnar_antijoin_op(const wl_plan_op_t *op, eval_stack_t *stack,
     }
 
     /* Hash antijoin: build hash set from right, iterate left. */
-    uint32_t aj_nbuckets = wl_columnar_filter_next_pow2(right->nrows >
-            0 ? right->nrows * 2 : 1);
+    uint32_t aj_nbuckets;
+    if (col_join_bucket_count(right->nrows, &aj_nbuckets) != 0) {
+        col_rel_destroy(out);
+        free(lk);
+        free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
+        if (left_e.owned)
+            col_rel_destroy(left);
+        return ENOMEM;
+    }
     uint32_t *aj_head = (uint32_t *)calloc(aj_nbuckets, sizeof(uint32_t));
     uint32_t *aj_next
         = (uint32_t *)malloc((right->nrows + 1) * sizeof(uint32_t));
@@ -1489,8 +1531,18 @@ wl_columnar_semijoin_op(const wl_plan_op_t *op, eval_stack_t *stack,
     }
 
     /* Build hash set from right relation join keys: O(|R|) */
-    uint32_t nbuckets = wl_columnar_filter_next_pow2(right->nrows >
-            0 ? right->nrows * 2 : 1);
+    uint32_t nbuckets;
+    if (col_join_bucket_count(right->nrows, &nbuckets) != 0) {
+        free(tmp);
+        col_rel_destroy(out);
+        free(lk);
+        free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
+        if (left_e.owned)
+            col_rel_destroy(left);
+        return ENOMEM;
+    }
     uint32_t *ht_head = (uint32_t *)calloc(nbuckets, sizeof(uint32_t));
     uint32_t *ht_next = (uint32_t *)malloc((right->nrows > 0 ? right->nrows : 1)
             * sizeof(uint32_t));
@@ -2065,8 +2117,18 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
         }
     } else {
         /* Ephemeral hash table fallback (same as col_op_join) */
-        uint32_t nbuckets_ep = wl_columnar_filter_next_pow2(right->nrows >
-                0 ? right->nrows * 2 : 1);
+        uint32_t nbuckets_ep;
+        if (col_join_bucket_count(right->nrows, &nbuckets_ep) != 0) {
+            free(tmp);
+            col_rel_destroy(out);
+            free(lk);
+            free(rk);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
+            if (left_e.owned)
+                col_rel_destroy(left);
+            return ENOMEM;
+        }
         uint32_t *ht_head_ep = (uint32_t *)calloc(nbuckets_ep,
                 sizeof(uint32_t));
         uint32_t *ht_next_ep = (uint32_t *)malloc(

--- a/wirelog/columnar/session_hash.c
+++ b/wirelog/columnar/session_hash.c
@@ -39,12 +39,14 @@ session_rel_hash_string(const char *name, uint32_t nbuckets)
     return (uint32_t)(h & (uint64_t)(nbuckets - 1));
 }
 
-/* Round n up to the next power of 2; minimum 16. */
+/* Round n up to the next power of 2; minimum 16. Returns 0 on overflow. */
 static uint32_t
 session_rel_next_pow2(uint32_t n)
 {
     if (n < 16u)
         return 16u;
+    if (n > UINT32_MAX / 2u + 1u)
+        return 0;
     n--;
     n |= n >> 1;
     n |= n >> 2;
@@ -67,7 +69,11 @@ int
 session_rel_build_hash(wl_col_session_t *sess)
 {
     uint32_t nrels = sess->nrels;
+    if (nrels > UINT32_MAX / 2u)
+        return ENOMEM;
     uint32_t nbuckets = session_rel_next_pow2(nrels > 0 ? nrels * 2u : 16u);
+    if (nbuckets == 0)
+        return ENOMEM;
 
     /* Reallocate bucket heads if size changed. */
     if (nbuckets != sess->rel_hash_nbuckets) {
@@ -147,7 +153,11 @@ session_rel_hash_insert(wl_col_session_t *sess, uint32_t idx)
     }
 
     /* Rebuild if load factor would exceed 50% or chain array capacity insufficient. */
+    if (sess->nrels > UINT32_MAX / 2u)
+        return ENOMEM;
     uint32_t needed = session_rel_next_pow2(sess->nrels * 2u);
+    if (needed == 0)
+        return ENOMEM;
     if (needed != sess->rel_hash_nbuckets || idx >= sess->rel_hash_chain_cap) {
         return session_rel_build_hash(sess);
     }

--- a/wirelog/util/lockfree_queue.c
+++ b/wirelog/util/lockfree_queue.c
@@ -92,12 +92,14 @@ typedef struct {
     uint32_t _pad_head[15];    /* Pad to avoid next allocation boundary */
 } wl_spsc_queue_t;
 
-/* Round v up to the nearest power of 2 (minimum 2). */
+/* Round v up to the nearest power of 2 (minimum 2); return 0 on overflow. */
 static uint32_t
 next_pow2(uint32_t v)
 {
     if (v < 2)
         v = 2;
+    if (v > UINT32_MAX / 2u + 1u)
+        return 0;
     v--;
     v |= v >> 1;
     v |= v >> 2;
@@ -111,6 +113,8 @@ static int
 spsc_init(wl_spsc_queue_t *q, uint32_t capacity)
 {
     capacity = next_pow2(capacity);
+    if (capacity == 0)
+        return -1;
     q->slots = (wl_delta_msg_t *)calloc(capacity, sizeof(wl_delta_msg_t));
     if (!q->slots)
         return -1;


### PR DESCRIPTION
## Summary
- reject overflowing power-of-two rounding before bucket and queue allocations
- cover filter/join, session hash, and lock-free queue caller paths
- add regression coverage and keep the threading audit citation synchronized

## Validation
- full Meson suite: 289 passed, 1 stale documentation citation fixed, 12 skipped
- focused overflow/session/queue tests: 4 passed
- threading documentation gate: passed
- tidy suite: 4 passed
- `git diff --check`: passed

Follow-up issue #1192 tracks the separate `eval.c` and `workqueue.c` capacity arithmetic audit.

Closes #1126
