### PR TITLE
fix: reclaim duplicate TDD delta payloads

### DIFF
--- a/tests/test_tdd_multiworker.c
+++ b/tests/test_tdd_multiworker.c
@@ -825,40 +825,6 @@ test_tdd_queue_discard_large_dimensions(void)
     PASS();
 }
 
-static void
-test_discard_drains_all_messages(void)
-{
-    TEST("tdd discard drains more than one W*nrels batch");
-
-    wl_mpsc_queue_t *queue = wl_mpsc_queue_create(2, 16);
-    if (!queue) {
-        FAIL("queue creation failed");
-        return;
-    }
-    discard_destroy_count = 0;
-    for (uint32_t i = 0; i < 12; i++) {
-        void *delta = malloc(1);
-        if (!delta || wl_mpsc_enqueue(queue, i % 2, delta, 0, i) != 0) {
-            free(delta);
-            wl_columnar_eval_tdd_queue_discard_delta_queue_with_destroyer(
-                queue, count_discard_destroy);
-            wl_mpsc_queue_destroy(queue);
-            FAIL("delta enqueue failed");
-            return;
-        }
-    }
-
-    wl_columnar_eval_tdd_queue_discard_delta_queue_with_destroyer(
-        queue, count_discard_destroy);
-    int empty = wl_mpsc_size(queue) == 0 && discard_destroy_count == 12;
-    wl_mpsc_queue_destroy(queue);
-    if (!empty) {
-        FAIL("discard left queued deltas");
-        return;
-    }
-    PASS();
-}
-
 /* ======================================================================== */
 /* main                                                                     */
 /* ======================================================================== */

--- a/tests/test_tdd_multiworker.c
+++ b/tests/test_tdd_multiworker.c
@@ -755,6 +755,49 @@ test_tdd_queue_discard_large_dimensions(void)
     PASS();
 }
 
+static int discard_destroy_count = 0;
+
+static void
+count_discard_destroy(void *payload)
+{
+    discard_destroy_count++;
+    free(payload);
+}
+
+static void
+test_discard_drains_all_messages(void)
+{
+    TEST("tdd discard drains more than one W*nrels batch");
+
+    wl_mpsc_queue_t *queue = wl_mpsc_queue_create(2, 16);
+    if (!queue) {
+        FAIL("queue creation failed");
+        return;
+    }
+    discard_destroy_count = 0;
+    for (uint32_t i = 0; i < 12; i++) {
+        void *delta = malloc(1);
+        if (!delta || wl_mpsc_enqueue(queue, i % 2, delta, 0, i) != 0) {
+            free(delta);
+            wl_columnar_eval_tdd_queue_discard_delta_queue_with_destroyer(
+                queue, count_discard_destroy);
+            wl_mpsc_queue_destroy(queue);
+            FAIL("delta enqueue failed");
+            return;
+        }
+    }
+
+    wl_columnar_eval_tdd_queue_discard_delta_queue_with_destroyer(
+        queue, count_discard_destroy);
+    int empty = wl_mpsc_size(queue) == 0 && discard_destroy_count == 12;
+    wl_mpsc_queue_destroy(queue);
+    if (!empty) {
+        FAIL("discard left queued deltas");
+        return;
+    }
+    PASS();
+}
+
 /* ======================================================================== */
 /* main                                                                     */
 /* ======================================================================== */

--- a/tests/test_tdd_multiworker.c
+++ b/tests/test_tdd_multiworker.c
@@ -615,7 +615,7 @@ test_reconstruct_sparse(void)
 static int
 test_reconstruct_duplicate(void)
 {
-    TEST("tdd_reconstruct_delta_matrix: duplicate pair, last write wins");
+    TEST("tdd_reconstruct_delta_matrix: duplicate ownership is exact-once");
 
     col_eval_tdd_worker_ctx_t ctxs[1];
     col_rel_t *dr[4];
@@ -623,19 +623,89 @@ test_reconstruct_duplicate(void)
     memset(ctxs, 0, sizeof(ctxs));
     ctxs[0].delta_rels = dr;
 
-    col_rel_t *first = (col_rel_t *)(uintptr_t)0xBEEF1u;
-    col_rel_t *second = (col_rel_t *)(uintptr_t)0xBEEF2u;
+    col_rel_t *first = (col_rel_t *)calloc(1, sizeof(col_rel_t));
+    col_rel_t *second = (col_rel_t *)calloc(1, sizeof(col_rel_t));
     wl_delta_msg_t msgs[2] = {
         {.delta = first,  .worker_id = 0, .rel_idx = 1},
         {.delta = second, .worker_id = 0, .rel_idx = 1},
     };
 
-    wl_columnar_eval_tdd_queue_reconstruct_delta_matrix(ctxs, msgs, 2, 1, 4);
+    discard_destroy_count = 0;
+    wl_columnar_eval_tdd_queue_reconstruct_delta_matrix_with_destroyer(
+        ctxs, msgs, 2, 1, 4, count_discard_destroy);
 
-    if (ctxs[0].delta_rels[1] != second) {
-        FAIL("last write did not win for duplicate pair");
+    if (ctxs[0].delta_rels[1] != second || discard_destroy_count != 1) {
+        FAIL("distinct duplicate did not destroy the replaced payload");
         return 1;
     }
+
+    count_discard_destroy(ctxs[0].delta_rels[1]);
+    if (discard_destroy_count != 2) {
+        FAIL("retained duplicate payload was not destroyed once");
+        return 1;
+    }
+
+    col_rel_t *alias = (col_rel_t *)calloc(1, sizeof(col_rel_t));
+    memset(dr, 0, sizeof(dr));
+    wl_delta_msg_t aliases[2] = {
+        {.delta = alias, .worker_id = 0, .rel_idx = 1},
+        {.delta = alias, .worker_id = 0, .rel_idx = 1},
+    };
+    discard_destroy_count = 0;
+    wl_columnar_eval_tdd_queue_reconstruct_delta_matrix_with_destroyer(
+        ctxs, aliases, 2, 1, 4, count_discard_destroy);
+    if (ctxs[0].delta_rels[1] != alias || discard_destroy_count != 0) {
+        FAIL("same-pointer duplicate was mishandled");
+        return 1;
+    }
+    count_discard_destroy(alias);
+
+    col_rel_t *cross_key = (col_rel_t *)calloc(1, sizeof(col_rel_t));
+    memset(dr, 0, sizeof(dr));
+    wl_delta_msg_t cross_key_msgs[2] = {
+        {.delta = cross_key, .worker_id = 0, .rel_idx = 1},
+        {.delta = cross_key, .worker_id = 0, .rel_idx = 2},
+    };
+    discard_destroy_count = 0;
+    wl_columnar_eval_tdd_queue_reconstruct_delta_matrix_with_destroyer(
+        ctxs, cross_key_msgs, 2, 1, 4, count_discard_destroy);
+    if (ctxs[0].delta_rels[1] != cross_key
+        || ctxs[0].delta_rels[2] != NULL || discard_destroy_count != 0) {
+        FAIL("cross-key alias was not retained under one owner");
+        return 1;
+    }
+    count_discard_destroy(cross_key);
+
+    col_rel_t *invalid = (col_rel_t *)calloc(1, sizeof(col_rel_t));
+    memset(dr, 0, sizeof(dr));
+    wl_delta_msg_t invalid_msgs[2] = {
+        {.delta = invalid, .worker_id = 9, .rel_idx = 0},
+        {.delta = invalid, .worker_id = 9, .rel_idx = 0},
+    };
+    discard_destroy_count = 0;
+    wl_columnar_eval_tdd_queue_reconstruct_delta_matrix_with_destroyer(
+        ctxs, invalid_msgs, 2, 1, 4, count_discard_destroy);
+    if (discard_destroy_count != 1 || ctxs[0].delta_rels[1] != NULL) {
+        FAIL("invalid duplicate was not destroyed exactly once");
+        return 1;
+    }
+
+    col_rel_t *invalid_then_valid = (col_rel_t *)calloc(1,
+            sizeof(col_rel_t));
+    memset(dr, 0, sizeof(dr));
+    wl_delta_msg_t invalid_then_valid_msgs[2] = {
+        {.delta = invalid_then_valid, .worker_id = 9, .rel_idx = 0},
+        {.delta = invalid_then_valid, .worker_id = 0, .rel_idx = 3},
+    };
+    discard_destroy_count = 0;
+    wl_columnar_eval_tdd_queue_reconstruct_delta_matrix_with_destroyer(
+        ctxs, invalid_then_valid_msgs, 2, 1, 4, count_discard_destroy);
+    if (ctxs[0].delta_rels[3] != invalid_then_valid
+        || discard_destroy_count != 0) {
+        FAIL("invalid-before-valid alias was mishandled");
+        return 1;
+    }
+    count_discard_destroy(invalid_then_valid);
     PASS();
     return 0;
 }

--- a/tests/test_tdd_multiworker.c
+++ b/tests/test_tdd_multiworker.c
@@ -825,15 +825,6 @@ test_tdd_queue_discard_large_dimensions(void)
     PASS();
 }
 
-static int discard_destroy_count = 0;
-
-static void
-count_discard_destroy(void *payload)
-{
-    discard_destroy_count++;
-    free(payload);
-}
-
 static void
 test_discard_drains_all_messages(void)
 {

--- a/wirelog/columnar/eval_tdd_queue.c
+++ b/wirelog/columnar/eval_tdd_queue.c
@@ -19,22 +19,78 @@ tdd_destroy_delta_payload(void *payload)
     col_rel_destroy((col_rel_t *)payload);
 }
 
+static bool
+tdd_matrix_contains_payload(const col_eval_tdd_worker_ctx_t *ctxs,
+    uint32_t num_workers, uint32_t nrels, const void *payload)
+{
+    for (uint32_t w = 0; w < num_workers; w++)
+        for (uint32_t ri = 0; ri < nrels; ri++)
+            if (ctxs[w].delta_rels[ri] == payload)
+                return true;
+    return false;
+}
+
+static void
+tdd_reconstruct_delta_matrix_with_destroyer(
+    col_eval_tdd_worker_ctx_t *ctxs, const wl_delta_msg_t *msgs,
+    uint32_t count, uint32_t num_workers, uint32_t nrels,
+    wl_mpsc_payload_destroy_fn destroy_payload)
+{
+    for (uint32_t i = 0; i < count; i++) {
+        uint32_t w = msgs[i].worker_id;
+        uint32_t ri = msgs[i].rel_idx;
+        void *payload = msgs[i].delta;
+
+        if (w >= num_workers || ri >= nrels || !payload)
+            continue;
+
+        /* A pointer can be mentioned by more than one malformed message.
+         * Keep its first matrix owner and reject later aliases. */
+        if (tdd_matrix_contains_payload(ctxs, num_workers, nrels, payload))
+            continue;
+        ctxs[w].delta_rels[ri] = (col_rel_t *)payload;
+    }
+
+    /* Destroy every rejected/replaced payload exactly once.  Deferring this
+     * pass handles invalid-before-valid aliases without dangling a slot. */
+    for (uint32_t i = 0; i < count; i++) {
+        void *payload = msgs[i].delta;
+        if (!payload || tdd_matrix_contains_payload(ctxs, num_workers, nrels,
+            payload))
+            continue;
+        bool seen = false;
+        for (uint32_t j = 0; j < i; j++) {
+            if (msgs[j].delta == payload) {
+                seen = true;
+                break;
+            }
+        }
+        if (!seen)
+            destroy_payload(payload);
+    }
+}
+
 void
 wl_columnar_eval_tdd_queue_reconstruct_delta_matrix(
     col_eval_tdd_worker_ctx_t *ctxs, const wl_delta_msg_t *msgs,
     uint32_t count, uint32_t num_workers, uint32_t nrels)
 {
-    for (uint32_t i = 0; i < count; i++) {
-        uint32_t w = msgs[i].worker_id;
-        uint32_t ri = msgs[i].rel_idx;
+    if (!ctxs || (!msgs && count != 0))
+        return;
+    tdd_reconstruct_delta_matrix_with_destroyer(ctxs, msgs, count,
+        num_workers, nrels, tdd_destroy_delta_payload);
+}
 
-        if (w >= num_workers || ri >= nrels) {
-            col_rel_destroy((col_rel_t *)msgs[i].delta);
-            continue;
-        }
-
-        ctxs[w].delta_rels[ri] = (col_rel_t *)msgs[i].delta;
-    }
+void
+wl_columnar_eval_tdd_queue_reconstruct_delta_matrix_with_destroyer(
+    col_eval_tdd_worker_ctx_t *ctxs, const wl_delta_msg_t *msgs,
+    uint32_t count, uint32_t num_workers, uint32_t nrels,
+    wl_mpsc_payload_destroy_fn destroy_payload)
+{
+    if (!ctxs || (!msgs && count != 0) || !destroy_payload)
+        return;
+    tdd_reconstruct_delta_matrix_with_destroyer(ctxs, msgs, count,
+        num_workers, nrels, destroy_payload);
 }
 
 void

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -2000,14 +2000,27 @@ typedef struct {
  *
  * Precondition: ctxs[w].delta_rels[ri] == NULL for all w,ri (freshly reset).
  * Postcondition: ctxs[msg.worker_id].delta_rels[msg.rel_idx] holds the
- *                delta pointer from each message (last write wins on dup).
+ *                last valid, non-aliased delta for each pair.  Distinct
+ *                duplicates are destroyed; repeated pointer aliases are
+ *                retained under one slot owner.  Invalid messages are
+ *                destroyed exactly once unless the same pointer also has a
+ *                valid occurrence, in which case that valid occurrence
+ *                retains the sole ownership token.
  *
- * Pure: no allocations, no side effects, no atomics.  O(count) time, O(1) space.
+ * No allocations or atomics are performed.  The matrix is mutated and
+ * rejected/replaced payloads are destroyed.  The bounded malformed-input
+ * checks use O(count * (num_workers * nrels + count)) time and O(1) space.
  */
 void
 wl_columnar_eval_tdd_queue_reconstruct_delta_matrix(
     col_eval_tdd_worker_ctx_t *ctxs, const wl_delta_msg_t *msgs,
     uint32_t count, uint32_t num_workers, uint32_t nrels);
+
+void
+wl_columnar_eval_tdd_queue_reconstruct_delta_matrix_with_destroyer(
+    col_eval_tdd_worker_ctx_t *ctxs, const wl_delta_msg_t *msgs,
+    uint32_t count, uint32_t num_workers, uint32_t nrels,
+    wl_mpsc_payload_destroy_fn destroy_payload);
 
 void
 wl_columnar_eval_tdd_queue_discard_delta_queue(wl_mpsc_queue_t *queue,


### PR DESCRIPTION
## Summary
- preserve last-valid-wins reconstruction while reclaiming replaced duplicate deltas
- retain one owner for same-pointer and cross-key aliases
- destroy invalid duplicate payloads exactly once, including invalid-before-valid ordering
- add real-payload exact-once ownership tests

Closes #1205

## Validation
- `meson test -C build --print-errorlogs` (290 passed, 12 skipped)
- `meson test -C build tdd_multiworker lockfree_queue wirelog:threading_doc wirelog:clang_tidy_ratchet`
