### PR TITLE
fix: define MPSC delta payload ownership

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build binutils
+          sudo apt-get install -y meson ninja-build binutils file
 
       - name: Install NDK r27c
         id: setup-ndk

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -309,7 +309,7 @@ once and the surrounding overhead dominates.
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `kfusion.c:663` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:393`, which resets the TDD counter before `thread_create()` |
+| `kfusion.c:663` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:399`, which resets the TDD counter before `thread_create()` |
 
 The `stop` flag's `memory_order_relaxed` store is deliberate:
 cancellation is **cooperative**, not preemptive. A worker may observe
@@ -321,7 +321,7 @@ and the wasted work is bounded.
 
 | `file:line` | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `eval.c:393` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
+| `eval.c:399` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
 
 ### 5.7 `wirelog/columnar/session.c` — worker budget snapshot (1 row)
 

--- a/tests/test_lockfree_queue.c
+++ b/tests/test_lockfree_queue.c
@@ -37,6 +37,14 @@ typedef volatile int atomic_int;
 static int test_count = 0;
 static int pass_count = 0;
 static int fail_count = 0;
+static int payload_destroy_count = 0;
+
+static void
+counted_payload_destroy(void *payload)
+{
+    payload_destroy_count++;
+    free(payload);
+}
 
 #define TEST(name)                                         \
         do {                                                   \
@@ -437,6 +445,81 @@ test_concurrent(void)
     PASS();
 }
 
+static void
+test_payload_ownership(void)
+{
+    TEST("payload ownership transfers and queued payloads are reclaimed");
+
+    payload_destroy_count = 0;
+    wl_mpsc_queue_t *q = wl_mpsc_queue_create_with_destructor(
+        1, 4, counted_payload_destroy);
+    ASSERT(q != NULL, "create with destructor failed");
+
+    int *dequeued = (int *)malloc(sizeof(int));
+    int *pending_a = (int *)malloc(sizeof(int));
+    int *pending_b = (int *)malloc(sizeof(int));
+    ASSERT(dequeued && pending_a && pending_b, "payload allocation failed");
+    ASSERT(wl_mpsc_enqueue(q, 0, dequeued, 0, 0) == 0,
+        "enqueue dequeued payload failed");
+    ASSERT(wl_mpsc_enqueue(q, 0, pending_a, 0, 1) == 0,
+        "enqueue pending payload a failed");
+    ASSERT(wl_mpsc_enqueue(q, 0, pending_b, 0, 2) == 0,
+        "enqueue pending payload b failed");
+
+    wl_delta_msg_t msg;
+    ASSERT(wl_mpsc_dequeue(q, &msg) == 1, "dequeue payload failed");
+    ASSERT(msg.delta == dequeued, "dequeued payload mismatch");
+    free(msg.delta); /* ownership transferred to the receiver */
+    ASSERT(payload_destroy_count == 0,
+        "queue destroyed a payload transferred by dequeue");
+
+    wl_mpsc_queue_destroy(q);
+    ASSERT(payload_destroy_count == 2,
+        "queue did not destroy exactly the two pending payloads");
+
+    payload_destroy_count = 0;
+    q = wl_mpsc_queue_create_with_destructor(1, 4, counted_payload_destroy);
+    ASSERT(q != NULL, "create dequeue_all queue failed");
+    int *batch_a = (int *)malloc(sizeof(int));
+    int *batch_b = (int *)malloc(sizeof(int));
+    ASSERT(batch_a && batch_b, "dequeue_all allocation failed");
+    ASSERT(wl_mpsc_enqueue(q, 0, batch_a, 0, 0) == 0,
+        "enqueue dequeue_all payload a failed");
+    ASSERT(wl_mpsc_enqueue(q, 0, batch_b, 0, 1) == 0,
+        "enqueue dequeue_all payload b failed");
+    wl_delta_msg_t batch[2];
+    ASSERT(wl_mpsc_dequeue_all(q, batch, 2) == 2,
+        "dequeue_all did not transfer both payloads");
+    free(batch[0].delta);
+    free(batch[1].delta);
+    wl_mpsc_queue_destroy(q);
+    ASSERT(payload_destroy_count == 0,
+        "queue destroyed payloads transferred by dequeue_all");
+
+    q = wl_mpsc_queue_create_with_destructor(0, 4, counted_payload_destroy);
+    ASSERT(q == NULL, "invalid destructor queue creation succeeded");
+
+    /* A failed enqueue retains ownership with the caller. */
+    payload_destroy_count = 0;
+    q = wl_mpsc_queue_create_with_destructor(1, 2, counted_payload_destroy);
+    ASSERT(q != NULL, "create saturation queue failed");
+    int *full_a = (int *)malloc(sizeof(int));
+    int *full_b = (int *)malloc(sizeof(int));
+    int *caller_owned = (int *)malloc(sizeof(int));
+    ASSERT(full_a && full_b && caller_owned, "saturation allocation failed");
+    ASSERT(wl_mpsc_enqueue(q, 0, full_a, 0, 0) == 0,
+        "enqueue full payload a failed");
+    ASSERT(wl_mpsc_enqueue(q, 0, full_b, 0, 1) == 0,
+        "enqueue full payload b failed");
+    ASSERT(wl_mpsc_enqueue(q, 0, caller_owned, 0, 2) != 0,
+        "full queue accepted third payload");
+    free(caller_owned);
+    wl_mpsc_queue_destroy(q);
+    ASSERT(payload_destroy_count == 2,
+        "failed enqueue payload was destroyed by queue");
+    PASS();
+}
+
 /* ----------------------------------------------------------------
  * main
  * ---------------------------------------------------------------- */
@@ -454,6 +537,7 @@ main(void)
     test_multiple_producers();
     test_saturation();
     test_concurrent();
+    test_payload_ownership();
 
     printf("\n=== Results: %d passed, %d failed (of %d) ===\n",
         pass_count, fail_count, test_count);

--- a/tests/test_tdd_multiworker.c
+++ b/tests/test_tdd_multiworker.c
@@ -36,6 +36,14 @@
 static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
+static uint32_t discard_destroy_count = 0;
+
+static void
+count_discard_destroy(void *payload)
+{
+    discard_destroy_count++;
+    free(payload);
+}
 
 #define TEST(name)                            \
         do {                                      \
@@ -655,6 +663,42 @@ test_delta_queue_capacity_boundaries(void)
         return;
     }
     PASS();
+    return;
+}
+
+static int
+test_discard_drains_all_messages(void)
+{
+    TEST("tdd discard drains more than one W*nrels batch");
+
+    wl_mpsc_queue_t *queue = wl_mpsc_queue_create(2, 16);
+    if (!queue) {
+        FAIL("queue creation failed");
+        return 1;
+    }
+    discard_destroy_count = 0;
+    for (uint32_t i = 0; i < 12; i++) {
+        void *delta = malloc(1);
+        if (!delta || wl_mpsc_enqueue(queue, i % 2, delta, 0, i) != 0) {
+            free(delta);
+            wl_columnar_eval_tdd_queue_discard_delta_queue_with_destroyer(
+                queue, count_discard_destroy);
+            wl_mpsc_queue_destroy(queue);
+            FAIL("delta enqueue failed");
+            return 1;
+        }
+    }
+
+    wl_columnar_eval_tdd_queue_discard_delta_queue_with_destroyer(
+        queue, count_discard_destroy);
+    int empty = wl_mpsc_size(queue) == 0 && discard_destroy_count == 12;
+    wl_mpsc_queue_destroy(queue);
+    if (!empty) {
+        FAIL("discard left queued deltas");
+        return 1;
+    }
+    PASS();
+    return 0;
 }
 
 static void
@@ -747,6 +791,7 @@ main(void)
     test_delta_queue_capacity_boundaries();
     test_tdd_matrix_size_boundaries();
     test_tdd_queue_discard_large_dimensions();
+    test_discard_drains_all_messages();
 
     printf("\nPassed: %d/%d\n", tests_passed, tests_run);
     printf("Failed: %d/%d\n", tests_failed, tests_run);

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -26,6 +26,12 @@
 #define TDD_OWNER_FALLBACK_MIN_ITER 31u
 #define TDD_OWNER_FALLBACK_DELTA_ROWS 512u
 
+static void
+tdd_destroy_delta_payload(void *payload)
+{
+    col_rel_destroy((col_rel_t *)payload);
+}
+
 #define WL_COLUMNAR_EVAL_DEDUP_ROW_HASH wl_columnar_eval_dedup_row_hash
 #define WL_COLUMNAR_EVAL_DEDUP_SET_INSERT wl_columnar_eval_dedup_set_insert
 #define WL_COLUMNAR_EVAL_DEDUP_SET_CONTAINS wl_columnar_eval_dedup_set_contains
@@ -4132,7 +4138,8 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
      * Failure is non-fatal: enqueue is skipped when delta_queue is NULL.
      * An unrepresentable nrels*2 request is rejected before any stratum
      * state allocation, using the evaluator's ENOMEM failure signal. */
-    coord->delta_queue = wl_mpsc_queue_create(W, delta_queue_capacity);
+    coord->delta_queue = wl_mpsc_queue_create_with_destructor(
+        W, delta_queue_capacity, tdd_destroy_delta_payload);
 
     /* Issue #390: BDX snap array — pre-subpass IDB sizes per worker/relation.
      * Used to truncate worker IDB back to clean partition state after each
@@ -4368,23 +4375,25 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 wl_delta_msg_t *msgs = (wl_delta_msg_t *)calloc(
                     max_msgs > 0 ? max_msgs : 1u, sizeof(wl_delta_msg_t));
                 if (!msgs) {
+                    /* Queue-only workers have not written ctxs yet.  Drain
+                     * and destroy their queued deltas before aborting; do
+                     * not continue with a silently empty exchange. */
                     wl_columnar_eval_tdd_queue_discard_delta_queue(
                         coord->delta_queue, W, nrels);
                     rc = ENOMEM;
+                    coord->tdd_queue_drain_ns += now_ns() - queue_t0;
                     goto done;
                 }
-                {
-                    uint32_t msg_count = wl_mpsc_dequeue_all(
-                        coord->delta_queue, msgs, max_msgs);
+                uint32_t msg_count = wl_mpsc_dequeue_all(
+                    coord->delta_queue, msgs, max_msgs);
 
-                    /* Clear and reconstruct from queue messages. */
-                    for (uint32_t w = 0; w < W; w++)
-                        memset((void *)ctxs[w].delta_rels, 0,
-                            delta_rel_bytes);
-                    wl_columnar_eval_tdd_queue_reconstruct_delta_matrix(
-                        ctxs, msgs, msg_count, W, nrels);
-                    free(msgs);
-                }
+                /* Clear and reconstruct from queue messages. */
+                for (uint32_t w = 0; w < W; w++)
+                    memset((void *)ctxs[w].delta_rels, 0,
+                        delta_rel_bytes);
+                wl_columnar_eval_tdd_queue_reconstruct_delta_matrix(
+                    ctxs, msgs, msg_count, W, nrels);
+                free(msgs);
                 coord->tdd_queue_drain_ns += now_ns() - queue_t0;
             }
 

--- a/wirelog/columnar/eval_tdd_queue.c
+++ b/wirelog/columnar/eval_tdd_queue.c
@@ -13,6 +13,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+static void
+tdd_destroy_delta_payload(void *payload)
+{
+    col_rel_destroy((col_rel_t *)payload);
+}
+
 void
 wl_columnar_eval_tdd_queue_reconstruct_delta_matrix(
     col_eval_tdd_worker_ctx_t *ctxs, const wl_delta_msg_t *msgs,
@@ -32,22 +38,29 @@ wl_columnar_eval_tdd_queue_reconstruct_delta_matrix(
 }
 
 void
+wl_columnar_eval_tdd_queue_discard_delta_queue_with_destroyer(
+    wl_mpsc_queue_t *queue, wl_mpsc_payload_destroy_fn destroy_payload)
+{
+    if (!queue || !destroy_payload)
+        return;
+    wl_delta_msg_t msg;
+    while (wl_mpsc_dequeue(queue, &msg))
+        if (msg.delta)
+            destroy_payload(msg.delta);
+}
+
+void
 wl_columnar_eval_tdd_queue_discard_delta_queue(wl_mpsc_queue_t *queue,
     uint32_t W, uint32_t nrels)
 {
     if (!queue)
         return;
+    /* This error-path drain is intentionally allocation-free and ignores the
+    * historical sizing hints: every live queue message must be reclaimed. */
     (void)W;
     (void)nrels;
-    wl_delta_msg_t msgs[256];
-    for (;;) {
-        uint32_t msg_count = wl_mpsc_dequeue_all(queue, msgs,
-                (uint32_t)(sizeof(msgs) / sizeof(msgs[0])));
-        for (uint32_t i = 0; i < msg_count; i++)
-            col_rel_destroy((col_rel_t *)msgs[i].delta);
-        if (msg_count < sizeof(msgs) / sizeof(msgs[0]))
-            break;
-    }
+    wl_columnar_eval_tdd_queue_discard_delta_queue_with_destroyer(queue,
+        tdd_destroy_delta_payload);
 }
 
 int

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -2013,6 +2013,11 @@ void
 wl_columnar_eval_tdd_queue_discard_delta_queue(wl_mpsc_queue_t *queue,
     uint32_t W, uint32_t nrels);
 
+/* Allocation-free ownership-test seam; drains every live message. */
+void
+wl_columnar_eval_tdd_queue_discard_delta_queue_with_destroyer(
+    wl_mpsc_queue_t *queue, wl_mpsc_payload_destroy_fn destroy_payload);
+
 int
 wl_columnar_eval_tdd_queue_publish_delta(col_eval_tdd_worker_ctx_t *ctx,
     wl_col_session_t *sess, col_rel_t *delta, uint32_t rel_idx,

--- a/wirelog/util/lockfree_queue.c
+++ b/wirelog/util/lockfree_queue.c
@@ -198,10 +198,18 @@ struct wl_mpsc_queue {
     wl_spsc_queue_t *workers;     /* per-worker SPSC rings   */
     uint32_t num_workers;
     uint32_t dequeue_idx;         /* round-robin scan cursor */
+    wl_mpsc_payload_destroy_fn destroy_payload;
 };
 
 wl_mpsc_queue_t *
 wl_mpsc_queue_create(uint32_t num_workers, uint32_t capacity)
+{
+    return wl_mpsc_queue_create_with_destructor(num_workers, capacity, NULL);
+}
+
+wl_mpsc_queue_t *
+wl_mpsc_queue_create_with_destructor(uint32_t num_workers, uint32_t capacity,
+    wl_mpsc_payload_destroy_fn destroy_payload)
 {
     if (num_workers == 0 || capacity < 2)
         return NULL;
@@ -219,6 +227,7 @@ wl_mpsc_queue_create(uint32_t num_workers, uint32_t capacity)
 
     q->num_workers = num_workers;
     q->dequeue_idx = 0;
+    q->destroy_payload = destroy_payload;
 
     for (uint32_t i = 0; i < num_workers; i++) {
         if (spsc_init(&q->workers[i], capacity) != 0) {
@@ -238,6 +247,12 @@ wl_mpsc_queue_destroy(wl_mpsc_queue_t *q)
 {
     if (!q)
         return;
+    if (q->destroy_payload) {
+        wl_delta_msg_t item;
+        while (wl_mpsc_dequeue(q, &item))
+            if (item.delta)
+                q->destroy_payload(item.delta);
+    }
     for (uint32_t i = 0; i < q->num_workers; i++)
         spsc_destroy(&q->workers[i]);
     free(q->workers);

--- a/wirelog/util/lockfree_queue.h
+++ b/wirelog/util/lockfree_queue.h
@@ -54,7 +54,9 @@
  * wl_delta_msg_t:
  *
  * Element type enqueued by a worker and dequeued by the coordinator.
- * The @delta pointer is caller-owned; the queue does not manage its lifetime.
+ * The @delta pointer is transferred to the queue on a successful enqueue.
+ * A queue configured with a payload destructor reclaims messages that remain
+ * queued at destruction; dequeued messages transfer ownership to the caller.
  */
 typedef struct {
     void    *delta;     /* delta relation pointer                  */
@@ -65,6 +67,9 @@ typedef struct {
     uint16_t flags;     /* message status flags                    */
     int16_t rc;         /* return/result code                      */
 } wl_delta_msg_t;
+
+/* Called exactly once for each non-NULL payload still queued at destruction. */
+typedef void (*wl_mpsc_payload_destroy_fn)(void *payload);
 
 /**
  * wl_mpsc_queue_t:
@@ -91,11 +96,30 @@ wl_mpsc_queue_t *
 wl_mpsc_queue_create(uint32_t num_workers, uint32_t capacity);
 
 /**
+ * wl_mpsc_queue_create_with_destructor:
+ * @num_workers: Number of producer threads.  Must be >= 1.
+ * @capacity: Per-worker ring buffer capacity.  Must be >= 2.
+ * @destroy_payload: Optional destructor for non-NULL payloads still queued
+ *                   at destroy.  It receives no context.
+ *
+ * A successful enqueue transfers @delta ownership to the queue.  A failed
+ * enqueue leaves ownership with the caller.  Dequeue operations transfer
+ * ownership to their output buffer/caller.  A NULL destructor preserves the
+ * non-owning behavior of wl_mpsc_queue_create().  The callback is never
+ * called for a failed enqueue or a message already returned by dequeue.
+ */
+wl_mpsc_queue_t *
+wl_mpsc_queue_create_with_destructor(uint32_t num_workers, uint32_t capacity,
+    wl_mpsc_payload_destroy_fn destroy_payload);
+
+/**
  * wl_mpsc_queue_destroy:
  * @q: (transfer full) Queue to destroy.  NULL-safe.
  *
- * Free all resources.  All threads must have stopped using the queue
- * before this is called.
+ * Free all resources.  If the queue was created with a payload destructor,
+ * destroy every still-queued non-NULL @delta exactly once before freeing the
+ * ring storage.  All threads must have stopped using the queue before this
+ * is called.
  */
 void
 wl_mpsc_queue_destroy(wl_mpsc_queue_t *q);


### PR DESCRIPTION
## Summary
- define explicit MPSC delta ownership and optional pending-payload destruction
- bind TDD queues to relation cleanup and make discard allocation-free
- abort cleanly on queue-drain buffer allocation failure instead of continuing empty
- add exact-count queue/TDD ownership and discard-drain tests

Closes #1197

## Validation
- `meson test -C build --print-errorlogs` (290 passed, 12 skipped)
- `meson test -C build lockfree_queue tdd_multiworker wirelog:threading_doc wirelog:clang_tidy_ratchet`
