### PR TITLE
fix: downgrade multi-adornment magic-set relations

### DIFF
--- a/tests/test_magic_sets.c
+++ b/tests/test_magic_sets.c
@@ -10,7 +10,7 @@
  *   2. Magic relation and rule generation
  *   3. All-free adornment optimization (skip magic)
  *   4. No demand through negation (ANTIJOIN right child)
- *   5. Multiple adornments for the same relation
+ *   5. Multiple adornments for the same relation downgrade safely
  *   6. EDB relations do not get magic relations
  *   7. Correctness: magic-optimized result == full result (integration)
  */
@@ -799,7 +799,7 @@ test_negation_no_demand(void)
 
 /* ======================================================================== */
 /* Test 6: test_multiple_adornments                                         */
-/* Same relation used with both bf and fb adornments.                      */
+/* Same relation demanded with both bf and fb adornments downgrades.       */
 /* ======================================================================== */
 
 static void
@@ -808,25 +808,18 @@ test_multiple_adornments(void)
     TEST("test_multiple_adornments");
 
     /*
-     * A(x, y) :- Edge(x, z), B(z, y).     // B with first arg bound -> B_bf
-     * B(x, y) :- Edge(y, z), A(z, x).     // A with first arg bound -> A_bf
-     *
-     * With demand A_bf (x bound):
-     *   Rule for A: bound={x}, atoms=[Edge(x,z), B(z,y)]
-     *     Edge EDB, adds {x,z}
-     *     B(z,y): z bound -> adornment bf -> $m$B_bf
-     *   Process B_bf:
-     *     Rule for B: bound={z}, atoms=[Edge(y,z), A(z,x)]
-     *       Edge EDB, adds {y,z}  (note: z already bound)
-     *       A(z,x): z bound -> adornment bf -> $m$A_bf (already in set)
-     *   -> adorned: {A_bf, B_bf}
+     * R has two distinct same-relation adornments.  Until the pass can union
+     * those demands, it must downgrade R to unrestricted instead of inserting
+     * two conjunctive guards.  S is a single-adornment control and must still
+     * get normal magic-set treatment in the same pass invocation.
      */
     const char *src = ".decl Edge(x: int32, y: int32)\n"
-        ".decl A(x: int32, y: int32)\n"
-        ".decl B(x: int32, y: int32)\n"
-        ".output A\n"
-        "A(x, y) :- Edge(x, z), B(z, y).\n"
-        "B(x, y) :- Edge(y, z), A(z, x).\n";
+        ".decl R(x: int32, y: int32)\n"
+        ".decl S(x: int32, y: int32)\n"
+        ".output R\n"
+        ".output S\n"
+        "R(x, y) :- Edge(x, y).\n"
+        "S(x, y) :- Edge(x, y).\n";
 
     struct wirelog_program *prog = parse_and_optimize(src);
     if (!prog) {
@@ -834,39 +827,79 @@ test_multiple_adornments(void)
         return;
     }
 
-    wl_magic_demand_t demands[1];
-    demands[0].relation_name = "A";
+    wl_magic_demand_t demands[3];
+    demands[0].relation_name = "R";
     demands[0].bound_mask = 0x1; /* x bound */
     demands[0].arity = 2;
+    demands[1].relation_name = "R";
+    demands[1].bound_mask = 0x2; /* y bound */
+    demands[1].arity = 2;
+    demands[2].relation_name = "S";
+    demands[2].bound_mask = 0x1; /* x bound */
+    demands[2].arity = 2;
 
     wl_magic_sets_stats_t stats;
-    int rc = wl_magic_sets_apply_with_demands(prog, demands, 1, &stats);
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 3, &stats);
     if (rc != 0) {
         wirelog_program_free(prog);
         FAIL("magic sets returned error");
         return;
     }
 
-    bool has_a_magic = has_relation(prog, "$m$A_bf");
-    bool has_b_magic = has_relation(prog, "$m$B_bf");
-
-    if (!has_a_magic || !has_b_magic) {
-        char msg[128];
-        snprintf(msg, sizeof(msg), "expected $m$A_bf=%s $m$B_bf=%s",
-            has_a_magic ? "yes" : "NO", has_b_magic ? "yes" : "NO");
+    if (has_relation(prog, "$m$R_bf") || has_relation(prog, "$m$R_fb")) {
         wirelog_program_free(prog);
-        FAIL(msg);
+        FAIL("multi-adornment R must not get magic relations");
+        return;
+    }
+    if (has_rule_for(prog, "$m$R_bf") || has_rule_for(prog, "$m$R_fb")) {
+        wirelog_program_free(prog);
+        FAIL("multi-adornment R must not get magic demand rules");
         return;
     }
 
-    /* At least A_bf and B_bf must be adorned; mutual recursion may
-     * discover additional adornments (A_bb, B_bb) as bound vars propagate. */
-    if (stats.adorned_predicates < 2) {
-        char msg[64];
-        snprintf(msg, sizeof(msg), "expected adorned_predicates>=2, got %u",
-            stats.adorned_predicates);
+    const wirelog_ir_node_t *r_body = rule_body_root(prog, "R", 0);
+    if (ir_contains_type(r_body, WIRELOG_IR_JOIN)) {
         wirelog_program_free(prog);
-        FAIL(msg);
+        FAIL("multi-adornment R must not get a magic guard");
+        return;
+    }
+
+    if (!has_relation(prog, "$m$S_bf")) {
+        wirelog_program_free(prog);
+        FAIL("single-adornment S must still get its magic relation");
+        return;
+    }
+    const wirelog_ir_node_t *s_body = rule_body_root(prog, "S", 0);
+    if (!ir_contains_type(s_body, WIRELOG_IR_JOIN)) {
+        wirelog_program_free(prog);
+        FAIL("single-adornment S must still get a magic guard");
+        return;
+    }
+
+    if (stats.multi_adornment_relations != 1) {
+        printf(" [multi_adornment_relations=%u]",
+            stats.multi_adornment_relations);
+        wirelog_program_free(prog);
+        FAIL("expected R to be the one multi-adornment downgrade");
+        return;
+    }
+    if (stats.unrestrictable_relations != 1) {
+        printf(" [unrestrictable_relations=%u]",
+            stats.unrestrictable_relations);
+        wirelog_program_free(prog);
+        FAIL("expected R and only R to be unrestrictable");
+        return;
+    }
+    if (stats.adorned_predicates != 1) {
+        printf(" [adorned_predicates=%u]", stats.adorned_predicates);
+        wirelog_program_free(prog);
+        FAIL("expected S_bf to be the one surviving adorned predicate");
+        return;
+    }
+    if (stats.original_rules_modified != 1) {
+        printf(" [original_rules_modified=%u]", stats.original_rules_modified);
+        wirelog_program_free(prog);
+        FAIL("expected only S to be guarded");
         return;
     }
 

--- a/tests/test_magic_sets.c
+++ b/tests/test_magic_sets.c
@@ -827,19 +827,22 @@ test_multiple_adornments(void)
         return;
     }
 
-    wl_magic_demand_t demands[3];
+    wl_magic_demand_t demands[4];
     demands[0].relation_name = "R";
     demands[0].bound_mask = 0x1; /* x bound */
     demands[0].arity = 2;
     demands[1].relation_name = "R";
     demands[1].bound_mask = 0x2; /* y bound */
     demands[1].arity = 2;
-    demands[2].relation_name = "S";
-    demands[2].bound_mask = 0x1; /* x bound */
+    demands[2].relation_name = "R";
+    demands[2].bound_mask = 0x3; /* both bound */
     demands[2].arity = 2;
+    demands[3].relation_name = "S";
+    demands[3].bound_mask = 0x1; /* x bound */
+    demands[3].arity = 2;
 
     wl_magic_sets_stats_t stats;
-    int rc = wl_magic_sets_apply_with_demands(prog, demands, 3, &stats);
+    int rc = wl_magic_sets_apply_with_demands(prog, demands, 4, &stats);
     if (rc != 0) {
         wirelog_program_free(prog);
         FAIL("magic sets returned error");

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -575,19 +575,16 @@ static bool
 seed_multi_adornment_relations(const struct wirelog_program *prog,
     const ms_adorned_set_t *processed, ms_relset_t *u, uint32_t *count)
 {
-    if (count)
-        *count = 0;
+    *count = 0;
 
     for (uint32_t i = 0; i < processed->count; i++) {
         const ms_adorned_t *ap = &processed->items[i];
-        if (!ap->rel_name || ap->bound_mask == 0
-            || !is_idb(prog, ap->rel_name))
+        if (!is_idb(prog, ap->rel_name))
             continue;
 
         bool already_checked = false;
         for (uint32_t j = 0; j < i; j++) {
-            if (processed->items[j].rel_name
-                && strcmp(processed->items[j].rel_name, ap->rel_name) == 0) {
+            if (strcmp(processed->items[j].rel_name, ap->rel_name) == 0) {
                 already_checked = true;
                 break;
             }
@@ -598,8 +595,7 @@ seed_multi_adornment_relations(const struct wirelog_program *prog,
         bool found_different_mask = false;
         for (uint32_t j = i + 1; j < processed->count; j++) {
             const ms_adorned_t *other = &processed->items[j];
-            if (!other->rel_name || other->bound_mask == 0
-                || strcmp(other->rel_name, ap->rel_name) != 0)
+            if (strcmp(other->rel_name, ap->rel_name) != 0)
                 continue;
             if (other->bound_mask != ap->bound_mask) {
                 found_different_mask = true;
@@ -608,8 +604,7 @@ seed_multi_adornment_relations(const struct wirelog_program *prog,
         }
 
         if (found_different_mask) {
-            if (count)
-                (*count)++;
+            (*count)++;
             if (!relset_add(u, ap->rel_name))
                 return false;
         }

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -566,6 +566,59 @@ close_unrestrictable(const struct wirelog_program *prog, ms_relset_t *u)
 }
 
 /*
+ * Same-relation multiple adornments are not safe under this pass's current
+ * one-rule-set-per-relation rewrite (#995).  Inserting one guard per
+ * adornment conjoins demands that should be unioned, so downgrade the relation
+ * to the same all-or-nothing path used by guard viability before closure.
+ */
+static bool
+seed_multi_adornment_relations(const struct wirelog_program *prog,
+    const ms_adorned_set_t *processed, ms_relset_t *u, uint32_t *count)
+{
+    if (count)
+        *count = 0;
+
+    for (uint32_t i = 0; i < processed->count; i++) {
+        const ms_adorned_t *ap = &processed->items[i];
+        if (!ap->rel_name || ap->bound_mask == 0
+            || !is_idb(prog, ap->rel_name))
+            continue;
+
+        bool already_checked = false;
+        for (uint32_t j = 0; j < i; j++) {
+            if (processed->items[j].rel_name
+                && strcmp(processed->items[j].rel_name, ap->rel_name) == 0) {
+                already_checked = true;
+                break;
+            }
+        }
+        if (already_checked)
+            continue;
+
+        bool found_different_mask = false;
+        for (uint32_t j = i + 1; j < processed->count; j++) {
+            const ms_adorned_t *other = &processed->items[j];
+            if (!other->rel_name || other->bound_mask == 0
+                || strcmp(other->rel_name, ap->rel_name) != 0)
+                continue;
+            if (other->bound_mask != ap->bound_mask) {
+                found_different_mask = true;
+                break;
+            }
+        }
+
+        if (found_different_mask) {
+            if (count)
+                (*count)++;
+            if (!relset_add(u, ap->rel_name))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+/*
  * The value domain of variable @var as bound somewhere under @node.
  *
  * Used to type the magic guard SCAN, whose columns hold the same values as
@@ -1053,6 +1106,7 @@ wl_magic_sets_apply_with_demands(struct wirelog_program *prog,
         stats->skipped_aggregate = 0;
         stats->skipped_constant_head = 0;
         stats->skipped_unsupported_head = 0;
+        stats->multi_adornment_relations = 0;
         stats->unrestrictable_relations = 0;
     }
 
@@ -1247,6 +1301,13 @@ next_atom:
         }
     }
 
+    uint32_t multi_adornment_relations = 0;
+    if (!seed_multi_adornment_relations(prog, &processed, &unrestrictable,
+        &multi_adornment_relations))
+        closure_incomplete = true;
+    if (stats)
+        stats->multi_adornment_relations = multi_adornment_relations;
+
     /*
      * === Guard-viability closure (Issue #1027) ===
      *
@@ -1280,11 +1341,12 @@ next_atom:
     if (closure_incomplete) {
         /*
          * Declined: `magic_sets_applied` stays false and the IR is untouched.
-         * Both closure-derived counters are zeroed because neither describes
-         * anything that happened -- `unrestrictable` is a partial set here.
+         * Closure-derived counters are zeroed because none describes anything
+         * that happened -- `unrestrictable` is a partial set here.
          */
         if (stats) {
             stats->adorned_predicates = 0;
+            stats->multi_adornment_relations = 0;
             stats->unrestrictable_relations = 0;
         }
         adorned_set_free(&processed);

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -584,34 +584,21 @@ seed_multi_adornment_relations(const struct wirelog_program *prog,
             || !is_idb(prog, ap->rel_name))
             continue;
 
-        bool already_checked = false;
-        for (uint32_t j = 0; j < i; j++) {
-            if (processed->items[j].rel_name
-                && strcmp(processed->items[j].rel_name, ap->rel_name) == 0) {
-                already_checked = true;
-                break;
-            }
-        }
-        if (already_checked)
-            continue;
+        bool already_unrestrictable = relset_contains(u, ap->rel_name);
 
-        bool found_different_mask = false;
         for (uint32_t j = i + 1; j < processed->count; j++) {
             const ms_adorned_t *other = &processed->items[j];
             if (!other->rel_name || other->bound_mask == 0
                 || strcmp(other->rel_name, ap->rel_name) != 0)
                 continue;
             if (other->bound_mask != ap->bound_mask) {
-                found_different_mask = true;
+                if (count)
+                    (*count)++;
+                if (!already_unrestrictable
+                    && !relset_add(u, ap->rel_name))
+                    return false;
                 break;
             }
-        }
-
-        if (found_different_mask) {
-            if (count)
-                (*count)++;
-            if (!relset_add(u, ap->rel_name))
-                return false;
         }
     }
 

--- a/wirelog/passes/magic_sets.c
+++ b/wirelog/passes/magic_sets.c
@@ -584,21 +584,34 @@ seed_multi_adornment_relations(const struct wirelog_program *prog,
             || !is_idb(prog, ap->rel_name))
             continue;
 
-        bool already_unrestrictable = relset_contains(u, ap->rel_name);
+        bool already_checked = false;
+        for (uint32_t j = 0; j < i; j++) {
+            if (processed->items[j].rel_name
+                && strcmp(processed->items[j].rel_name, ap->rel_name) == 0) {
+                already_checked = true;
+                break;
+            }
+        }
+        if (already_checked)
+            continue;
 
+        bool found_different_mask = false;
         for (uint32_t j = i + 1; j < processed->count; j++) {
             const ms_adorned_t *other = &processed->items[j];
             if (!other->rel_name || other->bound_mask == 0
                 || strcmp(other->rel_name, ap->rel_name) != 0)
                 continue;
             if (other->bound_mask != ap->bound_mask) {
-                if (count)
-                    (*count)++;
-                if (!already_unrestrictable
-                    && !relset_add(u, ap->rel_name))
-                    return false;
+                found_different_mask = true;
                 break;
             }
+        }
+
+        if (found_different_mask) {
+            if (count)
+                (*count)++;
+            if (!relset_add(u, ap->rel_name))
+                return false;
         }
     }
 

--- a/wirelog/passes/magic_sets.h
+++ b/wirelog/passes/magic_sets.h
@@ -94,6 +94,15 @@ struct wirelog_program;
  *                         2 BFS, so they never enter `processed` and the guard
  *                         loop never sees them.  The wide head is what remains
  *                         reachable in practice.
+ * @multi_adornment_relations: IDB relations downgraded because Phase 2 found
+ *                         two or more distinct nonzero adornments for the same
+ *                         relation (#995).  The current pass has one rule set
+ *                         per relation, not per adornment, so guarding those
+ *                         rules once per adornment would conjoin demands that
+ *                         should be unioned and silently lose answers.  Until
+ *                         union guards or true adorned-rule splitting exists,
+ *                         each such relation is added to the guard-viability
+ *                         set before closure and is left unrestricted.
  * @unrestrictable_relations: Relations excluded from the transformation
  *                         entirely by the guard-viability closure (#1027).
  *                         Seeded by an IDB body occurrence that binds nothing
@@ -146,7 +155,8 @@ struct wirelog_program;
  *
  *                         Seeds also cover IDBs behind unguarded
  *                         .output/.printsize consumers, IDBs under negation
- *                         (#1047), and IDBs feeding aggregate rules (#1048).
+ *                         (#1047), IDBs feeding aggregate rules (#1048), and
+ *                         same-relation multiple adornments (#995).
  *                         The closure is conservative: every such relation
  *                         and every positive IDB dependency it reads is left
  *                         unrestricted.
@@ -159,8 +169,8 @@ struct wirelog_program;
  * assignment of guards being consistent, not from any one rule's skip; the
  * guard-viability closure above is what enforces that across the consumer
  * shapes it seeds, including output, negation and aggregate consumers.  The
- * remaining limitations are conservative over-approximation and the separate
- * multiple-adornment issue (#995), not unseen #1047/#1048 shapes.
+ * remaining limitations are conservative over-approximation, including the
+ * multiple-adornment downgrade (#995), not unseen #1047/#1048 shapes.
  *
  * They are the only signal that a demand did not reach a rule -- but only for
  * a caller that supplies a stats struct.  The library's own pipeline passes
@@ -203,6 +213,7 @@ typedef struct {
     uint32_t skipped_aggregate;
     uint32_t skipped_constant_head;
     uint32_t skipped_unsupported_head;
+    uint32_t multi_adornment_relations;
     uint32_t unrestrictable_relations;
 } wl_magic_sets_stats_t;
 


### PR DESCRIPTION
Closes #995

When one relation has multiple distinct nonzero adornments, the current in-place rewrite would install conjunctive magic guards and silently drop answers. Reuse the existing unrestrictable/guard-viability path to leave only those relations unguarded until true adorned-rule splitting or union guards exist. Single-adornment relations remain optimized.

Validation:
- meson test -C build magic_sets --print-errorlogs
- meson test -C build optimizer_equivalence --print-errorlogs
- git diff --check