### PR TITLE
feat: add scalar addon callback policy metadata

### DIFF
--- a/tests/test_extension_registry.c
+++ b/tests/test_extension_registry.c
@@ -38,18 +38,45 @@ int main(void)
     failures += check(r != NULL, "create");
     desc.addon_abi_identity = UINT64_C(0x0123456789abcdef);
     desc.addon_abi_version = 7;
+    desc.callback_policy = WIRELOG_EXTENSION_CALLBACK_THREAD_SAFE
+        | WIRELOG_EXTENSION_CALLBACK_DETERMINISTIC
+        | WIRELOG_EXTENSION_CALLBACK_PURE;
     failures += check(wirelog_extension_register(r, &desc) == 0,
             "metadata descriptor register");
     s = wirelog_extension_snapshot_acquire(r);
     d = wirelog_extension_snapshot_find(s, "Math::Sin");
     failures += check(d != NULL && d->addon_abi_identity
-            == UINT64_C(0x0123456789abcdef) && d->addon_abi_version == 7,
+            == UINT64_C(0x0123456789abcdef) && d->addon_abi_version == 7
+            && d->callback_policy
+            == (WIRELOG_EXTENSION_CALLBACK_THREAD_SAFE
+            | WIRELOG_EXTENSION_CALLBACK_DETERMINISTIC
+            | WIRELOG_EXTENSION_CALLBACK_PURE),
             "metadata copied into snapshot");
     wirelog_extension_snapshot_release(s);
     failures += check(wirelog_extension_unregister(r, "Math::Sin") == 0,
             "metadata descriptor unregister");
     desc.addon_abi_identity = 0;
     desc.addon_abi_version = 0;
+    desc.callback_policy = 1u << 12;
+    failures += check(wirelog_extension_register(r, &desc) == -1
+            && strstr(wirelog_extension_last_error(), "callback policy"),
+            "unknown callback policy bits rejected");
+    desc.callback_policy = 0;
+    {
+        wirelog_extension_descriptor_t partial = desc;
+        partial.callback_policy = WIRELOG_EXTENSION_CALLBACK_PURE;
+        partial.size = (uint32_t)offsetof(wirelog_extension_descriptor_t,
+                callback_policy) + sizeof(uint16_t);
+        failures += check(wirelog_extension_register(r, &partial) == 0,
+                "partially covered policy field is accepted as legacy");
+        s = wirelog_extension_snapshot_acquire(r);
+        d = wirelog_extension_snapshot_find(s, "Math::Sin");
+        failures += check(d != NULL && d->callback_policy == 0,
+                "partially covered policy field was not published");
+        wirelog_extension_snapshot_release(s);
+        failures += check(wirelog_extension_unregister(r, "Math::Sin") == 0,
+                "partial policy descriptor unregister");
+    }
     {
         const size_t old_size = offsetof(wirelog_extension_descriptor_t,
                 addon_abi_identity);
@@ -66,7 +93,7 @@ int main(void)
         s = wirelog_extension_snapshot_acquire(r);
         d = wirelog_extension_snapshot_find(s, "Math::Sin");
         failures += check(d != NULL && d->addon_abi_identity == 0
-                && d->addon_abi_version == 0,
+                && d->addon_abi_version == 0 && d->callback_policy == 0,
                 "legacy metadata defaults");
         wirelog_extension_snapshot_release(s);
         failures += check(wirelog_extension_unregister(r, "Math::Sin") == 0,

--- a/wirelog/extension_registry.c
+++ b/wirelog/extension_registry.c
@@ -103,6 +103,12 @@ wl_extension_metadata_valid(uint64_t identity, uint32_t version)
            || (identity != 0 && version != 0);
 }
 
+static bool
+wl_extension_callback_policy_valid(uint32_t policy)
+{
+    return (policy & ~WIRELOG_EXTENSION_CALLBACK_POLICY_KNOWN_MASK) == 0;
+}
+
 /* Normalize a caller-owned descriptor before reading any field beyond size.
  * Older addons may pass an allocation ending at the old struct size. */
 static bool
@@ -121,10 +127,30 @@ wl_extension_descriptor_normalize(
     memset(normalized, 0, sizeof(*normalized));
     copy_size = declared_size < sizeof(*normalized)
         ? (size_t)declared_size : sizeof(*normalized);
+    /* Never publish a partially copied append-only field. */
+    if (copy_size > offsetof(wirelog_extension_descriptor_t,
+        addon_abi_identity)
+        && copy_size < offsetof(wirelog_extension_descriptor_t,
+        addon_abi_identity) + sizeof(normalized->addon_abi_identity))
+        copy_size = offsetof(wirelog_extension_descriptor_t,
+                addon_abi_identity);
+    if (copy_size > offsetof(wirelog_extension_descriptor_t,
+        addon_abi_version)
+        && copy_size < offsetof(wirelog_extension_descriptor_t,
+        addon_abi_version) + sizeof(normalized->addon_abi_version))
+        copy_size = offsetof(wirelog_extension_descriptor_t,
+                addon_abi_version);
+    if (copy_size > offsetof(wirelog_extension_descriptor_t,
+        callback_policy)
+        && copy_size < offsetof(wirelog_extension_descriptor_t,
+        callback_policy) + sizeof(normalized->callback_policy))
+        copy_size = offsetof(wirelog_extension_descriptor_t,
+                callback_policy);
     memcpy(normalized, source, copy_size);
     normalized->size = (uint32_t)copy_size;
     return wl_extension_metadata_valid(normalized->addon_abi_identity,
-               normalized->addon_abi_version);
+               normalized->addon_abi_version)
+           && wl_extension_callback_policy_valid(normalized->callback_policy);
 }
 
 static bool
@@ -234,7 +260,9 @@ wirelog_extension_register(wirelog_extension_registry_t *registry,
         wl_extension_error_set("descriptor or registry is NULL"); return -1;
     }
     if (!wl_extension_descriptor_normalize(source, &owned_source)) {
-        wl_extension_error_set("invalid descriptor metadata"); return -1;
+        wl_extension_error_set(
+            "invalid descriptor metadata or callback policy");
+        return -1;
     }
     if (owned_source.abi_version != WIRELOG_EXTENSION_ABI_VERSION) {
         wl_extension_error_set("ABI version mismatch"); return -1;

--- a/wirelog/wirelog-extension.h
+++ b/wirelog/wirelog-extension.h
@@ -49,6 +49,18 @@ typedef int (*wirelog_extension_scalar_fn)(
     wirelog_extension_value_t *result, void *user_data);
 typedef void (*wirelog_extension_destroy_fn)(void *user_data);
 
+/* Callback capabilities. A zero policy is the legacy/unspecified contract;
+ * runtime enforcement is added by the follow-up evaluator policy unit. */
+#define WIRELOG_EXTENSION_CALLBACK_THREAD_SAFE  (1u << 0)
+#define WIRELOG_EXTENSION_CALLBACK_DETERMINISTIC (1u << 1)
+#define WIRELOG_EXTENSION_CALLBACK_PURE        (1u << 2)
+#define WIRELOG_EXTENSION_CALLBACK_REENTRANT   (1u << 3)
+#define WIRELOG_EXTENSION_CALLBACK_POLICY_KNOWN_MASK \
+        (WIRELOG_EXTENSION_CALLBACK_THREAD_SAFE \
+        | WIRELOG_EXTENSION_CALLBACK_DETERMINISTIC \
+        | WIRELOG_EXTENSION_CALLBACK_PURE \
+        | WIRELOG_EXTENSION_CALLBACK_REENTRANT)
+
 /* size is the sizeof the struct known by the caller; fields beyond size are
  * ignored, allowing this descriptor to grow without breaking old addons. */
 typedef struct wirelog_extension_descriptor {
@@ -66,6 +78,8 @@ typedef struct wirelog_extension_descriptor {
      * These append-only fields are available only when covered by @size. */
     uint64_t addon_abi_identity;
     uint32_t addon_abi_version;
+    /* Capability declarations; zero means legacy/unspecified. */
+    uint32_t callback_policy;
 } wirelog_extension_descriptor_t;
 
 WIRELOG_API wirelog_extension_registry_t *


### PR DESCRIPTION
## Summary
- add append-only callback capability metadata to scalar addon descriptors
- preserve zero-policy legacy descriptors and old descriptor-size compatibility
- reject unknown policy bits before registry publication
- retain normalized policy metadata in registry snapshots

Part of #1253.
Runtime enforcement, reentrancy, callback lifetime, and delta atomicity are tracked in #1254.
