### PR TITLE
fix: enforce thread-safe scalar callback policy

### DIFF
--- a/tests/test_extension_filter.c
+++ b/tests/test_extension_filter.c
@@ -289,6 +289,9 @@ main(void)
     ctx.intern = NULL;
     ctx.extensions = snapshot;
     ctx.allow_extension_scalar_result = false;
+    ctx.configured_worker_count = 1;
+    ctx.active_worker_count = 1;
+    ctx.parallel_execution = false;
 
     /* ABI-tagged calls use explicit little-endian identity/version fields. */
     size = put_var(buf, 0);
@@ -358,6 +361,20 @@ main(void)
     callback_mode = 0;
     failures += run(buf, size, &ctx, &value, WL_COLUMNAR_EXPR_OK);
     failures += check(value == 1, "true result");
+
+    /* Legacy/policy-zero callbacks are valid at serial width but must not be
+     * invoked when the actual evaluator width is concurrent. */
+    callback_calls = 0;
+    ctx.configured_worker_count = 4;
+    ctx.active_worker_count = 2;
+    ctx.parallel_execution = true;
+    failures += run(buf, size, &ctx, &value,
+            WL_COLUMNAR_EXPR_CALLBACK_POLICY);
+    failures += check(callback_calls == 0,
+            "unsafe callback is rejected before invocation");
+    ctx.active_worker_count = 1;
+    ctx.parallel_execution = false;
+    failures += run(buf, size, &ctx, &value, WL_COLUMNAR_EXPR_OK);
 
     buf[0] = (uint8_t)WL_PLAN_EXPR_CONST_INT;
     memset(buf + 1, 0, 8);

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -170,11 +170,15 @@ tdd_cleanup_workers(wl_col_session_t *coord)
     }
     coord->tdd_workers_count = 0;
     coord->tdd_active_workers = 0;
+    coord->callback_active_workers = 1;
+    coord->callback_parallel_execution = false;
 }
 
 static void
 tdd_record_active_workers(wl_col_session_t *coord, uint32_t W)
 {
+    coord->callback_active_workers = W > 0 ? W : 1;
+    coord->callback_parallel_execution = coord->callback_active_workers > 1;
     coord->tdd_last_active_workers = W;
     if (W > coord->tdd_max_active_workers)
         coord->tdd_max_active_workers = W;
@@ -189,7 +193,7 @@ record_worker_expr_status(wl_col_session_t *coord,
     if (worker && worker->extension_expr_status != 0)
         coord->extension_expr_status = worker->extension_expr_status;
     else if (rc >= WL_COLUMNAR_EXPR_EXTENSION_MALFORMED
-        && rc <= WL_COLUMNAR_EXPR_ALLOCATION_FAILURE)
+        && rc <= WL_COLUMNAR_EXPR_CALLBACK_POLICY)
         coord->extension_expr_status = rc;
 }
 

--- a/wirelog/columnar/expr.c
+++ b/wirelog/columnar/expr.c
@@ -594,6 +594,13 @@ wl_columnar_expr_eval_run_ctx(const uint8_t *buf, uint32_t size,
                     *status = WL_COLUMNAR_EXPR_EXTENSION_ABI_MISMATCH;
                 goto bad;
             }
+            if (ctx->parallel_execution && ctx->active_worker_count > 1
+                && !(descriptor->callback_policy
+                & WIRELOG_EXTENSION_CALLBACK_THREAD_SAFE)) {
+                if (status)
+                    *status = WL_COLUMNAR_EXPR_CALLBACK_POLICY;
+                goto bad;
+            }
             if (nargs != descriptor->arity || nargs > s.top
                 || nargs > COL_FILTER_STACK) {
                 if (status)
@@ -1198,7 +1205,13 @@ int
 wl_columnar_expr_eval_run(const uint8_t *buf, uint32_t size, const int64_t *row,
     uint32_t ncols, int64_t *out_val, wl_intern_t *intern)
 {
-    wl_columnar_expr_context_t ctx = { intern, NULL };
+    wl_columnar_expr_context_t ctx = {
+        .intern = intern,
+        .extensions = NULL,
+        .configured_worker_count = 1,
+        .active_worker_count = 1,
+        .parallel_execution = false
+    };
     wl_columnar_expr_status_t status;
     return wl_columnar_expr_eval_run_ctx(buf, size, row, ncols, out_val,
                &ctx, &status) == WL_COLUMNAR_EXPR_OK ? 0 : 1;

--- a/wirelog/columnar/filter.c
+++ b/wirelog/columnar/filter.c
@@ -746,8 +746,11 @@ wl_columnar_filter_op(const wl_plan_op_t *op, eval_stack_t *stack,
 
     int64_t *const row = row_rb.ptr;
     wl_columnar_expr_context_t expr_ctx = {
-        sess ? sess->intern : NULL,
-        sess ? sess->base.extension_snapshot : NULL
+        .intern = sess ? sess->intern : NULL,
+        .extensions = sess ? sess->base.extension_snapshot : NULL,
+        .configured_worker_count = sess ? sess->callback_configured_workers : 1,
+        .active_worker_count = sess ? sess->callback_active_workers : 1,
+        .parallel_execution = sess ? sess->callback_parallel_execution : false
     };
     for (uint32_t r = 0; r < e.rel->nrows; r++) {
         col_rel_row_copy_out(e.rel, r, row);

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1298,6 +1298,9 @@ typedef struct wl_col_session_t {
      * stratum/operator. Workqueue threads and TDD worker slots are allocated
      * lazily for the selected active width, so workers=N means "use up to N". */
     uint32_t num_workers;
+    uint32_t callback_configured_workers;
+    uint32_t callback_active_workers;
+    bool callback_parallel_execution;
     /* Dynamic join output limit (Issue #221).
      * Maximum output rows per single join operation. Computed at session init
      * based on available physical memory, num_workers, and estimated row width.
@@ -1860,6 +1863,9 @@ typedef struct {
     wl_intern_t *intern;
     const wirelog_extension_snapshot_t *extensions; /* borrowed */
     bool allow_extension_scalar_result;
+    uint32_t configured_worker_count;
+    uint32_t active_worker_count;
+    bool parallel_execution;
 } wl_columnar_expr_context_t;
 
 typedef enum {
@@ -1872,7 +1878,8 @@ typedef enum {
     WL_COLUMNAR_EXPR_CALLBACK_FAILURE,
     WL_COLUMNAR_EXPR_INVALID_RESULT,
     WL_COLUMNAR_EXPR_ALLOCATION_FAILURE,
-    WL_COLUMNAR_EXPR_EXTENSION_ABI_MISMATCH
+    WL_COLUMNAR_EXPR_EXTENSION_ABI_MISMATCH,
+    WL_COLUMNAR_EXPR_CALLBACK_POLICY
 } wl_columnar_expr_status_t;
 
 wl_columnar_expr_compiled_t *

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -721,6 +721,8 @@ col_op_k_fusion_dispatch(const wl_plan_op_t *op, eval_stack_t *stack,
         worker_sess[d].wq_workers = 0;
         worker_sess[d].kfusion_adaptive = NULL;
         worker_sess[d].num_workers = 1;
+        worker_sess[d].callback_active_workers = active_workers;
+        worker_sess[d].callback_parallel_execution = active_workers > 1;
         worker_sess[d].tdd_workers = NULL;
         worker_sess[d].tdd_workers_cap = 0;
         worker_sess[d].tdd_workers_count = 0;

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -230,9 +230,12 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
 
     int64_t *const row = row_rb.ptr;
     wl_columnar_expr_context_t expr_ctx = {
-        sess ? sess->intern : NULL,
-        sess ? sess->base.extension_snapshot : NULL,
-        true
+        .intern = sess ? sess->intern : NULL,
+        .extensions = sess ? sess->base.extension_snapshot : NULL,
+        .allow_extension_scalar_result = true,
+        .configured_worker_count = sess ? sess->callback_configured_workers : 1,
+        .active_worker_count = sess ? sess->callback_active_workers : 1,
+        .parallel_execution = sess ? sess->callback_parallel_execution : false
     };
     for (uint32_t r = 0; r < e.rel->nrows; r++) {
         col_rel_row_copy_out(e.rel, r, row);

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -963,6 +963,11 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
     }
 #undef WL_MAX_WORKERS_HARD_LIMIT
 
+    /* The callback policy uses the effective cap after RAM/env clamping. */
+    sess->callback_configured_workers = sess->num_workers;
+    sess->callback_active_workers = 1;
+    sess->callback_parallel_execution = false;
+
     /* Dynamic join output limit (Issue #221) */
     {
         const char *join_limit_env = getenv("WIRELOG_JOIN_OUTPUT_LIMIT");

--- a/wirelog/extension_registry.c
+++ b/wirelog/extension_registry.c
@@ -62,6 +62,9 @@ wl_extension_error_set_expr_status(int status)
     case 8: wl_extension_error_set("scalar extension allocation failed"); break;
     case 9: wl_extension_error_set(
             "scalar extension ABI identity/version mismatch"); break;
+    case 10: wl_extension_error_set(
+            "scalar extension callback policy forbids concurrent execution "
+            "without THREAD_SAFE"); break;
     default: break;
     }
 }


### PR DESCRIPTION
## Summary\n- preserve configured and actual callback execution width across session, TDD, and K-fusion workers\n- reject policy-zero scalar callbacks before argument preparation during concurrent execution\n- report a dedicated callback-policy diagnostic and add regression coverage\n\nCloses #1254\n\n## Validation\n- meson test -C builddir extension_filter extension_registry --print-errorlogs\n- meson test -C builddir --suite abi --print-errorlogs\n- ninja -C builddir libwirelog.so.0.54.99