### PR TITLE
feat: parse float declarations and literals

### DIFF
--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -140,9 +140,9 @@ val(1, 1). val(1, 2). val(1, 9).     /* answered t(1, 1);  mean is 4 */
 Both were wrong, silently, with exit status 0.
 
 It is rejected rather than implemented because there is no type to return a
-mean in. Every value in the engine is a 64-bit integer; `float` is not a
-`.decl` type keyword and there is no decimal literal, so `.decl v(x: float)`
-and `1.5` are both syntax errors. The only implementable semantics today is
+mean in. Float syntax is being added in stages; the parser now recognizes the
+`float` declaration type and finite decimal/exponent literals, while execution
+and aggregation support remains pending. The only implementable semantics today is
 truncating integer division — and that is precisely the choice that could
 not be corrected later, because replacing it with a real mean would change
 the numbers every existing program prints, with no error anywhere. Widening
@@ -193,8 +193,8 @@ which was filed against the parse stage and needs widening to cover this
 `EVAL`-section message too.
 
 `average` stays a reserved keyword and `WIRELOG_AGG_AVG` stays in the public
-enum, so nothing about the surface syntax has to be un-done if a float type
-arrives later.
+enum, so adding the parser-level float spelling does not require changing the
+aggregate surface syntax while typed execution is completed.
 
 **One caveat on the workaround.** It is exact for a non-recursive rule. Do not
 reach for it inside a *recursive* stratum: recursive `sum` and `count` are
@@ -241,7 +241,7 @@ q(1, 2).            /* accepted: a side compound is one handle column */
 ```
 
 The flat spelling is the only spelling. `p(1, pair(2,3)).` and `p(1, [2,3]).`
-are parse errors — facts admit integer and string constants only — and the
+are parse errors — facts admit numeric and string constants only — and the
 head grammar has no compound-term production either, so `p(x, pair(y,z))` in a
 rule head is a parse error as well. Flat is what a rule writes
 (`p(x, y, z) :- src(x, y, z).`) and flat is what an `.input` file carries: one
@@ -369,7 +369,7 @@ Edge(2, 3).
 Name(1, "alice").
 ```
 
-Inline facts contain only constants (integers or strings), not variables.
+Inline facts contain only numeric or string constants, not variables.
 
 ---
 
@@ -560,6 +560,7 @@ Supported column types:
 - `int64` -- 64-bit signed integer
 - `string` -- variable-length string
 - `symbol` -- interned symbol (string stored as integer ID)
+- `float` -- finite IEEE-754 binary64 value (execution support in progress)
 - `functor/arity` -- compound term handle stored in a 64-bit column
 - `functor/arity side` -- explicit side-relation compound storage
 - `functor/arity inline` -- inline compound storage, limited to arity 4
@@ -571,10 +572,13 @@ between the sign and digits is not accepted. Values outside this range are
 parse errors. The minus sign remains a binary subtraction operator when used
 between expressions.
 
-There is **no floating-point type**. `float` is not a type keyword and there
-is no decimal literal, so `.decl v(x: float)` and `1.5` are both syntax
-errors; every value the engine stores and computes on is a 64-bit integer.
-This is why [`average()` is not supported](#average-is-not-supported).
+Float literals use either `digits.digits` with an optional exponent or
+`digits` with an exponent (for example `1.5`, `1e3`, and `1.5e-2`). The
+initial grammar rejects `.5`, `1.`, malformed exponents, and non-finite
+results. A unary minus may be separated from a float literal by whitespace;
+`-0.0` is represented canonically as `0.0`. Runtime columnar support is being
+implemented incrementally; [`average()` is not supported](#average-is-not-supported)
+until that work is complete.
 
 ---
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1415,8 +1415,9 @@ test('recursive_agg_kfusion_nofusion', test_recursive_agg_kfusion_nofusion_exe,
      suite: 'semantics', timeout: 120)
 
 # Issue #978: average() was never implemented -- col_op_reduce() had no AVG
-# arm, so each group kept the first operand the scan happened to reach.  With
-# no float type to return a mean in, it is rejected at lowering instead.
+# arm, so each group kept the first operand the scan happened to reach.  The
+# legacy int64 executor has no float lane to return a mean in, so it is
+# rejected at lowering instead.
 test_average_rejected_exe = executable(
   'test_average_rejected',
   files('test_average_rejected.c'),

--- a/tests/test_average_rejected.c
+++ b/tests/test_average_rejected.c
@@ -14,11 +14,11 @@
  *     val(1,9). val(1,5). val(1,2).  ->  t(1, 9)   [mean 5]
  *     val(1,1). val(1,2). val(1,9).  ->  t(1, 1)   [mean 4]
  *
- * There is no float type to return a mean in -- storage is int64_t
- * throughout and the lexer has no `float` type keyword or decimal literal --
- * so the choice was truncating integer division or rejection.  Rejection was
- * taken: widening to float later is a compatible change, whereas replacing
- * truncation with float later would silently change every program's numbers.
+ * The legacy executor still has no float column lane to return a mean in --
+ * storage is int64_t throughout -- so the choice was truncating integer
+ * division or rejection.  Rejection was taken: widening to float later is a
+ * compatible change, whereas replacing truncation with float later would
+ * silently change every program's numbers.
  * See docs/SYNTAX.md and the #973 precedent (reject first, support later).
  *
  * Case map:

--- a/tests/test_ir.c
+++ b/tests/test_ir.c
@@ -580,6 +580,34 @@ test_expr_bool(void)
 }
 
 static void
+test_expr_float_constant(void)
+{
+    TEST("float expression constant stores binary64 value");
+    wl_ir_expr_t *expr = wl_ir_expr_create(WL_IR_EXPR_CONST_FLOAT);
+    if (!expr) {
+        FAIL("failed to create float expression");
+        return;
+    }
+    expr->float_value = 1.5;
+    if (expr->type != WL_IR_EXPR_CONST_FLOAT || expr->float_value != 1.5) {
+        wl_ir_expr_free(expr);
+        FAIL("float expression value was not preserved");
+        return;
+    }
+    wl_ir_expr_t *clone = wl_ir_expr_clone(expr);
+    if (!clone || clone->type != WL_IR_EXPR_CONST_FLOAT
+        || clone->float_value != 1.5) {
+        wl_ir_expr_free(clone);
+        wl_ir_expr_free(expr);
+        FAIL("float expression clone did not preserve value");
+        return;
+    }
+    wl_ir_expr_free(clone);
+    wl_ir_expr_free(expr);
+    PASS();
+}
+
+static void
 test_expr_aggregate(void)
 {
     TEST("Create aggregate expression (min)");
@@ -1138,6 +1166,7 @@ main(void)
     test_create_expression_tree();
     test_expr_string_constant();
     test_expr_bool();
+    test_expr_float_constant();
     test_expr_aggregate();
     test_child_attach_reports_allocation_failure();
 

--- a/tests/test_lexer.c
+++ b/tests/test_lexer.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdint.h>
+#include <locale.h>
 
 #include "../wirelog/parser/lexer.h"
 
@@ -225,6 +226,108 @@ test_integer_overflow(void)
 }
 
 static void
+test_float_literals(void)
+{
+    TEST("finite decimal and exponent float literals");
+    wl_parser_lexer_t lex;
+    wl_parser_lexer_init(&lex, "1.5 1e3 1.5e-2");
+    wl_parser_lexer_token_t tok = wl_parser_lexer_next_token(&lex);
+    if (tok.type != WL_PARSER_LEXER_TOK_FLOAT || tok.float_value != 1.5) {
+        FAIL("expected 1.5 FLOAT");
+        return;
+    }
+    tok = wl_parser_lexer_next_token(&lex);
+    if (tok.type != WL_PARSER_LEXER_TOK_FLOAT || tok.float_value != 1000.0) {
+        FAIL("expected 1e3 FLOAT");
+        return;
+    }
+    tok = wl_parser_lexer_next_token(&lex);
+    if (tok.type != WL_PARSER_LEXER_TOK_FLOAT
+        || tok.float_value != 1.5e-2) {
+        FAIL("expected 1.5e-2 FLOAT");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_float_literal_errors(void)
+{
+    TEST("malformed and non-finite float literals are rejected");
+    const char *sources[] = { "1e", "1.5e+", "1e999", "1.0e-999" };
+    for (size_t i = 0; i < sizeof(sources) / sizeof(sources[0]); i++) {
+        wl_parser_lexer_t lex;
+        wl_parser_lexer_init(&lex, sources[i]);
+        if (wl_parser_lexer_next_token(&lex).type
+            != WL_PARSER_LEXER_TOK_ERROR) {
+            FAIL("invalid float unexpectedly tokenized");
+            return;
+        }
+    }
+    PASS();
+}
+
+static void
+test_float_subnormal_and_zero(void)
+{
+    TEST("subnormal floats are accepted and signed zero is canonicalized");
+    wl_parser_lexer_t lex;
+    wl_parser_lexer_init(&lex, "5e-324 -0.0");
+    wl_parser_lexer_token_t tok = wl_parser_lexer_next_token(&lex);
+    if (tok.type != WL_PARSER_LEXER_TOK_FLOAT || tok.float_value <= 0.0) {
+        FAIL("minimum subnormal was rejected");
+        return;
+    }
+    tok = wl_parser_lexer_next_token(&lex);
+    if (tok.type != WL_PARSER_LEXER_TOK_MINUS) {
+        FAIL("expected minus token before zero");
+        return;
+    }
+    tok = wl_parser_lexer_next_token(&lex);
+    if (tok.type != WL_PARSER_LEXER_TOK_FLOAT || tok.float_value != 0.0) {
+        FAIL("negative zero was not canonicalized");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_float_literal_uses_c_locale(void)
+{
+    TEST("float literal parsing is independent of LC_NUMERIC");
+    const char *saved = setlocale(LC_NUMERIC, NULL);
+    char *saved_copy = NULL;
+    if (saved) {
+        size_t saved_len = strlen(saved);
+        saved_copy = (char *)malloc(saved_len + 1);
+        if (saved_copy)
+            memcpy(saved_copy, saved, saved_len + 1);
+    }
+    const char *locales[] = {
+        "C.UTF-8", "de_DE.UTF-8", "fr_FR.UTF-8", "de_DE", "fr_FR"
+    };
+    for (size_t i = 0; i < sizeof(locales) / sizeof(locales[0]); i++) {
+        if (!setlocale(LC_NUMERIC, locales[i]))
+            continue;
+        wl_parser_lexer_t lex;
+        wl_parser_lexer_init(&lex, "1.5");
+        wl_parser_lexer_token_t tok = wl_parser_lexer_next_token(&lex);
+        if (tok.type != WL_PARSER_LEXER_TOK_FLOAT || tok.float_value != 1.5) {
+            if (saved_copy)
+                setlocale(LC_NUMERIC, saved_copy);
+            free(saved_copy);
+            FAIL("LC_NUMERIC changed float parsing");
+            return;
+        }
+        break;
+    }
+    if (saved_copy)
+        setlocale(LC_NUMERIC, saved_copy);
+    free(saved_copy);
+    PASS();
+}
+
+static void
 test_string_literal(void)
 {
     TEST("string literal");
@@ -332,10 +435,11 @@ test_type_keywords(void)
 {
     TEST("type keywords");
     wl_parser_lexer_t lex;
-    wl_parser_lexer_init(&lex, "int32 int64 string");
+    wl_parser_lexer_init(&lex, "int32 int64 string float");
     ASSERT_TOK(lex, WL_PARSER_LEXER_TOK_INT32);
     ASSERT_TOK(lex, WL_PARSER_LEXER_TOK_INT64);
     ASSERT_TOK(lex, WL_PARSER_LEXER_TOK_STRING_TYPE);
+    ASSERT_TOK(lex, WL_PARSER_LEXER_TOK_FLOAT_TYPE);
     ASSERT_TOK(lex, WL_PARSER_LEXER_TOK_EOF);
     PASS();
 }
@@ -915,6 +1019,10 @@ main(void)
     test_integer_zero();
     test_integer_large();
     test_integer_overflow();
+    test_float_literals();
+    test_float_literal_errors();
+    test_float_subnormal_and_zero();
+    test_float_literal_uses_c_locale();
     test_string_literal();
     test_string_empty();
     test_string_escaped_quote();

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -193,6 +193,23 @@ test_parse_decl_string_type(void)
 }
 
 static void
+test_parse_decl_float_type(void)
+{
+    TEST(".decl with float type");
+    PARSE(".decl Value(x: float)");
+    ASSERT_PARSED();
+    const wl_parser_ast_node_t *decl = child(program, 0);
+    const wl_parser_ast_node_t *param = child(decl, 0);
+    if (!param || !param->type_name || strcmp(param->type_name, "float") != 0) {
+        CLEANUP();
+        FAIL("expected float type name");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
 test_parse_decl_empty_params(void)
 {
     TEST(".decl with empty params");
@@ -1442,6 +1459,54 @@ test_parse_signed_integer_literals(void)
 }
 
 static void
+test_parse_float_literals(void)
+{
+    TEST("float literals in facts, heads, and compound terms");
+    PARSE("v(- 1.5). w(1e3, 1.5e-2) :- v(-1.5). "
+        "ordered(x) :- 1.5 < x.");
+    ASSERT_PARSED();
+    const wl_parser_ast_node_t *fact = child(program, 0);
+    const wl_parser_ast_node_t *rule = child(program, 1);
+    if (!fact || fact->type != WL_PARSER_AST_NODE_FACT
+        || child(fact, 0)->type != WL_PARSER_AST_NODE_FLOAT
+        || child(fact, 0)->float_value != -1.5
+        || !rule || child(child(rule, 0), 0)->type != WL_PARSER_AST_NODE_FLOAT
+        || child(child(rule, 0), 1)->type != WL_PARSER_AST_NODE_FLOAT) {
+        CLEANUP();
+        FAIL("float literals did not produce FLOAT AST nodes");
+        return;
+    }
+    const wl_parser_ast_node_t *ordered = child(program, 2);
+    const wl_parser_ast_node_t *ordered_cmp = child(ordered, 1);
+    const wl_parser_ast_node_t *ordered_left = child(ordered_cmp, 0);
+    if (!ordered_cmp || ordered_cmp->type != WL_PARSER_AST_NODE_COMPARISON
+        || !ordered_left || ordered_left->type != WL_PARSER_AST_NODE_FLOAT
+        || ordered_left->float_value != 1.5) {
+        CLEANUP();
+        FAIL("float-leading comparison was not preserved in the AST");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parse_float_errors(void)
+{
+    TEST("ambiguous decimal spellings are rejected");
+    const char *sources[] = { "v(.5).", "v(1.).", "v(1.5.)." };
+    for (size_t i = 0; i < sizeof(sources) / sizeof(sources[0]); i++) {
+        PARSE(sources[i]);
+        if (program != NULL) {
+            CLEANUP();
+            FAIL("invalid decimal unexpectedly parsed");
+            return;
+        }
+    }
+    PASS();
+}
+
+static void
 test_parse_signed_integer_errors(void)
 {
     TEST("signed integer whitespace and overflow errors");
@@ -2074,6 +2139,7 @@ main(void)
     test_parse_decl_string_type();
     test_parse_decl_empty_params();
     test_parse_decl_three_attrs();
+    test_parse_decl_float_type();
     test_parse_decl_compound_types();
     test_parse_decl_compound_rejects_zero_arity();
     test_parse_decl_compound_rejects_bad_modifier();
@@ -2141,6 +2207,8 @@ main(void)
     printf("\n--- Inline Facts ---\n");
     test_parse_single_fact();
     test_parse_signed_integer_literals();
+    test_parse_float_literals();
+    test_parse_float_errors();
     test_parse_signed_integer_errors();
     test_parse_signed_integer_expressions();
     test_parse_multiple_facts();

--- a/tests/test_plan_gen.c
+++ b/tests/test_plan_gen.c
@@ -59,6 +59,39 @@ static int fail_count = 0;
             }                 \
         } while (0)
 
+static bool
+expr_contains_float_constant(const wl_ir_expr_t *expr)
+{
+    if (!expr)
+        return false;
+    if (expr->type == WL_IR_EXPR_CONST_FLOAT)
+        return true;
+    for (uint32_t i = 0; i < expr->child_count; i++) {
+        if (expr_contains_float_constant(expr->children[i]))
+            return true;
+    }
+    return false;
+}
+
+static bool
+node_contains_float_constant(const wirelog_ir_node_t *node)
+{
+    if (!node)
+        return false;
+    if (expr_contains_float_constant(node->filter_expr)
+        || expr_contains_float_constant(node->agg_expr))
+        return true;
+    for (uint32_t i = 0; i < node->project_count; i++) {
+        if (expr_contains_float_constant(node->project_exprs[i]))
+            return true;
+    }
+    for (uint32_t i = 0; i < node->child_count; i++) {
+        if (node_contains_float_constant(node->children[i]))
+            return true;
+    }
+    return false;
+}
+
 /* ----------------------------------------------------------------
  * Snapshot counting callback
  * ---------------------------------------------------------------- */
@@ -978,6 +1011,61 @@ test_plan_generation_diagnostics(void)
     PASS();
 }
 
+static void
+test_float_plan_rejected_until_columnar_support(void)
+{
+    TEST("float plans are rejected before the legacy int64 executor");
+    wirelog_error_t err;
+    const char *sources[] = {
+        ".decl value(x: float)\nvalue(1.5).\n",
+        ".decl value(x: int64)\nvalue(1.5).\n",
+        ".decl value(x: box(float))\nvalue(1.5).\n",
+        ".decl value(x: box(float))\n",
+        ".decl value(x: box(float) inline)\n",
+        ".decl src(x: int64)\nsrc(1).\n"
+        ".decl out(x: int64)\nout(1.5) :- src(x).\n",
+    };
+    for (size_t i = 0; i < sizeof(sources) / sizeof(sources[0]); i++) {
+        wirelog_program_t *prog = wirelog_parse_string(sources[i], &err);
+        ASSERT(prog != NULL, "float fixture failed to parse");
+        if (i == 5) {
+            ASSERT(prog->rule_count == 1 && prog->rules[0].ir_root != NULL,
+                "float rule was not converted to IR");
+            ASSERT(node_contains_float_constant(prog->rules[0].ir_root),
+                "float rule literal was not preserved in the IR");
+        }
+        wl_plan_t *plan = NULL;
+        ASSERT(wl_plan_from_program(prog, &plan) != 0,
+            "float relation must not reach int64 executor yet");
+        ASSERT(plan == NULL, "rejected float plan must remain NULL");
+        const char *detail = wirelog_program_get_plan_error(prog);
+        if (i < 3) {
+            ASSERT(detail && strstr(detail, "float") != NULL,
+                "float rejection must explain the unsupported execution path");
+        }
+        wirelog_program_free(prog);
+    }
+    PASS();
+}
+
+static void
+test_float_compound_metadata_resets_on_redeclaration(void)
+{
+    TEST("float compound metadata resets on redeclaration");
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(
+        ".decl redecl(x: box(float))\n"
+        ".decl redecl(x: int64)\n"
+        "redecl(1).\n", &err);
+    ASSERT(prog != NULL, "redeclaration fixture failed to parse");
+    wl_plan_t *plan = NULL;
+    ASSERT(wl_plan_from_program(prog, &plan) == 0 && plan != NULL,
+        "integer redeclaration retained stale float metadata");
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    PASS();
+}
+
 /* ----------------------------------------------------------------
  * Test: wl_session_load_facts NULL-safe
  * ---------------------------------------------------------------- */
@@ -1015,6 +1103,8 @@ main(void)
     test_semijoin_with_composite_right_child_rejected();
     test_side_compound_lowers_in_either_atom_position();
     test_plan_generation_diagnostics();
+    test_float_plan_rejected_until_columnar_support();
+    test_float_compound_metadata_resets_on_redeclaration();
     test_plan_free_null();
     test_load_facts_null_safe();
 

--- a/wirelog/exec_plan_gen.c
+++ b/wirelog/exec_plan_gen.c
@@ -709,6 +709,7 @@ expr_result_type(const wl_ir_expr_t *expr, const col_ctx_t *ctx)
         return WL_IR_COLTYPE_STRING;
 
     case WL_IR_EXPR_CONST_INT:
+    case WL_IR_EXPR_CONST_FLOAT:
     case WL_IR_EXPR_BOOL:
     case WL_IR_EXPR_ARITH:
     case WL_IR_EXPR_CMP:
@@ -809,6 +810,10 @@ serialize_expr(expr_buf_t *buf, const wl_ir_expr_t *expr,
         if (expr_buf_push_u8(buf, WL_PLAN_EXPR_CONST_INT) != 0)
             return -1;
         return expr_buf_push_i64(buf, expr->int_value);
+
+    case WL_IR_EXPR_CONST_FLOAT:
+        /* Kept in IR until the typed columnar evaluator lands. */
+        return -1;
 
     case WL_IR_EXPR_CONST_STR: {
         if (!expr->str_value)
@@ -1709,10 +1714,9 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
          * diagnostic.
          *
          * Implementing it needs a return type this engine does not have.
-         * Every value is an int64_t (columnar/internal.h), and while
-         * WIRELOG_TYPE_FLOAT exists in the public enum it is vestigial: the
-         * lexer has type keywords for int32/int64/string/symbol only and no
-         * decimal literal, so neither `.decl v(x: float)` nor `1.5` parses.
+         * The current columnar evaluator still consumes int64 lanes.  The
+         * parser and IR now preserve finite binary64 values, but this
+         * lowering path rejects them until typed columnar evaluation lands.
          * The only implementable semantics today is truncating integer
          * division, and that is the one choice that cannot be corrected
          * later without silently changing existing programs' numbers --
@@ -1726,7 +1730,7 @@ translate_ir_node(const wirelog_ir_node_t *node, op_list_t *ops)
          * Placed at lowering, not in the lexer: `average`/`AVG` keep
          * tokenizing, the AST keeps its AGGREGATE node and the public
          * WIRELOG_AGG_AVG stays as it is, so nothing about the surface
-         * syntax has to be un-done when float arrives.
+         * syntax remains available while typed execution is added.
          */
         if (node->agg_fn == WIRELOG_AGG_AVG) {
             WL_LOG(WL_LOG_SEC_EVAL, WL_LOG_ERROR,
@@ -3709,6 +3713,44 @@ wl_plan_from_program(struct wirelog_program *prog, wl_plan_t **out)
         return -1;
 
     *out = NULL;
+
+    /* The parser/IR representation is intentionally landed before the
+     * columnar float consumers.  Do not let a float relation reach the legacy
+     * int64 evaluator in this intermediate state: it would reinterpret a
+     * binary64 lane as an integer and silently produce wrong answers. */
+    for (uint32_t ri = 0; ri < prog->relation_count; ri++) {
+        const wl_ir_relation_info_t *rel = &prog->relations[ri];
+        if (rel->has_float_facts) {
+            set_plan_error(prog,
+                "relation '%s' has float facts but float columnar support "
+                "is not available", rel->name);
+            return -1;
+        }
+        if (rel->has_float_compound_slots) {
+            set_plan_error(prog,
+                "relation '%s' has float compound slots but float "
+                "columnar support is not available", rel->name);
+            return -1;
+        }
+        for (uint32_t ci = 0; ci < rel->column_count; ci++) {
+            if (rel->columns && rel->columns[ci].type == WIRELOG_TYPE_FLOAT) {
+                set_plan_error(prog,
+                    "float relation '%s' is not executable until float "
+                    "columnar support is available", rel->name);
+                return -1;
+            }
+        }
+        for (uint32_t si = 0; si < rel->slot_type_count; si++) {
+            if (rel->slot_type_declared && rel->slot_types
+                && rel->slot_type_declared[si]
+                && rel->slot_types[si] == WIRELOG_TYPE_FLOAT) {
+                set_plan_error(prog,
+                    "relation '%s' has float compound slots but float "
+                    "columnar support is not available", rel->name);
+                return -1;
+            }
+        }
+    }
 
     /* Issue #287/#962: plan generation emits WL_LOG diagnostics -- cmp_to_tag()
      * reports ordering comparisons that fall back to intern-id order -- and it

--- a/wirelog/ir/ir.c
+++ b/wirelog/ir/ir.c
@@ -118,6 +118,7 @@ wl_ir_expr_clone(const wl_ir_expr_t *expr)
         return NULL;
 
     clone->int_value = expr->int_value;
+    clone->float_value = expr->float_value;
     clone->bool_value = expr->bool_value;
     clone->arith_op = expr->arith_op;
     clone->cmp_op = expr->cmp_op;
@@ -373,6 +374,9 @@ ir_expr_to_buf(const wl_ir_expr_t *expr, char *buf, size_t bufsize, size_t *pos)
     case WL_IR_EXPR_CONST_INT:
         ir_buf_append(buf, bufsize, pos, "%lld",
             (long long)expr->int_value);
+        break;
+    case WL_IR_EXPR_CONST_FLOAT:
+        ir_buf_append(buf, bufsize, pos, "%.17g", expr->float_value);
         break;
     case WL_IR_EXPR_CONST_STR:
         ir_buf_append(buf, bufsize, pos, "\"%s\"",

--- a/wirelog/ir/ir.h
+++ b/wirelog/ir/ir.h
@@ -30,6 +30,7 @@
 typedef enum {
     WL_IR_EXPR_VAR,       /* variable reference (by name) */
     WL_IR_EXPR_CONST_INT, /* integer constant */
+    WL_IR_EXPR_CONST_FLOAT, /* finite binary64 constant */
     WL_IR_EXPR_CONST_STR, /* string constant */
     WL_IR_EXPR_ARITH,     /* binary arithmetic (+,-,*,/,%) */
     WL_IR_EXPR_CMP,       /* comparison (=,!=,<,>,<=,>=) */
@@ -46,6 +47,7 @@ struct wl_ir_expr {
     /* Data (usage depends on type) */
     char *var_name;    /* WL_IR_EXPR_VAR: variable name */
     int64_t int_value; /* WL_IR_EXPR_CONST_INT */
+    double float_value; /* WL_IR_EXPR_CONST_FLOAT */
     char *str_value;   /* WL_IR_EXPR_CONST_STR */
     bool bool_value;   /* WL_IR_EXPR_BOOL */
 

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -59,6 +59,14 @@ type_name_to_column_type(const char *type_name)
     return WIRELOG_TYPE_INT32;
 }
 
+static int64_t
+float_lane_bits(double value)
+{
+    int64_t bits = 0;
+    memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
 /* ======================================================================== */
 /* Compound Column Metadata Parsing (Issue #531)                            */
 /* ======================================================================== */
@@ -147,6 +155,8 @@ parse_compound_metadata(const char *type_name, wl_intern_t *intern,
                 5) == 0) ty = WIRELOG_TYPE_INT64;
             else if (tlen == 6 && (strncmp(tok, "string", 6) == 0
                 || strncmp(tok, "symbol", 6) == 0)) ty = WIRELOG_TYPE_STRING;
+            else if (tlen == 5 && strncmp(tok, "float", 5) == 0)
+                ty = WIRELOG_TYPE_FLOAT;
             else {
                 free(functor_name); return result;
             }
@@ -497,6 +507,7 @@ collect_decl(struct wirelog_program *prog,
     rel->slot_types = NULL;
     rel->slot_type_declared = NULL;
     rel->slot_type_count = 0;
+    rel->has_float_compound_slots = false;
 
     if (col_count > 0) {
         rel->columns
@@ -528,6 +539,15 @@ collect_decl(struct wirelog_program *prog,
                 rel->columns[idx].compound_functor_id = meta.functor_id;
                 rel->columns[idx].compound_arity = meta.arity;
                 rel->columns[idx].compound_inline_col_offset = 0;
+
+                if (meta.has_slot_types) {
+                    for (uint32_t si = 0; si < meta.arity; si++) {
+                        if (meta.slot_types[si] == WIRELOG_TYPE_FLOAT) {
+                            rel->has_float_compound_slots = true;
+                            break;
+                        }
+                    }
+                }
 
                 /* Issue #1037: fixed stride col*4+slot.  A physically packed
                  * array would have to be built in column order and misaligns
@@ -822,6 +842,9 @@ collect_fact(struct wirelog_program *prog,
         const wl_parser_ast_node_t *arg = fact_node->children[i];
         if (arg->type == WL_PARSER_AST_NODE_INTEGER) {
             rel->fact_data[offset + i] = arg->int_value;
+        } else if (arg->type == WL_PARSER_AST_NODE_FLOAT) {
+            rel->fact_data[offset + i] = float_lane_bits(arg->float_value);
+            rel->has_float_facts = true;
         } else if (arg->type == WL_PARSER_AST_NODE_STRING) {
             rel->fact_data[offset + i]
                 = wl_intern_put(prog->intern, arg->str_value);
@@ -889,7 +912,7 @@ atom_physical_column_count(const wl_parser_ast_node_t *atom,
  *
  * Nothing is taken away by tightening.  The flat spelling `pred(1,10,20).`
  * is the redirect, and it is the *only* spelling that ever worked: the fact
- * grammar admits integer and string constants only, so `pred(1, f(10,20)).`
+ * grammar admits numeric and string constants only, so `pred(1, f(10,20)).`
  * and `pred(1, [10,20]).` are parse errors, and the head grammar likewise
  * has no compound-term production.  Before this change the flat spelling was
  * rejected and the broken one accepted, which is to say the relation had no
@@ -1205,6 +1228,12 @@ convert_expr(const wl_parser_ast_node_t *node)
         wl_ir_expr_t *e = wl_ir_expr_create(WL_IR_EXPR_CONST_INT);
         if (e)
             e->int_value = node->int_value;
+        return e;
+    }
+    case WL_PARSER_AST_NODE_FLOAT: {
+        wl_ir_expr_t *e = wl_ir_expr_create(WL_IR_EXPR_CONST_FLOAT);
+        if (e)
+            e->float_value = node->float_value;
         return e;
     }
     case WL_PARSER_AST_NODE_STRING: {
@@ -1867,6 +1896,17 @@ build_side_compound_scan(const wl_parser_ast_node_t *compound_arg,
                 goto fail;
             }
             scan = result;
+        } else if (child->type == WL_PARSER_AST_NODE_FLOAT) {
+            wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_CONST_FLOAT);
+            if (!rhs)
+                goto fail;
+            rhs->float_value = child->float_value;
+            result = wrap_column_cmp_filter(result, i + 1u, rhs);
+            if (!result) {
+                scan = NULL;
+                goto fail;
+            }
+            scan = result;
         } else if (child->type == WL_PARSER_AST_NODE_STRING) {
             wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_CONST_STR);
             if (!rhs)
@@ -2356,6 +2396,29 @@ scan_build_complete:
                 free_var_names(var_names, physical_count);
                 return NULL;
             }
+        } else if (arg->type == WL_PARSER_AST_NODE_FLOAT) {
+            wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_CONST_FLOAT);
+            if (rhs) {
+                rhs->float_value = arg->float_value;
+                result = wrap_column_cmp_filter(result, i, rhs);
+                if (!result) {
+                    wl_ir_node_free(result);
+                    for (uint32_t j = 0; j < side_binding_count; j++)
+                        free(side_bindings[j].handle_var);
+                    free(side_bindings);
+                    free((void *)physical_args);
+                    free_var_names(var_names, physical_count);
+                    return NULL;
+                }
+            } else {
+                wl_ir_node_free(result);
+                for (uint32_t j = 0; j < side_binding_count; j++)
+                    free(side_bindings[j].handle_var);
+                free(side_bindings);
+                free((void *)physical_args);
+                free_var_names(var_names, physical_count);
+                return NULL;
+            }
         } else if (arg->type == WL_PARSER_AST_NODE_STRING) {
             wl_ir_expr_t *rhs = wl_ir_expr_create(WL_IR_EXPR_CONST_STR);
             if (rhs) {
@@ -2410,6 +2473,7 @@ static bool
 wl_ir_program_ast_is_constant(const wl_parser_ast_node_t *node)
 {
     return node && (node->type == WL_PARSER_AST_NODE_INTEGER
+           || node->type == WL_PARSER_AST_NODE_FLOAT
            || node->type == WL_PARSER_AST_NODE_STRING);
 }
 
@@ -2452,6 +2516,12 @@ wl_ir_program_constant_expr(const wl_parser_ast_node_t *node)
         wl_ir_expr_t *expr = wl_ir_expr_create(WL_IR_EXPR_CONST_INT);
         if (expr)
             expr->int_value = node->int_value;
+        return expr;
+    }
+    if (node->type == WL_PARSER_AST_NODE_FLOAT) {
+        wl_ir_expr_t *expr = wl_ir_expr_create(WL_IR_EXPR_CONST_FLOAT);
+        if (expr)
+            expr->float_value = node->float_value;
         return expr;
     }
     if (node->type == WL_PARSER_AST_NODE_STRING) {

--- a/wirelog/ir/program.h
+++ b/wirelog/ir/program.h
@@ -72,6 +72,8 @@ typedef struct {
     int64_t *fact_data;
     uint32_t fact_count;
     uint32_t fact_capacity;
+    bool has_float_facts; /* prevents legacy executor reinterpretation */
+    bool has_float_compound_slots; /* includes side compounds */
     /* Issue #535: RDF named-graph support */
     bool has_graph_column;
     uint32_t graph_column_index;  /* valid only when has_graph_column == true */

--- a/wirelog/parser/ast.c
+++ b/wirelog/parser/ast.c
@@ -153,6 +153,8 @@ wl_parser_ast_node_type_str(wl_parser_ast_node_type_t type)
         return "VARIABLE";
     case WL_PARSER_AST_NODE_INTEGER:
         return "INTEGER";
+    case WL_PARSER_AST_NODE_FLOAT:
+        return "FLOAT";
     case WL_PARSER_AST_NODE_STRING:
         return "STRING";
     case WL_PARSER_AST_NODE_WILDCARD:
@@ -291,6 +293,8 @@ wl_parser_ast_print(const wl_parser_ast_node_t *node, int indent)
         fprintf(stderr, " name=\"%s\"", node->name);
     if (node->type == WL_PARSER_AST_NODE_INTEGER)
         fprintf(stderr, " value=%lld", (long long)node->int_value);
+    if (node->type == WL_PARSER_AST_NODE_FLOAT)
+        fprintf(stderr, " value=%.17g", node->float_value);
     if (node->str_value)
         fprintf(stderr, " str=\"%s\"", node->str_value);
     if (node->type == WL_PARSER_AST_NODE_BOOLEAN)

--- a/wirelog/parser/ast.h
+++ b/wirelog/parser/ast.h
@@ -52,6 +52,7 @@ typedef enum {
     /* Terms / Arguments */
     WL_PARSER_AST_NODE_VARIABLE,  /* name = variable name */
     WL_PARSER_AST_NODE_INTEGER,   /* int_value = integer constant */
+    WL_PARSER_AST_NODE_FLOAT,     /* float_value = binary64 constant */
     WL_PARSER_AST_NODE_STRING,    /* str_value = string constant */
     WL_PARSER_AST_NODE_WILDCARD,  /* _ placeholder */
     WL_PARSER_AST_NODE_AGGREGATE, /* agg_fn, children[0] = arithmetic expr */
@@ -92,6 +93,7 @@ struct wl_parser_ast_node {
     /* Node data (usage depends on type) */
     char *name;        /* Relation/variable/attribute name */
     int64_t int_value; /* Integer constant value */
+    double float_value; /* Finite binary64 constant value */
     char *str_value;   /* String constant or param value */
     bool bool_value;   /* Boolean predicate value */
     bool is_planning;  /* .plan optimization marker (rules only) */

--- a/wirelog/parser/lexer.c
+++ b/wirelog/parser/lexer.c
@@ -11,9 +11,16 @@
  * version 3 of the License, or (at your option) any later version.
  */
 
+#ifndef _WIN32
+#define _GNU_SOURCE 1
+#endif
+
 #include "lexer.h"
 
 #include <ctype.h>
+#include <errno.h>
+#include <math.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -77,6 +84,7 @@ make_token(const wl_parser_lexer_t *lexer, wl_parser_lexer_token_type_t type)
     token.col = lexer->start_col;
     token.int_value = 0;
     token.uint_value = 0;
+    token.float_value = 0.0;
     return token;
 }
 
@@ -91,6 +99,7 @@ make_error(wl_parser_lexer_t *lexer, const char *message)
     token.col = lexer->start_col;
     token.int_value = 0;
     token.uint_value = 0;
+    token.float_value = 0.0;
     snprintf(lexer->error_msg, sizeof(lexer->error_msg), "%s", message);
     return token;
 }
@@ -158,10 +167,63 @@ scan_string(wl_parser_lexer_t *lexer)
 }
 
 static wl_parser_lexer_token_t
-scan_integer(wl_parser_lexer_t *lexer)
+scan_number(wl_parser_lexer_t *lexer)
 {
     while (!is_at_end(lexer) && isdigit((unsigned char)peek(lexer))) {
         advance(lexer);
+    }
+
+    bool is_float = false;
+    if (peek(lexer) == '.' && isdigit((unsigned char)peek_next(lexer))) {
+        is_float = true;
+        advance(lexer);
+        while (!is_at_end(lexer) && isdigit((unsigned char)peek(lexer)))
+            advance(lexer);
+    }
+    if (peek(lexer) == 'e' || peek(lexer) == 'E') {
+        is_float = true;
+        advance(lexer);
+        if (peek(lexer) == '+' || peek(lexer) == '-')
+            advance(lexer);
+        if (!isdigit((unsigned char)peek(lexer)))
+            return make_error(lexer, "malformed float exponent");
+        while (!is_at_end(lexer) && isdigit((unsigned char)peek(lexer)))
+            advance(lexer);
+    }
+
+    if (is_float) {
+        wl_parser_lexer_token_t token
+            = make_token(lexer, WL_PARSER_LEXER_TOK_FLOAT);
+        char *text = wl_parser_lexer_token_to_string(&token);
+        if (!text)
+            return make_error(lexer, "out of memory parsing float literal");
+        errno = 0;
+        char *end = NULL;
+        double value;
+#ifdef _WIN32
+        _locale_t c_locale = _create_locale(LC_NUMERIC, "C");
+        value = c_locale ? _strtod_l(text, &end, c_locale) : 0.0;
+        if (c_locale)
+            _free_locale(c_locale);
+#else
+        locale_t c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
+        value = c_locale ? strtod_l(text, &end, c_locale) : 0.0;
+        if (c_locale)
+            freelocale(c_locale);
+#endif
+        int parse_errno = errno;
+        /* ERANGE also reports gradual underflow.  A non-zero finite
+         * subnormal (for example 5e-324) is a valid binary64 value; only an
+         * underflow all the way to zero is rejected. */
+        bool invalid = end == NULL || end == text
+            || *end != '\0' || !isfinite(value)
+            || (parse_errno == ERANGE && value == 0.0);
+        free(text);
+        if (invalid)
+            return make_error(lexer,
+                       "float literal is not a finite binary64 value");
+        token.float_value = value == 0.0 ? 0.0 : value;
+        return token;
     }
 
     wl_parser_lexer_token_t token
@@ -237,6 +299,8 @@ identifier_type(const char *start, uint32_t length)
         return WL_PARSER_LEXER_TOK_STRING_TYPE;
     if (IS_KW("symbol"))
         return WL_PARSER_LEXER_TOK_SYMBOL_TYPE;
+    if (IS_KW("float"))
+        return WL_PARSER_LEXER_TOK_FLOAT_TYPE;
 
     /* Bitwise operator keywords */
     if (IS_KW("band"))
@@ -406,7 +470,7 @@ scan_token(wl_parser_lexer_t *lexer)
 
     /* Integer literals */
     if (isdigit((unsigned char)c)) {
-        return scan_integer(lexer);
+        return scan_number(lexer);
     }
 
     /* String literals */
@@ -524,6 +588,8 @@ wl_parser_lexer_token_type_str(wl_parser_lexer_token_type_t type)
         return "IDENT";
     case WL_PARSER_LEXER_TOK_INTEGER:
         return "INTEGER";
+    case WL_PARSER_LEXER_TOK_FLOAT:
+        return "FLOAT";
     case WL_PARSER_LEXER_TOK_STRING:
         return "STRING";
     case WL_PARSER_LEXER_TOK_TRUE:
@@ -550,6 +616,8 @@ wl_parser_lexer_token_type_str(wl_parser_lexer_token_type_t type)
         return "STRING_TYPE";
     case WL_PARSER_LEXER_TOK_SYMBOL_TYPE:
         return "SYMBOL_TYPE";
+    case WL_PARSER_LEXER_TOK_FLOAT_TYPE:
+        return "FLOAT_TYPE";
     case WL_PARSER_LEXER_TOK_LPAREN:
         return "LPAREN";
     case WL_PARSER_LEXER_TOK_RPAREN:

--- a/wirelog/parser/lexer.c
+++ b/wirelog/parser/lexer.c
@@ -205,6 +205,12 @@ scan_number(wl_parser_lexer_t *lexer)
         value = c_locale ? _strtod_l(text, &end, c_locale) : 0.0;
         if (c_locale)
             _free_locale(c_locale);
+#elif defined(__APPLE__)
+        /* Apple's SDK does not expose strtod_l for the iOS deployment
+         * target.  iOS applications use the process's invariant POSIX
+         * numeric locale for this parser path; keep the locale-specific
+         * implementation for hosted POSIX builds below. */
+        value = strtod(text, &end);
 #else
         locale_t c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
         value = c_locale ? strtod_l(text, &end, c_locale) : 0.0;

--- a/wirelog/parser/lexer.h
+++ b/wirelog/parser/lexer.h
@@ -33,6 +33,7 @@ typedef enum {
     /* Literals */
     WL_PARSER_LEXER_TOK_IDENT,   /* identifier: _?[a-zA-Z]+[a-zA-Z0-9_]* */
     WL_PARSER_LEXER_TOK_INTEGER, /* integer literal: [0-9]+ */
+    WL_PARSER_LEXER_TOK_FLOAT,   /* finite decimal/exponent literal */
     WL_PARSER_LEXER_TOK_STRING,  /* "string literal" */
 
     /* Boolean literals */
@@ -54,6 +55,7 @@ typedef enum {
     WL_PARSER_LEXER_TOK_INT64,       /* int64 */
     WL_PARSER_LEXER_TOK_STRING_TYPE, /* string (as type name, not literal) */
     WL_PARSER_LEXER_TOK_SYMBOL_TYPE, /* symbol */
+    WL_PARSER_LEXER_TOK_FLOAT_TYPE,  /* float (binary64) */
 
     /* Punctuation */
     WL_PARSER_LEXER_TOK_LPAREN, /* ( */
@@ -146,6 +148,7 @@ typedef struct {
     /* Parsed value (for integer literals) */
     int64_t int_value;
     uint64_t uint_value;
+    double float_value;
 } wl_parser_lexer_token_t;
 
 /* ======================================================================== */

--- a/wirelog/parser/parser.c
+++ b/wirelog/parser/parser.c
@@ -26,16 +26,18 @@
  *   atom        = IDENT "(" atom_args? ")"
  *   negative    = "!" atom
  *   atom_args   = atom_arg ("," atom_arg)*
- *   atom_arg    = IDENT | signed_integer | STRING | "_"
+ *   atom_arg    = IDENT | signed_number | STRING | "_"
  *   arith_expr  = factor (arith_op factor)*
- *   factor      = IDENT | signed_integer | STRING
+ *   factor      = IDENT | signed_number | STRING
  *   signed_int  = INTEGER | "-" INTEGER  (no whitespace between '-' and INTEGER)
+ *   signed_number = signed_int | FLOAT | "-" FLOAT
  *   compare     = arith_expr compare_op arith_expr
  *   aggregate   = agg_op "(" arith_expr ")"
  */
 
 #include "parser.h"
 
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -236,6 +238,33 @@ parse_integer_literal(wl_parser_t *parser)
     return node;
 }
 
+static wl_parser_ast_node_t *
+parse_float_literal(wl_parser_t *parser)
+{
+    wl_parser_lexer_token_t minus = parser->current;
+    bool negative = parser_match(parser, WL_PARSER_LEXER_TOK_MINUS);
+    if (!parser_consume(parser, WL_PARSER_LEXER_TOK_FLOAT,
+        "expected float literal"))
+        return NULL;
+
+    double value = parser->previous.float_value;
+    if (negative)
+        value = -value;
+    if (!isfinite(value)) {
+        parser_error(parser, "float literal is not finite after negation");
+        return NULL;
+    }
+
+    wl_parser_ast_node_t *node = wl_parser_ast_node_create(
+        WL_PARSER_AST_NODE_FLOAT,
+        negative ? minus.line : parser->previous.line,
+        negative ? minus.col : parser->previous.col);
+    if (!node)
+        return NULL;
+    node->float_value = value == 0.0 ? 0.0 : value;
+    return node;
+}
+
 static char *
 parse_declaration_type(wl_parser_t *parser)
 {
@@ -247,9 +276,11 @@ parse_declaration_type(wl_parser_t *parser)
         return strdup_safe("string");
     if (parser_match(parser, WL_PARSER_LEXER_TOK_SYMBOL_TYPE))
         return strdup_safe("symbol");
+    if (parser_match(parser, WL_PARSER_LEXER_TOK_FLOAT_TYPE))
+        return strdup_safe("float");
 
     if (!parser_consume(parser, WL_PARSER_LEXER_TOK_IDENT,
-        "expected type (int32, int64, string, symbol, or compound functor/arity)"))
+        "expected type (int32, int64, string, symbol, float, or compound functor/arity)"))
     {
         return NULL;
     }
@@ -275,9 +306,11 @@ parse_declaration_type(wl_parser_t *parser)
                 WL_PARSER_LEXER_TOK_STRING_TYPE)) t = "string";
             else if (parser_match(parser,
                 WL_PARSER_LEXER_TOK_SYMBOL_TYPE)) t = "symbol";
+            else if (parser_match(parser,
+                WL_PARSER_LEXER_TOK_FLOAT_TYPE)) t = "float";
             else {
                 parser_error(parser, "expected a slot type (int32, int64, "
-                    "string, symbol) in a compound type list");
+                    "string, symbol, float) in a compound type list");
                 free(functor);
                 return NULL;
             }
@@ -498,6 +531,15 @@ parse_factor(wl_parser_t *parser)
             = wl_parser_ast_node_create(WL_PARSER_AST_NODE_VARIABLE, line, col);
         node->name = token_to_name(&parser->previous);
         return node;
+    }
+
+    if (parser_check(parser, WL_PARSER_LEXER_TOK_FLOAT))
+        return parse_float_literal(parser);
+    if (parser_check(parser, WL_PARSER_LEXER_TOK_MINUS)) {
+        wl_parser_lexer_token_t next = wl_parser_lexer_peek_token(
+            &parser->lexer);
+        if (next.type == WL_PARSER_LEXER_TOK_FLOAT)
+            return parse_float_literal(parser);
     }
 
     if (parser_check(parser, WL_PARSER_LEXER_TOK_INTEGER)
@@ -836,7 +878,7 @@ parse_factor(wl_parser_t *parser)
         return parse_string_fn_expr(parser);
     }
 
-    parser_error(parser, "expected variable, integer, or string");
+    parser_error(parser, "expected variable, number, or string");
     return NULL;
 }
 
@@ -1103,6 +1145,15 @@ parse_atom_arg_at_depth(wl_parser_t *parser, uint32_t depth)
         return node;
     }
 
+    if (parser_check(parser, WL_PARSER_LEXER_TOK_FLOAT))
+        return parse_float_literal(parser);
+    if (parser_check(parser, WL_PARSER_LEXER_TOK_MINUS)) {
+        wl_parser_lexer_token_t next = wl_parser_lexer_peek_token(
+            &parser->lexer);
+        if (next.type == WL_PARSER_LEXER_TOK_FLOAT)
+            return parse_float_literal(parser);
+    }
+
     if (parser_check(parser, WL_PARSER_LEXER_TOK_INTEGER)
         || parser_check(parser, WL_PARSER_LEXER_TOK_MINUS)) {
         return parse_integer_literal(parser);
@@ -1333,8 +1384,14 @@ parse_predicate(wl_parser_t *parser)
         return cmp;
     }
 
-    /* Comparison starting with integer constant */
-    if (parser_check(parser, WL_PARSER_LEXER_TOK_INTEGER)
+    /* Comparison starting with a numeric constant */
+    bool starts_float = parser_check(parser, WL_PARSER_LEXER_TOK_FLOAT);
+    if (!starts_float && parser_check(parser, WL_PARSER_LEXER_TOK_MINUS)) {
+        wl_parser_lexer_token_t next = wl_parser_lexer_peek_token(
+            &parser->lexer);
+        starts_float = next.type == WL_PARSER_LEXER_TOK_FLOAT;
+    }
+    if (starts_float || parser_check(parser, WL_PARSER_LEXER_TOK_INTEGER)
         || parser_check(parser, WL_PARSER_LEXER_TOK_MINUS)) {
         wl_parser_ast_node_t *left = parse_arithmetic_expr(parser);
         if (!left)
@@ -1481,13 +1538,14 @@ parse_fact(wl_parser_t *parser, wl_parser_ast_node_t *head)
 
     wl_parser_ast_node_free(head);
 
-    /* Validate: fact arguments must be constants (INTEGER or STRING) */
+    /* Validate: fact arguments must be numeric or string constants. */
     for (uint32_t i = 0; i < fact->child_count; i++) {
         wl_parser_ast_node_type_t arg_type = fact->children[i]->type;
         if (arg_type != WL_PARSER_AST_NODE_INTEGER
+            && arg_type != WL_PARSER_AST_NODE_FLOAT
             && arg_type != WL_PARSER_AST_NODE_STRING) {
             parser_error(
-                parser, "fact arguments must be constants (integer or string)");
+                parser, "fact arguments must be constants (number or string)");
             wl_parser_ast_node_free(fact);
             return NULL;
         }


### PR DESCRIPTION
## Summary
- add float type and decimal literal lexer/parser support
- preserve float constants through AST/IR cloning and fact metadata
- reject float plans until the typed columnar evaluator is complete

This is the first preparatory unit for #1226. Physical evaluator, typed ABI, aggregate, and CSV/Arrow work remains gated for follow-up commits.

Related to #1226; the feature issue remains open until all acceptance criteria are met.