### PR TITLE
ci: use stable anchors for threading audit citations

### DIFF
--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -230,34 +230,34 @@ Every `atomic_*` call site in `wirelog/` production sources. Counted
 mechanically by `scripts/ci/check-threading-doc.sh`; row count must
 match the script's count (currently **44**).
 
-Format: `file:line` | field | operation | order | justification.
+Format: `file:function[#N]` | field | operation | order | justification.
 
 ### 5.1 `wirelog/columnar/mem_ledger.c` — accounting (22 rows)
 
-| `file:line` | Field | Op | Order | Justification |
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `mem_ledger.c:73` | `*peak_atom` (subsys or global) | `atomic_load_explicit` | `relaxed` | Read-current for monotone peak-update CAS loop; no happens-before edge required |
-| `mem_ledger.c:75` | `*peak_atom` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Monotone high-water bump; if another thread won, retry; observed values are non-decreasing |
-| `mem_ledger.c:94` | `ledger->total_budget` | `atomic_store_explicit` | `relaxed` | Set-once at init; readers see the value eventually via per-counter relaxed loads |
-| `mem_ledger.c:108` | `ledger->subsys_bytes[subsys]` | `atomic_fetch_add_explicit` | `relaxed` | Per-subsystem counter; ordering of distinct subsystems is independent |
-| `mem_ledger.c:114` | `ledger->current_bytes` | `atomic_fetch_add_explicit` | `relaxed` | Aggregate accounting counter; per-allocator skew is tolerated |
-| `mem_ledger.c:133` | `ledger->subsys_bytes[subsys]` | `atomic_load_explicit` | `relaxed` | Read-current for clamp-to-zero free path |
-| `mem_ledger.c:138` | `ledger->subsys_bytes[subsys]` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Clamp-to-zero CAS loop; loss-of-race retries |
-| `mem_ledger.c:145` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Read-current for clamp-to-zero free path |
-| `mem_ledger.c:150` | `ledger->current_bytes` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Clamp-to-zero CAS loop |
-| `mem_ledger.c:162` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Query path; no edge required |
-| `mem_ledger.c:166` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Query path |
-| `mem_ledger.c:176` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Query path |
-| `mem_ledger.c:180` | `ledger->subsys_bytes[subsys]` | `atomic_load_explicit` | `relaxed` | Query path |
-| `mem_ledger.c:192` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Query path |
-| `mem_ledger.c:198` | `ledger->subsys_bytes[subsys]` | `atomic_load_explicit` | `relaxed` | Query path |
-| `mem_ledger.c:210` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Snapshot path |
-| `mem_ledger.c:214` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Snapshot path |
-| `mem_ledger.c:227` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Reporter path |
-| `mem_ledger.c:229` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Reporter path |
-| `mem_ledger.c:231` | `ledger->peak_bytes` | `atomic_load_explicit` | `relaxed` | Reporter path |
-| `mem_ledger.c:240` | `ledger->subsys_bytes[i]` | `atomic_load_explicit` | `relaxed` | Reporter per-subsys path |
-| `mem_ledger.c:242` | `ledger->subsys_peak[i]` | `atomic_load_explicit` | `relaxed` | Reporter per-subsys path |
+| `mem_ledger.c:update_peak` | `*peak_atom` (subsys or global) | `atomic_load_explicit` | `relaxed` | Read-current for monotone peak-update CAS loop; no happens-before edge required |
+| `mem_ledger.c:update_peak` | `*peak_atom` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Monotone high-water bump; if another thread won, retry; observed values are non-decreasing |
+| `mem_ledger.c:wl_mem_ledger_init` | `ledger->total_budget` | `atomic_store_explicit` | `relaxed` | Set-once at init; readers see the value eventually via per-counter relaxed loads |
+| `mem_ledger.c:wl_mem_ledger_alloc` | `ledger->subsys_bytes[subsys]` | `atomic_fetch_add_explicit` | `relaxed` | Per-subsystem counter; ordering of distinct subsystems is independent |
+| `mem_ledger.c:wl_mem_ledger_alloc#2` | `ledger->current_bytes` | `atomic_fetch_add_explicit` | `relaxed` | Aggregate accounting counter; per-allocator skew is tolerated |
+| `mem_ledger.c:wl_mem_ledger_free` | `ledger->subsys_bytes[subsys]` | `atomic_load_explicit` | `relaxed` | Read-current for clamp-to-zero free path |
+| `mem_ledger.c:wl_mem_ledger_free` | `ledger->subsys_bytes[subsys]` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Clamp-to-zero CAS loop; loss-of-race retries |
+| `mem_ledger.c:wl_mem_ledger_free#2` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Read-current for clamp-to-zero free path |
+| `mem_ledger.c:wl_mem_ledger_free#2` | `ledger->current_bytes` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Clamp-to-zero CAS loop |
+| `mem_ledger.c:wl_mem_ledger_over_budget` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Query path; no edge required |
+| `mem_ledger.c:wl_mem_ledger_over_budget#2` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Query path |
+| `mem_ledger.c:wl_mem_ledger_subsys_over_budget` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Query path |
+| `mem_ledger.c:wl_mem_ledger_subsys_over_budget#2` | `ledger->subsys_bytes[subsys]` | `atomic_load_explicit` | `relaxed` | Query path |
+| `mem_ledger.c:wl_mem_ledger_should_backpressure` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Query path |
+| `mem_ledger.c:wl_mem_ledger_should_backpressure#2` | `ledger->subsys_bytes[subsys]` | `atomic_load_explicit` | `relaxed` | Query path |
+| `mem_ledger.c:wl_mem_ledger_bytes_remaining` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Snapshot path |
+| `mem_ledger.c:wl_mem_ledger_bytes_remaining#2` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Snapshot path |
+| `mem_ledger.c:wl_mem_ledger_report` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Reporter path |
+| `mem_ledger.c:wl_mem_ledger_report#2` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Reporter path |
+| `mem_ledger.c:wl_mem_ledger_report#3` | `ledger->peak_bytes` | `atomic_load_explicit` | `relaxed` | Reporter path |
+| `mem_ledger.c:wl_mem_ledger_report#4` | `ledger->subsys_bytes[i]` | `atomic_load_explicit` | `relaxed` | Reporter per-subsys path |
+| `mem_ledger.c:wl_mem_ledger_report#5` | `ledger->subsys_peak[i]` | `atomic_load_explicit` | `relaxed` | Reporter per-subsys path |
 
 The ledger's design accepts **accounting skew** between
 `current_bytes` and the sum of `subsys_bytes[]`; this is documented in
@@ -266,12 +266,12 @@ The ledger's design accepts **accounting skew** between
 
 ### 5.2 `wirelog/util/lockfree_queue.c` — SPSC ring buffer (4 rows)
 
-| `file:line` | Field | Op | Order | Justification |
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `lockfree_queue.c:50` | (macro `WL_ATOMIC_LOAD_RELAXED`) | `atomic_load_explicit` | `relaxed` | Producer reading its own `tail` cursor / consumer reading own `head` cursor (no synchronization edge needed for own cursor) |
-| `lockfree_queue.c:52` | (macro `WL_ATOMIC_LOAD_ACQUIRE`) | `atomic_load_explicit` | `acquire` | Producer reading consumer's `head` cursor (or vice versa) to determine free slots; pairs with peer's release-store and acquires every slot the peer published |
-| `lockfree_queue.c:54` | (macro `WL_ATOMIC_STORE_RELAXED`) | `atomic_store_explicit` | `relaxed` | Producer writing its own `tail` (or consumer writing own `head`) **when no slot is being published** in the same step |
-| `lockfree_queue.c:56` | (macro `WL_ATOMIC_STORE_RELEASE`) | `atomic_store_explicit` | `release` | Producer publishing a new slot (writes `slots[i]` then `tail`); the release ordering ensures the consumer that acquire-loads `tail` sees the slot contents |
+| `lockfree_queue.c:WL_ATOMIC_LOAD_RELAXED` | (macro `WL_ATOMIC_LOAD_RELAXED`) | `atomic_load_explicit` | `relaxed` | Producer reading its own `tail` cursor / consumer reading own `head` cursor (no synchronization edge needed for own cursor) |
+| `lockfree_queue.c:WL_ATOMIC_LOAD_ACQUIRE` | (macro `WL_ATOMIC_LOAD_ACQUIRE`) | `atomic_load_explicit` | `acquire` | Producer reading consumer's `head` cursor (or vice versa) to determine free slots; pairs with peer's release-store and acquires every slot the peer published |
+| `lockfree_queue.c:WL_ATOMIC_STORE_RELAXED` | (macro `WL_ATOMIC_STORE_RELAXED`) | `atomic_store_explicit` | `relaxed` | Producer writing its own `tail` (or consumer writing own `head`) **when no slot is being published** in the same step |
+| `lockfree_queue.c:WL_ATOMIC_STORE_RELEASE` | (macro `WL_ATOMIC_STORE_RELEASE`) | `atomic_store_explicit` | `release` | Producer publishing a new slot (writes `slots[i]` then `tail`); the release ordering ensures the consumer that acquire-loads `tail` sees the slot contents |
 
 The 64-byte padding between `tail` and `head`
 (`lockfree_queue.c:69-81`) prevents false sharing; without it the
@@ -280,10 +280,10 @@ throughput by 2-10x.
 
 ### 5.3 `wirelog/io/io_adapter.c` — one-shot init gate (2 rows)
 
-| `file:line` | Field | Op | Order | Justification |
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `io_adapter.c:88` | `s_mutex_init_ok` | `atomic_store` | `seq_cst` (default) | One-shot mutex-init publish; the bare API used here gives sequential consistency which is the strongest order and safe for an init publisher |
-| `io_adapter.c:112` | `s_mutex_init_ok` | `atomic_load` | `seq_cst` (default) | Pairs with the init publish; gates all later mutex operations |
+| `io_adapter.c:init_mutex` | `s_mutex_init_ok` | `atomic_store` | `seq_cst` (default) | One-shot mutex-init publish; the bare API used here gives sequential consistency which is the strongest order and safe for an init publisher |
+| `io_adapter.c:ensure_builtins` | `s_mutex_init_ok` | `atomic_load` | `seq_cst` (default) | Pairs with the init publish; gates all later mutex operations |
 
 This is the only site in `wirelog/` that uses the **non-explicit**
 atomic APIs (`atomic_load`/`atomic_store`); they default to
@@ -292,24 +292,24 @@ once and the surrounding overhead dominates.
 
 ### 5.4 `wirelog/columnar/join.c` — keyed-join cancel/budget (10 rows)
 
-| `file:line` | Field | Op | Order | Justification |
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `join.c:151` | `sess->join_output_shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Tuple-budget accumulator across keyed-join workers; counter only |
-| `join.c:369` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll; eventual visibility is acceptable for cooperative cancel |
-| `join.c:377` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll |
-| `join.c:387` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
-| `join.c:392` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag — best-effort signal, **not a synchronization point**; readers may observe the previous value for a bounded period |
-| `join.c:402` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
-| `join.c:405` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag (see :392 note) |
-| `join.c:2010` | `stop` (local) | `atomic_load_explicit` | `relaxed` | Compaction-loop cancel poll |
-| `join.c:2031` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
-| `join.c:2033` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
+| `join.c:col_join_output_limit_reached` | `sess->join_output_shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Tuple-budget accumulator across keyed-join workers; counter only |
+| `join.c:col_join_keyed_count_worker_fn` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll; eventual visibility is acceptable for cooperative cancel |
+| `join.c:col_join_keyed_count_worker_fn#2` | `*ctx->stop` | `atomic_load_explicit` | `relaxed` | Cancellation poll |
+| `join.c:col_join_keyed_count_worker_fn` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
+| `join.c:col_join_keyed_count_worker_fn` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag — best-effort signal, **not a synchronization point**; readers may observe the previous value for a bounded period |
+| `join.c:col_join_keyed_count_worker_fn#2` | `*ctx->shared_count` | `atomic_fetch_add_explicit` | `relaxed` | Cross-worker counter increment |
+| `join.c:col_join_keyed_count_worker_fn#2` | `*ctx->stop` | `atomic_store_explicit` | `relaxed` | Cooperative cancel flag (see the preceding cancellation note) |
+| `join.c:wl_columnar_join_diff_op` | `stop` (local) | `atomic_load_explicit` | `relaxed` | Compaction-loop cancel poll |
+| `join.c:wl_columnar_join_diff_op#2` | `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
+| `join.c:wl_columnar_join_diff_op#3` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Backpressure poll; advisory, no edge required |
 
 ### 5.5 `wirelog/columnar/kfusion.c` — K-fusion shared counter (1 row)
 
-| `file:line` | Field | Op | Order | Justification |
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `kfusion.c:663` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:399`, which resets the TDD counter before `thread_create()` |
+| `kfusion.c:col_op_k_fusion` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:399`, which resets the TDD counter before `thread_create()` |
 
 The `stop` flag's `memory_order_relaxed` store is deliberate:
 cancellation is **cooperative**, not preemptive. A worker may observe
@@ -319,15 +319,15 @@ and the wasted work is bounded.
 
 ### 5.6 `wirelog/columnar/eval.c` — shared counter (1 row)
 
-| `file:line` | Field | Op | Order | Justification |
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `eval.c:399` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
+| `eval.c:wl_columnar_eval_nonrec_relation_parallel` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Reset before workers spawn; happens-before edge is provided by `thread_create()` itself |
 
 ### 5.7 `wirelog/columnar/session.c` — worker budget snapshot (1 row)
 
-| `file:line` | Field | Op | Order | Justification |
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `session.c:1499` | per-worker view of `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Worker session reads coordinator's budget snapshot; advisory, no edge required |
+| `session.c:col_worker_session_create` | per-worker view of `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Worker session reads coordinator's budget snapshot; advisory, no edge required |
 
 ### 5.8 `wirelog/intern.c` — shared symbol table (3 rows)
 
@@ -339,23 +339,22 @@ operations and a lock there costs more than the parallelism is worth.
 The three sites are the macro bodies; the call sites they serve are
 named in the justification.
 
-| `file:line` | Field | Op | Order | Justification |
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `intern.c:82` | `intern->count` | `atomic_load_explicit` | `acquire` | `WL_INTERN_LOAD_ACQUIRE`, used by `wl_intern_reverse`/`wl_intern_count`. Pairs with the release store below: an id below the observed count names a fully written entry, and the segment holding it is allocated and never moves |
-| `intern.c:84` | `intern->count` | `atomic_load_explicit` | `relaxed` | `WL_INTERN_LOAD_RELAXED`, used by `wl_intern_put`, `intern_resize` and `wl_intern_free`. The writer holds `intern->lock` (or, in `free`, has exclusive access), so no edge is needed |
-| `intern.c:86` | `intern->count` | `atomic_store_explicit` | `release` | `WL_INTERN_STORE_RELEASE`, used by `wl_intern_put` after the string and its segment pointer are written. Publishing the count first would let a lock-free reader dereference an unwritten slot |
+| `intern.c:WL_INTERN_LOAD_ACQUIRE` | `intern->count` | `atomic_load_explicit` | `acquire` | `WL_INTERN_LOAD_ACQUIRE`, used by `wl_intern_reverse`/`wl_intern_count`. Pairs with the release store below: an id below the observed count names a fully written entry, and the segment holding it is allocated and never moves |
+| `intern.c:WL_INTERN_LOAD_RELAXED` | `intern->count` | `atomic_load_explicit` | `relaxed` | `WL_INTERN_LOAD_RELAXED`, used by `wl_intern_put`, `intern_resize` and `wl_intern_free`. The writer holds `intern->lock` (or, in `free`, has exclusive access), so no edge is needed |
+| `intern.c:WL_INTERN_STORE_RELEASE` | `intern->count` | `atomic_store_explicit` | `release` | `WL_INTERN_STORE_RELEASE`, used by `wl_intern_put` after the string and its segment pointer are written. Publishing the count first would let a lock-free reader dereference an unwritten slot |
 
 ### 5.9 Total
 
 22 + 4 + 2 + 10 + 1 + 1 + 1 + 3 = **44 atomic call sites**.
 
-`scripts/ci/check-threading-doc.sh` extracts the same count from
-`grep -rE '(^|[^[:alnum:]_])atomic_(load|store|fetch_add|fetch_sub|fetch_or|fetch_and|fetch_xor|compare_exchange_weak|compare_exchange_strong|exchange|init|thread_fence)(_explicit)?[[:space:]]*\(' wirelog/ --include='*.c' --include='*.h'`
-minus the MSVC shim definitions in `mem_ledger.h:46-81` and
-`lockfree_queue.c:22-37`. It also resolves each audit row to a unique
-source file and logical (backslash-continued) line, checks the documented
-operation, and compares the resolved-row count with the source count. A
-mismatch or stale citation fails `meson test --suite abi:threading_doc`.
+`scripts/ci/check-threading-doc.sh` uses
+`scripts/ci/threading_doc_anchors.py` to discover the same source sites,
+ignoring comments, strings, and function-pointer declarations. Each audit
+row resolves to a unique `file:function[#N]` or macro anchor, checks the
+documented operation, and is compared against the complete source inventory.
+A mismatch or stale anchor fails `meson test --suite abi:threading_doc`.
 
 ---
 

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -1,233 +1,76 @@
 #!/usr/bin/env bash
-# check-threading-doc.sh - Issue #734 backstop.
-#
-# Asserts that the atomics audit table in `docs/THREADING.md` has one
-# row for every `atomic_*` call site in `wirelog/` production sources
-# (`.c` and `.h` under the project root, excluding MSVC shim
-# definitions in `mem_ledger.h` and the macro-definition block at the
-# top of `lockfree_queue.c`).
-#
-# A row is a line in `docs/THREADING.md` whose first cell starts with
-# a backtick-quoted file:line reference under `wirelog/`.  Rows are
-# pattern-matched as: `| \`file:line\` | ...`.
-#
-# Exit codes:
-#   0 - row count and every cited source location match the code.
-#   1 - mismatch (atomic_* added or removed; doc needs an audit
-#       refresh), an unresolved citation, or other hard failure.
-#
-# Intended to register under `meson test --suite abi:threading_doc`.
-
+# Verify the symbol-anchored atomics audit and preserve its exact inventory.
 set -euo pipefail
-
-tmp_dir=$(mktemp -d)
-trap 'rm -rf "$tmp_dir"' EXIT
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="${WIRELOG_THREADING_DOC_ROOT:-$(cd "$script_dir/../.." && pwd)}"
 doc="$repo_root/docs/THREADING.md"
+helper="$script_dir/threading_doc_anchors.py"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
 
-if [ ! -f "$doc" ]; then
-    echo "check-threading-doc: FAIL: docs/THREADING.md missing" >&2
-    exit 1
+[ -f "$doc" ] || { echo "check-threading-doc: FAIL: docs/THREADING.md missing" >&2; exit 1; }
+if command -v uv >/dev/null 2>&1; then
+    uv run python "$helper" "$repo_root" --dump >"$tmp_dir/inventory"
+else
+    python3 "$helper" "$repo_root" --dump >"$tmp_dir/inventory"
 fi
 
-# Count atomic_* call sites in wirelog/ production sources.
-# Restricted to .c and .h.  The MSVC shim block in mem_ledger.h
-# (lines containing `#define atomic_`) is excluded; ditto the
-# WL_ATOMIC_* macro definitions inside lockfree_queue.c (the
-# definitions are at lines 22-37 and 47-57; the actual atomic_*
-# tokens are inside the macro bodies and are the contract sites we
-# do want to count as "atomic operations on the SPSC ring").
-sites=$(grep -rEn '(^|[^[:alnum:]_])atomic_(load|store|fetch_add|fetch_sub|fetch_or|fetch_and|fetch_xor|compare_exchange_weak|compare_exchange_strong|exchange|init|thread_fence)(_explicit)?[[:space:]]*\(' \
-        "$repo_root/wirelog" \
-        --include='*.c' --include='*.h' \
-    | grep -v '#define atomic_' \
-    | grep -v '#define WL_ATOMIC' \
-    | wc -l)
-
-# Count audit-table rows in docs/THREADING.md.  Rows begin with
-# `| \`wirelog/...` or `| \`mem_ledger.c:...` (file:line ref in the
-# first table cell).  Pattern: a line starting with `| \`` followed
-# by an identifier and a colon and a digit, ending the first cell
-# with a backtick.
-rows=$(grep -cE '^\| `[A-Za-z_./-]+:[0-9]+`' "$doc" || true)
-
-# Return success only when the cited physical line and its backslash
-# continuations contain an atomic_* call. Status 2 means the line is past EOF.
-logical_line_has_atomic() {
-    local source=$1
-    local line=$2
-    local operation=$3
-    awk -v wanted="$line" -v operation="$operation" '
-        NR == wanted {
-            logical = $0
-            while (logical ~ /\\$/ && getline > 0)
-                logical = logical "\n" $0
-            found = logical ~ ("(^|[^[:alnum:]_])" operation "[[:space:]]*\\(")
-            seen = 1
-            exit
-        }
-        END {
-            if (!seen)
-                exit 2
-            if (!found)
-                exit 1
-        }
-    ' "$source"
+rows="$tmp_dir/rows"
+sed -nE 's/^\| `([^`]+:[A-Za-z_][A-Za-z0-9_]*(#[0-9]+)?)` \| [^|]* \| `([^`]*)` \|.*/\1\t\3/p' "$doc" >"$rows"
+row_count=$(wc -l <"$rows")
+expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-44}"
+[ "$row_count" -eq "$expected_rows" ] || {
+    echo "check-threading-doc: FAIL: expected $expected_rows audit rows, found $row_count" >&2
+    exit 1
 }
 
-atomic_token_line() {
-    local source=$1
-    local line=$2
-    local operation=$3
-    awk -v wanted="$line" -v operation="$operation" '
-        NR == wanted {
-            physical = NR
-            while (1) {
-                if ($0 ~ ("(^|[^[:alnum:]_])" operation "[[:space:]]*\\(")) {
-                    print physical
-                    found = 1
-                    exit
-                }
-                if ($0 !~ /\\$/ || getline <= 0)
-                    exit
-                physical++
-            }
-        }
-        END {
-            if (!found)
-                exit 1
-        }
-    ' "$source"
-}
-
-# Resolve basename references used by the audit table. The document predates
-# repo-relative citations, so candidates are selected by the cited logical
-# line; a tie fails loudly rather than depending on `find` ordering.
-resolve_source() {
-    local reference=$1
-    local operation=$2
-    local basename=${reference%%:*}
-    local line=${reference##*:}
-    local -a candidates
-    local -a matches=()
-    local candidate
-    candidates=()
-    while IFS= read -r candidate; do
-        candidates+=("$candidate")
-    done < <(find "$repo_root/wirelog" -type f -name "$basename" -print | sort)
-    if [ "${#candidates[@]}" -eq 0 ]; then
-        echo "check-threading-doc: FAIL: $reference has no matching source; fix the audit row to name an existing wirelog file" >&2
-        return 1
-    fi
-    for candidate in "${candidates[@]}"; do
-        if logical_line_has_atomic "$candidate" "$line" "$operation"; then
-            matches+=("$candidate")
-        fi
-    done
-    if [ "${#matches[@]}" -eq 1 ]; then
-        printf '%s\n' "${matches[0]}"
-        return 0
-    fi
-    if [ "${#matches[@]}" -eq 0 ]; then
-        echo "check-threading-doc: FAIL: $reference does not contain $operation on its logical line; fix the file:line or operation citation" >&2
-    else
-        printf 'check-threading-doc: FAIL: %s is ambiguous; matching candidates:\n' "$reference" >&2
-        printf '  %s\n' "${matches[@]}" >&2
-        echo "  Fix the audit row to use a uniquely identifying file:line citation." >&2
-    fi
-    return 1
-}
-
-# Check the complete logical preprocessor line, not only its first physical
-# line. The intern.c audit deliberately cites macro definitions whose
-# atomic_* token is on the continuation line.
-check_citation() {
-    local reference=$1
-    local operation=$2
-    local source
-    source=$(resolve_source "$reference" "$operation") || return 1
-    return 0
-}
-
-# Validate every audit-table citation after the count check. Keep the first
-# cell deliberately narrow so prose references elsewhere do not become rows.
-validated_rows=0
-while IFS=$'\t' read -r reference operation; do
-    if [[ ! "$operation" =~ ^atomic_[A-Za-z0-9_]+$ ]]; then
-        echo "check-threading-doc: FAIL: $reference has invalid operation '$operation'; fix the audit row" >&2
+audit="$tmp_dir/audit"
+: >"$tmp_dir/keys"
+: >"$audit"
+while IFS=$'\t' read -r anchor operation; do
+    [[ "$operation" =~ ^atomic_[A-Za-z0-9_]+$ ]] || {
+        echo "check-threading-doc: FAIL: $anchor has invalid operation '$operation'" >&2
+        exit 1
+    }
+    matches=$(awk -F '\t' -v anchor="$anchor" -v operation="$operation" \
+        '$5 == anchor && $4 == operation' "$tmp_dir/inventory")
+    count=$(printf '%s\n' "$matches" | sed '/^$/d' | wc -l)
+    [ "$count" -eq 1 ] || {
+        echo "check-threading-doc: FAIL: $anchor does not resolve uniquely to $operation" >&2
+        exit 1
+    }
+    key="$anchor:$operation"
+    if grep -Fqx "$key" "$tmp_dir/keys"; then
+        echo "check-threading-doc: FAIL: duplicate audit anchor $key" >&2
         exit 1
     fi
-    check_citation "$reference" "$operation" || exit 1
-    validated_rows=$((validated_rows + 1))
-done < <(sed -nE 's/^\| `([A-Za-z_./-]+:[0-9]+)` \| [^|]* \| `([^`]*)` \|.*/\1\t\2/p' "$doc")
+    printf '%s\n' "$key" >>"$tmp_dir/keys"
+    printf '%s\n' "$matches" >>"$audit"
+done <"$rows"
 
-if [ "$validated_rows" -ne "$rows" ]; then
-    echo "check-threading-doc: FAIL: $rows audit rows found but only $validated_rows rows have a valid citation shape" >&2
-    exit 1
-fi
-
-if [ "$sites" -ne "$rows" ]; then
-    echo "check-threading-doc: FAIL:" >&2
-    echo "  atomic_* call sites in wirelog/: $sites" >&2
-    echo "  audit table rows in $doc: $rows" >&2
-    echo "" >&2
-    echo "Drift detected. Either update docs/THREADING.md §5 to add or remove the matching row." >&2
-    exit 1
-fi
-
-# Compare the normalized source-site inventory with the audit references. The
-# count check alone cannot detect a duplicated row that hides an omitted site.
-source_sites="$tmp_dir/source-sites"
-audit_sites="$tmp_dir/audit-sites"
-grep -rEn '(^|[^[:alnum:]_])atomic_(load|store|fetch_add|fetch_sub|fetch_or|fetch_and|fetch_xor|compare_exchange_weak|compare_exchange_strong|exchange|init|thread_fence)(_explicit)?[[:space:]]*\(' \
-        "$repo_root/wirelog" \
-        --include='*.c' --include='*.h' \
-    | grep -v '#define atomic_' \
-    | grep -v '#define WL_ATOMIC' \
-    | awk -F: '{print $1 ":" $2}' \
-    | while IFS=: read -r source line; do
-        file=$source
-        file=${file##*/}
-        printf '%s:%s\n' "$file" "$line"
-    done \
-    | sort > "$source_sites"
-while IFS=$'\t' read -r reference operation; do
-    source=$(resolve_source "$reference" "$operation") || exit 1
-    token_line=$(atomic_token_line "$source" "${reference##*:}" "$operation") || exit 1
-    file=${source##*/}
-    printf '%s:%s\n' "$file" "$token_line"
-done < <(sed -nE 's/^\| `([A-Za-z_./-]+:[0-9]+)` \| [^|]* \| `([^`]*)` \|.*/\1\t\2/p' "$doc") \
-    | sort > "$audit_sites"
-if ! cmp -s "$source_sites" "$audit_sites"; then
+cut -f1,2,4 "$tmp_dir/inventory" | sort >"$tmp_dir/source-sites"
+cut -f1,2,4 "$audit" | sort >"$tmp_dir/audit-sites"
+if ! cmp -s "$tmp_dir/source-sites" "$tmp_dir/audit-sites"; then
     echo "check-threading-doc: FAIL: audit citations do not cover the exact atomic-site inventory" >&2
-    echo "  source-only or duplicate audit entries:" >&2
-    comm -3 "$source_sites" "$audit_sites" >&2
+    comm -3 "$tmp_dir/source-sites" "$tmp_dir/audit-sites" >&2
     exit 1
 fi
 
-# Validate line and range references in prose as well as audit rows. Ranges
-# are bounds checks only; the operation-specific check above remains the
-# authoritative validation for table rows.
 resolve_reference_source() {
-    local basename=$1
-    local start=$2
-    local end=$3
-    local -a candidates=()
-    local -a matches=()
-    local candidate line_count
+    local basename=$1 start=$2 end=$3 candidate line_count
+    local -a candidates=() matches=()
     if [[ "$basename" == wirelog/* ]]; then
         candidates=("$repo_root/$basename")
     else
-        while IFS= read -r candidate; do
-            candidates+=("$candidate")
-        done < <(find "$repo_root/wirelog" -type f -name "$basename" -print | sort)
+        while IFS= read -r candidate; do candidates+=("$candidate"); done \
+            < <(find "$repo_root/wirelog" -type f -name "$basename" -print | sort)
     fi
     for candidate in "${candidates[@]}"; do
         [ -f "$candidate" ] || continue
-        line_count=$(wc -l < "$candidate")
-        if [ "$start" -ge 1 ] && [ "$end" -ge "$start" ] && [ "$end" -le "$line_count" ]; then
+        line_count=$(wc -l <"$candidate")
+        if [ "$start" -ge 1 ] && [ "$end" -ge "$start" ] \
+            && [ "$end" -le "$line_count" ]; then
             matches+=("$candidate")
         fi
     done
@@ -235,28 +78,23 @@ resolve_reference_source() {
 }
 
 while IFS= read -r citation; do
-    citation=${citation#\`}
-    citation=${citation%\`}
-    basename=${citation%%:*}
-    locations=${citation#*:}
-    IFS=',' read -ra location_list <<< "$locations"
+    citation=${citation#\`}; citation=${citation%\`}
+    basename=${citation%%:*}; locations=${citation#*:}
+    IFS=',' read -ra location_list <<<"$locations"
     for location in "${location_list[@]}"; do
         if [[ "$location" =~ ^([0-9]+)-([0-9]+)$ ]]; then
-            start=${BASH_REMATCH[1]}
-            end=${BASH_REMATCH[2]}
+            start=${BASH_REMATCH[1]}; end=${BASH_REMATCH[2]}
         elif [[ "$location" =~ ^[0-9]+$ ]]; then
-            start=$location
-            end=$location
+            start=$location; end=$location
         else
             echo "check-threading-doc: FAIL: malformed prose citation '$citation'" >&2
             exit 1
         fi
         if ! resolve_reference_source "$basename" "$start" "$end"; then
-            echo "check-threading-doc: FAIL: prose citation '$basename:$location' does not resolve to an in-range source" >&2
+            echo "check-threading-doc: FAIL: prose citation '$basename:$location' does not resolve" >&2
             exit 1
         fi
     done
 done < <(grep -oE '`[A-Za-z0-9_./-]+\.(c|h):[0-9]+([,-][0-9]+)*`' "$doc" || true)
 
-echo "check-threading-doc: OK; $sites atomic_* call sites and $rows resolved audit rows match in docs/THREADING.md"
-exit 0
+echo "check-threading-doc: OK; $row_count audit rows cover the exact atomic-site inventory"

--- a/scripts/ci/test-threading-doc.sh
+++ b/scripts/ci/test-threading-doc.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-# Focused regression tests for check-threading-doc.sh.
-
+# Focused regression tests for the symbol-anchored threading-doc checker.
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 checker="$script_dir/check-threading-doc.sh"
-fixture="$(mktemp -d)"
+fixture=$(mktemp -d)
 trap 'rm -rf "$fixture"' EXIT
 
 make_fixture() {
@@ -14,20 +13,8 @@ make_fixture() {
 }
 
 run_checker() {
-    WIRELOG_THREADING_DOC_ROOT="$fixture" "$checker"
-}
-
-replace_doc() {
-    local old=$1
-    local new=$2
-    sed "s#$old#$new#" "$fixture/docs/THREADING.md" > "$fixture/docs/THREADING.md.tmp"
-    mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"
-}
-
-delete_doc_lines() {
-    local pattern=$1
-    sed "/$pattern/d" "$fixture/docs/THREADING.md" > "$fixture/docs/THREADING.md.tmp"
-    mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"
+    WIRELOG_THREADING_DOC_ROOT="$fixture" \
+        WIRELOG_THREADING_EXPECTED_ROWS=3 "$checker"
 }
 
 expect_failure() {
@@ -35,7 +22,6 @@ expect_failure() {
     shift
     if "$@" >"$fixture/stdout" 2>"$fixture/stderr"; then
         echo "test-threading-doc: FAIL: $label unexpectedly passed" >&2
-        cat "$fixture/stderr" >&2
         exit 1
     fi
     grep -F "$label" "$fixture/stderr" >/dev/null || {
@@ -45,57 +31,63 @@ expect_failure() {
     }
 }
 
-# A unique basename resolves and a backslash-continued macro is accepted.
 make_fixture
-printf '%s\n' 'atomic_load_explicit(&value, memory_order_relaxed);' 'not an atomic site' > "$fixture/wirelog/foo.c"
-printf '%s\n' '#define LOAD(p) \' '    atomic_load_explicit((p), memory_order_acquire)' > "$fixture/wirelog/intern.c"
-printf '%s\n' 'int session(void) {' '    atomic_store_explicit(&value, 1, memory_order_relaxed);' '}' > "$fixture/wirelog/columnar/session.c"
-printf '%s\n' '/* duplicate basename must not be selected */' > "$fixture/wirelog/session.c"
-cat > "$fixture/docs/THREADING.md" <<'EOF'
-| `foo.c:1` | value | `atomic_load_explicit` | relaxed | test |
-| `intern.c:1` | value | `atomic_load_explicit` | acquire | test |
-| `session.c:2` | value | `atomic_store_explicit` | relaxed | test |
+printf '%s\n' \
+    'int foo(void) {' \
+    '    atomic_load_explicit(&value, memory_order_relaxed);' \
+    '}' >"$fixture/wirelog/foo.c"
+printf '%s\n' \
+    '#define LOAD(p) \' \
+    '    atomic_load_explicit((p), memory_order_acquire)' >"$fixture/wirelog/intern.c"
+printf '%s\n' \
+    'int session(void) {' \
+    '    atomic_store_explicit(&value, 1, memory_order_relaxed);' \
+    '}' >"$fixture/wirelog/columnar/session.c"
+cat >"$fixture/docs/THREADING.md" <<'EOF'
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
+|---|---|---|---|---|
+| `foo.c:foo` | value | `atomic_load_explicit` | relaxed | test |
+| `intern.c:LOAD` | value | `atomic_load_explicit` | acquire | test |
+| `session.c:session` | value | `atomic_store_explicit` | relaxed | test |
 EOF
 run_checker >/dev/null
 
-# A duplicate valid row cannot hide an omitted source site: exact inventory
-# comparison must catch it even when counts still match.
-replace_doc 'intern.c:1' 'foo.c:1'
-expect_failure 'audit citations do not cover the exact atomic-site inventory' run_checker
-replace_doc 'foo.c:1` | value | `atomic_load_explicit` | acquire' 'intern.c:1` | value | `atomic_load_explicit` | acquire'
+# A header-like cell is not an audit row, while the macro continuation is.
+grep -q '3 audit rows' <(WIRELOG_THREADING_DOC_ROOT="$fixture" \
+    WIRELOG_THREADING_EXPECTED_ROWS=3 "$checker" 2>/dev/null) || exit 1
 
-# The documented operation must match the cited source operation.
-replace_doc 'atomic_load_explicit` | relaxed' 'atomic_store_explicit` | relaxed'
-expect_failure 'foo.c:1 does not contain atomic_store_explicit' run_checker
-replace_doc 'atomic_store_explicit` | relaxed' 'atomic_load_explicit` | relaxed'
-replace_doc 'atomic_load_explicit` | relaxed' 'not_atomic` | relaxed'
-expect_failure 'foo.c:1 has invalid operation' run_checker
-replace_doc 'not_atomic` | relaxed' 'atomic_load_explicit` | relaxed'
-replace_doc 'session.c:2.*atomic_load_explicit' 'session.c:2` | value | `atomic_store_explicit'
+# A duplicated anchor cannot hide an omitted source site.
+sed 's/intern.c:LOAD/foo.c:foo/' "$fixture/docs/THREADING.md" \
+    >"$fixture/docs/THREADING.md.tmp" && mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"
+expect_failure 'duplicate audit anchor' run_checker
+sed 's/foo.c:foo` | value | `atomic_load_explicit` | acquire/intern.c:LOAD` | value | `atomic_load_explicit` | acquire/' \
+    "$fixture/docs/THREADING.md" >"$fixture/docs/THREADING.md.tmp" && mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"
 
-# An existing file with a non-atomic cited line is rejected.
-replace_doc 'foo.c:1' 'foo.c:2'
-expect_failure 'foo.c:2 does not contain atomic_load_explicit' run_checker
+# A renamed function and an invalid operation are hard failures.
+sed 's/foo.c:foo/foo.c:renamed/' "$fixture/docs/THREADING.md" \
+    >"$fixture/docs/THREADING.md.tmp" && mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"
+expect_failure 'does not resolve uniquely' run_checker
+sed 's/foo.c:renamed/foo.c:foo/' "$fixture/docs/THREADING.md" \
+    >"$fixture/docs/THREADING.md.tmp" && mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"
+sed 's/atomic_store_explicit`/not_atomic`/' "$fixture/docs/THREADING.md" \
+    >"$fixture/docs/THREADING.md.tmp" && mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"
+expect_failure 'has invalid operation' run_checker
 
-# The ambiguity rule reports both candidates instead of picking one.
-replace_doc 'foo.c:2' 'foo.c:1'
-mkdir -p "$fixture/wirelog/extra"
-printf '%s\n' 'atomic_load_explicit(&value, memory_order_relaxed);' > "$fixture/wirelog/extra/foo.c"
-expect_failure 'foo.c:1 is ambiguous' run_checker
-
-# Out-of-range citations name the offending row and source.
-rm "$fixture/wirelog/foo.c"
-printf '%s\n' 'atomic_load_explicit(&value, memory_order_relaxed);' > "$fixture/wirelog/foo.c"
-rm "$fixture/wirelog/extra/foo.c"
-replace_doc 'foo.c:1' 'foo.c:99'
-expect_failure 'foo.c:99 does not contain atomic_load_explicit' run_checker
-
-# A basename with no source candidate reports the row and remediation.
-replace_doc 'foo.c:99' 'missing.c:1'
-expect_failure 'missing.c:1 has no matching source' run_checker
-
-# The original count backstop remains active.
-delete_doc_lines '`missing.c:1`'
-expect_failure 'atomic_* call sites in wirelog/' run_checker
+# A function pointer declaration/call and comment/string text do not create sites.
+make_fixture
+printf '%s\n' \
+    '/* atomic_load_explicit(&fake, x); */' \
+    'const char *s = "atomic_store_explicit(&fake, x)";' \
+    'void (*callback)(void);' \
+    'int real(void) {' \
+    '    atomic_load_explicit(&value, memory_order_relaxed);' \
+    '}' >"$fixture/wirelog/foo.c"
+cat >"$fixture/docs/THREADING.md" <<'EOF'
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
+|---|---|---|---|---|
+| `foo.c:real` | value | `atomic_load_explicit` | relaxed | test |
+EOF
+WIRELOG_THREADING_EXPECTED_ROWS=1 WIRELOG_THREADING_DOC_ROOT="$fixture" \
+    "$checker" >/dev/null
 
 echo 'test-threading-doc: OK'

--- a/scripts/ci/threading_doc_anchors.py
+++ b/scripts/ci/threading_doc_anchors.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Build and resolve the stable anchors used by the threading audit gate."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ATOMIC = re.compile(
+    r"\batomic_(?:load|store|fetch_add|fetch_sub|fetch_or|fetch_and|fetch_xor|"
+    r"compare_exchange_weak|compare_exchange_strong|exchange|init|thread_fence)"
+    r"(?:_explicit)?\s*\("
+)
+FUNCTION = re.compile(
+    r"\b([A-Za-z_]\w*)\s*\([^;{}]*\)\s*"
+    r"(?:__[A-Za-z_]\w*\s*)*\{"
+)
+DEFINE = re.compile(r"^\s*#\s*define\s+([A-Za-z_]\w*)")
+CONTROL = {"if", "for", "while", "switch", "catch", "sizeof"}
+
+
+@dataclass(frozen=True)
+class Site:
+    file: str
+    line: int
+    symbol: str
+    operation: str
+    anchor: str
+    offset: int
+
+
+def _mask_comments_and_strings(text: str) -> str:
+    out = list(text)
+    i = 0
+    state = "code"
+    while i < len(out):
+        c = out[i]
+        n = out[i + 1] if i + 1 < len(out) else ""
+        if state == "block":
+            if c == "*" and n == "/":
+                out[i] = out[i + 1] = " "
+                i += 2
+                state = "code"
+                continue
+            if c != "\n":
+                out[i] = " "
+            i += 1
+            continue
+        if state in {"string", "char"}:
+            if c == "\\":
+                if c != "\n":
+                    out[i] = " "
+                if i + 1 < len(out) and out[i + 1] != "\n":
+                    out[i + 1] = " "
+                i += 2
+                continue
+            if (state == "string" and c == '"') or (
+                state == "char" and c == "'"
+            ):
+                out[i] = " "
+                state = "code"
+            elif c != "\n":
+                out[i] = " "
+            i += 1
+            continue
+        if c == "/" and n == "/":
+            out[i] = out[i + 1] = " "
+            i += 2
+            while i < len(out) and out[i] != "\n":
+                out[i] = " "
+                i += 1
+            continue
+        if c == "/" and n == "*":
+            out[i] = out[i + 1] = " "
+            i += 2
+            state = "block"
+            continue
+        if c == '"':
+            out[i] = " "
+            state = "string"
+        elif c == "'":
+            out[i] = " "
+            state = "char"
+        i += 1
+    return "".join(out)
+
+
+def _line_starts(text: str) -> list[int]:
+    starts = [0]
+    starts.extend(i + 1 for i, c in enumerate(text) if c == "\n")
+    return starts
+
+
+def _brace_end(text: str, opening: int) -> int:
+    depth = 0
+    for i in range(opening, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+    return len(text)
+
+
+def inventory(source: Path) -> list[Site]:
+    raw = source.read_text(encoding="utf-8")
+    clean = _mask_comments_and_strings(raw)
+    starts = _line_starts(clean)
+    basename = source.name
+    ranges: list[tuple[int, int, str]] = []
+    for match in FUNCTION.finditer(clean):
+        symbol = match.group(1)
+        if symbol in CONTROL:
+            continue
+        opening = match.end() - 1
+        ranges.append((opening, _brace_end(clean, opening), symbol))
+
+    macro_lines: set[int] = set()
+    macro_ranges: list[tuple[int, int, str]] = []
+    raw_lines = raw.splitlines(keepends=True)
+    line = 0
+    while line < len(raw_lines):
+        match = DEFINE.match(raw_lines[line])
+        if not match:
+            line += 1
+            continue
+        end = line
+        while raw_lines[end].rstrip("\n").rstrip().endswith("\\"):
+            if end + 1 >= len(raw_lines):
+                break
+            end += 1
+        macro_ranges.append((line, end, match.group(1)))
+        macro_lines.update(range(line, end + 1))
+        line = end + 1
+
+    sites: list[Site] = []
+    counts: dict[tuple[str, str], int] = {}
+
+    def add(match: re.Match[str], line_number: int, symbol: str) -> None:
+        operation = match.group(0).split("(", 1)[0].strip()
+        key = (symbol, operation)
+        counts[key] = counts.get(key, 0) + 1
+        suffix = "" if counts[key] == 1 else f"#{counts[key]}"
+        anchor = f"{basename}:{symbol}{suffix}"
+        sites.append(
+            Site(basename, line_number, symbol, operation, anchor, match.start())
+        )
+
+    for first, last, symbol in macro_ranges:
+        if symbol.startswith("atomic_"):
+            continue
+        for number in range(first, last + 1):
+            start = starts[number]
+            end = starts[number + 1] if number + 1 < len(starts) else len(clean)
+            for match in ATOMIC.finditer(clean[start:end]):
+                add(match, number + 1, symbol)
+
+    for number, _raw_line in enumerate(raw_lines):
+        if number in macro_lines:
+            continue
+        start = starts[number]
+        end = starts[number + 1] if number + 1 < len(starts) else len(clean)
+        symbol = "<global>"
+        containing = [r for r in ranges if r[0] <= start < r[1]]
+        if containing:
+            symbol = min(containing, key=lambda r: r[1] - r[0])[2]
+        for match in ATOMIC.finditer(clean[start:end]):
+            add(match, number + 1, symbol)
+    return sites
+
+
+def inventory_tree(root: Path) -> list[Site]:
+    sites: list[Site] = []
+    for source in sorted(root.rglob("*")):
+        if source.suffix in {".c", ".h"} and source.is_file():
+            sites.extend(inventory(source))
+    return sites
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--dump", action="store_true")
+    args = parser.parse_args()
+    root = args.root
+    sites = inventory_tree(root / "wirelog")
+    if args.dump:
+        for site in sites:
+            print(
+                f"{site.file}\t{site.line}\t{site.symbol}\t"
+                f"{site.operation}\t{site.anchor}"
+            )
+        return 0
+    print(len(sites))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1223

Replace line-number threading audit citations with stable function and macro anchors. The checker now builds a comment/string-aware source inventory, verifies exact site coverage, and keeps prose citation validation separate. Added focused fixtures for macros, headers, duplicate anchors, renamed symbols, invalid operations, and false positives.

Validation:
- bash scripts/ci/test-threading-doc.sh
- bash scripts/ci/check-threading-doc.sh
- meson test -C build-1223 threading_doc threading_doc_selftest --print-errorlogs
- meson test -C build-1223 --suite abi --print-errorlogs