### PR TITLE
perf: add adaptive low-K K-fusion dispatch

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -35,6 +35,7 @@ bench_backend_src = files(
   subdir_wirelog / 'columnar/join.c',
   subdir_wirelog / 'columnar/merge.c',
   subdir_wirelog / 'columnar/kfusion.c',
+  subdir_wirelog / 'columnar/kfusion_adaptive.c',
   subdir_wirelog / 'columnar/diff.c',
   subdir_wirelog / 'columnar/inline.c',
   subdir_wirelog / 'columnar/eval_dedup.c',

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -422,32 +422,35 @@ emits a non-fused chain.
 
 ### 7.2 Parallel-runtime threshold (K ≥ 4)
 
-`wirelog/columnar/ops.c:19` defines:
+`wirelog/columnar/kfusion.c` defines:
 
 ```
 #define WL_KFUSION_MIN_PARALLEL_K 4
 ```
 
-At the dispatch site (`kfusion.c:609-623`), the runtime picks between
+At the dispatch site, the runtime picks between
 parallel and serial K-fusion:
 
 ```c
 uint32_t active_workers = live_count < sess->num_workers
     ? live_count : sess->num_workers;
 wl_work_queue_t *wq = NULL;
-if (active_workers > 1 && live_count >= WL_KFUSION_MIN_PARALLEL_K) {
+if (active_workers > 1
+    && (live_count >= WL_KFUSION_MIN_PARALLEL_K || adaptive_parallel)) {
     /* ... ensure workqueue, dispatch parallel branches ... */
     wq = sess->wq;
 }
-if (!wq || live_count < WL_KFUSION_MIN_PARALLEL_K) {
+if (!wq || (live_count < WL_KFUSION_MIN_PARALLEL_K
+        && !adaptive_parallel)) {
     return col_op_k_fusion_serial(op, stack, sess);
 }
 ```
 
 So:
 
-- **K = 2 or K = 3**: plan emits `WL_PLAN_OP_K_FUSION`, runtime takes
-  the **serial** branch (`col_op_k_fusion_serial`).
+- **K = 2 or K = 3**: plan emits `WL_PLAN_OP_K_FUSION`, runtime starts on
+  the **serial** branch and may enable parallel dispatch after adaptive
+  evidence (`col_op_k_fusion_serial`).
 - **K ≥ 4 and `num_workers > 1`**: runtime allocates per-worker
   sessions and dispatches branches in parallel.
 
@@ -459,18 +462,38 @@ session allocation (`COL_SESSION(sess)->kfusion_alloc_ns` profiled
 at `kfusion.c:633`) exceed the saved tuple work for the CRDT and
 DDISASM workloads measured in the v0.40 perf gate
 (`tests/test_crdt_perf_gate.c`, `bench/bench_flowlog.c`). The
-`ops.c:17-19` comment block records the measurement summary:
+    `kfusion.c` comment block records the measurement summary:
 **DDISASM K = 3 is 14% slower with 8-worker parallel than serial.**
 
 Cross-reference: #731 (CRDT median-time perf gate landing) for the
 empirical evidence anchoring K = 4.
 
-### 7.4 Workload-adaptive future work
+### 7.4 Workload-adaptive low-K dispatch
 
-The threshold is currently a compile-time constant. A
-workload-adaptive variant (e.g. K-fusion dispatch decided per-stratum
-based on tuple-count estimates) is out of scope for v0.41 and would
-require a separate evaluator restructure.
+K=2 and K=3 use a session-local conservative policy in
+`wirelog/columnar/kfusion_adaptive.c`. Each K-fusion operator starts in
+the serial path. The policy records the complete invocation duration,
+including branch evaluation, workqueue wait, merge, cleanup, and result
+stack effects. After three valid serial observations it permits parallel
+probe invocations; three valid parallel observations must beat the serial
+EWMA by at least 5% before the policy enters the parallel state.
+
+The policy has three states: `UNKNOWN`, `SERIAL`, and `PARALLEL`. A
+cooldown provides hysteresis after transitions, and invalid timing,
+dispatch errors, insufficient observations, or ambiguous results return
+to the serial fallback. A change in operator, worker count, or relation
+size class creates a fresh record, so stale measurements are not reused.
+
+The adaptive records belong only to the coordinator session. K-fusion
+worker session copies set the policy pointer to `NULL`; workers never
+update or free coordinator state. Session snapshot profiling preserves
+the learned records, while session destruction releases them.
+
+The fixed `K >= 4` threshold and its parallel path are unchanged. The
+adaptive policy does not change planner metadata, public ABI, merge logic,
+or worker cleanup semantics. Deterministic policy tests use synthetic
+observations rather than wall-clock sleeps; workload-level calibration
+remains a pinned-runner measurement task.
 
 ---
 
@@ -759,7 +782,7 @@ advisory leg); issue #826 (native TSan SEGV triage);
 - `wirelog/meson.build:40-72` — `cc.links()` C11-threads detection.
 - `meson_options.txt:14-19` — `threads` build option (`native` |
   `posix`).
-- `wirelog/columnar/ops.c:17-22` — `WL_KFUSION_MIN_PARALLEL_K` plus
+- `wirelog/columnar/kfusion.c:10` — `WL_KFUSION_MIN_PARALLEL_K` plus
   the rationale comment block citing the DDISASM K = 3 measurement.
 - `wirelog/columnar/kfusion.c:609-623` — K-fusion parallel-dispatch
   gate.

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -318,7 +318,7 @@ once and the surrounding overhead dominates.
 
 | Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
-| `kfusion.c:col_op_k_fusion` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:399`, which resets the TDD counter before `thread_create()` |
+| `kfusion.c:col_op_k_fusion_dispatch` | `shared_join_count` | `atomic_store_explicit` | `relaxed` | Issue #959: zeroed before branch tasks are submitted, so the happens-before edge comes from task submission itself -- same argument as `eval.c:399`, which resets the TDD counter before `thread_create()` |
 
 The `stop` flag's `memory_order_relaxed` store is deliberate:
 cancellation is **cooperative**, not preemptive. A worker may observe

--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -62,6 +62,7 @@ wirelog/columnar/handle_remap.c
 wirelog/columnar/handle_remap_apply.c
 wirelog/columnar/handle_remap_apply_side.c
 wirelog/columnar/inline.c
+wirelog/columnar/kfusion_adaptive.c
 wirelog/columnar/lftj.c
 wirelog/columnar/mem_ledger.c
 wirelog/columnar/merge.c

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -991,6 +991,7 @@ backend_src = files(
   '../wirelog/columnar/join.c',
   '../wirelog/columnar/merge.c',
   '../wirelog/columnar/kfusion.c',
+  '../wirelog/columnar/kfusion_adaptive.c',
   '../wirelog/columnar/diff.c',
   '../wirelog/columnar/inline.c',
   '../wirelog/columnar/eval_dedup.c',
@@ -1822,6 +1823,14 @@ test_k_fusion_e2e_exe = executable(
 )
 
 test('k_fusion_e2e', test_k_fusion_e2e_exe)
+
+test_k_fusion_adaptive_exe = executable(
+  'test_k_fusion_adaptive',
+  files('test_k_fusion_adaptive.c'),
+  files('../wirelog/columnar/kfusion_adaptive.c'),
+  include_directories: [wirelog_inc, wirelog_src_inc],
+)
+test('k_fusion_adaptive', test_k_fusion_adaptive_exe)
 
 # ============================================================================
 # K-Fusion Memory Isolation Tests (Issue #196)

--- a/tests/test_k_fusion_adaptive.c
+++ b/tests/test_k_fusion_adaptive.c
@@ -1,0 +1,64 @@
+/*
+ * test_k_fusion_adaptive.c - deterministic low-K K-fusion policy tests.
+ */
+
+#include "columnar/kfusion_adaptive.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+static void
+observe_serial(wl_kfusion_adaptive_ctx_t *ctx, const void *key,
+    uint32_t workers, uint64_t elapsed)
+{
+    wl_kfusion_adaptive_observe(ctx, key, 2, workers, 16,
+        WL_KFUSION_ADAPTIVE_DECISION_SERIAL, elapsed, true);
+}
+
+static void
+observe_parallel(wl_kfusion_adaptive_ctx_t *ctx, const void *key,
+    uint32_t workers, uint64_t elapsed)
+{
+    wl_kfusion_adaptive_observe(ctx, key, 2, workers, 16,
+        WL_KFUSION_ADAPTIVE_DECISION_PARALLEL, elapsed, true);
+}
+
+int
+main(void)
+{
+    wl_kfusion_adaptive_ctx_t *ctx = wl_kfusion_adaptive_create();
+    assert(ctx != NULL);
+    int key = 1;
+
+    assert(wl_kfusion_adaptive_begin(ctx, &key, 2, 4, 16)
+        == WL_KFUSION_ADAPTIVE_DECISION_SERIAL);
+    observe_serial(ctx, &key, 4, 100);
+    observe_serial(ctx, &key, 4, 100);
+    observe_serial(ctx, &key, 4, 100);
+
+    /* Three fast parallel observations are required before promotion. */
+    assert(wl_kfusion_adaptive_begin(ctx, &key, 2, 4, 16)
+        == WL_KFUSION_ADAPTIVE_DECISION_PARALLEL);
+    observe_parallel(ctx, &key, 4, 80);
+    observe_parallel(ctx, &key, 4, 80);
+    observe_parallel(ctx, &key, 4, 80);
+    assert(ctx->records[0].state == WL_KFUSION_ADAPTIVE_PARALLEL);
+
+    /* A worker-width change gets a fresh record and starts conservatively. */
+    assert(wl_kfusion_adaptive_begin(ctx, &key, 2, 8, 16)
+        == WL_KFUSION_ADAPTIVE_DECISION_SERIAL);
+
+    /* A failed sample and a marginally slower probe both return to serial. */
+    wl_kfusion_adaptive_observe(ctx, &key, 2, 4, 16,
+        WL_KFUSION_ADAPTIVE_DECISION_PARALLEL, 100, true);
+    assert(ctx->records[0].state == WL_KFUSION_ADAPTIVE_SERIAL);
+    wl_kfusion_adaptive_observe(ctx, &key, 2, 4, 16,
+        WL_KFUSION_ADAPTIVE_DECISION_PARALLEL, 100, false);
+    assert(ctx->records[0].state == WL_KFUSION_ADAPTIVE_SERIAL);
+
+    assert(wl_kfusion_adaptive_begin(ctx, &key, 4, 4, 16)
+        == WL_KFUSION_ADAPTIVE_DECISION_SERIAL);
+    wl_kfusion_adaptive_destroy(ctx);
+    return 0;
+}

--- a/tests/test_k_fusion_e2e.c
+++ b/tests/test_k_fusion_e2e.c
@@ -538,6 +538,7 @@ test_k2_all_inactive_branches_preserve_target_schema(void)
     eval_stack_drain(&stack);
 
     col_rel_destroy(target);
+    wl_kfusion_adaptive_destroy(sess.kfusion_adaptive);
     free(sess.rels);
     session_rel_free_hash(&sess);
     PASS();

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -21,6 +21,7 @@
 #include "columnar/diff_trace.h"
 #include "columnar/delta_pool.h"
 #include "columnar/mem_ledger.h"
+#include "columnar/kfusion_adaptive.h"
 #include "columnar/progress.h"
 #include "session.h"
 #include "intern.h"
@@ -1218,6 +1219,9 @@ typedef struct wl_col_session_t {
     uint64_t kfusion_dispatch_ns;
     uint64_t kfusion_merge_ns;
     uint64_t kfusion_cleanup_ns;
+    /* Coordinator-owned adaptive policy for K=2/K=3 K-fusion. Worker
+    * session copies set this to NULL and never mutate or free it. */
+    wl_kfusion_adaptive_ctx_t *kfusion_adaptive;
     /* Exchange path timing (Issue #413): accumulated wall time spent in
      * tdd_exchange_deltas / tdd_bdx_exchange_deltas across all sub-pass
      * barriers.  Used to compute serial_fraction = exchange_time_ns / total_ns

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -554,8 +554,10 @@ cleanup:
  */
 static int
 col_op_k_fusion_dispatch(const wl_plan_op_t *op, eval_stack_t *stack,
-    wl_col_session_t *sess, bool adaptive_parallel)
+    wl_col_session_t *sess, bool adaptive_parallel, bool *parallel_executed)
 {
+    if (parallel_executed)
+        *parallel_executed = false;
     if (!op->opaque_data)
         return EINVAL;
 
@@ -639,6 +641,8 @@ col_op_k_fusion_dispatch(const wl_plan_op_t *op, eval_stack_t *stack,
         free(live_indices);
         return col_op_k_fusion_serial(op, stack, sess);
     }
+    if (parallel_executed)
+        *parallel_executed = true;
 
     col_rel_t **results = (col_rel_t **)calloc(live_count, sizeof(col_rel_t *));
     col_op_k_fusion_worker_t *workers = (col_op_k_fusion_worker_t *)calloc(
@@ -1007,7 +1011,7 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
     if (k == 0)
         return EINVAL;
     if (k >= WL_KFUSION_MIN_PARALLEL_K)
-        return col_op_k_fusion_dispatch(op, stack, sess, false);
+        return col_op_k_fusion_dispatch(op, stack, sess, false, NULL);
 
     /* Preserve the established serial safety cases and avoid allocating
      * policy state in worker sessions. */
@@ -1030,10 +1034,15 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
     wl_kfusion_adaptive_decision_t decision = wl_kfusion_adaptive_begin(
         sess->kfusion_adaptive, meta, k, sess->num_workers, size_class);
     uint64_t started = now_ns();
+    bool parallel_executed = false;
     int rc = decision == WL_KFUSION_ADAPTIVE_DECISION_PARALLEL
-        ? col_op_k_fusion_dispatch(op, stack, sess, true)
+        ? col_op_k_fusion_dispatch(op, stack, sess, true,
+            &parallel_executed)
         : col_op_k_fusion_serial(op, stack, sess);
     uint64_t elapsed = now_ns() - started;
+    if (decision == WL_KFUSION_ADAPTIVE_DECISION_PARALLEL
+        && !parallel_executed)
+        decision = WL_KFUSION_ADAPTIVE_DECISION_SERIAL;
     wl_kfusion_adaptive_observe(sess->kfusion_adaptive, meta, k,
         sess->num_workers, size_class, decision, elapsed, rc == 0);
     return rc;

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -552,9 +552,9 @@ cleanup:
  * parallel (or sequentially on single-threaded systems).
  * Results are merged via col_rel_merge_k() after all workers complete.
  */
-int
-col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
-    wl_col_session_t *sess)
+static int
+col_op_k_fusion_dispatch(const wl_plan_op_t *op, eval_stack_t *stack,
+    wl_col_session_t *sess, bool adaptive_parallel)
 {
     if (!op->opaque_data)
         return EINVAL;
@@ -624,7 +624,8 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
     uint32_t active_workers = live_count < sess->num_workers
         ? live_count : sess->num_workers;
     wl_work_queue_t *wq = NULL; /* NULL when serial or in workers */
-    if (active_workers > 1 && live_count >= WL_KFUSION_MIN_PARALLEL_K) {
+    if (active_workers > 1
+        && (live_count >= WL_KFUSION_MIN_PARALLEL_K || adaptive_parallel)) {
         int ensure_rc = wl_columnar_session_ensure_workqueue(sess,
                 active_workers);
         if (ensure_rc != 0) {
@@ -633,7 +634,8 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         }
         wq = sess->wq;
     }
-    if (!wq || live_count < WL_KFUSION_MIN_PARALLEL_K) {
+    if (!wq || (live_count < WL_KFUSION_MIN_PARALLEL_K
+        && !adaptive_parallel)) {
         free(live_indices);
         return col_op_k_fusion_serial(op, stack, sess);
     }
@@ -694,6 +696,7 @@ col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
         worker_sess[d] = *sess;
         worker_sess[d].wq = NULL; /* prevent nested K-fusion from workers */
         worker_sess[d].wq_workers = 0;
+        worker_sess[d].kfusion_adaptive = NULL;
         worker_sess[d].num_workers = 1;
         worker_sess[d].tdd_workers = NULL;
         worker_sess[d].tdd_workers_cap = 0;
@@ -983,5 +986,55 @@ cleanup_wq:
     free(workers);
     free(live_indices);
     COL_SESSION(sess)->kfusion_cleanup_ns += now_ns() - _phase_t0;
+    return rc;
+}
+
+/*
+ * Adaptive low-K entry point.  The existing fixed K>=4 path is deliberately
+ * untouched.  K=2/K=3 starts serial, then periodically samples the complete
+ * parallel invocation; the policy only changes dispatch and never participates
+ * in result construction or worker cleanup.
+ */
+int
+col_op_k_fusion(const wl_plan_op_t *op, eval_stack_t *stack,
+    wl_col_session_t *sess)
+{
+    if (!op || !op->opaque_data || !stack || !sess)
+        return EINVAL;
+
+    wl_plan_op_k_fusion_t *meta = (wl_plan_op_k_fusion_t *)op->opaque_data;
+    uint32_t k = meta->k;
+    if (k == 0)
+        return EINVAL;
+    if (k >= WL_KFUSION_MIN_PARALLEL_K)
+        return col_op_k_fusion_dispatch(op, stack, sess, false);
+
+    /* Preserve the established serial safety cases and avoid allocating
+     * policy state in worker sessions. */
+    if (sess->tdd_subpass_active || sess->coordinator
+        || sess->num_workers <= 1)
+        return col_op_k_fusion_serial(op, stack, sess);
+
+    if (!sess->kfusion_adaptive) {
+        sess->kfusion_adaptive = wl_kfusion_adaptive_create();
+        if (!sess->kfusion_adaptive)
+            return col_op_k_fusion_serial(op, stack, sess);
+    }
+
+    uint64_t size_class = 0;
+    if (op->relation_name) {
+        col_rel_t *target = session_find_rel(sess, op->relation_name);
+        if (target)
+            size_class = target->nrows;
+    }
+    wl_kfusion_adaptive_decision_t decision = wl_kfusion_adaptive_begin(
+        sess->kfusion_adaptive, meta, k, sess->num_workers, size_class);
+    uint64_t started = now_ns();
+    int rc = decision == WL_KFUSION_ADAPTIVE_DECISION_PARALLEL
+        ? col_op_k_fusion_dispatch(op, stack, sess, true)
+        : col_op_k_fusion_serial(op, stack, sess);
+    uint64_t elapsed = now_ns() - started;
+    wl_kfusion_adaptive_observe(sess->kfusion_adaptive, meta, k,
+        sess->num_workers, size_class, decision, elapsed, rc == 0);
     return rc;
 }

--- a/wirelog/columnar/kfusion_adaptive.c
+++ b/wirelog/columnar/kfusion_adaptive.c
@@ -1,0 +1,121 @@
+/*
+ * columnar/kfusion_adaptive.c - session-local low-K K-fusion policy
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#include "columnar/kfusion_adaptive.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static wl_kfusion_adaptive_record_t *
+find_record(wl_kfusion_adaptive_ctx_t *ctx, const void *key, uint32_t k,
+    uint32_t workers, uint64_t size_class)
+{
+    wl_kfusion_adaptive_record_t *free_record = NULL;
+    for (uint32_t i = 0; i < WL_KFUSION_ADAPTIVE_MAX_OPS; i++) {
+        wl_kfusion_adaptive_record_t *record = &ctx->records[i];
+        if (record->key == key) {
+            if (record->k != k || record->workers != workers
+                || record->size_class != size_class) {
+                memset(record, 0, sizeof(*record));
+                record->key = key;
+                record->k = k;
+                record->workers = workers;
+                record->size_class = size_class;
+            }
+            return record;
+        }
+        if (!record->key && !free_record)
+            free_record = record;
+    }
+    if (!free_record)
+        free_record = &ctx->records[0];
+    memset(free_record, 0, sizeof(*free_record));
+    free_record->key = key;
+    free_record->k = k;
+    free_record->workers = workers;
+    free_record->size_class = size_class;
+    return free_record;
+}
+
+static void
+update_ewma(uint64_t *ewma, uint64_t sample)
+{
+    if (*ewma == 0)
+        *ewma = sample;
+    else if (*ewma > UINT64_MAX / 3
+        || sample > UINT64_MAX - (*ewma * 3))
+        *ewma = UINT64_MAX;
+    else
+        *ewma = (*ewma * 3 + sample) / 4;
+}
+
+wl_kfusion_adaptive_ctx_t *
+wl_kfusion_adaptive_create(void)
+{
+    return (wl_kfusion_adaptive_ctx_t *)calloc(1,
+               sizeof(wl_kfusion_adaptive_ctx_t));
+}
+
+void
+wl_kfusion_adaptive_destroy(wl_kfusion_adaptive_ctx_t *ctx)
+{
+    free(ctx);
+}
+
+wl_kfusion_adaptive_decision_t
+wl_kfusion_adaptive_begin(wl_kfusion_adaptive_ctx_t *ctx, const void *key,
+    uint32_t k, uint32_t workers, uint64_t size_class)
+{
+    if (!ctx || !key || k >= 4 || workers <= 1)
+        return WL_KFUSION_ADAPTIVE_DECISION_SERIAL;
+    wl_kfusion_adaptive_record_t *record
+        = find_record(ctx, key, k, workers, size_class);
+    if (record->cooldown > 0) {
+        record->cooldown--;
+        return record->state == WL_KFUSION_ADAPTIVE_PARALLEL
+            ? WL_KFUSION_ADAPTIVE_DECISION_PARALLEL
+            : WL_KFUSION_ADAPTIVE_DECISION_SERIAL;
+    }
+    if (record->state == WL_KFUSION_ADAPTIVE_PARALLEL)
+        return WL_KFUSION_ADAPTIVE_DECISION_PARALLEL;
+    if (record->serial_samples < WL_KFUSION_ADAPTIVE_MIN_SAMPLES)
+        return WL_KFUSION_ADAPTIVE_DECISION_SERIAL;
+    return WL_KFUSION_ADAPTIVE_DECISION_PARALLEL;
+}
+
+void
+wl_kfusion_adaptive_observe(wl_kfusion_adaptive_ctx_t *ctx, const void *key,
+    uint32_t k, uint32_t workers, uint64_t size_class,
+    wl_kfusion_adaptive_decision_t decision, uint64_t elapsed_ns, bool success)
+{
+    if (!ctx || !key || k >= 4 || workers <= 1)
+        return;
+    wl_kfusion_adaptive_record_t *record
+        = find_record(ctx, key, k, workers, size_class);
+    if (!success || elapsed_ns == 0 || elapsed_ns > UINT64_MAX / 2) {
+        record->state = WL_KFUSION_ADAPTIVE_SERIAL;
+        record->cooldown = WL_KFUSION_ADAPTIVE_COOLDOWN;
+        return;
+    }
+    if (decision == WL_KFUSION_ADAPTIVE_DECISION_PARALLEL) {
+        update_ewma(&record->parallel_ewma_ns, elapsed_ns);
+        record->parallel_samples++;
+    } else {
+        update_ewma(&record->serial_ewma_ns, elapsed_ns);
+        record->serial_samples++;
+    }
+    if (record->serial_samples < WL_KFUSION_ADAPTIVE_MIN_SAMPLES
+        || record->parallel_samples < WL_KFUSION_ADAPTIVE_MIN_SAMPLES) {
+        record->state = WL_KFUSION_ADAPTIVE_SERIAL;
+        return;
+    }
+    uint64_t parallel_limit = record->serial_ewma_ns / 100u
+        * (100u - WL_KFUSION_ADAPTIVE_MARGIN_PERCENT);
+    record->state = record->parallel_ewma_ns <= parallel_limit
+        ? WL_KFUSION_ADAPTIVE_PARALLEL : WL_KFUSION_ADAPTIVE_SERIAL;
+    record->cooldown = WL_KFUSION_ADAPTIVE_COOLDOWN;
+}

--- a/wirelog/columnar/kfusion_adaptive.h
+++ b/wirelog/columnar/kfusion_adaptive.h
@@ -1,0 +1,55 @@
+/*
+ * columnar/kfusion_adaptive.h - session-local low-K K-fusion policy
+ *
+ * INTERNAL HEADER - not installed, not part of public API.
+ */
+
+#ifndef WL_COLUMNAR_KFUSION_ADAPTIVE_H
+#define WL_COLUMNAR_KFUSION_ADAPTIVE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define WL_KFUSION_ADAPTIVE_MAX_OPS 32u
+#define WL_KFUSION_ADAPTIVE_MIN_SAMPLES 3u
+#define WL_KFUSION_ADAPTIVE_MARGIN_PERCENT 5u
+#define WL_KFUSION_ADAPTIVE_COOLDOWN 3u
+
+typedef enum {
+    WL_KFUSION_ADAPTIVE_UNKNOWN = 0,
+    WL_KFUSION_ADAPTIVE_SERIAL,
+    WL_KFUSION_ADAPTIVE_PARALLEL,
+} wl_kfusion_adaptive_state_t;
+
+typedef struct {
+    const void *key;
+    uint32_t k;
+    uint32_t workers;
+    uint64_t size_class;
+    uint64_t serial_ewma_ns;
+    uint64_t parallel_ewma_ns;
+    uint32_t serial_samples;
+    uint32_t parallel_samples;
+    uint32_t cooldown;
+    wl_kfusion_adaptive_state_t state;
+} wl_kfusion_adaptive_record_t;
+
+typedef struct {
+    wl_kfusion_adaptive_record_t records[WL_KFUSION_ADAPTIVE_MAX_OPS];
+} wl_kfusion_adaptive_ctx_t;
+
+typedef enum {
+    WL_KFUSION_ADAPTIVE_DECISION_SERIAL = 0,
+    WL_KFUSION_ADAPTIVE_DECISION_PARALLEL,
+} wl_kfusion_adaptive_decision_t;
+
+wl_kfusion_adaptive_ctx_t *wl_kfusion_adaptive_create(void);
+void wl_kfusion_adaptive_destroy(wl_kfusion_adaptive_ctx_t *ctx);
+wl_kfusion_adaptive_decision_t wl_kfusion_adaptive_begin(
+    wl_kfusion_adaptive_ctx_t *ctx, const void *key, uint32_t k,
+    uint32_t workers, uint64_t size_class);
+void wl_kfusion_adaptive_observe(wl_kfusion_adaptive_ctx_t *ctx,
+    const void *key, uint32_t k, uint32_t workers, uint64_t size_class,
+    wl_kfusion_adaptive_decision_t decision, uint64_t elapsed_ns, bool success);
+
+#endif /* WL_COLUMNAR_KFUSION_ADAPTIVE_H */

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1342,6 +1342,7 @@ col_session_destroy(wl_session_t *session)
     session_rel_free_hash(sess);
     col_mat_cache_clear(&sess->mat_cache);
     wl_workqueue_destroy(sess->wq);
+    wl_kfusion_adaptive_destroy(sess->kfusion_adaptive);
     /* Free arrangement registry (Phase 3C) */
     for (uint32_t i = 0; i < sess->arr_count; i++) {
         free(sess->arr_entries[i].rel_name);
@@ -1447,6 +1448,7 @@ col_worker_session_create(wl_col_session_t *coordinator,
     /* Step 3: NULL all owned pointers (safe for cleanup on early abort) */
     out_worker->wq = NULL;
     out_worker->wq_workers = 0;
+    out_worker->kfusion_adaptive = NULL;
     out_worker->eval_arena = NULL;
     out_worker->delta_pool = NULL;
     out_worker->rels = NULL;

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -90,7 +90,7 @@ wirelog_lockfree_queue_src = files('util/lockfree_queue.c', )
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
 wirelog_backend_src = files('columnar/relation.c', 'columnar/cache.c',
-                           'columnar/ops.c', 'columnar/arithmetic.c', 'columnar/expr.c', 'columnar/filter.c', 'columnar/join.c', 'columnar/merge.c', 'columnar/kfusion.c', 'columnar/diff.c', 'columnar/inline.c', 'columnar/eval_dedup.c', 'columnar/eval_delta.c', 'columnar/eval_tdd_queue.c', 'columnar/eval_tdd_plan.c', 'columnar/eval_plan.c', 'columnar/eval_stack.c', 'columnar/eval_serial.c', 'columnar/eval.c',
+                           'columnar/ops.c', 'columnar/arithmetic.c', 'columnar/expr.c', 'columnar/filter.c', 'columnar/join.c', 'columnar/merge.c', 'columnar/kfusion.c', 'columnar/kfusion_adaptive.c', 'columnar/diff.c', 'columnar/inline.c', 'columnar/eval_dedup.c', 'columnar/eval_delta.c', 'columnar/eval_tdd_queue.c', 'columnar/eval_tdd_plan.c', 'columnar/eval_plan.c', 'columnar/eval_stack.c', 'columnar/eval_serial.c', 'columnar/eval.c',
                            'columnar/arrangement.c', 'columnar/frontier.c', 'columnar/frontier_epoch.c',
                            'columnar/mobius.c', 'columnar/session.c', 'columnar/session_hash.c',
                            'columnar/delta_pool.c', 'columnar/lftj.c',


### PR DESCRIPTION
## Summary
- add a coordinator-owned adaptive policy for K=2/K=3 K-fusion dispatch
- retain the fixed K>=4 parallel threshold and all existing worker/merge/cleanup paths
- use conservative serial warm-up, full-invocation observations, EWMA margin, cooldown, and reset on worker/size changes
- add deterministic policy tests and update threading documentation

## Validation
- `meson test -C builddir k_fusion_adaptive k_fusion_e2e k_fusion_correctness --print-errorlogs`
- `ninja -C builddir libwirelog.so.0.54.99`
- `git diff --check`

Hardware-specific CRDT W=8, DDISASM W=8, and CSPA calibration remains a provisioned-runner measurement step.

Related to #808
