### PR TITLE
parser: add unambiguous scalar extension calls

### DIFF
--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -2021,6 +2021,74 @@ test_parser_compound_error_trailing_comma(void)
     PASS();
 }
 
+static void
+test_parser_extension_call(void)
+{
+    TEST("generic scalar extension call");
+    PARSE(".decl R(x: string)\nR(x) :- @call(\"demo.fn\", x).");
+    ASSERT_PARSED();
+    const wl_parser_ast_node_t *rule = child(program, 1);
+    const wl_parser_ast_node_t *call = child(rule, 1);
+    if (!call || call->type != WL_PARSER_AST_NODE_EXTENSION_CALL
+        || strcmp(call->name, "demo.fn") != 0 || call->child_count != 1
+        || child(call, 0)->type != WL_PARSER_AST_NODE_VARIABLE
+        || strcmp(child(call, 0)->name, "x") != 0) {
+        CLEANUP();
+        FAIL("expected normalized extension call AST");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parser_extension_call_trim_and_relation_name(void)
+{
+    TEST("extension call trim and call relation compatibility");
+    PARSE(
+        ".decl R(x: string)\nR(x) :- @call(\"  demo.fn  \", x), call(\"literal\", x).");
+    ASSERT_PARSED();
+    const wl_parser_ast_node_t *rule = child(program, 1);
+    const wl_parser_ast_node_t *extension = child(rule, 1);
+    const wl_parser_ast_node_t *relation = child(rule, 2);
+    if (!extension || extension->type != WL_PARSER_AST_NODE_EXTENSION_CALL
+        || strcmp(extension->name, "demo.fn") != 0 || !relation
+        || relation->type != WL_PARSER_AST_NODE_ATOM
+        || strcmp(relation->name, "call") != 0) {
+        CLEANUP();
+        FAIL("expected extension and ordinary call relation");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
+static void
+test_parser_extension_call_errors(void)
+{
+    TEST("extension call malformed name errors");
+    PARSE(".decl R(x: string)\nR(x) :- @call(\"   \", x).");
+    if (program) {
+        CLEANUP();
+        FAIL("blank extension name should fail");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_parser_extension_call_name_errors(void)
+{
+    TEST("extension call names require namespace");
+    PARSE(".decl R(x: string)\nR(x) :- @call(\"missing\", x).");
+    if (program) {
+        CLEANUP();
+        FAIL("unqualified extension name should fail");
+        return;
+    }
+    PASS();
+}
+
 /* ======================================================================== */
 /* Parser: Error Cases                                                      */
 /* ======================================================================== */
@@ -2227,6 +2295,10 @@ main(void)
     test_parser_compound_error_empty_args();
     test_parser_compound_error_unbalanced_paren();
     test_parser_compound_error_trailing_comma();
+    test_parser_extension_call();
+    test_parser_extension_call_trim_and_relation_name();
+    test_parser_extension_call_errors();
+    test_parser_extension_call_name_errors();
 
     printf("\n--- Error Cases ---\n");
     test_parse_error_missing_horn();

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -2089,6 +2089,25 @@ test_parser_extension_call_name_errors(void)
     PASS();
 }
 
+static void
+test_parser_negated_extension_call(void)
+{
+    TEST("negated extension call has explicit AST node");
+    PARSE(".decl R(x: string)\nR(x) :- !@call(\"demo.fn\", x).");
+    ASSERT_PARSED();
+    const wl_parser_ast_node_t *rule = child(program, 1);
+    const wl_parser_ast_node_t *negation = child(rule, 1);
+    if (!negation || negation->type != WL_PARSER_AST_NODE_NEGATION
+        || negation->child_count != 1
+        || child(negation, 0)->type != WL_PARSER_AST_NODE_EXTENSION_CALL) {
+        CLEANUP();
+        FAIL("expected negated extension call AST");
+        return;
+    }
+    CLEANUP();
+    PASS();
+}
+
 /* ======================================================================== */
 /* Parser: Error Cases                                                      */
 /* ======================================================================== */
@@ -2299,6 +2318,7 @@ main(void)
     test_parser_extension_call_trim_and_relation_name();
     test_parser_extension_call_errors();
     test_parser_extension_call_name_errors();
+    test_parser_negated_extension_call();
 
     printf("\n--- Error Cases ---\n");
     test_parse_error_missing_horn();

--- a/wirelog/ir/program.c
+++ b/wirelog/ir/program.c
@@ -2748,6 +2748,13 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
         const wl_parser_ast_node_t *b = rule_node->children[i];
         if (!b)
             continue;
+        if (b->type == WL_PARSER_AST_NODE_EXTENSION_CALL) {
+            wl_ir_program_set_error(prog,
+                "scalar extension call '%s' is not executable yet in rule "
+                "'%s'", b->name ? b->name : "?",
+                head->name ? head->name : "?");
+            goto conversion_failed;
+        }
         if (b->type == WL_PARSER_AST_NODE_ATOM) {
             WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_DEBUG,
                 "convert_rule: build scan for body atom relation=%s",
@@ -3028,6 +3035,15 @@ convert_rule(const wl_parser_ast_node_t *rule_node,
 
     for (uint32_t i = 1; i < rule_node->child_count; i++) {
         const wl_parser_ast_node_t *b = rule_node->children[i];
+        if (b->type == WL_PARSER_AST_NODE_NEGATION && b->child_count >= 1
+            && b->children[0]->type == WL_PARSER_AST_NODE_EXTENSION_CALL) {
+            wl_ir_program_set_error(prog,
+                "negated scalar extension call '%s' is not executable yet "
+                "in rule '%s'", b->children[0]->name
+                    ? b->children[0]->name : "?",
+                head->name ? head->name : "?");
+            goto conversion_failed;
+        }
         if (b->type == WL_PARSER_AST_NODE_NEGATION && b->child_count >= 1
             && current) {
             const wl_parser_ast_node_t *neg_atom = b->children[0];

--- a/wirelog/parser/ast.c
+++ b/wirelog/parser/ast.c
@@ -167,6 +167,8 @@ wl_parser_ast_node_type_str(wl_parser_ast_node_type_t type)
         return "BINARY_EXPR";
     case WL_PARSER_AST_NODE_STR_FUNCTION:
         return "STR_FUNCTION";
+    case WL_PARSER_AST_NODE_EXTENSION_CALL:
+        return "EXTENSION_CALL";
     case WL_PARSER_AST_NODE_FACT:
         return "FACT";
     case WL_PARSER_AST_NODE_TYPED_PARAM:

--- a/wirelog/parser/ast.h
+++ b/wirelog/parser/ast.h
@@ -64,6 +64,7 @@ typedef enum {
     /* Expressions */
     WL_PARSER_AST_NODE_BINARY_EXPR, /* arith_op, children[0]=left, children[1]=right */
     WL_PARSER_AST_NODE_STR_FUNCTION, /* str_fn, children = arguments */
+    WL_PARSER_AST_NODE_EXTENSION_CALL, /* name=addon function, children=args */
 
     /* Inline facts */
     WL_PARSER_AST_NODE_FACT, /* name=relation, children=constant args */

--- a/wirelog/parser/lexer.c
+++ b/wirelog/parser/lexer.c
@@ -511,6 +511,9 @@ scan_token(wl_parser_lexer_t *lexer)
             return make_token(lexer, WL_PARSER_LEXER_TOK_NEQ);
         return make_token(lexer, WL_PARSER_LEXER_TOK_BANG);
 
+    case '@':
+        return make_token(lexer, WL_PARSER_LEXER_TOK_AT);
+
     case '=':
         return make_token(lexer, WL_PARSER_LEXER_TOK_EQ);
 
@@ -636,6 +639,8 @@ wl_parser_lexer_token_type_str(wl_parser_lexer_token_type_t type)
         return "COLON";
     case WL_PARSER_LEXER_TOK_BANG:
         return "BANG";
+    case WL_PARSER_LEXER_TOK_AT:
+        return "AT";
     case WL_PARSER_LEXER_TOK_HORN:
         return "HORN";
     case WL_PARSER_LEXER_TOK_EQ:

--- a/wirelog/parser/lexer.h
+++ b/wirelog/parser/lexer.h
@@ -64,6 +64,7 @@ typedef enum {
     WL_PARSER_LEXER_TOK_DOT,    /* . */
     WL_PARSER_LEXER_TOK_COLON,  /* : */
     WL_PARSER_LEXER_TOK_BANG,   /* ! */
+    WL_PARSER_LEXER_TOK_AT,     /* @ */
 
     /* Operators */
     WL_PARSER_LEXER_TOK_HORN,    /* :- */

--- a/wirelog/parser/parser.c
+++ b/wirelog/parser/parser.c
@@ -1174,6 +1174,116 @@ parse_atom_arg_at_depth(wl_parser_t *parser, uint32_t depth)
 /* Atom Parsing                                                             */
 /* ======================================================================== */
 
+static void
+trim_ascii_whitespace(char *value)
+{
+    size_t start = 0;
+    size_t length;
+
+    if (!value)
+        return;
+    length = strlen(value);
+    while (start < length
+        && (value[start] == ' ' || value[start] == '\t'
+        || value[start] == '\n' || value[start] == '\r'
+        || value[start] == '\f' || value[start] == '\v'))
+        start++;
+    while (length > start
+        && (value[length - 1] == ' ' || value[length - 1] == '\t'
+        || value[length - 1] == '\n' || value[length - 1] == '\r'
+        || value[length - 1] == '\f' || value[length - 1] == '\v'))
+        length--;
+    if (start)
+        memmove(value, value + start, length - start);
+    value[length - start] = '\0';
+}
+
+static bool
+valid_extension_name(const char *value)
+{
+    bool saw_dot = false;
+    bool segment_has_char = false;
+
+    if (!value || !value[0])
+        return false;
+    for (const unsigned char *p = (const unsigned char *)value; *p; p++) {
+        if ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z')
+            || (*p >= '0' && *p <= '9') || *p == '_') {
+            segment_has_char = true;
+        } else if (*p == '.' && segment_has_char) {
+            saw_dot = true;
+            segment_has_char = false;
+        } else {
+            return false;
+        }
+    }
+    return saw_dot && segment_has_char;
+}
+
+static wl_parser_ast_node_t *
+parse_extension_call_after_lparen(wl_parser_t *parser, uint32_t line,
+    uint32_t col)
+{
+    char *function_name;
+    wl_parser_ast_node_t *call;
+
+    if (!parser_match(parser, WL_PARSER_LEXER_TOK_STRING)) {
+        parser_error(parser,
+            "extension call requires a quoted function name as its first argument");
+        return NULL;
+    }
+    function_name = token_to_str_value(&parser->previous);
+    if (!function_name) {
+        parser_error(parser, "out of memory while reading extension name");
+        return NULL;
+    }
+    trim_ascii_whitespace(function_name);
+    if (strlen(function_name) > 255 || !valid_extension_name(function_name)) {
+        free(function_name);
+        parser_error(parser,
+            "extension function name must be namespace.name using ASCII "
+            "letters, digits, and underscores");
+        return NULL;
+    }
+
+    call = wl_parser_ast_node_create(WL_PARSER_AST_NODE_EXTENSION_CALL, line,
+            col);
+    if (!call) {
+        free(function_name);
+        parser_error(parser, "out of memory while creating extension call");
+        return NULL;
+    }
+    call->name = function_name;
+
+    if (!parser_check(parser, WL_PARSER_LEXER_TOK_RPAREN)) {
+        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_COMMA,
+            "expected ',' after extension function name")) {
+            wl_parser_ast_node_free(call);
+            return NULL;
+        }
+        wl_parser_ast_node_t *arg = parse_atom_arg(parser);
+        if (!arg) {
+            wl_parser_ast_node_free(call);
+            return NULL;
+        }
+        PARSER_ADD_CHILD_OR_RETURN(call, arg);
+        while (parser_match(parser, WL_PARSER_LEXER_TOK_COMMA)) {
+            arg = parse_atom_arg(parser);
+            if (!arg) {
+                wl_parser_ast_node_free(call);
+                return NULL;
+            }
+            PARSER_ADD_CHILD_OR_RETURN(call, arg);
+        }
+    }
+    if (!parser_consume(parser, WL_PARSER_LEXER_TOK_RPAREN,
+        "expected ')' after extension call")) {
+        wl_parser_ast_node_free(call);
+        return NULL;
+    }
+    return call;
+}
+
 static wl_parser_ast_node_t *
 parse_atom(wl_parser_t *parser)
 {
@@ -1262,6 +1372,25 @@ parse_predicate(wl_parser_t *parser)
     uint32_t line = parser->current.line;
     uint32_t col = parser->current.col;
 
+    /* The sigil keeps the extension namespace separate from relation names. */
+    if (parser_match(parser, WL_PARSER_LEXER_TOK_AT)) {
+        char *marker;
+        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_IDENT,
+            "expected 'call' after '@'"))
+            return NULL;
+        marker = token_to_name(&parser->previous);
+        if (!marker || strcmp(marker, "call") != 0) {
+            free(marker);
+            parser_error(parser, "expected '@call' extension marker");
+            return NULL;
+        }
+        free(marker);
+        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_LPAREN,
+            "expected '(' after '@call'"))
+            return NULL;
+        return parse_extension_call_after_lparen(parser, line, col);
+    }
+
     /* Boolean predicate */
     if (parser_match(parser, WL_PARSER_LEXER_TOK_TRUE)) {
         wl_parser_ast_node_t *node
@@ -1276,13 +1405,31 @@ parse_predicate(wl_parser_t *parser)
         return node;
     }
 
-    /* Negative atom */
+    /* Negative atom or explicitly marked extension call. */
     if (parser_match(parser, WL_PARSER_LEXER_TOK_BANG)) {
-        if (!parser_consume(parser, WL_PARSER_LEXER_TOK_IDENT,
-            "expected relation name after '!'")) {
-            return NULL;
+        wl_parser_ast_node_t *atom;
+        if (parser_match(parser, WL_PARSER_LEXER_TOK_AT)) {
+            char *marker;
+            if (!parser_consume(parser, WL_PARSER_LEXER_TOK_IDENT,
+                "expected 'call' after '!@'"))
+                return NULL;
+            marker = token_to_name(&parser->previous);
+            if (!marker || strcmp(marker, "call") != 0) {
+                free(marker);
+                parser_error(parser, "expected '!@call' extension marker");
+                return NULL;
+            }
+            free(marker);
+            if (!parser_consume(parser, WL_PARSER_LEXER_TOK_LPAREN,
+                "expected '(' after '!@call'"))
+                return NULL;
+            atom = parse_extension_call_after_lparen(parser, line, col);
+        } else {
+            if (!parser_consume(parser, WL_PARSER_LEXER_TOK_IDENT,
+                "expected relation name after '!'"))
+                return NULL;
+            atom = parse_atom(parser);
         }
-        wl_parser_ast_node_t *atom = parse_atom(parser);
         if (!atom)
             return NULL;
 


### PR DESCRIPTION
## Summary\n- preserve existing call(...) relation atoms\n- parse @call("namespace.name", args...) as a distinct AST node\n- reject unsupported extension lowering deterministically\n\n## Validation\n- meson test -C build-parser parser\n\nRelated to #1245\nDepends on #1247