### PR TITLE
build: add safe metadata-free mbedTLS prefix fallback

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev
+          sudo apt-get install -y meson ninja-build pkg-config libmbedtls-dev
 
       - name: Configure with mbedTLS enabled
         run: meson setup builddir-mbedtls -Dtests=true -DmbedTLS=enabled
@@ -247,6 +247,9 @@ jobs:
       # evaluator arms compiled in.
       - name: Test mbedTLS crypto built-ins
         run: meson test -C builddir-mbedtls cryptographic_hashes symbol_digests --print-errorlogs
+
+      - name: Test metadata-free mbedTLS prefix discovery
+        run: scripts/ci/test-mbedtls-prefix.sh
 
       - name: Publish results
         if: always()

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -456,7 +456,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev
+          sudo apt-get install -y meson ninja-build pkg-config libmbedtls-dev
 
       - name: Configure with mbedTLS enabled
         run: meson setup builddir-mbedtls -Dtests=true -DmbedTLS=enabled
@@ -475,6 +475,9 @@ jobs:
       # evaluator arms compiled in.
       - name: Test mbedTLS crypto built-ins
         run: meson test -C builddir-mbedtls cryptographic_hashes symbol_digests --print-errorlogs
+
+      - name: Test metadata-free mbedTLS prefix discovery
+        run: scripts/ci/test-mbedtls-prefix.sh
 
   # ==========================================================================
   # Phase: Sanitizer Matrix (starts after lint, parallel with build-primary)

--- a/docs/EMBEDDED.md
+++ b/docs/EMBEDDED.md
@@ -34,6 +34,7 @@ The Meson options below are user-visible for embedded builds:
 | `threads` | Selects threading backend: `native` auto-detects C11/POSIX, `posix` forces pthreads. See `docs/THREADING.md`. |
 | `wirelog_log_max_level` | Release and embedded builds should usually set `-Dwirelog_log_max_level=error` to compile out higher-volume logging sites. |
 | `mbedTLS` | Defaults to `disabled`. Keep disabled unless crypto built-ins are required; enabling changes dependency and export posture. See `docs/SECURITY_MODEL.md`. |
+| `mbedTLS_prefix` | Optional native-build fallback for a metadata-free, single-prefix mbedTLS install. Use `-DmbedTLS_prefix=/path` only when `<path>/include` and `<path>/lib` (or `lib64`) contain the matching headers and libraries. |
 | `io_plugin_dlopen` | Enables optional CLI plugin loading through `dlopen` where supported. Most embedded hosts link adapters directly or own dynamic loading themselves. |
 | `android` | Opt-in Android cross-build path. Source build support exists; packaged AAR/Prefab artifacts are deferred. |
 | `ios` | Opt-in iOS build path. Source build support exists; packaged XCFramework artifacts are deferred. |

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -68,6 +68,14 @@ wirelog exposes the following mbedTLS-backed Datalog built-ins:
 
 wirelog does not currently expose broader digest-family or generic
 HMAC-family built-ins as callable Datalog functions.
+
+For a native installation without pkg-config or CMake metadata, configure
+with `-DmbedTLS_prefix=/path/to/mbedtls`. The fallback only considers matching
+headers under `<prefix>/include` and complete library bundles under
+`<prefix>/lib` or `<prefix>/lib64`, then reruns the PSA link probe. It is never
+used for cross builds, and `mbedTLS=disabled` ignores the prefix. Existing
+metadata-based discovery always takes priority.
+
 Digest and HMAC built-ins take their input bytes from the operand's
 declared type (#963): the string's own bytes for a `symbol`/`string`
 column, `strlen()` many with no NUL terminator, and the 8-byte `int64`

--- a/meson.build
+++ b/meson.build
@@ -174,6 +174,7 @@ endif
 #Phase 2A : nanoarrow for columnar backend(via meson wrap)
 nanoarrow_proj = subproject('nanoarrow', default_options: ['tests=disabled', 'apps=disabled', 'ipc=disabled', 'device=disabled', 'testing=disabled'])
 nanoarrow_dep = nanoarrow_proj.get_variable('nanoarrow_dep')
+fs = import('fs')
 
 #Built-in functions : xxHash3 for hash() function
 xxhash_proj = subproject('xxhash', default_options: [])
@@ -262,6 +263,103 @@ if mbedtls_option == 'auto' or mbedtls_option == 'enabled'
       mbedtls_psa_rejections += [_mbedtls_candidate + ': failed PSA Crypto link probe']
     endif
   endforeach
+
+  if mbedtls_psa_provider == '' and get_option('mbedTLS_prefix') != ''
+    if meson.is_cross_build()
+      mbedtls_psa_rejections += ['metadata-free prefix: disabled for cross builds']
+    else
+      _mbedtls_prefix = get_option('mbedTLS_prefix')
+      _mbedtls_realpath = find_program('realpath', required: false)
+      if not _mbedtls_realpath.found()
+        mbedtls_psa_rejections += ['metadata-free prefix: realpath is unavailable']
+      else
+        _mbedtls_prefix_realpath_result = run_command(_mbedtls_realpath,
+          '-e', _mbedtls_prefix, check: false)
+        _mbedtls_prefix_realpath = _mbedtls_prefix_realpath_result.stdout().strip()
+        if _mbedtls_prefix_realpath_result.returncode() != 0 or _mbedtls_prefix_realpath == ''
+          mbedtls_psa_rejections += ['metadata-free prefix: cannot resolve ' + _mbedtls_prefix]
+        else
+      _mbedtls_prefix_include = include_directories(_mbedtls_prefix / 'include')
+      _mbedtls_lib_dirs = [_mbedtls_prefix / 'lib', _mbedtls_prefix / 'lib64']
+      foreach _mbedtls_candidate : mbedtls_psa_candidates
+        if mbedtls_psa_provider != ''
+          continue
+        endif
+        _mbedtls_header_path = _mbedtls_prefix / 'include' / 'psa' / 'crypto.h'
+        _mbedtls_header_realpath_result = run_command(_mbedtls_realpath,
+          '-e', _mbedtls_header_path, check: false)
+        _mbedtls_header_realpath = _mbedtls_header_realpath_result.stdout().strip()
+        if _mbedtls_header_realpath_result.returncode() != 0 or not _mbedtls_header_realpath.startswith(_mbedtls_prefix_realpath + '/')
+          mbedtls_psa_rejections += ['metadata-free prefix: missing <psa/crypto.h> under ' + _mbedtls_prefix]
+          break
+        endif
+
+        _mbedtls_component_names = []
+        if _mbedtls_candidate == 'tfpsacrypto'
+          _mbedtls_component_names = ['tfpsacrypto', 'mbedcrypto']
+        elif _mbedtls_candidate == 'mbedcrypto'
+          _mbedtls_component_names = ['mbedcrypto']
+        else
+          _mbedtls_component_names = ['mbedtls', 'mbedx509', 'mbedcrypto']
+        endif
+
+        _mbedtls_fallback_link_args = []
+        _mbedtls_missing_components = []
+        foreach _mbedtls_component : _mbedtls_component_names
+          _mbedtls_component_path = ''
+            foreach _mbedtls_lib_dir : _mbedtls_lib_dirs
+              foreach _mbedtls_suffix : ['.so', '.a', '.dylib', '.lib']
+              if _mbedtls_component_path == '' and fs.exists(_mbedtls_lib_dir / ('lib' + _mbedtls_component + _mbedtls_suffix))
+                _mbedtls_component_path = _mbedtls_lib_dir / ('lib' + _mbedtls_component + _mbedtls_suffix)
+              elif _mbedtls_component_path == '' and fs.exists(_mbedtls_lib_dir / (_mbedtls_component + _mbedtls_suffix))
+                _mbedtls_component_path = _mbedtls_lib_dir / (_mbedtls_component + _mbedtls_suffix)
+              endif
+            endforeach
+          endforeach
+          if _mbedtls_component_path == ''
+            _mbedtls_missing_components += [_mbedtls_component]
+            continue
+          endif
+          _mbedtls_component_realpath_result = run_command(_mbedtls_realpath,
+            '-e', _mbedtls_component_path, check: false)
+          _mbedtls_component_realpath = _mbedtls_component_realpath_result.stdout().strip()
+          if _mbedtls_component_realpath_result.returncode() != 0 or not _mbedtls_component_realpath.startswith(_mbedtls_prefix_realpath + '/')
+            _mbedtls_missing_components += [_mbedtls_component + ' (outside prefix)']
+            continue
+          endif
+          _mbedtls_fallback_link_args += [_mbedtls_component_path]
+        endforeach
+        if _mbedtls_missing_components.length() > 0
+          mbedtls_psa_rejections += ['metadata-free ' + _mbedtls_candidate + ': missing libraries ' + ', '.join(_mbedtls_missing_components)]
+          continue
+        endif
+
+        _mbedtls_fallback_transitive_deps = [threads_dep]
+        _mbedtls_dl_dep = cc.find_library('dl', required: false)
+        if _mbedtls_dl_dep.found()
+          _mbedtls_fallback_transitive_deps += [_mbedtls_dl_dep]
+        endif
+        _mbedtls_fallback_candidate_dep = declare_dependency(
+          dependencies: _mbedtls_fallback_transitive_deps,
+          link_args: _mbedtls_fallback_link_args,
+          include_directories: _mbedtls_prefix_include)
+        if cc.links(mbedtls_psa_probe,
+            dependencies: [_mbedtls_fallback_candidate_dep],
+            name: 'PSA Crypto hash, HMAC, and random APIs via metadata-free ' + _mbedtls_candidate)
+          mbedtls_dep = [_mbedtls_fallback_candidate_dep]
+          mbedtls_psa_provider = _mbedtls_candidate
+          mbedtls_psa_provider_version = 'unknown'
+          message('  mbedTLS discovery: metadata-free prefix')
+          message('  mbedTLS prefix: ' + _mbedtls_prefix)
+          message('  mbedTLS libraries: ' + ', '.join(_mbedtls_component_names))
+        else
+          mbedtls_psa_rejections += ['metadata-free ' + _mbedtls_candidate + ': failed PSA Crypto link probe']
+        endif
+      endforeach
+        endif
+      endif
+    endif
+  endif
 
   if mbedtls_psa_provider != ''
     message('  mbedTLS PSA provider: ' + mbedtls_psa_provider + ' ' + mbedtls_psa_provider_version)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -81,6 +81,13 @@ option(
 )
 
 option(
+  'mbedTLS_prefix',
+  type: 'string',
+  value: '',
+  description: 'Explicit single-prefix metadata-free mbedTLS installation to use after pkg-config/CMake discovery fails (native builds only).'
+)
+
+option(
   'wirelog_log_max_level',
   type: 'combo',
   choices: ['error', 'warn', 'info', 'debug', 'trace'],

--- a/scripts/ci/test-mbedtls-prefix.sh
+++ b/scripts/ci/test-mbedtls-prefix.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+prefix=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-mbedtls-prefix.XXXXXX")
+build_dir=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-mbedtls-build.XXXXXX")
+trap 'rm -rf "$prefix" "$build_dir"' EXIT
+
+mkdir -p "$prefix/include" "$prefix/lib" "$prefix/empty-pkgconfig"
+cp -a /usr/include/psa "$prefix/include/"
+if [[ -d /usr/include/mbedtls ]]; then
+    cp -a /usr/include/mbedtls "$prefix/include/"
+fi
+
+for component in tfpsacrypto mbedcrypto mbedtls mbedx509; do
+    library=$(find /usr/lib /lib -type f -o -type l 2>/dev/null \
+        | grep -E "/lib${component}\\.(so|a)(\\.|$)" \
+        | head -n 1 || true)
+    if [[ -n "$library" ]]; then
+        library_dir=$(dirname "$library")
+        cp -a "$library_dir/lib${component}.so"* "$prefix/lib/" 2>/dev/null || true
+        cp -a "$library_dir/lib${component}.a"* "$prefix/lib/" 2>/dev/null || true
+    fi
+done
+
+if [[ ! -e "$prefix/include/psa/crypto.h" ]]; then
+    echo "metadata-free mbedTLS fixture: PSA headers are unavailable" >&2
+    exit 1
+fi
+
+configure_log="$build_dir/configure.log"
+if ! PKG_CONFIG_LIBDIR="$prefix/empty-pkgconfig" PKG_CONFIG_PATH= \
+    CMAKE_PREFIX_PATH= CMAKE_FIND_ROOT_PATH= \
+    meson setup "$build_dir" "$repo_root" -Dtests=true \
+    -DmbedTLS=enabled -DmbedTLS_prefix="$prefix" >"$configure_log" 2>&1; then
+    cat "$configure_log"
+    exit 1
+fi
+if ! grep -q 'mbedTLS discovery: metadata-free prefix' "$configure_log"; then
+    cat "$configure_log"
+    echo "metadata-free mbedTLS fixture was not selected" >&2
+    exit 1
+fi
+meson compile -C "$build_dir"
+meson test -C "$build_dir" cryptographic_hashes symbol_digests --print-errorlogs
+
+incomplete_prefix=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-mbedtls-incomplete.XXXXXX")
+trap 'rm -rf "$prefix" "$build_dir" "$incomplete_prefix"' EXIT
+mkdir -p "$incomplete_prefix/include"
+cp -a "$prefix/include/psa" "$incomplete_prefix/include/"
+if PKG_CONFIG_LIBDIR="$incomplete_prefix/empty-pkgconfig" PKG_CONFIG_PATH= \
+    CMAKE_PREFIX_PATH= CMAKE_FIND_ROOT_PATH= \
+    meson setup "$build_dir/incomplete" "$repo_root" -Dtests=false \
+    -DmbedTLS=enabled -DmbedTLS_prefix="$incomplete_prefix" \
+    >"$build_dir/incomplete.log" 2>&1; then
+    cat "$build_dir/incomplete.log"
+    echo "incomplete mbedTLS prefix unexpectedly configured" >&2
+    exit 1
+fi
+grep -q 'missing libraries' "$build_dir/incomplete.log"


### PR DESCRIPTION
## Summary
- add explicit single-prefix `-DmbedTLS_prefix` fallback after pkg-config/CMake discovery
- require canonical header/library paths to remain inside the selected prefix and probe the complete provider bundle
- preserve disabled/cross-build behavior and include threads/dl in the fallback dependency
- document the option and add normal plus metadata-free/incomplete-prefix CI coverage

Closes #1231

## Validation
- metadata-provided mbedTLS configure
- metadata-free mbedTLS configure/build and crypto tests
- incomplete and outside-prefix symlink fixtures rejected
- `git diff --check` and shell syntax validation passed