### PR TITLE
fix: guard TDD worker relation matrix sizes

### DIFF
--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -309,7 +309,7 @@ once and the surrounding overhead dominates.
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `kfusion.c:663` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:305`, which resets the TDD counter before `thread_create()` |
+| `kfusion.c:663` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:324`, which resets the TDD counter before `thread_create()` |
 
 The `stop` flag's `memory_order_relaxed` store is deliberate:
 cancellation is **cooperative**, not preemptive. A worker may observe
@@ -321,7 +321,7 @@ and the wasted work is bounded.
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `eval.c:305` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
+| `eval.c:324` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
 
 ### 5.7 `wirelog/columnar/session.c` — worker budget snapshot (1 row)
 

--- a/tests/test_tdd_multiworker.c
+++ b/tests/test_tdd_multiworker.c
@@ -595,6 +595,60 @@ test_delta_queue_capacity_boundaries(void)
     PASS();
 }
 
+static void
+test_tdd_matrix_size_boundaries(void)
+{
+    TEST("TDD W*nrels matrix sizing rejects wrapped counts");
+
+    size_t count = 0;
+    if (wl_columnar_eval_tdd_matrix_size(0, 0, sizeof(uint32_t), &count)
+        != 0
+        || count != 0
+        || wl_columnar_eval_tdd_matrix_size(1, 1, sizeof(uint32_t), &count)
+        != 0
+        || count != 1
+        || wl_columnar_eval_tdd_matrix_size(2, UINT32_MAX / 2u,
+        1, &count) != 0
+        || count != UINT32_MAX - 1u
+        || wl_columnar_eval_tdd_matrix_size(2, UINT32_MAX / 2u + 1u,
+        1, &count) != EOVERFLOW
+        || wl_columnar_eval_tdd_matrix_size(UINT32_MAX, 2,
+        sizeof(uint32_t), &count) != EOVERFLOW) {
+        FAIL("unexpected TDD matrix-size boundary result");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_tdd_queue_discard_large_dimensions(void)
+{
+    TEST("TDD queue discard drains without W*nrels allocation");
+
+    wl_mpsc_queue_t *queue = wl_mpsc_queue_create(2, 4);
+    col_rel_t *first = col_rel_new_auto("$discard$first", 1);
+    col_rel_t *second = col_rel_new_auto("$discard$second", 1);
+    if (!queue || !first || !second
+        || wl_mpsc_enqueue(queue, 0, first, 0, 0) != 0
+        || wl_mpsc_enqueue(queue, 1, second, 0, 1) != 0) {
+        col_rel_destroy(first);
+        col_rel_destroy(second);
+        wl_mpsc_queue_destroy(queue);
+        FAIL("could not prepare discard queue");
+        return;
+    }
+
+    wl_columnar_eval_tdd_queue_discard_delta_queue(queue, UINT32_MAX, 2);
+    wl_delta_msg_t msg;
+    if (wl_mpsc_dequeue(queue, &msg) != 0) {
+        wl_mpsc_queue_destroy(queue);
+        FAIL("discard left queued payloads");
+        return;
+    }
+    wl_mpsc_queue_destroy(queue);
+    PASS();
+}
+
 /* ======================================================================== */
 /* main                                                                     */
 /* ======================================================================== */
@@ -627,6 +681,8 @@ main(void)
     test_reconstruct_sparse();
     test_reconstruct_duplicate();
     test_delta_queue_capacity_boundaries();
+    test_tdd_matrix_size_boundaries();
+    test_tdd_queue_discard_large_dimensions();
 
     printf("\nPassed: %d/%d\n", tests_passed, tests_run);
     printf("Failed: %d/%d\n", tests_failed, tests_run);

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -45,6 +45,25 @@ wl_columnar_eval_delta_queue_capacity(uint32_t nrels, uint32_t *out)
     return 0;
 }
 
+int
+wl_columnar_eval_tdd_matrix_size(uint32_t W, uint32_t nrels,
+    size_t element_size, size_t *out)
+{
+    if (!out || element_size == 0)
+        return EINVAL;
+    if (W == 0 || nrels == 0) {
+        *out = 0;
+        return 0;
+    }
+    if ((size_t)nrels > SIZE_MAX / (size_t)W)
+        return EOVERFLOW;
+    size_t count = (size_t)W * nrels;
+    if (count > UINT32_MAX || count > SIZE_MAX / element_size)
+        return EOVERFLOW;
+    *out = count;
+    return 0;
+}
+
 /* Relation-plan dispatch is implemented in columnar/eval_plan.c. */
 /* Serial stratum evaluation is implemented in columnar/eval_serial.c. */
 
@@ -3168,7 +3187,7 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
             col_rel_t *widb = session_find_rel(
                 &coord->tdd_workers[w], rel_name);
             if (widb)
-                widb->nrows = snap[w * nrels + ri];
+                widb->nrows = snap[(size_t)w * nrels + ri];
         }
         coord->tdd_exchange_coordinator_ns += now_ns() - prepare_t0;
 
@@ -3230,7 +3249,7 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
             /* Step 6: Update snap after hash-exchange */
             col_rel_t *widb = session_find_rel(
                 &coord->tdd_workers[w], rel_name);
-            snap[w * nrels + ri] = widb ? widb->nrows : 0;
+            snap[(size_t)w * nrels + ri] = widb ? widb->nrows : 0;
             col_rel_destroy(parts[w]);
         }
         free((void *)parts);
@@ -3958,8 +3977,13 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
      * Used to truncate worker IDB back to clean partition state after each
      * sub-pass (removes cross-partition pollution from join output). */
     if (bdx_mode) {
-        bdx_snap = (uint32_t *)calloc(
-            (size_t)W * nrels, sizeof(uint32_t));
+        size_t bdx_count = 0;
+        if (wl_columnar_eval_tdd_matrix_size(W, nrels,
+            sizeof(uint32_t), &bdx_count) != 0) {
+            rc = EOVERFLOW;
+            goto done;
+        }
+        bdx_snap = (uint32_t *)calloc(bdx_count, sizeof(uint32_t));
         if (!bdx_snap) {
             rc = ENOMEM;
             goto done;
@@ -3969,7 +3993,7 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
             for (uint32_t ri = 0; ri < nrels; ri++) {
                 col_rel_t *widb = session_find_rel(
                     &coord->tdd_workers[w], sp->relations[ri].name);
-                bdx_snap[w * nrels + ri] = widb ? widb->nrows : 0;
+                bdx_snap[(size_t)w * nrels + ri] = widb ? widb->nrows : 0;
             }
         }
         /* Initialize coordinator IDB from worker partitions for dedup.
@@ -4171,10 +4195,24 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
              * ctx and queue; shadow assert verifies agreement (debug only). */
             if (coord->delta_queue) {
                 uint64_t queue_t0 = now_ns();
-                uint32_t max_msgs = W * nrels;
+                size_t matrix_count = 0;
+                if (wl_columnar_eval_tdd_matrix_size(W, nrels,
+                    sizeof(wl_delta_msg_t), &matrix_count) != 0) {
+                    wl_columnar_eval_tdd_queue_discard_delta_queue(
+                        coord->delta_queue, W, nrels);
+                    rc = EOVERFLOW;
+                    goto done;
+                }
+                uint32_t max_msgs = (uint32_t)matrix_count;
                 wl_delta_msg_t *msgs = (wl_delta_msg_t *)calloc(
                     max_msgs > 0 ? max_msgs : 1u, sizeof(wl_delta_msg_t));
-                if (msgs) {
+                if (!msgs) {
+                    wl_columnar_eval_tdd_queue_discard_delta_queue(
+                        coord->delta_queue, W, nrels);
+                    rc = ENOMEM;
+                    goto done;
+                }
+                {
                     uint32_t msg_count = wl_mpsc_dequeue_all(
                         coord->delta_queue, msgs, max_msgs);
 

--- a/wirelog/columnar/eval_tdd_queue.c
+++ b/wirelog/columnar/eval_tdd_queue.c
@@ -37,17 +37,17 @@ wl_columnar_eval_tdd_queue_discard_delta_queue(wl_mpsc_queue_t *queue,
 {
     if (!queue)
         return;
-    uint32_t max_msgs = W * nrels;
-    if (max_msgs == 0)
-        max_msgs = 1;
-    wl_delta_msg_t *msgs = (wl_delta_msg_t *)calloc(max_msgs,
-            sizeof(wl_delta_msg_t));
-    if (!msgs)
-        return;
-    uint32_t msg_count = wl_mpsc_dequeue_all(queue, msgs, max_msgs);
-    for (uint32_t i = 0; i < msg_count; i++)
-        col_rel_destroy((col_rel_t *)msgs[i].delta);
-    free(msgs);
+    (void)W;
+    (void)nrels;
+    wl_delta_msg_t msgs[256];
+    for (;;) {
+        uint32_t msg_count = wl_mpsc_dequeue_all(queue, msgs,
+                (uint32_t)(sizeof(msgs) / sizeof(msgs[0])));
+        for (uint32_t i = 0; i < msg_count; i++)
+            col_rel_destroy((col_rel_t *)msgs[i].delta);
+        if (msg_count < sizeof(msgs) / sizeof(msgs[0]))
+            break;
+    }
 }
 
 int

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1817,6 +1817,9 @@ wl_columnar_eval_nonrec_relation_parallel(const wl_plan_relation_t *rp,
     wl_col_session_t *coord);
 int
 wl_columnar_eval_delta_queue_capacity(uint32_t nrels, uint32_t *out);
+int
+wl_columnar_eval_tdd_matrix_size(uint32_t W, uint32_t nrels,
+    size_t element_size, size_t *out);
 
 /* ======================================================================== */
 /* Relation Partitioning (columnar/partition.c)                             */


### PR DESCRIPTION
## Summary
- validate TDD `W*nrels` matrix counts and allocation byte sizes before use
- use widened snapshot indexing and reject overflowing dequeue capacities
- drain queued delta payloads in bounded chunks on overflow/allocation failure
- add portable boundary and cleanup regression tests

## Validation
- full Meson suite: 290 passed, 0 failed, 12 skipped
- focused `tdd_multiworker`: passed
- threading documentation gate: passed
- tidy suite: 4/4 passed
- `git diff --check`: passed

Follow-up issues #1196, #1197, and #1198 track independent row-count, payload-ownership, and nrels-only size-arithmetic audits.

Closes #1194
