### PR TITLE
fix: reject non-reentrant scalar callback recursion

### DIFF
--- a/tests/test_extension_filter.c
+++ b/tests/test_extension_filter.c
@@ -13,6 +13,10 @@ static _Atomic int callback_calls;
 static int fail_on_call;
 static const uint8_t *expected_string;
 static size_t expected_string_length;
+static const uint8_t *nested_buf;
+static uint32_t nested_size;
+static wl_columnar_expr_context_t *nested_ctx;
+static int nested_rc;
 
 static int
 check(int condition, const char *message);
@@ -95,6 +99,17 @@ extension_callback(const wirelog_extension_value_t *args, uint32_t nargs,
         result->size = sizeof(returned_string) - 1;
         result->as.string_value.data = returned_string;
         result->as.string_value.length = sizeof(returned_string) - 1;
+        return 0;
+    }
+    if (callback_mode == 6) {
+        int64_t nested_value = 0;
+        wl_columnar_expr_status_t nested_status = WL_COLUMNAR_EXPR_OK;
+        nested_rc = wl_columnar_expr_eval_run_ctx(nested_buf, nested_size,
+                &nested_value, 1, &nested_value, nested_ctx, &nested_status);
+        nested_rc = nested_status;
+        result->type = WIRELOG_EXTENSION_VALUE_BOOL;
+        result->size = sizeof(uint8_t);
+        result->as.bool_value = 1;
         return 0;
     }
     result->type = WIRELOG_EXTENSION_VALUE_BOOL;
@@ -504,6 +519,25 @@ main(void)
     ctx.active_worker_count = 1;
     ctx.parallel_execution = false;
     failures += run(buf, size, &ctx, &value, WL_COLUMNAR_EXPR_OK);
+
+    /* A callback may not recursively invoke the same logical evaluator
+     * session unless it declares REENTRANT.  The guard must be restored after
+     * the callback so a later serial evaluation remains usable. */
+    ctx.session_key = &ctx;
+    nested_buf = buf;
+    nested_size = size;
+    nested_ctx = &ctx;
+    nested_rc = WL_COLUMNAR_EXPR_OK;
+    callback_mode = 6;
+    callback_calls = 0;
+    failures += run(buf, size, &ctx, &value, WL_COLUMNAR_EXPR_OK);
+    failures += check(callback_calls == 1,
+            "nested evaluator does not invoke callback twice");
+    failures += check(nested_rc == WL_COLUMNAR_EXPR_CALLBACK_REENTRANT,
+            "nested evaluator reports reentrancy policy");
+    callback_mode = 0;
+    failures += run(buf, size, &ctx, &value, WL_COLUMNAR_EXPR_OK);
+    ctx.session_key = NULL;
 
     buf[0] = (uint8_t)WL_PLAN_EXPR_CONST_INT;
     memset(buf + 1, 0, 8);

--- a/tests/test_extension_filter.c
+++ b/tests/test_extension_filter.c
@@ -16,6 +16,9 @@ static size_t expected_string_length;
 static const uint8_t *nested_buf;
 static uint32_t nested_size;
 static wl_columnar_expr_context_t *nested_ctx;
+static wl_columnar_expr_context_t *nested_ctx_a;
+static wl_columnar_expr_context_t *nested_ctx_b;
+static int nested_stage;
 static int nested_rc;
 
 static int
@@ -104,9 +107,24 @@ extension_callback(const wirelog_extension_value_t *args, uint32_t nargs,
     if (callback_mode == 6) {
         int64_t nested_value = 0;
         wl_columnar_expr_status_t nested_status = WL_COLUMNAR_EXPR_OK;
-        nested_rc = wl_columnar_expr_eval_run_ctx(nested_buf, nested_size,
-                &nested_value, 1, &nested_value, nested_ctx, &nested_status);
+        (void)wl_columnar_expr_eval_run_ctx(nested_buf, nested_size,
+            &nested_value, 1, &nested_value, nested_ctx, &nested_status);
         nested_rc = nested_status;
+        result->type = WIRELOG_EXTENSION_VALUE_BOOL;
+        result->size = sizeof(uint8_t);
+        result->as.bool_value = 1;
+        return 0;
+    }
+    if (callback_mode == 7) {
+        int64_t nested_value = 0;
+        wl_columnar_expr_status_t nested_status = WL_COLUMNAR_EXPR_OK;
+        int current_stage = nested_stage++;
+        wl_columnar_expr_context_t *target = current_stage == 0
+            ? nested_ctx_b : nested_ctx_a;
+        (void)wl_columnar_expr_eval_run_ctx(nested_buf, nested_size,
+            &nested_value, 1, &nested_value, target, &nested_status);
+        if (current_stage != 0)
+            nested_rc = nested_status;
         result->type = WIRELOG_EXTENSION_VALUE_BOOL;
         result->size = sizeof(uint8_t);
         result->as.bool_value = 1;
@@ -537,6 +555,24 @@ main(void)
             "nested evaluator reports reentrancy policy");
     callback_mode = 0;
     failures += run(buf, size, &ctx, &value, WL_COLUMNAR_EXPR_OK);
+    ctx.session_key = NULL;
+
+    /* A stack, rather than one TLS slot, is required for A -> B -> A. */
+    wl_columnar_expr_context_t other_ctx = ctx;
+    ctx.session_key = &ctx;
+    other_ctx.session_key = &other_ctx;
+    nested_ctx_a = &ctx;
+    nested_ctx_b = &other_ctx;
+    nested_stage = 0;
+    nested_rc = WL_COLUMNAR_EXPR_OK;
+    callback_mode = 7;
+    callback_calls = 0;
+    failures += run(buf, size, &ctx, &value, WL_COLUMNAR_EXPR_OK);
+    failures += check(callback_calls == 2,
+            "multi-session nesting invokes only A and B callbacks");
+    failures += check(nested_rc == WL_COLUMNAR_EXPR_CALLBACK_REENTRANT,
+            "callback stack detects A re-entry after B");
+    callback_mode = 0;
     ctx.session_key = NULL;
 
     buf[0] = (uint8_t)WL_PLAN_EXPR_CONST_INT;

--- a/tests/test_extension_filter.c
+++ b/tests/test_extension_filter.c
@@ -249,6 +249,9 @@ run_kfusion_policy_case(const uint8_t *buf, uint32_t size,
             expected_rc == 0 ? "K-fusion accepts safe callback"
                              : "K-fusion rejects unsafe callback");
     if (expected_rc != 0)
+        failures += check(session.extension_expr_status == expected_rc,
+                "K-fusion preserves worker extension diagnostic");
+    if (expected_rc != 0)
         failures += check(callback_calls == 0,
                 "K-fusion rejects before callback invocation");
     else

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -193,7 +193,7 @@ record_worker_expr_status(wl_col_session_t *coord,
     if (worker && worker->extension_expr_status != 0)
         coord->extension_expr_status = worker->extension_expr_status;
     else if (rc >= WL_COLUMNAR_EXPR_EXTENSION_MALFORMED
-        && rc <= WL_COLUMNAR_EXPR_CALLBACK_POLICY)
+        && rc <= WL_COLUMNAR_EXPR_CALLBACK_REENTRANT)
         coord->extension_expr_status = rc;
 }
 

--- a/wirelog/columnar/expr.c
+++ b/wirelog/columnar/expr.c
@@ -25,6 +25,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(_MSC_VER)
+static __declspec(thread) const void *wl_active_callback_session_key;
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+static _Thread_local const void *wl_active_callback_session_key;
+#else
+static __thread const void *wl_active_callback_session_key;
+#endif
+
 typedef struct {
     int64_t vals[COL_FILTER_STACK];
     uint32_t types[COL_FILTER_STACK];
@@ -601,6 +609,14 @@ wl_columnar_expr_eval_run_ctx(const uint8_t *buf, uint32_t size,
                     *status = WL_COLUMNAR_EXPR_CALLBACK_POLICY;
                 goto bad;
             }
+            if (ctx->session_key
+                && wl_active_callback_session_key == ctx->session_key
+                && !(descriptor->callback_policy
+                & WIRELOG_EXTENSION_CALLBACK_REENTRANT)) {
+                if (status)
+                    *status = WL_COLUMNAR_EXPR_CALLBACK_REENTRANT;
+                goto bad;
+            }
             if (nargs != descriptor->arity || nargs > s.top
                 || nargs > COL_FILTER_STACK) {
                 if (status)
@@ -641,9 +657,14 @@ wl_columnar_expr_eval_run_ctx(const uint8_t *buf, uint32_t size,
                     args[arg].as.int64_value = s.vals[index];
             }
             s.top -= nargs;
-            if (!descriptor->invoke
-                || descriptor->invoke(args, nargs, &result,
-                descriptor->user_data) != 0) {
+            const void *previous_session_key =
+                wl_active_callback_session_key;
+            wl_active_callback_session_key = ctx->session_key;
+            int callback_rc = descriptor->invoke
+                ? descriptor->invoke(args, nargs, &result,
+                    descriptor->user_data) : -1;
+            wl_active_callback_session_key = previous_session_key;
+            if (callback_rc != 0) {
                 if (status)
                     *status = WL_COLUMNAR_EXPR_CALLBACK_FAILURE;
                 goto bad;
@@ -1210,7 +1231,8 @@ wl_columnar_expr_eval_run(const uint8_t *buf, uint32_t size, const int64_t *row,
         .extensions = NULL,
         .configured_worker_count = 1,
         .active_worker_count = 1,
-        .parallel_execution = false
+        .parallel_execution = false,
+        .session_key = NULL
     };
     wl_columnar_expr_status_t status;
     return wl_columnar_expr_eval_run_ctx(buf, size, row, ncols, out_val,

--- a/wirelog/columnar/expr.c
+++ b/wirelog/columnar/expr.c
@@ -25,12 +25,20 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define WL_CALLBACK_SESSION_STACK_MAX 64
+
 #if defined(_MSC_VER)
-static __declspec(thread) const void *wl_active_callback_session_key;
+static __declspec(thread) const void *wl_callback_session_stack[
+    WL_CALLBACK_SESSION_STACK_MAX];
+static __declspec(thread) uint32_t wl_callback_session_depth;
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-static _Thread_local const void *wl_active_callback_session_key;
+static _Thread_local const void *wl_callback_session_stack[
+    WL_CALLBACK_SESSION_STACK_MAX];
+static _Thread_local uint32_t wl_callback_session_depth;
 #else
-static __thread const void *wl_active_callback_session_key;
+static __thread const void *wl_callback_session_stack[
+    WL_CALLBACK_SESSION_STACK_MAX];
+static __thread uint32_t wl_callback_session_depth;
 #endif
 
 typedef struct {
@@ -610,12 +618,17 @@ wl_columnar_expr_eval_run_ctx(const uint8_t *buf, uint32_t size,
                 goto bad;
             }
             if (ctx->session_key
-                && wl_active_callback_session_key == ctx->session_key
                 && !(descriptor->callback_policy
                 & WIRELOG_EXTENSION_CALLBACK_REENTRANT)) {
-                if (status)
-                    *status = WL_COLUMNAR_EXPR_CALLBACK_REENTRANT;
-                goto bad;
+                for (uint32_t depth = 0;
+                    depth < wl_callback_session_depth; depth++) {
+                    if (wl_callback_session_stack[depth]
+                        == ctx->session_key) {
+                        if (status)
+                            *status = WL_COLUMNAR_EXPR_CALLBACK_REENTRANT;
+                        goto bad;
+                    }
+                }
             }
             if (nargs != descriptor->arity || nargs > s.top
                 || nargs > COL_FILTER_STACK) {
@@ -657,13 +670,21 @@ wl_columnar_expr_eval_run_ctx(const uint8_t *buf, uint32_t size,
                     args[arg].as.int64_value = s.vals[index];
             }
             s.top -= nargs;
-            const void *previous_session_key =
-                wl_active_callback_session_key;
-            wl_active_callback_session_key = ctx->session_key;
+            if (ctx->session_key
+                && wl_callback_session_depth
+                >= WL_CALLBACK_SESSION_STACK_MAX) {
+                if (status)
+                    *status = WL_COLUMNAR_EXPR_CALLBACK_REENTRANT;
+                goto bad;
+            }
+            if (ctx->session_key)
+                wl_callback_session_stack[wl_callback_session_depth++]
+                    = ctx->session_key;
             int callback_rc = descriptor->invoke
                 ? descriptor->invoke(args, nargs, &result,
                     descriptor->user_data) : -1;
-            wl_active_callback_session_key = previous_session_key;
+            if (ctx->session_key)
+                wl_callback_session_depth--;
             if (callback_rc != 0) {
                 if (status)
                     *status = WL_COLUMNAR_EXPR_CALLBACK_FAILURE;

--- a/wirelog/columnar/filter.c
+++ b/wirelog/columnar/filter.c
@@ -750,7 +750,8 @@ wl_columnar_filter_op(const wl_plan_op_t *op, eval_stack_t *stack,
         .extensions = sess ? sess->base.extension_snapshot : NULL,
         .configured_worker_count = sess ? sess->callback_configured_workers : 1,
         .active_worker_count = sess ? sess->callback_active_workers : 1,
-        .parallel_execution = sess ? sess->callback_parallel_execution : false
+        .parallel_execution = sess ? sess->callback_parallel_execution : false,
+        .session_key = sess ? sess->callback_session_key : NULL
     };
     for (uint32_t r = 0; r < e.rel->nrows; r++) {
         col_rel_row_copy_out(e.rel, r, row);

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1301,6 +1301,7 @@ typedef struct wl_col_session_t {
     uint32_t callback_configured_workers;
     uint32_t callback_active_workers;
     bool callback_parallel_execution;
+    const void *callback_session_key;
     /* Dynamic join output limit (Issue #221).
      * Maximum output rows per single join operation. Computed at session init
      * based on available physical memory, num_workers, and estimated row width.
@@ -1866,6 +1867,7 @@ typedef struct {
     uint32_t configured_worker_count;
     uint32_t active_worker_count;
     bool parallel_execution;
+    const void *session_key;
 } wl_columnar_expr_context_t;
 
 typedef enum {
@@ -1879,7 +1881,8 @@ typedef enum {
     WL_COLUMNAR_EXPR_INVALID_RESULT,
     WL_COLUMNAR_EXPR_ALLOCATION_FAILURE,
     WL_COLUMNAR_EXPR_EXTENSION_ABI_MISMATCH,
-    WL_COLUMNAR_EXPR_CALLBACK_POLICY
+    WL_COLUMNAR_EXPR_CALLBACK_POLICY,
+    WL_COLUMNAR_EXPR_CALLBACK_REENTRANT
 } wl_columnar_expr_status_t;
 
 wl_columnar_expr_compiled_t *

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -838,6 +838,9 @@ col_op_k_fusion_dispatch(const wl_plan_op_t *op, eval_stack_t *stack,
     _phase_t0 = now_ns();
     for (uint32_t d = 0; d < live_count; d++) {
         if (workers[d].rc != 0) {
+            if (worker_sess[d].extension_expr_status != 0)
+                sess->extension_expr_status
+                    = worker_sess[d].extension_expr_status;
             rc = workers[d].rc;
             goto cleanup_results;
         }

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -235,7 +235,8 @@ col_op_map(const wl_plan_op_t *op, eval_stack_t *stack, wl_col_session_t *sess)
         .allow_extension_scalar_result = true,
         .configured_worker_count = sess ? sess->callback_configured_workers : 1,
         .active_worker_count = sess ? sess->callback_active_workers : 1,
-        .parallel_execution = sess ? sess->callback_parallel_execution : false
+        .parallel_execution = sess ? sess->callback_parallel_execution : false,
+        .session_key = sess ? sess->callback_session_key : NULL
     };
     for (uint32_t r = 0; r < e.rel->nrows; r++) {
         col_rel_row_copy_out(e.rel, r, row);

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -967,6 +967,7 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
     sess->callback_configured_workers = sess->num_workers;
     sess->callback_active_workers = 1;
     sess->callback_parallel_execution = false;
+    sess->callback_session_key = sess;
 
     /* Dynamic join output limit (Issue #221) */
     {
@@ -1447,6 +1448,7 @@ col_worker_session_create(wl_col_session_t *coordinator,
     out_worker->worker_id = worker_id;
     out_worker->coordinator = coordinator;
     out_worker->extension_expr_status = 0;
+    out_worker->callback_session_key = coordinator->callback_session_key;
 
     /* Prevent accidental wl_session_destroy on stack-allocated worker */
     out_worker->base.backend = NULL;

--- a/wirelog/extension_registry.c
+++ b/wirelog/extension_registry.c
@@ -65,6 +65,9 @@ wl_extension_error_set_expr_status(int status)
     case 10: wl_extension_error_set(
             "scalar extension callback policy forbids concurrent execution "
             "without THREAD_SAFE"); break;
+    case 11: wl_extension_error_set(
+            "scalar extension callback cannot re-enter the same session");
+        break;
     default: break;
     }
 }

--- a/wirelog/wirelog-extension.h
+++ b/wirelog/wirelog-extension.h
@@ -55,8 +55,9 @@ typedef int (*wirelog_extension_scalar_fn)(
     wirelog_extension_value_t *result, void *user_data);
 typedef void (*wirelog_extension_destroy_fn)(void *user_data);
 
-/* Callback capabilities. A zero policy is the legacy/unspecified contract;
- * runtime enforcement is added by the follow-up evaluator policy unit. */
+/* Callback capabilities. A zero policy is the legacy/unspecified contract.
+ * Unless REENTRANT is declared, a callback must not recursively evaluate the
+ * same logical session.  The evaluator enforces this synchronously. */
 #define WIRELOG_EXTENSION_CALLBACK_THREAD_SAFE  (1u << 0)
 #define WIRELOG_EXTENSION_CALLBACK_DETERMINISTIC (1u << 1)
 #define WIRELOG_EXTENSION_CALLBACK_PURE        (1u << 2)


### PR DESCRIPTION
## Summary\n- track the logical session key through coordinator and worker expression contexts\n- reject same-session callback recursion unless REENTRANT is declared\n- restore the thread-local guard across callback success and failure\n- add deterministic diagnostic mapping and regression coverage\n\nPart of #1260\n\n## Validation\n- meson test -C builddir extension_filter extension_registry k_fusion_e2e k_fusion_adaptive --print-errorlogs\n- meson test -C builddir-san extension_filter --print-errorlogs\n- meson test -C builddir --suite abi --print-errorlogs