### PR TITLE
fix: reject queue capacity arithmetic overflow

### DIFF
--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -309,7 +309,7 @@ once and the surrounding overhead dominates.
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `kfusion.c:663` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:292`, which resets the TDD counter before `thread_create()` |
+| `kfusion.c:663` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:305`, which resets the TDD counter before `thread_create()` |
 
 The `stop` flag's `memory_order_relaxed` store is deliberate:
 cancellation is **cooperative**, not preemptive. A worker may observe
@@ -321,7 +321,7 @@ and the wasted work is bounded.
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `eval.c:292` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
+| `eval.c:305` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
 
 ### 5.7 `wirelog/columnar/session.c` — worker budget snapshot (1 row)
 

--- a/tests/test_tdd_multiworker.c
+++ b/tests/test_tdd_multiworker.c
@@ -23,6 +23,7 @@
 #include "../wirelog/wirelog.h"
 #include "columnar/internal.h"
 
+#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -569,6 +570,31 @@ test_reconstruct_duplicate(void)
     return 0;
 }
 
+static void
+test_delta_queue_capacity_boundaries(void)
+{
+    TEST("delta queue capacity rejects multiplication overflow");
+
+    uint32_t capacity = 0;
+    if (wl_columnar_eval_delta_queue_capacity(0, &capacity) != 0
+        || capacity != 2u
+        || wl_columnar_eval_delta_queue_capacity(1, &capacity) != 0
+        || capacity != 2u
+        || wl_columnar_eval_delta_queue_capacity(UINT32_C(1) << 30,
+        &capacity) != 0
+        || capacity != (UINT32_C(1) << 31)
+        || wl_columnar_eval_delta_queue_capacity((UINT32_C(1) << 30) + 1u,
+        &capacity) != EOVERFLOW
+        || wl_columnar_eval_delta_queue_capacity(UINT32_MAX / 2u,
+        &capacity) != EOVERFLOW
+        || wl_columnar_eval_delta_queue_capacity(UINT32_MAX, &capacity)
+        != EOVERFLOW) {
+        FAIL("unexpected delta queue capacity boundary result");
+        return;
+    }
+    PASS();
+}
+
 /* ======================================================================== */
 /* main                                                                     */
 /* ======================================================================== */
@@ -600,6 +626,7 @@ main(void)
     test_reconstruct_full_matrix();
     test_reconstruct_sparse();
     test_reconstruct_duplicate();
+    test_delta_queue_capacity_boundaries();
 
     printf("\nPassed: %d/%d\n", tests_passed, tests_run);
     printf("Failed: %d/%d\n", tests_failed, tests_run);

--- a/tests/test_workqueue_capacity.c
+++ b/tests/test_workqueue_capacity.c
@@ -354,10 +354,18 @@ test_large_batch_submission(void)
 static void
 test_overflow_protection(void)
 {
-    TEST("overflow protection for W > UINT32_MAX/2");
+    TEST("overflow protection before power-of-two rounding");
 
-    uint32_t huge_workers = UINT32_MAX;
-    wl_work_queue_t *wq = wl_workqueue_create(huge_workers);
+    uint32_t boundary_workers = UINT32_C(1) << 30;
+    wl_work_queue_t *wq = wl_workqueue_create(boundary_workers + 1u);
+    ASSERT(wq == NULL,
+        "create(2^30+1) should reject before the rounding loop");
+
+    wq = wl_workqueue_create(UINT32_MAX / 2u);
+    ASSERT(wq == NULL,
+        "create(UINT32_MAX/2) should reject an unrepresentable rounded cap");
+
+    wq = wl_workqueue_create(UINT32_MAX);
     ASSERT(wq == NULL,
         "create(UINT32_MAX) should return NULL (overflow protection)");
 

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -32,6 +32,19 @@
 #define WL_COLUMNAR_EVAL_DEDUP_SET_INIT_FROM_REL \
         wl_columnar_eval_dedup_set_init_from_rel
 
+int
+wl_columnar_eval_delta_queue_capacity(uint32_t nrels, uint32_t *out)
+{
+    if (!out)
+        return EINVAL;
+    /* wl_mpsc_queue_create rounds capacity to a uint32 power of two;
+     * 2^31 is its largest non-wrapping request on the current base. */
+    if (nrels > (UINT32_C(1) << 30))
+        return EOVERFLOW;
+    *out = nrels > 0 ? nrels * 2u : 2u;
+    return 0;
+}
+
 /* Relation-plan dispatch is implemented in columnar/eval_plan.c. */
 /* Serial stratum evaluation is implemented in columnar/eval_serial.c. */
 
@@ -3659,6 +3672,13 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
     int rc = 0;
     uint64_t tdd_total_t0 = now_ns();
 
+    uint32_t delta_queue_capacity = 0;
+    if (wl_columnar_eval_delta_queue_capacity(nrels,
+        &delta_queue_capacity) != 0) {
+        coord->tdd_total_ns += now_ns() - tdd_total_t0;
+        return ENOMEM;
+    }
+
     /* Pre-register empty IDB relations on coordinator
      * (eval_serial.c:276-289) */
     for (uint32_t ri = 0; ri < nrels; ri++) {
@@ -3929,8 +3949,10 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
 
     /* Issue #410: Create MPSC delta queue for dual-write transport.
      * Capacity = W × nrels × 2 (2x headroom; at most W×nrels per sub-pass).
-     * Failure is non-fatal: enqueue is skipped when delta_queue is NULL. */
-    coord->delta_queue = wl_mpsc_queue_create(W, nrels * 2 < 2 ? 2 : nrels * 2);
+     * Failure is non-fatal: enqueue is skipped when delta_queue is NULL.
+     * An unrepresentable nrels*2 request is rejected before any stratum
+     * state allocation, using the evaluator's ENOMEM failure signal. */
+    coord->delta_queue = wl_mpsc_queue_create(W, delta_queue_capacity);
 
     /* Issue #390: BDX snap array — pre-subpass IDB sizes per worker/relation.
      * Used to truncate worker IDB back to clean partition state after each

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1815,6 +1815,8 @@ wl_columnar_eval_serial_canonicalize_aggregates(const wl_plan_stratum_t *sp,
 int
 wl_columnar_eval_nonrec_relation_parallel(const wl_plan_relation_t *rp,
     wl_col_session_t *coord);
+int
+wl_columnar_eval_delta_queue_capacity(uint32_t nrels, uint32_t *out);
 
 /* ======================================================================== */
 /* Relation Partitioning (columnar/partition.c)                             */

--- a/wirelog/workqueue.c
+++ b/wirelog/workqueue.c
@@ -65,6 +65,30 @@ struct wl_work_queue {
     uint32_t num_workers;
 };
 
+static int
+workqueue_ring_capacity(uint32_t num_workers, uint32_t *out)
+{
+    if (!out || num_workers == 0
+        || num_workers > (UINT32_C(1) << 30))
+        return -1;
+
+    uint64_t min_cap = (uint64_t)num_workers * 2u;
+    if (min_cap < 256u)
+        min_cap = 256u;
+    uint32_t cap = 1u;
+    while ((uint64_t)cap < min_cap) {
+        if (cap > UINT32_MAX / 2u)
+            return -1;
+        cap <<= 1u;
+    }
+#if UINTPTR_MAX <= UINT32_MAX
+    if (cap > SIZE_MAX / sizeof(wl_work_item_t))
+        return -1;
+#endif
+    *out = cap;
+    return 0;
+}
+
 /* ======================================================================== */
 /* Worker Thread                                                             */
 /* ======================================================================== */
@@ -114,10 +138,10 @@ worker_thread(void *arg)
 wl_work_queue_t *
 wl_workqueue_create(uint32_t num_workers)
 {
-    if (num_workers == 0)
-        return NULL;
-    /* Guard: ring capacity = num_workers * 2 must not overflow uint32_t */
-    if (num_workers > UINT32_MAX / 2u)
+    uint32_t ring_capacity = 0;
+    /* Validate capacity before allocating the queue, synchronization state,
+     * worker array, or ring storage. */
+    if (workqueue_ring_capacity(num_workers, &ring_capacity) != 0)
         return NULL;
 
     wl_work_queue_t *wq = (wl_work_queue_t *)calloc(1, sizeof(wl_work_queue_t));
@@ -161,16 +185,8 @@ wl_workqueue_create(uint32_t num_workers)
     /* Allocate ring buffer dynamically (Phase 0: support W=512+).
      * Capacity = num_workers * 2, rounded up to power of 2, minimum 256.
      * This ensures a full batch of W items always fits without back-pressure. */
-    uint32_t min_cap = num_workers * 2u;
-    if (min_cap < 256u)
-        min_cap = 256u;
-
-    /* Round up to next power of 2 */
-    uint32_t cap = 1u;
-    while (cap < min_cap)
-        cap <<= 1u;
-
-    wq->ring = (wl_work_item_t *)calloc(cap, sizeof(wl_work_item_t));
+    wq->ring = (wl_work_item_t *)calloc(ring_capacity,
+            sizeof(wl_work_item_t));
     if (!wq->ring) {
         free(wq->threads);
         cond_destroy(&wq->all_done);
@@ -179,7 +195,7 @@ wl_workqueue_create(uint32_t num_workers)
         free(wq);
         return NULL;
     }
-    wq->capacity = cap;
+    wq->capacity = ring_capacity;
 
     for (uint32_t i = 0; i < num_workers; i++) {
         if (thread_create(&wq->threads[i], worker_thread, wq) != 0) {

--- a/wirelog/workqueue.h
+++ b/wirelog/workqueue.h
@@ -98,7 +98,9 @@ typedef struct wl_work_queue wl_work_queue_t;
 
 /**
  * wl_workqueue_create:
- * @num_workers: Number of worker threads to spawn.  Must be >= 1.
+ * @num_workers: Number of worker threads to spawn.  Must be in the range
+ *               1..2^30; larger values cannot be rounded to a representable
+ *               power-of-two ring capacity.
  *
  * Create a work queue backed by a fixed-size thread pool.
  * Worker threads are created immediately and block until work is


### PR DESCRIPTION
## Summary
- reject overflowing TDD delta-queue relation capacities before state allocation
- replace workqueue power-of-two growth with widened, allocation-safe capacity validation
- add boundary regression tests and update shifted threading audit citations

## Validation
- full Meson suite: 290 passed, 0 failed, 12 skipped
- focused `workqueue_capacity` and `tdd_multiworker`: passed
- threading documentation gate: passed
- tidy suite: 4/4 passed
- `git diff --check`: passed

Follow-up issue #1194 tracks the separate TDD `W*nrels` buffer/dequeue arithmetic audit.

Closes #1192
