### PR TITLE
fix: harden clang-tidy ratchet execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,8 @@ git add -u' > .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
 
-See [docs/LINTING.md](docs/LINTING.md) for complete linting documentation, check rationale, and rollout plan.
+See the [clang-tidy Ratchet](CLAUDE.md#clang-tidy-ratchet-issue-1100) section
+and the ratchet registers under `scripts/ci/` for linting policy and checks.
 
 ### Perf-suite gate for heap-touching edits
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -4,7 +4,7 @@ This document is the **canonical procedure for cutting a wirelog
 release tag and publishing the release notes that accompany it**.
 It is the operational counterpart of:
 
-- `CONTRIBUTING.md` — Changelog Conventions (the per-PR rules).
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — Changelog Conventions (the per-PR rules).
 - `CHANGELOG.md` — the source-of-truth changelog.
 - `docs/MIGRATION.md` — version-to-version migration recipes.
 - `docs/SECURITY_MODEL.md` — vulnerability-disclosure policy.

--- a/scripts/ci/check-clang-tidy-backlog-monotonic.sh
+++ b/scripts/ci/check-clang-tidy-backlog-monotonic.sh
@@ -132,7 +132,9 @@ if [ -n "$added" ]; then
          "$backlog_rel relative to the merge base with $base_ref" \
          "($merge_base):" >&2
     echo "" >&2
-    printf '  %s\n' $added >&2
+    while IFS= read -r entry; do
+        printf '  %s\n' "$entry"
+    done <<< "$added" >&2
     echo "" >&2
     echo "The backlog may only shrink. Fix the source before adding it to" >&2
     echo "the register; new translation units must enter the allowlist clean." >&2

--- a/scripts/ci/check-clang-tidy-ratchet.py
+++ b/scripts/ci/check-clang-tidy-ratchet.py
@@ -83,6 +83,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from collections import Counter
 
 SKIP_EXIT = 77
 
@@ -177,6 +178,30 @@ def entry_source(entry: dict) -> pathlib.Path:
     return (pathlib.Path(entry["directory"]) / entry["file"]).resolve()
 
 
+LAUNCHERS = {"ccache", "sccache", "distcc", "icecc", "gomacc"}
+
+
+def command_basename(token: str) -> str:
+    """Normalize POSIX and Windows-style executable paths in a command."""
+    return token.replace("\\", "/").rsplit("/", 1)[-1].lower()
+
+
+def compiler_name(tokens: list[str]) -> str:
+    """Return the compiler after any supported compiler-cache launcher."""
+    for token in tokens:
+        name = command_basename(token)
+        if name in LAUNCHERS:
+            continue
+        return name
+    return ""
+
+
+def is_msvc_command(tokens: list[str]) -> bool:
+    """Recognize direct or launcher-wrapped cl.exe command lines."""
+    return any(command_basename(token) in ("cl", "cl.exe")
+               for token in tokens)
+
+
 def select_entries(build_dir: pathlib.Path) -> list[dict]:
     """Pick one canonical entry per libwirelog.so translation unit."""
     db_path = build_dir / "compile_commands.json"
@@ -224,7 +249,45 @@ def prune_db(entries: list[dict], workdir: pathlib.Path) -> pathlib.Path:
     """
     db_path = workdir / "compile_commands.json"
     db_path.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+    try:
+        written = json.loads(db_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise GateError(f"cannot validate pruned compilation database: {exc}") \
+            from exc
+    expected_sources = {entry_source(entry) for entry in entries}
+    written_sources = {entry_source(entry) for entry in written}
+    duplicates = sorted(source for source, count in
+                        Counter(entry_source(entry) for entry in written).items()
+                        if count != 1)
+    if duplicates:
+        raise GateError("pruned compilation database has duplicate target(s): "
+                        + ", ".join(rel_to_repo(path) for path in duplicates))
+    missing = sorted(expected_sources - written_sources)
+    if missing:
+        raise GateError("pruned compilation database is missing target(s): "
+                        + ", ".join(rel_to_repo(path) for path in missing))
     return db_path
+
+
+def validate_pruned_db(db_dir: pathlib.Path, entries: list[dict]) -> None:
+    """Ensure every target has a real compile command before clang-tidy runs."""
+    db_path = db_dir / "compile_commands.json"
+    try:
+        database = json.loads(db_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise GateError(f"cannot read pruned compilation database {db_path}: "
+                        f"{exc}") from exc
+    available = {entry_source(entry) for entry in database}
+    duplicates = sorted(source for source, count in
+                        Counter(entry_source(entry) for entry in database).items()
+                        if count != 1)
+    if duplicates:
+        raise GateError("pruned compilation database has duplicate target(s): "
+                        + ", ".join(rel_to_repo(path) for path in duplicates))
+    missing = sorted({entry_source(entry) for entry in entries} - available)
+    if missing:
+        raise GateError("pruned compilation database is missing target(s): "
+                        + ", ".join(rel_to_repo(path) for path in missing))
 
 
 # ---------------------------------------------------------------------------
@@ -377,8 +440,7 @@ def check_configuration(entries: list[dict]) -> None:
                     f"({token} on {rel_to_repo(entry_source(entry))}); the "
                     "allowlist was calibrated against an uninstrumented "
                     "default build")
-        compiler = pathlib.PurePath(tokens[0]).name.lower() if tokens else ""
-        if compiler in ("cl", "cl.exe"):
+        if is_msvc_command(tokens):
             raise SkipGate("the database records MSVC-style command lines, "
                            "which clang-tidy cannot consume as-is")
 
@@ -521,6 +583,7 @@ def job_count() -> int:
 
 def run_all(exe: str, db_dir: pathlib.Path,
             entries: list[dict]) -> list[Result]:
+    validate_pruned_db(db_dir, entries)
     jobs = job_count()
     with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
         futures = [pool.submit(run_clang_tidy, exe, db_dir, entry)

--- a/tests/test_clang_tidy_ratchet_guards.py
+++ b/tests/test_clang_tidy_ratchet_guards.py
@@ -2,6 +2,7 @@
 """Unit tests for the clang-tidy ratchet's fail-closed guards."""
 
 import importlib.util
+import json
 import pathlib
 import re
 import tempfile
@@ -36,6 +37,34 @@ class RatchetGuardTests(unittest.TestCase):
         self.assertEqual(RATCHET.check_version("clang-tidy", False), "99")
         with self.assertRaises(RATCHET.SkipGate):
             RATCHET.check_version("clang-tidy", True)
+
+    def test_launcher_aware_compiler_detection(self):
+        for launcher in ("ccache", "sccache", "distcc", "icecc"):
+            self.assertEqual(
+                RATCHET.compiler_name([launcher, "/usr/bin/clang"]),
+                "clang")
+        self.assertEqual(
+            RATCHET.compiler_name(["C:\\tools\\cl.exe", "/c"]), "cl.exe")
+        self.assertEqual(
+            RATCHET.compiler_name(["/usr/bin/ccache", "/usr/bin/cc"]), "cc")
+        self.assertTrue(RATCHET.is_msvc_command(
+            ["ccache", "--direct", "C:\\tools\\cl.exe", "/c"]))
+        self.assertFalse(RATCHET.is_msvc_command(
+            ["sccache", "--start-server", "/usr/bin/clang", "-c"]))
+
+    def test_pruned_database_requires_each_target_once(self):
+        entry = {"directory": str(ROOT), "file": "wirelog/example.c"}
+        with tempfile.TemporaryDirectory() as temp:
+            directory = pathlib.Path(temp)
+            database = directory / "compile_commands.json"
+            database.write_text(json.dumps([entry]), encoding="utf-8")
+            RATCHET.validate_pruned_db(directory, [entry])
+            database.write_text(json.dumps([]), encoding="utf-8")
+            with self.assertRaises(RATCHET.GateError):
+                RATCHET.validate_pruned_db(directory, [entry])
+            database.write_text(json.dumps([entry, entry]), encoding="utf-8")
+        with self.assertRaises(RATCHET.GateError):
+            RATCHET.validate_pruned_db(directory, [entry])
 
     def test_config_values_are_compared_but_user_is_ignored(self):
         baseline = RATCHET.normalized_config_lines(


### PR DESCRIPTION
## Summary
- verify every ratchet target appears exactly once in the pruned compile database
- detect launcher-wrapped MSVC commands and preserve wrapped compiler handling
- fix stale documentation links and whitespace-unsafe backlog diagnostics

Closes #1116

## Validation
- uv venv .venv; python -m unittest tests/test_clang_tidy_ratchet_guards.py
- python -m py_compile scripts/ci/check-clang-tidy-ratchet.py
- bash -n scripts/ci/check-clang-tidy-backlog-monotonic.sh
- git diff --check