### PR TITLE
fix: preserve typed inline slot comparisons

### DIFF
--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -257,15 +257,14 @@ that destructures the column read it regardless:
 data. Rejecting is forced rather than chosen — `0` is a valid `int64` and a
 valid intern id, so no filler value could mean "not written".
 
-One thing a fact can do that an `.input` file cannot: put a **symbol** in an
-inline compound slot. `p(1, "aa", "bb").` against
+An inline compound fact can contain symbols. `p(1, "aa", "bb").` against
 `.decl p(id: int64, lbl: pair/2 inline)` works, and
-`o(a, b, c) :- p(a, pair(b, c)).` gives `o(1, "aa", "bb")`. The same three
-values in a CSV file fail the load, because the `.decl` grammar records one
-type per declared column and has no way to say that slot 1 of `lbl` is a
-symbol — so the loader types every inline slot as `int64` and the reader
-cannot parse `aa`. This is a gap in the `.input` path, not a property of the
-storage; the slots are ordinary `int64` cells and hold interned ids fine.
+`o(a, b, c) :- p(a, pair(b, c)).` gives `o(1, "aa", "bb")`. For `.input`, the
+legacy slash form keeps every slot at `int64`, so the same CSV values fail the
+load. Use the typed form, for example
+`.decl p(id: int64, lbl: pair(symbol, symbol) inline)`, to declare the slot
+types and let the loader intern the text fields. The slots remain ordinary
+`int64` cells; the declaration controls decoding and comparison semantics.
 
 The physical width is also the row stride reported by
 `wirelog_program_get_facts`. It agrees with the `column_count` of

--- a/docs/io-adapters.md
+++ b/docs/io-adapters.md
@@ -90,10 +90,11 @@ scalar, so the two numbers agree for every relation that declares no inline
 compound column.
 
 `wirelog_io_ctx_col_type(ctx, i)` is indexed by the same physical position:
-`i` runs over slots, not over declared columns. Each slot of an inline
-compound reports `WIRELOG_TYPE_INT64`, because the slots carry raw `int64`
-payload and the declared type of the compound column does not describe them.
-For the relation above the types are `INT64, INT64, INT64, STRING`.
+`i` runs over slots, not over declared columns. Legacy slash declarations
+report `WIRELOG_TYPE_INT64` for each inline slot because no per-slot type was
+given. The typed form, such as `pair(symbol, int64) inline`, reports the
+declared type for each slot; for the relation above, if `p` uses that form,
+the types are `INT64, STRING, INT64, STRING`.
 
 Before #985 both accessors reported the *declared* column count and the
 declared per-column types, which named a stride the storage does not use. The

--- a/tests/test_symbol_ordering.c
+++ b/tests/test_symbol_ordering.c
@@ -603,6 +603,39 @@ test_inline_compound_relation(void)
     PASS();
 }
 
+static void
+test_typed_inline_slot_ordering(void)
+{
+    TEST("explicit inline slot types drive string ordering");
+
+    const char *src =
+        ".decl ev(id: int64, lbl: pair(symbol, symbol) inline)\n"
+        "ev(1, \"zz\", \"aa\").\n"
+        "ev(2, \"aa\", \"zz\").\n"
+        ".decl out(a: symbol, b: symbol)\n"
+        "out(a, b) :- ev(i, pair(a, b)), a < b.\n";
+    collect_t c;
+    ASSERT(eval_relation(src, "out", &c) == 0, "evaluation failed");
+    ASSERT(c.count == 1, "expected exactly one ordered pair");
+    ASSERT(saw(&c, "aa|zz"),
+        "explicit inline symbol slots must compare lexicographically");
+    ASSERT(!saw(&c, "zz|aa"),
+        "inline slot comparison must not use intern-id ordering");
+
+    const char *mixed_src =
+        ".decl mixed(prefix: int64, lbl: pair(symbol, int64) inline, "
+        "suffix: int64)\n"
+        "mixed(1, \"zz\", 5, 10).\n"
+        "mixed(2, \"aa\", 6, 11).\n"
+        ".decl mixed_out(a: symbol)\n"
+        "mixed_out(a) :- mixed(i, pair(a, n), s), a < \"zz\".\n";
+    ASSERT(eval_relation(mixed_src, "mixed_out", &c) == 0,
+        "mixed inline-slot evaluation failed");
+    ASSERT(c.count == 1 && saw(&c, "aa"),
+        "slot types must use logical stride with a scalar before the compound");
+    PASS();
+}
+
 int
 main(void)
 {
@@ -617,6 +650,7 @@ main(void)
     test_string_function_results_order_lexicographically();
     test_types_survive_the_column_layout_operators();
     test_inline_compound_relation();
+    test_typed_inline_slot_ordering();
 
     printf("\n--- Results: %d/%d passed", pass_count, test_count);
     if (fail_count > 0)

--- a/wirelog/io/io_ctx.c
+++ b/wirelog/io/io_ctx.c
@@ -59,29 +59,16 @@ wirelog_io_ctx_create_for_relation(const wl_ir_relation_info_t *rel,
          * or a trailing `symbol` lands on an inline slot and the file is
          * read under the wrong types.
          *
-         * Each inline slot is pinned to WIRELOG_TYPE_INT64, which is a
-         * CHOICE about this path and not a fact about the storage.  The
-         * slots are ordinary int64 cells and hold interned string ids
-         * perfectly well: `p(1, "aa", "bb").` against
-         * `.decl p(id: int64, lbl: pair/2 inline)` with
-         * `o(a,b,c) :- p(a, pair(b,c)).` evaluates to o(1, "aa", "bb") in
-         * this same release, through the fact path.  The `.input` path
-         * cannot do that, and the reason is a missing input, not a property
-         * of the layout: the grammar records one type per *declared* column
-         * (`rel->columns[i].type`, which for any `functor/arity` spelling is
-         * just WIRELOG_TYPE_INT64 -- see type_name_to_column_type() in
-         * ir/program.c), so there is nowhere to say that slot 1 of `lbl` is
-         * a symbol and slot 2 an integer.  Absent per-slot types, int64 is
-         * the only defensible default.
+         * Legacy slash declarations keep every inline slot at INT64.  An
+         * explicit declaration such as `pair(symbol, int64) inline` carries
+         * its per-slot types in rel->slot_types, so the input path can load
+         * interned symbols as well as numeric cells.  The slots remain
+         * ordinary int64 storage; the type only selects how the adapter
+         * decodes and renders each value.
          *
-         * Consequence, stated as the limitation it is: a symbol cannot be
-         * loaded into an inline compound slot from an `.input` file.  The
-         * 3-field CSV matching the fact above fails the load outright --
-         * "adapter 'csv' failed to read data" -- because the integer-only
-         * reader cannot parse "aa".  It fails loudly rather than
-         * fabricating, which is the right failure, but it is still a gap.
-         * Lifting it needs per-slot compound types in the `.decl` grammar;
-         * a follow-up issue tracks that. */
+         * An untyped slash declaration still rejects symbolic input, because
+         * its all-INT64 contract gives the adapter no authority to intern a
+         * text field. */
         uint32_t k = 0;
         for (uint32_t i = 0; i < rel->column_count; i++) {
             if (rel->columns[i].compound_kind

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -585,6 +585,12 @@ collect_decl(struct wirelog_program *prog,
         }
     }
 
+    if (rel->column_count > 0 && !rel->columns) {
+        wl_ir_program_set_error(prog,
+            "missing column metadata for relation '%s'", decl_node->name);
+        return -1;
+    }
+
     uint32_t physical_offset = 0;
     for (uint32_t i = 0; i < rel->column_count; i++) {
         wirelog_column_t *col = &rel->columns[i];

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -265,6 +265,7 @@ relation_info_free(wl_ir_relation_info_t *info)
         free(info->columns);
     }
     free(info->slot_types); /* Issue #1037 */
+    free(info->slot_type_declared);
     if (info->input_param_names) {
         for (uint32_t i = 0; i < info->input_param_count; i++) {
             free(info->input_param_names[i]);
@@ -481,19 +482,23 @@ collect_decl(struct wirelog_program *prog,
         }
     }
 
+    /* Issue #724: a second .decl for the same relation overwrites the
+     * columns array.  Reset it even for `.decl r()` so no stale columns or
+     * per-slot metadata survive a zero-column redeclaration. */
+    if (rel->columns) {
+        for (uint32_t i = 0; i < rel->column_count; i++)
+            free((char *)rel->columns[i].name);
+        free(rel->columns);
+        rel->columns = NULL;
+        rel->column_count = 0;
+    }
+    free(rel->slot_types);
+    free(rel->slot_type_declared);
+    rel->slot_types = NULL;
+    rel->slot_type_declared = NULL;
+    rel->slot_type_count = 0;
+
     if (col_count > 0) {
-        /* Issue #724: a second .decl for the same relation overwrites the
-         * columns array.  Free any prior allocation so the per-column
-         * name strings and the array itself do not leak when programs
-         * are assembled by concatenating templates that share a
-         * declaration. */
-        if (rel->columns) {
-            for (uint32_t i = 0; i < rel->column_count; i++)
-                free((char *)rel->columns[i].name);
-            free(rel->columns);
-            rel->columns = NULL;
-            rel->column_count = 0;
-        }
         rel->columns
             = (wirelog_column_t *)calloc(col_count, sizeof(wirelog_column_t));
         if (!rel->columns)
@@ -533,18 +538,32 @@ collect_decl(struct wirelog_program *prog,
                 if (meta.has_slot_types
                     && meta.kind == WIRELOG_COMPOUND_KIND_INLINE) {
                     if (!rel->slot_types) {
-                        rel->slot_types = (wirelog_column_type_t *)calloc(
-                            (size_t)rel->column_count * 4,
-                            sizeof(wirelog_column_type_t));
-                        rel->slot_type_count = rel->slot_types
-                            ? rel->column_count * 4 : 0;
+                        wirelog_column_type_t *slot_types
+                            = (wirelog_column_type_t *)calloc(
+                                (size_t)rel->column_count * 4,
+                                sizeof(wirelog_column_type_t));
+                        bool *slot_type_declared = (bool *)calloc(
+                            (size_t)rel->column_count * 4, sizeof(bool));
+                        if (!slot_types || !slot_type_declared) {
+                            free(slot_types);
+                            free(slot_type_declared);
+                            wl_ir_program_set_error(prog,
+                                "allocation failed for inline slot types "
+                                "in relation '%s'", decl_node->name);
+                            return -1;
+                        }
+                        rel->slot_types = slot_types;
+                        rel->slot_type_declared = slot_type_declared;
+                        rel->slot_type_count = rel->column_count * 4;
                         for (uint32_t z = 0; z < rel->slot_type_count; z++)
                             rel->slot_types[z] = WIRELOG_TYPE_INT64;
                     }
-                    if (rel->slot_types
+                    if (rel->slot_types && rel->slot_type_declared
                         && (idx * 4 + meta.arity) <= rel->slot_type_count) {
-                        for (uint32_t si = 0; si < meta.arity; si++)
+                        for (uint32_t si = 0; si < meta.arity; si++) {
                             rel->slot_types[idx * 4 + si] = meta.slot_types[si];
+                            rel->slot_type_declared[idx * 4 + si] = true;
+                        }
                     }
                 }
 
@@ -1489,10 +1508,11 @@ compound_arg_functor_matches(const wl_parser_ast_node_t *arg,
 /*
  * The comparison lattice value of logical column @logical_idx, or UNKNOWN
  * when the relation was never declared, was declared with fewer columns than
- * the atom uses, or the column is a compound.  Compound columns carry no
- * meaningful `type`: type_name_to_column_type() does not recognise
- * "pair/2 inline" and falls through to its INT32 default, so reporting that
- * would be reporting a parser artifact as a declaration (Issue #962).
+ * the atom uses, or the column is a compound without explicit slot types.
+ * Compound columns carry no useful top-level `type`: type_name_to_column_type()
+ * does not recognise "pair/2 inline" and falls through to its INT32 default,
+ * so reporting that would be reporting a parser artifact as a declaration
+ * (Issue #962).
  */
 static wl_ir_coltype_t
 declared_coltype(const wl_ir_relation_info_t *rel_info, uint32_t logical_idx)
@@ -1504,6 +1524,21 @@ declared_coltype(const wl_ir_relation_info_t *rel_info, uint32_t logical_idx)
     if (col->compound_kind != WIRELOG_COMPOUND_KIND_NONE)
         return WL_IR_COLTYPE_UNKNOWN;
     return wl_ir_coltype_from_column_type(col->type);
+}
+
+static wl_ir_coltype_t
+declared_inline_slot_coltype(const wl_ir_relation_info_t *rel_info,
+    uint32_t logical_idx, uint32_t slot_idx)
+{
+    if (!rel_info || !rel_info->slot_types || !rel_info->slot_type_declared
+        || logical_idx >= rel_info->column_count || slot_idx >= 4)
+        return WL_IR_COLTYPE_UNKNOWN;
+
+    uint32_t index = logical_idx * 4u + slot_idx;
+    if (index >= rel_info->slot_type_count
+        || !rel_info->slot_type_declared[index])
+        return WL_IR_COLTYPE_UNKNOWN;
+    return wl_ir_coltype_from_column_type(rel_info->slot_types[index]);
 }
 
 static uint32_t
@@ -2108,10 +2143,12 @@ build_atom_scan(const wl_parser_ast_node_t *atom,
                     scan->column_names[phys_idx] = NULL;
                     var_names[phys_idx] = NULL;
                 }
-                /* A declaration names the functor and arity of an inline
-                 * compound but not the types of its arguments, so these
-                 * slots genuinely have no declared type. */
-                scan->column_types[phys_idx] = WL_IR_COLTYPE_UNKNOWN;
+                /* Legacy functor/arity declarations remain UNKNOWN, while
+                 * #1037's explicit per-slot types reach comparison planning.
+                 * The metadata uses logical-column stride (col*4+slot),
+                 * whereas phys_idx is the packed physical position. */
+                scan->column_types[phys_idx]
+                    = declared_inline_slot_coltype(rel_info, i, c);
                 phys_idx++;
             }
         } else if (rel_info && i < rel_info->column_count

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -39,6 +39,7 @@ typedef struct {
      * layout break rather than a manifest update.  A side array keeps the
      * ABI still, the same shape as plan->edb_declared_width (#1038). */
     wirelog_column_type_t *slot_types;
+    bool *slot_type_declared;
     uint32_t slot_type_count;
     uint32_t column_count;
     /* Issue #977: true once a `.decl` for this relation has been collected.


### PR DESCRIPTION
## Summary
- preserve explicit #1037 inline compound slot types when building IR scans
- keep legacy functor/arity declarations on the existing UNKNOWN/integer fallback
- reset slot metadata safely on redeclaration and document typed versus legacy input behavior

Closes #1130

## Validation
- meson test -C build wirelog:symbol_ordering wirelog:program_oom wirelog:inline_slot_types
- uncrustify checks
- git diff --check