### PR TITLE
feat: enforce scalar callback in-flight lifetime

### DIFF
--- a/tests/test_extension_filter.c
+++ b/tests/test_extension_filter.c
@@ -20,6 +20,9 @@ static wl_columnar_expr_context_t *nested_ctx_a;
 static wl_columnar_expr_context_t *nested_ctx_b;
 static int nested_stage;
 static int nested_rc;
+static wirelog_extension_registry_t *lifetime_registry;
+static wirelog_extension_snapshot_t *lifetime_snapshot;
+static int lifetime_destroy_calls;
 
 static int
 check(int condition, const char *message);
@@ -102,6 +105,21 @@ extension_callback(const wirelog_extension_value_t *args, uint32_t nargs,
         result->size = sizeof(returned_string) - 1;
         result->as.string_value.data = returned_string;
         result->as.string_value.length = sizeof(returned_string) - 1;
+        return 0;
+    }
+    if (callback_mode == 8) {
+        wirelog_extension_snapshot_t *held_snapshot = lifetime_snapshot;
+        if (!lifetime_registry
+            || wirelog_extension_unregister(lifetime_registry,
+            "test.lifetime") != 0)
+            return 1;
+        lifetime_snapshot = NULL;
+        wirelog_extension_snapshot_release(held_snapshot);
+        if (lifetime_destroy_calls != 0)
+            return 1;
+        result->type = WIRELOG_EXTENSION_VALUE_BOOL;
+        result->size = sizeof(uint8_t);
+        result->as.bool_value = 1;
         return 0;
     }
     if (callback_mode == 6) {
@@ -317,6 +335,13 @@ check(int condition, const char *message)
     return condition ? 0 : 1;
 }
 
+static void
+lifetime_destroy(void *user_data)
+{
+    (void)user_data;
+    lifetime_destroy_calls++;
+}
+
 static uint32_t
 put_var(uint8_t *buf, uint32_t pos)
 {
@@ -416,6 +441,7 @@ main(void)
         extension_callback, NULL, NULL
     };
     wirelog_extension_descriptor_t safe_descriptor = scalar_descriptor;
+    wirelog_extension_descriptor_t lifetime_descriptor = descriptor;
     wirelog_extension_registry_t *registry =
         wirelog_extension_registry_create();
     wirelog_extension_snapshot_t *snapshot;
@@ -434,12 +460,16 @@ main(void)
     scalar_descriptor.addon_abi_version = 9;
     safe_descriptor.name = "test.safe";
     safe_descriptor.callback_policy = WIRELOG_EXTENSION_CALLBACK_THREAD_SAFE;
+    lifetime_descriptor.name = "test.lifetime";
+    lifetime_descriptor.destroy = lifetime_destroy;
     failures += check(wirelog_extension_register(registry, &descriptor) == 0,
             "register predicate");
     failures += check(wirelog_extension_register(registry,
             &scalar_descriptor) == 0, "register scalar callback");
     failures += check(wirelog_extension_register(registry,
             &safe_descriptor) == 0, "register thread-safe callback");
+    failures += check(wirelog_extension_register(registry,
+            &lifetime_descriptor) == 0, "register lifetime callback");
     snapshot = wirelog_extension_snapshot_acquire(registry);
     ctx.intern = NULL;
     ctx.extensions = snapshot;
@@ -785,6 +815,19 @@ main(void)
     size = put_bool(buf, 0, 1);
     size = put_call(buf, size, "test.pred", 1);
     failures += run(buf, size, &ctx, &value, WL_COLUMNAR_EXPR_OK);
+    lifetime_registry = registry;
+    lifetime_snapshot = snapshot;
+    lifetime_destroy_calls = 0;
+    callback_mode = 8;
+    size = put_var(buf, 0);
+    size = put_call(buf, size, "test.lifetime", 1);
+    failures += run(buf, size, &ctx, &value, WL_COLUMNAR_EXPR_OK);
+    failures += check(lifetime_destroy_calls == 1,
+            "in-flight callback defers destroy until lease release");
+    snapshot = NULL;
+    ctx.extensions = NULL;
+    lifetime_registry = NULL;
+    callback_mode = 0;
     failures += check(wirelog_extension_unregister(registry, "test.scalar")
             == 0, "unregister scalar callback");
     failures += check(wirelog_extension_unregister(registry, "test.safe")

--- a/wirelog/columnar/expr.c
+++ b/wirelog/columnar/expr.c
@@ -680,9 +680,19 @@ wl_columnar_expr_eval_run_ctx(const uint8_t *buf, uint32_t size,
             if (ctx->session_key)
                 wl_callback_session_stack[wl_callback_session_depth++]
                     = ctx->session_key;
+            void *callback_lease = wl_extension_callback_lease_acquire(
+                ctx->extensions, descriptor);
+            if (!callback_lease) {
+                if (ctx->session_key)
+                    wl_callback_session_depth--;
+                if (status)
+                    *status = WL_COLUMNAR_EXPR_MISSING_EXTENSION;
+                goto bad;
+            }
             int callback_rc = descriptor->invoke
                 ? descriptor->invoke(args, nargs, &result,
                     descriptor->user_data) : -1;
+            wl_extension_callback_lease_release(callback_lease);
             if (ctx->session_key)
                 wl_callback_session_depth--;
             if (callback_rc != 0) {

--- a/wirelog/extension_registry.c
+++ b/wirelog/extension_registry.c
@@ -21,6 +21,7 @@ typedef struct wl_extension_entry {
     size_t references;
     size_t pins;
     bool registered;
+    wirelog_extension_registry_t *registry;
 } wl_extension_entry_t;
 
 struct wirelog_extension_registry {
@@ -29,6 +30,7 @@ struct wirelog_extension_registry {
     size_t count;
     size_t capacity;
     size_t active_snapshots;
+    size_t active_leases;
 };
 
 struct wirelog_extension_snapshot {
@@ -243,7 +245,8 @@ wirelog_extension_registry_destroy(wirelog_extension_registry_t *registry)
         wl_extension_error_set("registry is NULL"); return -1;
     }
     mutex_lock(&registry->mutex);
-    if (registry->count != 0 || registry->active_snapshots != 0) {
+    if (registry->count != 0 || registry->active_snapshots != 0
+        || registry->active_leases != 0) {
         mutex_unlock(&registry->mutex);
         wl_extension_error_set("registry is not empty"); return -1;
     }
@@ -293,6 +296,7 @@ wirelog_extension_register(wirelog_extension_registry_t *registry,
         wl_extension_error_set("invalid descriptor or allocation failed");
         return -1;
     }
+    entry->registry = registry;
     mutex_lock(&registry->mutex);
     for (i = 0; i < registry->count; i++) {
         if (strcmp(registry->entries[i]->name, entry->name) == 0) {
@@ -466,6 +470,48 @@ wirelog_extension_snapshot_find(const wirelog_extension_snapshot_t *snapshot,
         }
     free(normalized); wl_extension_error_set("extension not found");
     return NULL;
+}
+
+/* A callback lease keeps the entry alive independently of its snapshot.  A
+ * callback may release its last snapshot reference or unregister itself, so
+ * the evaluator cannot rely on the snapshot remaining alive until invoke()
+ * returns.  The lease never holds the registry mutex while user code runs. */
+void *
+wl_extension_callback_lease_acquire(
+    const wirelog_extension_snapshot_t *snapshot,
+    const wirelog_extension_descriptor_t *descriptor)
+{
+    size_t i;
+    wl_extension_entry_t *entry = NULL;
+    if (!snapshot || !descriptor)
+        return NULL;
+    mutex_lock(&snapshot->registry->mutex);
+    for (i = 0; i < snapshot->count; i++) {
+        if (&snapshot->entries[i]->descriptor == descriptor) {
+            entry = snapshot->entries[i];
+            entry->references++;
+            snapshot->registry->active_leases++;
+            break;
+        }
+    }
+    mutex_unlock(&snapshot->registry->mutex);
+    return entry;
+}
+
+void
+wl_extension_callback_lease_release(void *lease)
+{
+    wl_extension_entry_t *entry = (wl_extension_entry_t *)lease;
+    bool destroy;
+    if (!entry || !entry->registry)
+        return;
+    mutex_lock(&entry->registry->mutex);
+    if (entry->registry->active_leases != 0)
+        entry->registry->active_leases--;
+    destroy = wl_extension_entry_release_locked(entry);
+    mutex_unlock(&entry->registry->mutex);
+    if (destroy)
+        wl_extension_entry_destroy(entry);
 }
 
 int

--- a/wirelog/wirelog-extension.h
+++ b/wirelog/wirelog-extension.h
@@ -44,7 +44,10 @@ typedef struct wirelog_extension_value {
     } as;
 } wirelog_extension_value_t;
 
-/* Callback arguments are borrowed for the duration of invoke().  The engine
+/* Callback arguments are borrowed for the duration of invoke().  The
+ * descriptor and user_data remain valid for the entire synchronous callback,
+ * even if the callback unregisters the extension or releases its snapshot.
+ * The engine
  * copies accepted BOOL and INT64 results after invoke() returns; callbacks
  * must therefore not expect the engine to retain pointers or release memory.
  * STRING results are reserved for a future ownership-aware ABI and are

--- a/wirelog/wirelog-internal.h
+++ b/wirelog/wirelog-internal.h
@@ -24,6 +24,16 @@ wl_extension_error_set(const char *message);
 void
 wl_extension_error_set_expr_status(int status);
 
+/* Internal callback lifetime lease. The lease token is valid until released,
+ * even if the originating snapshot is released or the entry is unregistered
+ * while the callback is running. */
+void *
+wl_extension_callback_lease_acquire(
+    const wirelog_extension_snapshot_t *snapshot,
+    const wirelog_extension_descriptor_t *descriptor);
+void
+wl_extension_callback_lease_release(void *lease);
+
 /* ======================================================================== */
 /* String Utilities (Pure C11)                                             */
 /* ======================================================================== */


### PR DESCRIPTION
## Summary
- add a private callback lease independent of snapshot lifetime
- allow callback-time unregister and snapshot release without deadlock or use-after-free
- defer destroy until the final lease/reference is released
- add normal and sanitizer regression coverage

Closes #1262

## Validation
- meson test -C builddir extension_filter extension_registry --print-errorlogs
- meson test -C builddir-san extension_filter extension_registry --print-errorlogs