### PR TITLE
feat: expose plan generation diagnostics

### DIFF
--- a/abi/libwirelog-1.0.abi.json
+++ b/abi/libwirelog-1.0.abi.json
@@ -58,6 +58,7 @@
     <elf-symbol name='wirelog_program_free' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_facts' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_intern' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='wirelog_program_get_plan_error' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_relation_ir' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_rule_count' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='wirelog_program_get_schema' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>

--- a/abi/libwirelog-1.0.symbols
+++ b/abi/libwirelog-1.0.symbols
@@ -56,6 +56,7 @@ wirelog_parse_with_error_info
 wirelog_program_free
 wirelog_program_get_facts
 wirelog_program_get_intern
+wirelog_program_get_plan_error
 wirelog_program_get_relation_ir
 wirelog_program_get_rule_count
 wirelog_program_get_schema

--- a/tests/test_cli_parse_diagnostics.py
+++ b/tests/test_cli_parse_diagnostics.py
@@ -92,6 +92,36 @@ CASES = [
         'z(1).\n',
         ["__graph_metadata"],
     ),
+    (
+        "recursive count aggregate",
+        '.decl plan_edge(x: int64, y: int64)\n'
+        'plan_edge(1, 2).\n'
+        '.decl plan_count(x: int64, n: int64)\n'
+        'plan_count(1, 1).\n'
+        'plan_count(y, count(n)) :- plan_count(x, n), plan_edge(x, y).\n',
+        ["recursive aggregate", "count", "plan_count"],
+    ),
+    (
+        "recursive sum aggregate",
+        '.decl plan_sum_edge(x: int64, y: int64)\n'
+        'plan_sum_edge(1, 2).\n'
+        '.decl plan_sum(x: int64, n: int64)\n'
+        'plan_sum(1, 1).\n'
+        'plan_sum(y, sum(n)) :- plan_sum(x, n), plan_sum_edge(x, y).\n',
+        ["recursive aggregate", "sum", "plan_sum"],
+    ),
+    (
+        "recursive min aggregate same SCC",
+        '.decl plan_edge(x: int64, y: int64)\n'
+        'plan_edge(1, 2). plan_edge(2, 3).\n'
+        '.decl plan_label(x: int64, l: int64)\n'
+        'plan_label(x, min(x)) :- plan_edge(x, y).\n'
+        'plan_label(y, min(y)) :- plan_edge(x, y).\n'
+        '.decl plan_big(x: int64)\n'
+        'plan_big(x) :- plan_label(x, l), l > 0.\n'
+        'plan_label(x, min(9)) :- plan_big(x).\n',
+        ["same stratum", "plan_label", "plan_big"],
+    ),
 ]
 
 # A syntactically malformed program.  This is the errbuf that

--- a/tests/test_plan_gen.c
+++ b/tests/test_plan_gen.c
@@ -892,6 +892,55 @@ test_plan_free_null(void)
     PASS();
 }
 
+static void
+test_plan_generation_diagnostics(void)
+{
+    TEST("plan-generation diagnostics are retained on the public program");
+
+    ASSERT(wirelog_program_get_plan_error(NULL)[0] == '\0',
+        "NULL program must have an empty plan diagnostic");
+
+    const char *src =
+        ".decl plan_edge(x: int64, y: int64)\n"
+        "plan_edge(1, 2).\n"
+        ".decl plan_count(x: int64, n: int64)\n"
+        "plan_count(1, 1).\n"
+        "plan_count(y, count(n)) :- plan_count(x, n), plan_edge(x, y).\n";
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    ASSERT(prog != NULL, "diagnostic fixture failed to parse");
+
+    wl_plan_t *plan = NULL;
+    ASSERT(wl_plan_from_program(prog, &plan) != 0,
+        "recursive count fixture unexpectedly generated a plan");
+    ASSERT(plan == NULL, "failed plan generation must leave plan NULL");
+    const char *detail = wirelog_program_get_plan_error(prog);
+    ASSERT(detail && strstr(detail, "recursive aggregate") != NULL,
+        "plan diagnostic must identify recursive aggregate rejection");
+    ASSERT(strstr(detail, "plan_count") != NULL,
+        "plan diagnostic must identify the rejected relation");
+
+    ASSERT(wl_plan_from_program(prog, NULL) != 0,
+        "NULL output must be rejected");
+    detail = wirelog_program_get_plan_error(prog);
+    ASSERT(strcmp(detail, "execution plan generation failed") == 0,
+        "NULL output must retain the generic plan diagnostic");
+
+    wirelog_program_free(prog);
+
+    wirelog_program_t *ok = wirelog_parse_string(
+        ".decl plan_ok(x: int64)\nplan_ok(1).\n", &err);
+    ASSERT(ok != NULL, "control fixture failed to parse");
+    wl_plan_t *ok_plan = NULL;
+    ASSERT(wl_plan_from_program(ok, &ok_plan) == 0 && ok_plan != NULL,
+        "valid control unexpectedly failed plan generation");
+    ASSERT(wirelog_program_get_plan_error(ok)[0] == '\0',
+        "successful plan generation must clear its previous diagnostic");
+    wl_plan_free(ok_plan);
+    wirelog_program_free(ok);
+    PASS();
+}
+
 /* ----------------------------------------------------------------
  * Test: wl_session_load_facts NULL-safe
  * ---------------------------------------------------------------- */
@@ -927,6 +976,7 @@ main(void)
     test_antijoin_with_composite_right_child_rejected();
     test_semijoin_with_composite_right_child_rejected();
     test_side_compound_lowers_in_either_atom_position();
+    test_plan_generation_diagnostics();
     test_plan_free_null();
     test_load_facts_null_safe();
 

--- a/wirelog/cli/driver.c
+++ b/wirelog/cli/driver.c
@@ -445,7 +445,11 @@ wl_run_pipeline(const char *source, uint32_t num_workers, bool delta_mode,
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
     if (rc != 0) {
-        fprintf(stderr, "Plan generation failed: rc=%d\n", rc);
+        const char *detail = wirelog_program_get_plan_error(prog);
+        if (detail && detail[0] != '\0')
+            fprintf(stderr, "Plan error: %s\n", detail);
+        else
+            fprintf(stderr, "Plan generation failed: rc=%d\n", rc);
         wirelog_program_free(prog);
         return -1;
     }

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -22,6 +22,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -49,6 +50,18 @@
 /* ======================================================================== */
 /* Internal helpers                                                         */
 /* ======================================================================== */
+
+static void
+set_plan_error(struct wirelog_program *prog, const char *fmt, ...)
+{
+    if (!prog || !fmt)
+        return;
+
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(prog->plan_error, sizeof(prog->plan_error), fmt, ap);
+    va_end(ap);
+}
 
 static char *
 dup_str(const char *s)
@@ -3496,7 +3509,8 @@ plan_relation_reads(const wl_plan_relation_t *relation, const char *name)
  * does.
  */
 static int
-validate_recursive_aggregate_consumers(const wl_plan_t *plan)
+validate_recursive_aggregate_consumers(const wl_plan_t *plan,
+    struct wirelog_program *prog)
 {
     for (uint32_t s = 0; s < plan->stratum_count; s++) {
         const wl_plan_stratum_t *stratum = &plan->strata[s];
@@ -3538,6 +3552,13 @@ validate_recursive_aggregate_consumers(const wl_plan_t *plan)
                     "into '%s' so that '%s' lands in a later stratum",
                     consumer->name, stratum->stratum_id, agg->name,
                     agg->name, consumer->name);
+                set_plan_error(prog,
+                    "relation '%s' of stratum %u reads recursive aggregate "
+                    "relation '%s' from the same stratum: a recursive "
+                    "min/max aggregate may not share an SCC with any "
+                    "other relation; break the feedback edge into '%s'",
+                    consumer->name, stratum->stratum_id, agg->name,
+                    consumer->name);
                 return -1;
             }
         }
@@ -3554,7 +3575,8 @@ validate_recursive_aggregate_consumers(const wl_plan_t *plan)
  * The second pass, validate_recursive_aggregate_consumers(), rejects a
  * further shape for a related reason (#1021); see the comment on it. */
 static int
-validate_recursive_aggregates(const wl_plan_t *plan)
+validate_recursive_aggregates(const wl_plan_t *plan,
+    struct wirelog_program *prog)
 {
     for (uint32_t s = 0; s < plan->stratum_count; s++) {
         const wl_plan_stratum_t *stratum = &plan->strata[s];
@@ -3577,12 +3599,18 @@ validate_recursive_aggregates(const wl_plan_t *plan)
                     "are non-monotone across fixpoint iteration",
                     wirelog_agg_fn_str(op->agg_fn), relation->name,
                     stratum->stratum_id);
+                set_plan_error(prog,
+                    "recursive aggregate '%s' is not supported in relation "
+                    "'%s' of stratum %u: count, sum and average are "
+                    "non-monotone across fixpoint iteration",
+                    wirelog_agg_fn_str(op->agg_fn), relation->name,
+                    stratum->stratum_id);
                 return -1;
             }
         }
     }
 
-    return validate_recursive_aggregate_consumers(plan);
+    return validate_recursive_aggregate_consumers(plan, prog);
 }
 
 void
@@ -3630,9 +3658,17 @@ wl_plan_free(wl_plan_t *plan)
 }
 
 int
-wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
+wl_plan_from_program(struct wirelog_program *prog, wl_plan_t **out)
 {
-    if (!prog || !out)
+    if (!prog)
+        return -1;
+
+    prog->plan_error[0] = '\0';
+    /* Every failure path has at least a bounded generic diagnostic; the
+     * validation failures below replace it with their actionable reason. */
+    set_plan_error(prog, "execution plan generation failed");
+
+    if (!out)
         return -1;
 
     *out = NULL;
@@ -4074,7 +4110,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
      * the same mistake got made once in #975 and again in #1019.  It has to
      * sit here, after plan_stratum_record_refs() above and before the four
      * rewrites below. */
-    if (validate_recursive_aggregates(plan) != 0) {
+    if (validate_recursive_aggregates(plan, prog) != 0) {
         wl_plan_free(plan);
         return -1;
     }
@@ -4090,6 +4126,7 @@ wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out)
     }
     rewrite_insert_exchanges(plan);
 
+    prog->plan_error[0] = '\0';
     *out = plan;
     return 0;
 }

--- a/wirelog/exec_plan_gen.h
+++ b/wirelog/exec_plan_gen.h
@@ -23,7 +23,9 @@ struct wirelog_program;
 
 /**
  * wl_plan_from_program:
- * @prog: Parsed, stratified program (must not be NULL).
+ * @prog: Parsed, stratified mutable program (must not be NULL).  The
+ *        generator records its latest bounded diagnostic on the program;
+ *        callers must serialize plan generation and diagnostic access.
  * @out:  (out) Pointer to the newly created execution plan on success.
  *
  * Convert a parsed+stratified wirelog_program_t into a wl_plan_t
@@ -47,7 +49,7 @@ struct wirelog_program;
  *      unrecognized IR node type).
  */
 int
-wl_plan_from_program(const struct wirelog_program *prog, wl_plan_t **out);
+wl_plan_from_program(struct wirelog_program *prog, wl_plan_t **out);
 
 /**
  * wl_plan_free:

--- a/wirelog/ir/api.c
+++ b/wirelog/ir/api.c
@@ -49,6 +49,14 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error)
     return wl_ir_parse_string_err(program_text, error, NULL, 0);
 }
 
+const char *
+wirelog_program_get_plan_error(const wirelog_program_t *program)
+{
+    if (!program || program->plan_error[0] == '\0')
+        return "";
+    return program->plan_error;
+}
+
 wirelog_program_t *
 wl_ir_parse_string_err(const char *program_text, wirelog_error_t *error,
     char *errbuf, size_t errcap)

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -193,6 +193,9 @@ struct wirelog_program {
      * program on the failure path, since this dies with the struct. */
     char parse_error[512];
 
+    /* Reason from the most recent execution-plan generation attempt. */
+    char plan_error[512];
+
     /* Symbol intern table (string -> int64 mapping) */
     wl_intern_t *intern;
 

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -155,6 +155,16 @@ wirelog_parse_string(const char *program_text, wirelog_error_t *error);
 WIRELOG_API void
 wirelog_program_free(wirelog_program_t *program);
 
+/**
+ * Return the reason from the most recent execution-plan generation attempt.
+ * The returned string is borrowed from @program until its next plan attempt
+ * or destruction; an empty string means no diagnostic is available.
+ * Program handles are not safe for concurrent plan generation and diagnostic
+ * access; callers must serialize those operations.
+ */
+WIRELOG_API const char *
+wirelog_program_get_plan_error(const wirelog_program_t *program);
+
 /* ======================================================================== */
 /* Symbol Interning                                                         */
 /* ======================================================================== */


### PR DESCRIPTION
## Summary\n- retain bounded execution-plan rejection diagnostics on parsed programs\n- expose the latest reason through an additive public getter and print it from the CLI\n- cover recursive count/sum and same-SCC min/max rejections at the default log level\n\nCloses #1137\n\n## Validation\n- meson test -C build wirelog:plan_gen wirelog:cli_parse_diagnostics --print-errorlogs\n- ABI suite: 36/36 passed\n- uncrustify checks and git diff --check