### PR TITLE
fix: guard relation append row-count overflow

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4557,6 +4557,23 @@ test_tdd_multiworker_exe = executable(
 
 test('tdd_multiworker', test_tdd_multiworker_exe)
 
+test_relation_append_exe = executable(
+  'test_relation_append',
+  files('test_relation_append.c'),
+  backend_src,
+  parser_src,
+  ir_src,
+  optimizer_src,
+  arena_src,
+  io_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('relation_append', test_relation_append_exe)
+
 test_tdd_decision_stats_exe = executable(
   'test_tdd_decision_stats',
   files('test_tdd_decision_stats.c'),

--- a/tests/test_relation_append.c
+++ b/tests/test_relation_append.c
@@ -1,0 +1,65 @@
+/*
+ * test_relation_append.c - generic relation append overflow regression
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#include "columnar/internal.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+
+static int tests_failed;
+
+static void
+test_row_count_boundaries(void)
+{
+    col_rel_t dst = { 0 };
+    col_rel_t src = { 0 };
+
+    printf("  exact UINT32_MAX row total: ");
+    dst.capacity = UINT32_MAX;
+    dst.nrows = UINT32_MAX - 1u;
+    src.nrows = 1;
+    if (col_rel_append_all(&dst, &src, NULL) != 0
+        || dst.nrows != UINT32_MAX) {
+        printf("FAIL\n");
+        tests_failed++;
+    } else {
+        printf("PASS\n");
+    }
+
+    printf("  overflowing row total leaves destination unchanged: ");
+    dst.nrows = UINT32_MAX;
+    src.nrows = 1;
+    int64_t **columns = (int64_t **)(uintptr_t)0x1;
+    col_delta_timestamp_t *timestamps
+        = (col_delta_timestamp_t *)(uintptr_t)0x2;
+    bool *col_shared = (bool *)(uintptr_t)0x3;
+    wl_mem_ledger_t *mem_ledger = (wl_mem_ledger_t *)(uintptr_t)0x4;
+    dst.columns = columns;
+    dst.timestamps = timestamps;
+    dst.col_shared = col_shared;
+    dst.mem_ledger = mem_ledger;
+    dst.arena_owned = true;
+    if (col_rel_append_all(&dst, &src, NULL) != EOVERFLOW
+        || dst.nrows != UINT32_MAX || dst.capacity != UINT32_MAX
+        || dst.columns != columns || dst.timestamps != timestamps
+        || dst.col_shared != col_shared || dst.mem_ledger != mem_ledger
+        || !dst.arena_owned) {
+        printf("FAIL\n");
+        tests_failed++;
+    } else {
+        printf("PASS\n");
+    }
+}
+
+int
+main(void)
+{
+    printf("=== col_rel_append_all overflow tests (Issue #1200) ===\n");
+    test_row_count_boundaries();
+    return tests_failed != 0;
+}

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -495,6 +495,9 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
     if (src->nrows == 0)
         return 0;
 
+    if (src->nrows > UINT32_MAX - dst->nrows)
+        return EOVERFLOW;
+
     uint32_t dst_base = dst->nrows;
     uint32_t new_nrows = dst->nrows + src->nrows;
 


### PR DESCRIPTION
## Summary
- reject overflowing `dst->nrows + src->nrows` before mutation or allocation
- preserve exact `UINT32_MAX` totals
- add a dedicated relation append boundary and immutability test

Closes #1200

## Validation
- `meson test -C build --print-errorlogs` (291 passed, 12 skipped)
- `meson test -C build relation_append wirelog:clang_tidy_ratchet wirelog:threading_doc`
