### PR TITLE
ci: tolerate delayed CLA status publication

### DIFF
--- a/.github/workflows/cla-required.yml
+++ b/.github/workflows/cla-required.yml
@@ -23,15 +23,31 @@ jobs:
         run: |
           set -euo pipefail
 
-          attempts=12
+          # CLA Assistant publishes the hosted status asynchronously. Keep
+          # this bounded, but allow the provider roughly five minutes to
+          # publish it before failing closed.
+          attempts=31
           interval=10
+          overall_timeout=300
+          max_request_timeout=10
+          deadline=$((SECONDS + overall_timeout))
           status_url="https://api.github.com/repos/${REPOSITORY}/commits/${HEAD_SHA}/status"
 
           echo "Checking ${CLA_CONTEXT} on PR head SHA ${HEAD_SHA}."
 
           for attempt in $(seq 1 "$attempts"); do
+            remaining=$((deadline - SECONDS))
+            if [ "$remaining" -le 0 ]; then
+              break
+            fi
+            request_timeout="$remaining"
+            if [ "$request_timeout" -gt "$max_request_timeout" ]; then
+              request_timeout="$max_request_timeout"
+            fi
             response="$(
               curl --fail --silent --show-error --location \
+                --connect-timeout "$request_timeout" \
+                --max-time "$request_timeout" \
                 --header "Accept: application/vnd.github+json" \
                 --header "Authorization: Bearer ${GH_TOKEN}" \
                 --header "X-GitHub-Api-Version: 2022-11-28" \
@@ -77,9 +93,16 @@ jobs:
             esac
 
             if [ "$attempt" -lt "$attempts" ]; then
-              sleep "$interval"
+              remaining=$((deadline - SECONDS))
+              if [ "$remaining" -gt 0 ]; then
+                sleep_for="$interval"
+                if [ "$sleep_for" -gt "$remaining" ]; then
+                  sleep_for="$remaining"
+                fi
+                sleep "$sleep_for"
+              fi
             fi
           done
 
-          echo "::error::Timed out waiting for ${CLA_CONTEXT} to report success on ${HEAD_SHA}; latest state was ${cla_state}."
+          echo "::error::Timed out after ${overall_timeout}s (maximum ${attempts} attempts at ${interval}s intervals; request timeout capped at ${max_request_timeout}s) waiting for ${CLA_CONTEXT} to report success on ${HEAD_SHA}; latest state was ${cla_state}."
           exit 1

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -345,6 +345,15 @@ synthetic PR targeting `1.0` and verify:
 4. Merge is blocked while any required check is failing or pending.
 5. Linear-history and signed-commit constraints are enforced.
 
+The repository-owned `CLA signoff gate` polls for a bounded 300-second window,
+with each API request capped at 10 seconds, for the hosted `license/cla` status
+to appear on the exact PR head SHA. This bounded grace period covers normal
+asynchronous publication delays; it does not treat a missing or pending status
+as success. If the status is still missing or pending after the deadline, the
+gate fails closed and the workflow must be rerun after the hosted status is
+published. An explicit `failure` or `error` status continues to fail
+immediately.
+
 Phase B prerequisites for final #746 acceptance are not fully present in
 this repository state yet: `CODEOWNERS` and the always-emitting
 `CLA signoff gate` workflow are present, but final synthetic PR


### PR DESCRIPTION
## Summary
- tolerate delayed `license/cla` publication with a bounded 300-second deadline
- cap each status request and sleep by the remaining deadline
- preserve fail-closed behavior for missing/pending timeout and explicit failures
- document the retry contract and manual rerun recovery

## Validation
- `actionlint .github/workflows/cla-required.yml`
- `git diff --check`

Closes #1218