### PR TITLE
fix: skip bushy joins in JPP

### DIFF
--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -555,6 +555,62 @@ test_jpp_three_atom_reorder(void)
     PASS();
 }
 
+static void
+test_jpp_bushy_join_is_unchanged(void)
+{
+    TEST("jpp #1139: bushy JOIN is left unchanged");
+
+    wirelog_error_t err;
+    wirelog_program_t *prog
+        = wirelog_parse_string(".decl a(x: int32, y: int32)\n"
+            ".decl b(y: int32, z: int32)\n"
+            ".decl c(z: int32, w: int32)\n"
+            ".decl d(w: int32, v: int32)\n"
+            ".decl out(x: int32, v: int32)\n"
+            "out(x, v) :- a(x, y), b(y, z), c(z, w), d(w, v).\n",
+            &err);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+
+    wirelog_ir_node_t *root = find_join_root(find_relation_ir(prog, "out"));
+    if (!root || root->type != WIRELOG_IR_JOIN
+        || root->child_count != 2
+        || root->children[0]->type != WIRELOG_IR_JOIN
+        || root->children[0]->child_count != 2) {
+        FAIL("expected left-deep four-atom JOIN fixture");
+        wirelog_program_free(prog);
+        return;
+    }
+
+    /* The parser builds JOIN(JOIN(JOIN(a,b),c),d). Reuse the existing
+     * nodes to form JOIN(JOIN(a,b),JOIN(c,d)) without changing ownership. */
+    wirelog_ir_node_t *left_chain = root->children[0];
+    wirelog_ir_node_t *deep = left_chain->children[0];
+    wirelog_ir_node_t *c = left_chain->children[1];
+    wirelog_ir_node_t *d = root->children[1];
+    root->children[0] = deep;
+    root->children[1] = left_chain;
+    left_chain->children[0] = c;
+    left_chain->children[1] = d;
+
+    wl_jpp_stats_t stats = { 0 };
+    int rc = wl_jpp_apply(prog, &stats);
+    bool unchanged = rc == 0
+        && stats.joins_reordered == 0
+        && stats.projections_inserted == 0
+        && root->children[1] == left_chain
+        && left_chain->children[0] == c
+        && left_chain->children[1] == d
+        && count_type_in_tree(root, WIRELOG_IR_SCAN) == 4;
+    if (!unchanged)
+        FAIL("bushy JOIN was reordered or truncated");
+    else
+        PASS();
+    wirelog_program_free(prog);
+}
+
 /* ======================================================================== */
 /* Stats Tests                                                              */
 /* ======================================================================== */
@@ -2733,6 +2789,7 @@ main(void)
 
     /* Reorder */
     test_jpp_three_atom_reorder();
+    test_jpp_bushy_join_is_unchanged();
 
     /* Stats */
     test_jpp_already_optimal_three_atom();

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -49,6 +49,27 @@ collect_scans(wirelog_ir_node_t *node, wirelog_ir_node_t **out, uint32_t max)
     return n;
 }
 
+/* Count every non-JOIN leaf without the bounded output-array semantics of
+* collect_scans().  JPP only supports left-deep JOIN chains; this count is
+* used to reject bushy trees before any scratch allocation or mutation. */
+static uint32_t
+count_join_leaves(const wirelog_ir_node_t *node)
+{
+    if (!node)
+        return 0;
+    if (node->type != WIRELOG_IR_JOIN)
+        return 1;
+
+    uint32_t total = 0;
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        uint32_t child = count_join_leaves(node->children[i]);
+        if (child > UINT32_MAX - total)
+            return UINT32_MAX;
+        total += child;
+    }
+    return total;
+}
+
 /* ======================================================================== */
 /* Internal: variable set operations                                        */
 /* ======================================================================== */
@@ -921,6 +942,8 @@ insert_projections(wirelog_ir_node_t *join_root, char **head_vars,
         return 0; /* Need at least 3 atoms for intermediate projection */
 
     uint32_t nscan = depth + 1;
+    if (count_join_leaves(join_root) != nscan)
+        return 0; /* Bushy JOINs are outside the projection contract. */
     wirelog_ir_node_t **scans
         = (wirelog_ir_node_t **)calloc(nscan, sizeof(wirelog_ir_node_t *));
     wirelog_ir_node_t **joins
@@ -1336,6 +1359,8 @@ optimize_chain(wirelog_ir_node_t *join_root, char **head_vars,
     uint32_t nscan = depth + 1;
     if (nscan < 3)
         return result; /* Two-atom chains don't benefit from reordering */
+    if (count_join_leaves(join_root) != nscan)
+        return result; /* Only optimize complete left-deep chains. */
 
     /* Collect SCAN leaves and JOIN nodes */
     wirelog_ir_node_t **scans


### PR DESCRIPTION
## Summary\n- reject bushy JOIN trees before JPP scratch allocation or mutation\n- add regression coverage preserving bushy topology\n\nCloses #1139\n\n## Validation\n- meson test -C build wirelog:jpp --print-errorlogs\n- uncrustify --check\n- git diff --check