### PR TITLE
fix: preserve scalar extension diagnostics across evaluators

### DIFF
--- a/tests/test_extension_filter.c
+++ b/tests/test_extension_filter.c
@@ -1,5 +1,8 @@
 #include "columnar/internal.h"
+#include "exec_plan_gen.h"
+#include "session.h"
 #include "wirelog/wirelog-extension.h"
+#include "wirelog/wirelog-parser.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -12,6 +15,47 @@ static size_t expected_string_length;
 
 static int
 check(int condition, const char *message);
+
+static void
+ignore_snapshot_tuple(const char *relation, const int64_t *row,
+    uint32_t ncols, void *user_data)
+{
+    (void)relation;
+    (void)row;
+    (void)ncols;
+    (void)user_data;
+}
+
+static int
+check_snapshot_clears_extension_status(void)
+{
+    static const char *source =
+        ".decl input(x: int64)\n"
+        ".decl output(x: int64)\n"
+        "output(x) :- input(x).\n";
+    wirelog_error_t error = WIRELOG_OK;
+    wirelog_program_t *program = wirelog_parse_string(source, &error);
+    wl_plan_t *plan = NULL;
+    wl_session_t *session = NULL;
+    int rc = program ? wl_plan_from_program(program, &plan) : -1;
+
+    if (rc == 0)
+        rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc == 0) {
+        /* Simulate status retained from an earlier scalar callback failure. */
+        COL_SESSION(session)->extension_expr_status =
+            WL_COLUMNAR_EXPR_CALLBACK_FAILURE;
+        rc = wl_session_snapshot(session, ignore_snapshot_tuple, NULL);
+    }
+    int failures = check(rc == 0, "non-extension snapshot execution");
+    if (session)
+        failures += check(COL_SESSION(session)->extension_expr_status == 0,
+                "snapshot clears stale extension status");
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    wirelog_program_free(program);
+    return failures;
+}
 
 static int
 extension_callback(const wirelog_extension_value_t *args, uint32_t nargs,
@@ -206,6 +250,8 @@ main(void)
     uint32_t size;
     int64_t value = 0;
     int failures = 0;
+
+    failures += check_snapshot_clears_extension_status();
 
     failures += check(registry != NULL, "registry create");
     failures += check(wirelog_extension_register(registry, &descriptor) == 0,

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -140,6 +140,89 @@ capture_public_map_rows(const char *relation, const int64_t *row,
     }
 }
 
+static void
+ignore_typed_tuple(const char *relation, const wirelog_typed_row_v1_t *row,
+    int32_t diff, void *user_data)
+{
+    (void)relation;
+    (void)row;
+    (void)diff;
+    (void)user_data;
+}
+
+static int
+run_scalar_extension_failure_diagnostic(bool typed_snapshot)
+{
+    const uint32_t argument_types[] = { WIRELOG_EXTENSION_VALUE_INT64 };
+    wirelog_extension_descriptor_t descriptor = {
+        WIRELOG_EXTENSION_ABI_VERSION, sizeof(descriptor),
+        "test.public_snapshot", 1, argument_types,
+        WIRELOG_EXTENSION_VALUE_BOOL, snapshot_extension_invoke, NULL, NULL
+    };
+    wirelog_extension_registry_t *registry =
+        wirelog_extension_registry_create();
+    wirelog_extension_snapshot_t *snapshot = NULL;
+    wirelog_program_t *prog = parse_or_die(SNAPSHOT_EXTENSION_SRC,
+            "T-extension-failure-diagnostic");
+    wirelog_session_t *session = NULL;
+    int64_t value = 7;
+    int rc = 0;
+
+    snapshot_extension_fail = 0;
+    if (!registry || !prog
+        || wirelog_extension_register(registry, &descriptor) != 0)
+        rc = 1;
+    snapshot = registry ? wirelog_extension_snapshot_acquire(registry) : NULL;
+    if (!rc && (!snapshot
+        || wirelog_session_create_with_snapshot(prog,
+        WIRELOG_BACKEND_DEFAULT, 1, snapshot, &session) != WIRELOG_OK
+        || !session))
+        rc = 1;
+    if (snapshot) {
+        wirelog_extension_snapshot_release(snapshot);
+        snapshot = NULL;
+    }
+    if (!rc && wirelog_extension_unregister(registry, descriptor.name) != 0)
+        rc = 1;
+    if (!rc && wirelog_session_insert(session, "src", &value, 1, 1)
+        != WIRELOG_OK)
+        rc = 1;
+
+    snapshot_extension_fail = 1;
+    wirelog_error_t error = WIRELOG_OK;
+    if (!rc) {
+        if (typed_snapshot)
+            error = wirelog_session_snapshot_typed(session,
+                    ignore_typed_tuple, NULL);
+        else
+            error = wirelog_session_step(session);
+        if (error != WIRELOG_ERR_EXEC
+            || !strstr(wirelog_extension_last_error(), "callback"))
+            rc = 1;
+    }
+
+    wirelog_session_destroy(session);
+    wirelog_extension_snapshot_release(snapshot);
+    wirelog_program_free(prog);
+    if (registry && wirelog_extension_registry_destroy(registry) != 0)
+        rc = 1;
+    snapshot_extension_fail = 0;
+    return rc;
+}
+
+static int
+test_scalar_extension_step_failure_diagnostic(void)
+{
+    return run_scalar_extension_failure_diagnostic(false);
+}
+
+/* The easy facade has no typed snapshot API. */
+static int
+test_scalar_extension_typed_snapshot_failure_diagnostic(void)
+{
+    return run_scalar_extension_failure_diagnostic(true);
+}
+
 static int
 test_public_map_extension_execution(void)
 {
@@ -2292,6 +2375,8 @@ main(void)
     failures += test_create_with_snapshot_invalid_args();
     failures += test_public_snapshot_extension_execution();
     failures += test_public_map_extension_execution();
+    failures += test_scalar_extension_step_failure_diagnostic();
+    failures += test_scalar_extension_typed_snapshot_failure_diagnostic();
     failures += test_inline_facts_seeded();
     failures += test_insert_step_delta();
     failures += test_relation_name_lifetime();

--- a/tests/test_wirelog_easy.c
+++ b/tests/test_wirelog_easy.c
@@ -91,6 +91,7 @@ static const char *RELATION_NAME_LIFETIME_SRC
 /* ======================================================================== */
 
 static int easy_snapshot_destroy_calls;
+static int easy_snapshot_fail;
 
 static int
 easy_snapshot_invoke(const wirelog_extension_value_t *args, uint32_t nargs,
@@ -98,8 +99,12 @@ easy_snapshot_invoke(const wirelog_extension_value_t *args, uint32_t nargs,
 {
     (void)args;
     (void)nargs;
-    (void)result;
     (void)user_data;
+    if (easy_snapshot_fail)
+        return 1;
+    result->type = WIRELOG_EXTENSION_VALUE_INT64;
+    result->size = sizeof(int64_t);
+    result->as.int64_value = args[0].as.int64_value + 1;
     return 0;
 }
 
@@ -113,15 +118,18 @@ easy_snapshot_destroy(void *user_data)
 static wirelog_extension_registry_t *
 easy_snapshot_registry(wirelog_extension_snapshot_t **snapshot_out)
 {
+    static const uint32_t argument_types[] = {
+        WIRELOG_EXTENSION_VALUE_INT64
+    };
     wirelog_extension_registry_t *registry =
         wirelog_extension_registry_create();
     wirelog_extension_descriptor_t descriptor = {
         WIRELOG_EXTENSION_ABI_VERSION,
         sizeof(descriptor),
         "easy.test",
-        0,
-        NULL,
-        WIRELOG_EXTENSION_VALUE_BOOL,
+        1,
+        argument_types,
+        WIRELOG_EXTENSION_VALUE_INT64,
         easy_snapshot_invoke,
         NULL,
         easy_snapshot_destroy
@@ -310,6 +318,63 @@ test_easy_snapshot_old_options_size_compatibility(void)
         return;
     }
     wirelog_easy_close(session);
+    PASS();
+}
+
+static void
+test_scalar_extension_step_failure_diagnostic(void)
+{
+    static const char *src =
+        ".decl src(x: int64)\n"
+        ".decl out(x: int64)\n"
+        "out(@call(\"easy.test\", x)) :- src(x).\n";
+    TEST("scalar extension step failure exposes callback diagnostic");
+    wirelog_extension_snapshot_t *snapshot = NULL;
+    wirelog_extension_registry_t *registry = easy_snapshot_registry(&snapshot);
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
+    wirelog_easy_session_t *session = NULL;
+    int64_t value = 7;
+    bool ok = true;
+
+    easy_snapshot_fail = 0;
+    opts.num_workers = 1;
+    opts.eager_build = true;
+    opts.extension_snapshot = snapshot;
+    wirelog_error_t open_error = wirelog_easy_open_opts(src, &opts, &session);
+    if (!registry || !snapshot || open_error != WIRELOG_OK || !session) {
+        fprintf(stderr, "easy extension open: error=%d session=%p\n",
+            open_error, (void *)session);
+        ok = false;
+    }
+    wirelog_extension_snapshot_release(snapshot);
+    snapshot = NULL;
+    if (ok && wirelog_easy_insert(session, "src", &value, 1) != WIRELOG_OK) {
+        fprintf(stderr, "easy extension insert failed\n");
+        ok = false;
+    }
+
+    easy_snapshot_fail = 1;
+    if (ok) {
+        wirelog_error_t error = wirelog_easy_step(session);
+        const char *diagnostic = wirelog_extension_last_error();
+        if (error != WIRELOG_ERR_EXEC || !strstr(diagnostic, "callback")) {
+            fprintf(stderr, "easy extension failure: error=%d diagnostic=%s\n",
+                error, diagnostic);
+            ok = false;
+        }
+    }
+
+    wirelog_easy_close(session);
+    wirelog_extension_snapshot_release(snapshot);
+    if (registry && wirelog_extension_unregister(registry, "easy.test") != 0)
+        ok = false;
+    if (registry && wirelog_extension_registry_destroy(registry) != 0)
+        ok = false;
+    easy_snapshot_fail = 0;
+    if (!ok) {
+        FAIL("step failure did not preserve scalar callback diagnostic");
+        return;
+    }
     PASS();
 }
 
@@ -2456,6 +2521,7 @@ main(void)
     test_easy_snapshot_close_before_build();
     test_easy_snapshot_failure_preserves_caller_reference();
     test_easy_snapshot_old_options_size_compatibility();
+    test_scalar_extension_step_failure_diagnostic();
     test_num_workers_default_is_one();
     test_num_workers_explicit_four();
     test_intern_returns_same_id();

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -2350,6 +2350,7 @@ col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
 
     wl_col_session_t *sess = COL_SESSION(session);
     const wl_plan_t *plan = sess->plan;
+    sess->extension_expr_status = 0;
 
     /* K-fusion's pre-seeded delta expansion is designed for step-style
      * outbound evaluation.  On the snapshot route it can suppress the EDB

--- a/wirelog/wirelog-easy.c
+++ b/wirelog/wirelog-easy.c
@@ -392,6 +392,9 @@ wirelog_easy_step(wirelog_easy_session_t *s)
     if (err != WIRELOG_OK)
         return err;
     int rc = wl_session_step(s->session);
+    if (rc != 0)
+        wl_extension_error_set_expr_status(
+            COL_SESSION(s->session)->extension_expr_status);
     return (rc == 0) ? WIRELOG_OK : WIRELOG_ERR_EXEC;
 }
 

--- a/wirelog/wirelog_advanced.c
+++ b/wirelog/wirelog_advanced.c
@@ -563,6 +563,9 @@ wirelog_session_step(wirelog_session_t *session)
     if (!session)
         return WIRELOG_ERR_EXEC;
     int rc = wl_session_step(session->inner);
+    if (rc != 0)
+        wl_extension_error_set_expr_status(
+            COL_SESSION(session->inner)->extension_expr_status);
     return (rc == 0 && !session->typed_callback_failed) ? WIRELOG_OK
                                                         : WIRELOG_ERR_EXEC;
 }
@@ -684,6 +687,9 @@ wirelog_session_snapshot_typed(wirelog_session_t *session,
     session->typed_callback_failed = false;
     struct typed_snapshot_context ctx = { session, callback, user_data };
     int rc = wl_session_snapshot(session->inner, typed_snapshot_bridge, &ctx);
+    if (rc != 0)
+        wl_extension_error_set_expr_status(
+            COL_SESSION(session->inner)->extension_expr_status);
     return rc == 0 && !session->typed_callback_failed ? WIRELOG_OK
                                                       : WIRELOG_ERR_EXEC;
 }


### PR DESCRIPTION
## Summary
- propagate scalar extension diagnostics through advanced and easy `step` APIs
- add typed snapshot diagnostic parity
- clear stale extension status before snapshot evaluation
- add focused regression coverage for all public paths

Closes #1250

## Validation
- `meson test -C builddir extension_filter wirelog_advanced wirelog_easy public_header_surface public_api_macro public_api_exports abi_symbols --print-errorlogs`
