### PR TITLE
perf: replace arrangement bucket-head memset with versioned heads

### DIFF
--- a/tests/test_arr_hash_rows_batch.c
+++ b/tests/test_arr_hash_rows_batch.c
@@ -448,7 +448,8 @@ test_float_typed_arrangement_probe(void)
     arr.key_count = 1;
     arr.nbuckets = 16;
     arr.ht_cap = rel->nrows;
-    arr.ht_head = (uint32_t *)malloc(arr.nbuckets * sizeof(uint32_t));
+    arr.indexed_rows = rel->nrows;
+    arr.ht_head = (uint64_t *)malloc(arr.nbuckets * sizeof(uint64_t));
     arr.ht_next = (uint32_t *)malloc(arr.ht_cap * sizeof(uint32_t));
     if (!arr.ht_head || !arr.ht_next) {
         printf("  FAIL arrangement allocation\n");
@@ -459,12 +460,12 @@ test_float_typed_arrangement_probe(void)
         return;
     }
     for (uint32_t i = 0; i < arr.nbuckets; i++)
-        arr.ht_head[i] = UINT32_MAX;
+        arr.ht_head[i] = UINT64_C(0xFFFFFFFF);
     uint32_t hashes[2];
     arr_hash_rows_batch(rel, 0, rel->nrows, key_cols, 1, hashes);
     for (uint32_t row = 0; row < rel->nrows; row++) {
         uint32_t bucket = hashes[row] & (arr.nbuckets - 1u);
-        arr.ht_next[row] = arr.ht_head[bucket];
+        arr.ht_next[row] = (uint32_t)arr.ht_head[bucket];
         arr.ht_head[bucket] = row;
     }
     uint32_t row = col_arrangement_find_first_typed(&arr, rel, negative_zero);

--- a/tests/test_arrangement.c
+++ b/tests/test_arrangement.c
@@ -31,6 +31,7 @@
 #include "../wirelog/wirelog.h"
 
 #include <inttypes.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -225,21 +226,26 @@ find_rel_mirror(wl_session_t *sess, const char *rel_name)
  *   uint32_t *key_cols     8  (offset  0)
  *   uint32_t  key_count    4  (offset  8)
  *   uint32_t  nbuckets     4  (offset 12) — packed with key_count, no pad
- *   uint32_t *ht_head      8  (offset 16)
+ *   uint64_t *ht_head      8  (offset 16)
  *   uint32_t *ht_next      8  (offset 24)
  *   uint32_t  ht_cap       4  (offset 32)
  *   uint32_t  indexed_rows 4  (offset 36)
  *   uint64_t  content_hash 8  (offset 40)
- *                         = 48 bytes total
+ *   uint32_t  generation   4  (offset 48)
+ *                         = 56 bytes total
  * ================================================================ */
 static void
 test_arrangement_struct_size(void)
 {
     TEST("col_arrangement_t struct size (layout sentinel)");
 
-    /* 48 bytes: 3 pointers (24) + 4 uint32 (16) + 1 uint64 (8) */
-    ASSERT(sizeof(col_arrangement_t) == 48,
-        "col_arrangement_t must be 48 bytes; update if struct changes");
+    /* 56 bytes: 3 pointers (24) + 5 uint32 (20) + 1 uint64 (8). */
+    ASSERT(sizeof(col_arrangement_t) == 56,
+        "col_arrangement_t must be 56 bytes; update if struct changes");
+    ASSERT(offsetof(col_arrangement_t, ht_head) == 16,
+        "ht_head layout changed unexpectedly");
+    ASSERT(offsetof(col_arrangement_t, generation) == 48,
+        "generation layout changed unexpectedly");
 
     PASS();
 }
@@ -568,6 +574,63 @@ test_arrangement_registry_cache(void)
 }
 
 /* ================================================================
+ * Test 9: versioned bucket heads handle rebuilds and generation wrap.
+ * ================================================================ */
+static void
+test_arrangement_generation_wrap(void)
+{
+    TEST("arrangement: versioned heads ignore stale buckets and wrap safely");
+
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+        "edge(1, 2). edge(2, 3). edge(3, 4).\n"
+        ".decl reach(x: int32, y: int32)\n"
+        "reach(x, y) :- edge(x, y).\n";
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    ASSERT(make_session(src, &sess, &plan, &prog) == 0,
+        "session creation failed");
+
+    uint32_t key_cols[] = { 0 };
+    col_arrangement_t *arr
+        = col_session_get_arrangement(sess, "edge", key_cols, 1);
+    ASSERT(arr != NULL && arr->generation != 0,
+        "arrangement must have a live generation");
+    uint32_t old_generation = arr->generation;
+
+    test_col_rel_mirror_t *rel = find_rel_mirror(sess, "edge");
+    ASSERT(rel != NULL, "edge relation not found in session");
+    int64_t key_row[2] = { 2, 0 };
+
+    /* An empty rebuild must not expose rows from the previous generation. */
+    rel->nrows = 0;
+    col_session_invalidate_arrangements(sess, "edge");
+    arr = col_session_get_arrangement(sess, "edge", key_cols, 1);
+    ASSERT(arr != NULL && arr->indexed_rows == 0,
+        "empty relation must rebuild as empty");
+    ASSERT(col_arrangement_find_first(arr, rel->columns, rel->ncols, key_row)
+        == UINT32_MAX,
+        "empty rebuild must hide stale rows");
+
+    col_session_invalidate_arrangements(sess, "edge");
+    arr->generation = UINT32_MAX;
+    rel->nrows = 3;
+    arr = col_session_get_arrangement(sess, "edge", key_cols, 1);
+    ASSERT(arr != NULL, "arrangement must rebuild after generation wrap");
+    ASSERT(arr->generation == 1,
+        "wrapped generation must reset to one");
+    ASSERT(old_generation != UINT32_MAX,
+        "test setup must start below the wrap boundary");
+
+    ASSERT(col_arrangement_find_first(arr, rel->columns, rel->ncols, key_row)
+        != UINT32_MAX,
+        "find_first must work after a wrapped rebuild");
+
+    free_session(sess, plan, prog);
+    PASS();
+}
+
+/* ================================================================
  * main
  * ================================================================ */
 
@@ -584,6 +647,7 @@ main(void)
     test_arrangement_find_next_chain();
     test_arrangement_invalidate();
     test_arrangement_registry_cache();
+    test_arrangement_generation_wrap();
 
     printf("\nResults: %d/%d passed", pass_count, test_count);
     if (fail_count > 0)

--- a/tests/test_arrangement_lru_eviction.c
+++ b/tests/test_arrangement_lru_eviction.c
@@ -186,6 +186,10 @@ test_lru_clock_and_mem_bytes(void)
     ASSERT(entry != NULL, "entry must exist after get_arrangement");
     ASSERT(entry->lru_clock > 0, "lru_clock must be > 0 after first access");
     ASSERT(entry->mem_bytes > 0, "mem_bytes must be > 0 after build");
+    ASSERT(entry->mem_bytes
+        == (size_t)arr1->nbuckets * sizeof(uint64_t)
+        + (size_t)arr1->ht_cap * sizeof(uint32_t),
+        "mem_bytes must include tagged bucket heads and chain storage");
     ASSERT(cs->arr_total_bytes >= entry->mem_bytes,
         "arr_total_bytes must include entry mem_bytes");
 

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define ARR_HEAD_ROW(value) ((uint32_t)((value) & UINT64_C(0xFFFFFFFF)))
+#define ARR_HEAD_ROW(value) ((uint32_t)((value)&UINT64_C(0xFFFFFFFF)))
 #define ARR_HEAD_GENERATION(value) ((uint32_t)((value) >> 32))
 #define ARR_MAKE_HEAD(generation, row) \
         (((uint64_t)(generation) << 32) | (uint64_t)(row))

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -21,6 +21,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define ARR_HEAD_ROW(value) ((uint32_t)((value) & UINT64_C(0xFFFFFFFF)))
+#define ARR_HEAD_GENERATION(value) ((uint32_t)((value) >> 32))
+#define ARR_MAKE_HEAD(generation, row) \
+        (((uint64_t)(generation) << 32) | (uint64_t)(row))
+
 /* ======================================================================== */
 /* Arrangement Layer (Phase 3C)                                             */
 /* ======================================================================== */
@@ -107,7 +112,8 @@ arr_hash_rows_batch(const col_rel_t *rel, uint32_t row_begin, uint32_t row_end,
  * arr_index_rows:
  * Hash rows [@begin, @nrows) in batches and prepend each to its bucket chain.
  *
- * Chains use a UINT32_MAX empty sentinel and store the row index directly.
+ * Chains use a UINT32_MAX empty sentinel and store the row index in the low
+ * half of a tagged bucket head.
  * Rows are inserted in ascending order exactly as the per-row loop did, so
  * chain order is preserved bucket for bucket.
  *
@@ -131,8 +137,11 @@ arr_index_rows(col_arrangement_t *arr, const col_rel_t *rel, uint32_t begin,
         for (uint32_t j = 0; j < chunk; j++) {
             uint32_t row = base + j;
             uint32_t bucket = scratch[j] & (nbuckets - 1);
-            arr->ht_next[row] = arr->ht_head[bucket];
-            arr->ht_head[bucket] = row;
+            uint64_t head = arr->ht_head[bucket];
+            if (ARR_HEAD_GENERATION(head) != arr->generation)
+                head = ARR_MAKE_HEAD(arr->generation, UINT32_MAX);
+            arr->ht_next[row] = ARR_HEAD_ROW(head);
+            arr->ht_head[bucket] = ARR_MAKE_HEAD(arr->generation, row);
         }
 
         /* Advance by the clamped chunk so base cannot wrap past UINT32_MAX. */
@@ -177,6 +186,21 @@ arr_next_pow2(uint32_t n)
     return n + 1u;
 }
 
+static bool
+arr_memory_bytes(const col_arrangement_t *arr, size_t *out)
+{
+    size_t head_bytes = (size_t)arr->nbuckets * sizeof(uint64_t);
+    size_t next_bytes = (size_t)arr->ht_cap * sizeof(uint32_t);
+    if ((arr->nbuckets != 0
+        && head_bytes / sizeof(uint64_t) != arr->nbuckets)
+        || (arr->ht_cap != 0
+        && next_bytes / sizeof(uint32_t) != arr->ht_cap)
+        || head_bytes > SIZE_MAX - next_bytes)
+        return false;
+    *out = head_bytes + next_bytes;
+    return true;
+}
+
 /*
  * arr_free_contents: free hash table arrays only.
  * key_cols is NOT freed here — it is always owned by the registry entry
@@ -194,6 +218,7 @@ arr_free_contents(col_arrangement_t *arr)
     arr->nbuckets = 0;
     arr->ht_cap = 0;
     arr->indexed_rows = 0;
+    arr->generation = 0;
 }
 
 /* Full rebuild: index all nrows rows in rel into arr. */
@@ -243,28 +268,61 @@ arr_build_full(col_arrangement_t *arr, const col_rel_t *rel)
     if (nbuckets == 0)
         return ENOMEM;
 
-    /* Reallocate bucket heads if size changed. */
-    if (nbuckets != arr->nbuckets) {
-        uint32_t *head = (uint32_t *)malloc(nbuckets * sizeof(uint32_t));
-        if (!head)
-            return ENOMEM;
-        free(arr->ht_head);
-        arr->ht_head = head;
-        arr->nbuckets = nbuckets;
-    }
-    memset(arr->ht_head, 0xFF, nbuckets * sizeof(uint32_t)); /* UINT32_MAX */
+    uint64_t *new_head = NULL;
+    uint32_t *new_next = NULL;
+    uint32_t new_cap = arr->ht_cap;
 
+    /* Prepare every potentially failing allocation before publishing any
+     * part of the new arrangement.  This keeps a failed rebuild usable. */
+    if (nbuckets != arr->nbuckets) {
+        size_t head_bytes = (size_t)nbuckets * sizeof(uint64_t);
+        if (nbuckets != 0 && head_bytes / sizeof(uint64_t) != nbuckets)
+            return ENOMEM;
+        new_head = (uint64_t *)malloc(head_bytes);
+        if (!new_head)
+            return ENOMEM;
+        /* Zero has generation zero, which cannot match a live generation. */
+        memset(new_head, 0, head_bytes);
+    }
     /* Grow chain array if needed. */
     if (nrows > arr->ht_cap) {
-        uint32_t new_cap = nrows > arr->ht_cap * 2u ? nrows : arr->ht_cap * 2u;
+        uint32_t doubled = arr->ht_cap > UINT32_MAX / 2u
+            ? UINT32_MAX : arr->ht_cap * 2u;
+        new_cap = nrows > doubled ? nrows : doubled;
         if (new_cap < 16u)
             new_cap = 16u;
-        uint32_t *nxt = (uint32_t *)malloc(new_cap * sizeof(uint32_t));
-        if (!nxt)
+        size_t next_bytes = (size_t)new_cap * sizeof(uint32_t);
+        if (new_cap != 0 && next_bytes / sizeof(uint32_t) != new_cap) {
+            free(new_head);
             return ENOMEM;
+        }
+        new_next = (uint32_t *)malloc(next_bytes);
+        if (!new_next) {
+            free(new_head);
+            return ENOMEM;
+        }
+    }
+
+    if (new_head) {
+        free(arr->ht_head);
+        arr->ht_head = new_head;
+        arr->nbuckets = nbuckets;
+    }
+    if (new_next) {
         free(arr->ht_next);
-        arr->ht_next = nxt;
+        arr->ht_next = new_next;
         arr->ht_cap = new_cap;
+    }
+
+    /* Start a new epoch.  Only wraparound needs a full clear; normal rebuilds
+     * lazily replace each bucket head as that bucket receives its first row. */
+    if (arr->generation == UINT32_MAX) {
+        memset(arr->ht_head, 0, nbuckets * sizeof(uint64_t));
+        arr->generation = 1;
+    } else {
+        arr->generation++;
+        if (arr->generation == 0)
+            arr->generation = 1;
     }
 
     arr_index_rows(arr, rel, 0, nrows, nbuckets);
@@ -428,15 +486,18 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
             continue;
 
         /* Found: update if stale. */
-        if (e->arr.indexed_rows == 0 && rel->nrows > 0) {
+        if (e->arr.indexed_rows == 0) {
             /* Deduct stale bytes before rebuild; restore on failure. */
             cs->arr_total_bytes -= e->mem_bytes;
             if (arr_build_full(&e->arr, rel) != 0) {
                 cs->arr_total_bytes += e->mem_bytes;
                 return NULL;
             }
-            e->mem_bytes = (size_t)e->arr.nbuckets * sizeof(uint32_t)
-                + (size_t)e->arr.ht_cap * sizeof(uint32_t);
+            if (!arr_memory_bytes(&e->arr, &e->mem_bytes)) {
+                arr_free_contents(&e->arr);
+                e->mem_bytes = 0;
+                return NULL;
+            }
             cs->arr_total_bytes += e->mem_bytes;
         } else if (e->arr.indexed_rows < rel->nrows) {
             uint32_t old = e->arr.indexed_rows;
@@ -445,8 +506,11 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
                 cs->arr_total_bytes += e->mem_bytes; /* restore on failure */
                 return NULL;
             }
-            e->mem_bytes = (size_t)e->arr.nbuckets * sizeof(uint32_t)
-                + (size_t)e->arr.ht_cap * sizeof(uint32_t);
+            if (!arr_memory_bytes(&e->arr, &e->mem_bytes)) {
+                arr_free_contents(&e->arr);
+                e->mem_bytes = 0;
+                return NULL;
+            }
             cs->arr_total_bytes += e->mem_bytes;
         }
         /* Bump LRU clock on every access. */
@@ -517,7 +581,7 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
     e->arr.key_count = key_count;
 
     /* Initial build. */
-    if (rel->nrows > 0 && arr_build_full(&e->arr, rel) != 0) {
+    if (arr_build_full(&e->arr, rel) != 0) {
         free(e->rel_name);
         free(e->key_cols);
         memset(e, 0, sizeof(*e));
@@ -525,8 +589,15 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
             cs->arr_count--;
         return NULL;
     }
-    e->mem_bytes = (size_t)e->arr.nbuckets * sizeof(uint32_t)
-        + (size_t)e->arr.ht_cap * sizeof(uint32_t);
+    if (!arr_memory_bytes(&e->arr, &e->mem_bytes)) {
+        arr_free_contents(&e->arr);
+        free(e->rel_name);
+        free(e->key_cols);
+        memset(e, 0, sizeof(*e));
+        if (slot == cs->arr_count - 1)
+            cs->arr_count--;
+        return NULL;
+    }
     cs->arr_total_bytes += e->mem_bytes;
     e->lru_clock = ++cs->arr_clock;
     return &e->arr;
@@ -537,14 +608,17 @@ col_arrangement_find_first(const col_arrangement_t *arr,
     int64_t *const *columns, uint32_t rel_ncols,
     const int64_t *key_row)
 {
-    if (!arr || !columns || !key_row || arr->nbuckets == 0)
+    if (!arr || !columns || !key_row || arr->nbuckets == 0
+        || arr->indexed_rows == 0)
         return UINT32_MAX;
 
     (void)rel_ncols; /* used for bounds checking in debug builds */
 
     uint32_t bucket
         = arr_hash_key(key_row, arr->key_cols, arr->key_count, arr->nbuckets);
-    uint32_t row = arr->ht_head[bucket];
+    uint64_t head = arr->ht_head[bucket];
+    uint32_t row = ARR_HEAD_GENERATION(head) == arr->generation
+        ? ARR_HEAD_ROW(head) : UINT32_MAX;
     while (row != UINT32_MAX) {
         bool match = true;
         for (uint32_t k = 0; k < arr->key_count; k++) {
@@ -565,12 +639,15 @@ uint32_t
 col_arrangement_find_first_typed(const col_arrangement_t *arr,
     const col_rel_t *rel, const int64_t *key_row)
 {
-    if (!arr || !rel || !rel->columns || !key_row || arr->nbuckets == 0)
+    if (!arr || !rel || !rel->columns || !key_row || arr->nbuckets == 0
+        || arr->indexed_rows == 0)
         return UINT32_MAX;
 
     uint32_t bucket = arr_hash_key_typed(rel, key_row, arr->key_cols,
             arr->key_count, arr->nbuckets);
-    uint32_t row = arr->ht_head[bucket];
+    uint64_t head = arr->ht_head[bucket];
+    uint32_t row = ARR_HEAD_GENERATION(head) == arr->generation
+        ? ARR_HEAD_ROW(head) : UINT32_MAX;
     while (row != UINT32_MAX) {
         bool match = true;
         for (uint32_t k = 0; k < arr->key_count; k++) {

--- a/wirelog/columnar/columnar_nanoarrow.h
+++ b/wirelog/columnar/columnar_nanoarrow.h
@@ -225,7 +225,8 @@ typedef struct {
  * Rows are hashed into `nbuckets` buckets using FNV-1a over the key values.
  *
  * The hash table uses chaining (separate lists per bucket):
- *   ht_head[bucket]  UINT32_MAX = empty; else = first row index in chain
+ *   ht_head[bucket]  upper 32 bits = generation, lower 32 bits = row index
+ *                    UINT32_MAX row index = empty
  *   ht_next[row]     UINT32_MAX = end of chain; else = next row in chain
  *
  * `indexed_rows` tracks how many rows from the relation are currently
@@ -233,16 +234,22 @@ typedef struct {
  *
  * `content_hash` stores a fingerprint of the relation when last rebuilt
  * (reserved for future staleness detection; currently unused).
+ *
+ * Arrangement rebuild and probe operations are session-owned.  Worker
+ * sessions use independent clones, so a rebuild is never concurrent with a
+ * probe of the same arrangement; the tagged 64-bit head is not a published
+ * cross-thread atomic value.
  */
 typedef struct {
     uint32_t *key_cols;    /* owned, column positions in the relation     */
     uint32_t key_count;    /* number of key columns                       */
     uint32_t nbuckets;     /* hash table size (power of 2)                */
-    uint32_t *ht_head;     /* owned, size=nbuckets; UINT32_MAX=empty      */
+    uint64_t *ht_head;     /* owned, tagged generation + row index        */
     uint32_t *ht_next;     /* owned, size=capacity; UINT32_MAX=end        */
     uint32_t ht_cap;       /* allocated size of ht_next[]                 */
     uint32_t indexed_rows; /* rows indexed so far                         */
     uint64_t content_hash; /* fingerprint at last full rebuild (reserved) */
+    uint32_t generation;   /* current bucket epoch; zero means unbuilt    */
 } col_arrangement_t;
 
 /**

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -244,6 +244,9 @@ col_rel_merge_k(col_rel_t **relations, uint32_t k)
 static int
 col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst)
 {
+    size_t head_bytes = 0;
+    size_t next_bytes = 0;
+
     memset(dst, 0, sizeof(*dst));
 
     dst->rel_name = wl_strdup(src->rel_name);
@@ -269,13 +272,21 @@ col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst)
     dst->arr.content_hash = src->arr.content_hash;
     dst->arr.nbuckets = src->arr.nbuckets;
     dst->arr.ht_cap = src->arr.ht_cap;
+    dst->arr.generation = src->arr.generation;
     /* Issue #216: copy LRU metadata so worker clones inherit access state. */
     dst->lru_clock = src->lru_clock;
     dst->mem_bytes = src->mem_bytes;
 
     if (src->arr.nbuckets > 0 && src->arr.ht_head) {
+        head_bytes = (size_t)src->arr.nbuckets * sizeof(uint64_t);
+        if (head_bytes / sizeof(uint64_t) != src->arr.nbuckets) {
+            free(dst->key_cols);
+            free(dst->rel_name);
+            memset(dst, 0, sizeof(*dst));
+            return ENOMEM;
+        }
         dst->arr.ht_head
-            = (uint32_t *)malloc(src->arr.nbuckets * sizeof(uint32_t));
+            = (uint64_t *)malloc(head_bytes);
         if (!dst->arr.ht_head) {
             free(dst->key_cols);
             free(dst->rel_name);
@@ -283,12 +294,20 @@ col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst)
             return ENOMEM;
         }
         memcpy(dst->arr.ht_head, src->arr.ht_head,
-            src->arr.nbuckets * sizeof(uint32_t));
+            head_bytes);
     }
 
     if (src->arr.ht_cap > 0 && src->arr.ht_next) {
+        next_bytes = (size_t)src->arr.ht_cap * sizeof(uint32_t);
+        if (next_bytes / sizeof(uint32_t) != src->arr.ht_cap) {
+            free(dst->arr.ht_head);
+            free(dst->key_cols);
+            free(dst->rel_name);
+            memset(dst, 0, sizeof(*dst));
+            return ENOMEM;
+        }
         dst->arr.ht_next
-            = (uint32_t *)malloc(src->arr.ht_cap * sizeof(uint32_t));
+            = (uint32_t *)malloc(next_bytes);
         if (!dst->arr.ht_next) {
             free(dst->arr.ht_head);
             free(dst->key_cols);
@@ -297,7 +316,7 @@ col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst)
             return ENOMEM;
         }
         memcpy(dst->arr.ht_next, src->arr.ht_next,
-            src->arr.ht_cap * sizeof(uint32_t));
+            next_bytes);
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- replace full arr_build_full() bucket-head memset with lazily reset generation-tagged 64-bit heads
- preserve empty-relation invalidation, generation-wrap safety, transactional allocations, clone/free paths, and checked cache accounting
- add generation-wrap/empty-rebuild coverage and exact tagged-head memory accounting

## Validation
- meson test -C builddir wirelog:arrangement wirelog:arr_hash_rows_batch wirelog:delta_arrangement wirelog:join_arrangement wirelog:arrangement_cache_reuse wirelog:arrangement_incr_invalidation wirelog:arrangement_lru_eviction wirelog:k_fusion_inline_shadow wirelog:diff_arrangement_deep_copy_buckets --print-errorlogs
- all 9 focused tests passed under the repository sanitizer test environment
- uncrustify checks passed
- small CRDT benchmark (5 reps, same host): candidate W=1 45.5 ms/4372 KB RSS; candidate W=8 45.2 ms/4376 KB; origin/main W=1 44.0 ms/3944 KB; origin/main W=8 72.2 ms/3956 KB
- full CRDT benchmark was started but exceeded 60 seconds without output in this interactive environment; dedicated perf-runner validation remains residual evidence

Closes #806