### PR TITLE
fix: make delta callback publication atomic

### DIFF
--- a/tests/test_delta_callback.c
+++ b/tests/test_delta_callback.c
@@ -20,6 +20,7 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog-parser.h"
+#include "../wirelog/wirelog-extension.h"
 #include "../wirelog/wirelog.h"
 
 #include <stdio.h>
@@ -34,21 +35,32 @@ static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
+static int
+fail_extension(const wirelog_extension_value_t *args, uint32_t nargs,
+    wirelog_extension_value_t *result, void *user_data)
+{
+    (void)args;
+    (void)nargs;
+    (void)result;
+    (void)user_data;
+    return 1;
+}
+
 #define TEST(name)                            \
-    do {                                      \
-        tests_run++;                          \
-        printf("  [%d] %s", tests_run, name); \
-    } while (0)
+        do {                                      \
+            tests_run++;                          \
+            printf("  [%d] %s", tests_run, name); \
+        } while (0)
 #define PASS()                 \
-    do {                       \
-        tests_passed++;        \
-        printf(" ... PASS\n"); \
-    } while (0)
+        do {                       \
+            tests_passed++;        \
+            printf(" ... PASS\n"); \
+        } while (0)
 #define FAIL(msg)                         \
-    do {                                  \
-        tests_failed++;                   \
-        printf(" ... FAIL: %s\n", (msg)); \
-    } while (0)
+        do {                                  \
+            tests_failed++;                   \
+            printf(" ... FAIL: %s\n", (msg)); \
+        } while (0)
 
 /* ======================================================================== */
 /* Plan Helper                                                             */
@@ -91,7 +103,7 @@ typedef struct {
 
 static void
 collect_delta(const char *relation, const int64_t *row, uint32_t ncols,
-              int32_t diff, void *user_data)
+    int32_t diff, void *user_data)
 {
     delta_collector_t *c = (delta_collector_t *)user_data;
     if (c->count >= MAX_DELTAS)
@@ -132,8 +144,8 @@ test_delta_callback_invoked(void)
 
     /* Program: r(x) :- a(x).  EDB: a={42}  Expected delta: r(42) diff=+1 */
     wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
-                                ".decl r(x: int32)\n"
-                                "r(x) :- a(x).\n");
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return 1;
@@ -204,8 +216,8 @@ test_delta_set_difference(void)
      * Step 2: insert a(2) → delta fires r(2) diff=+1, NOT r(1) again
      */
     wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
-                                ".decl r(x: int32)\n"
-                                "r(x) :- a(x).\n");
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return 1;
@@ -300,8 +312,8 @@ test_delta_multi_step(void)
      * Step 2 (no new EDB) → no new deltas (convergence)
      */
     wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
-                                ".decl r(x: int32)\n"
-                                "r(x) :- a(x).\n");
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
     if (!ffi) {
         FAIL("could not generate FFI plan");
         return 1;
@@ -344,12 +356,91 @@ test_delta_multi_step(void)
     if (count_step2 != count_step1) {
         char msg[64];
         snprintf(msg, sizeof(msg), "step 2 fired %d extra deltas (expected 0)",
-                 count_step2 - count_step1);
+            count_step2 - count_step1);
         FAIL(msg);
         return 1;
     }
     PASS();
     return 0;
+}
+
+/* A later rule failure must not publish events staged by an earlier rule. */
+static int
+test_no_partial_delta_on_error(void)
+{
+    TEST("No partial delta callbacks on evaluation failure");
+    const char *source = ".decl a(x: int32)\n"
+        ".decl r(x: int32)\n"
+        ".decl s(x: int32)\n"
+        "r(x) :- a(x).\n"
+        "s(x) :- a(x), @call(\"test.fail\", x).\n";
+    wirelog_error_t error;
+    wirelog_program_t *program = wirelog_parse_string(source, &error);
+    uint32_t argument_type = WIRELOG_EXTENSION_VALUE_INT64;
+    wirelog_extension_descriptor_t descriptor = {
+        WIRELOG_EXTENSION_ABI_VERSION, sizeof(descriptor), "test.fail", 1,
+        &argument_type, WIRELOG_EXTENSION_VALUE_BOOL, fail_extension, NULL,
+        NULL
+    };
+    wirelog_extension_registry_t *registry
+        = wirelog_extension_registry_create();
+    wirelog_extension_snapshot_t *snapshot = registry
+        ? wirelog_extension_snapshot_acquire(registry) : NULL;
+    wl_plan_t *plan = NULL;
+    if (!program || !registry || !snapshot
+        || wirelog_extension_register(registry, &descriptor) != 0) {
+        wirelog_program_free(program);
+        wirelog_extension_snapshot_release(snapshot);
+        wirelog_extension_registry_destroy(registry);
+        FAIL("could not generate failure plan");
+        return 1;
+    }
+    wirelog_extension_snapshot_release(snapshot);
+    snapshot = wirelog_extension_snapshot_acquire(registry);
+    if (!snapshot || wl_plan_from_program_with_snapshot(program, snapshot,
+        &plan) != 0) {
+        wirelog_program_free(program);
+        wirelog_extension_snapshot_release(snapshot);
+        wirelog_extension_unregister(registry, "test.fail");
+        wirelog_extension_registry_destroy(registry);
+        FAIL("could not generate failure plan");
+        return 1;
+    }
+    wirelog_program_free(program);
+    wl_session_t *session = NULL;
+    if (wl_session_create_with_snapshot(wl_backend_columnar(), plan, 1,
+        snapshot, &session) != 0
+        || !session) {
+        wirelog_extension_snapshot_release(snapshot);
+        wl_plan_free(plan);
+        wirelog_extension_unregister(registry, "test.fail");
+        wirelog_extension_registry_destroy(registry);
+        FAIL("session_create failed");
+        return 1;
+    }
+    wirelog_extension_snapshot_release(snapshot);
+    delta_collector_t deltas;
+    memset(&deltas, 0, sizeof(deltas));
+    wl_session_set_delta_cb(session, collect_delta, &deltas);
+    int64_t input[] = { 7 };
+    wl_session_insert(session, "a", input, 1, 1);
+    int rc = wl_session_step(session);
+    int failures = 0;
+    if (rc == 0) {
+        failures++;
+        FAIL("expected scalar evaluation failure");
+    }
+    if (deltas.count != 0) {
+        failures++;
+        FAIL("partial delta callback was published");
+    }
+    if (failures == 0)
+        PASS();
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    wirelog_extension_unregister(registry, "test.fail");
+    wirelog_extension_registry_destroy(registry);
+    return failures;
 }
 
 /* ======================================================================== */
@@ -365,6 +456,7 @@ main(void)
     test_delta_callback_invoked();
     test_delta_set_difference();
     test_delta_multi_step();
+    test_no_partial_delta_on_error();
 
     printf("\n");
     printf("Passed: %d/%d\n", tests_passed, tests_run);

--- a/wirelog/columnar/eval_delta.c
+++ b/wirelog/columnar/eval_delta.c
@@ -504,6 +504,10 @@ col_stratum_step_with_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
         if (r->nrows > 0 && ncols > 0) {
             cur_flat = (int64_t *)malloc(
                 (size_t)r->nrows * ncols * sizeof(int64_t));
+            if (!cur_flat) {
+                rc = ENOMEM;
+                goto cleanup;
+            }
             if (cur_flat) {
                 for (uint32_t row = 0; row < r->nrows; row++)
                     col_rel_row_copy_out(r, row,
@@ -519,8 +523,11 @@ col_stratum_step_with_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                     rowp)) {
                     rc = wl_delta_event_append(sess, r->name, rowp, ncols,
                             +1);
-                    if (rc != 0)
+                    if (rc != 0) {
+                        free(cur_flat);
+                        cur_flat = NULL;
                         goto cleanup;
+                    }
                 }
             }
         }
@@ -535,8 +542,11 @@ col_stratum_step_with_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                     rowp)) {
                     rc = wl_delta_event_append(sess, r->name, rowp,
                             prev_ncols[ri], -1);
-                    if (rc != 0)
+                    if (rc != 0) {
+                        free(cur_flat);
+                        cur_flat = NULL;
                         goto cleanup;
+                    }
                 }
             }
         }

--- a/wirelog/columnar/eval_delta.c
+++ b/wirelog/columnar/eval_delta.c
@@ -14,6 +14,56 @@
 #include <stdlib.h>
 #include <string.h>
 
+static int
+wl_delta_event_append(wl_col_session_t *sess, const char *relation,
+    const int64_t *row, uint32_t ncols, int32_t diff)
+{
+    wl_col_delta_event_t *grown;
+    int64_t *copy;
+    if (sess->delta_event_count == sess->delta_event_capacity) {
+        size_t next = sess->delta_event_capacity
+            ? sess->delta_event_capacity * 2 : 16;
+        grown = (wl_col_delta_event_t *)realloc(sess->delta_events,
+                next * sizeof(*grown));
+        if (!grown)
+            return ENOMEM;
+        sess->delta_events = grown;
+        sess->delta_event_capacity = next;
+    }
+    copy = (int64_t *)malloc((size_t)ncols * sizeof(*copy));
+    if (!copy)
+        return ENOMEM;
+    memcpy(copy, row, (size_t)ncols * sizeof(*copy));
+    sess->delta_events[sess->delta_event_count++]
+        = (wl_col_delta_event_t){ relation, copy, ncols, diff };
+    return 0;
+}
+
+void
+wl_columnar_delta_events_clear(wl_col_session_t *sess)
+{
+    if (!sess)
+        return;
+    for (size_t i = 0; i < sess->delta_event_count; i++)
+        free(sess->delta_events[i].row);
+    free(sess->delta_events);
+    sess->delta_events = NULL;
+    sess->delta_event_count = 0;
+    sess->delta_event_capacity = 0;
+}
+
+void
+wl_columnar_delta_events_publish(wl_col_session_t *sess)
+{
+    if (!sess || !sess->delta_cb)
+        return;
+    for (size_t i = 0; i < sess->delta_event_count; i++) {
+        wl_col_delta_event_t *event = &sess->delta_events[i];
+        sess->delta_cb(event->relation, event->row, event->ncols,
+            event->diff, sess->delta_data);
+    }
+}
+
 static bool
 col_row_in_sorted(const int64_t *sorted_data, uint32_t nrows, uint32_t ncols,
     const int64_t *row)
@@ -467,7 +517,10 @@ col_stratum_step_with_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                 const int64_t *rowp = cur_flat + (size_t)row * ncols;
                 if (!col_row_in_sorted(prev_data[ri], prev_nrows[ri], ncols,
                     rowp)) {
-                    sess->delta_cb(r->name, rowp, ncols, +1, sess->delta_data);
+                    rc = wl_delta_event_append(sess, r->name, rowp, ncols,
+                            +1);
+                    if (rc != 0)
+                        goto cleanup;
                 }
             }
         }
@@ -480,15 +533,25 @@ col_stratum_step_with_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                     = prev_data[ri] + (size_t)row * prev_ncols[ri];
                 if (!col_row_in_sorted(cur_flat, r->nrows, prev_ncols[ri],
                     rowp)) {
-                    sess->delta_cb(r->name, rowp, prev_ncols[ri], -1,
-                        sess->delta_data);
+                    rc = wl_delta_event_append(sess, r->name, rowp,
+                            prev_ncols[ri], -1);
+                    if (rc != 0)
+                        goto cleanup;
                 }
             }
         }
         free(cur_flat);
     }
 
+    /* Publish only after every relation has evaluated and consolidated. */
+    if (!sess->delta_event_transaction) {
+        wl_columnar_delta_events_publish(sess);
+        wl_columnar_delta_events_clear(sess);
+    }
+
 cleanup:
+    if (rc != 0)
+        wl_columnar_delta_events_clear(sess);
     for (uint32_t i = 0; i < rc_cnt; i++) {
         if (rc != 0 && prev_data[i]) {
             /* Error path: restore from flat snapshot into column-major */

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1116,6 +1116,13 @@ typedef struct col_filt_arr_entry {
  * wl_session_t* to wl_col_session_t* is valid per C11 pointer
  * compatibility (address of struct == address of first member).
  */
+typedef struct {
+    const char *relation;
+    int64_t *row;
+    uint32_t ncols;
+    int32_t diff;
+} wl_col_delta_event_t;
+
 typedef struct wl_col_session_t {
     wl_session_t base;         /* MUST be first field (vtable dispatch)  */
     /* base.extension_snapshot is borrowed from the coordinator in workers;
@@ -1136,6 +1143,10 @@ typedef struct wl_col_session_t {
     uint32_t rel_hash_chain_cap;  /* allocated capacity of rel_hash_next[]  */
     wirelog_on_delta_fn delta_cb;   /* delta callback (NULL = disabled)       */
     void *delta_data;          /* opaque user context for delta_cb       */
+    wl_col_delta_event_t *delta_events; /* staged observer events */
+    size_t delta_event_count;
+    size_t delta_event_capacity;
+    bool delta_event_transaction;
     wl_arena_t *eval_arena;    /* arena for per-iteration temporaries    */
     col_mat_cache_t mat_cache; /* materialization cache (US-006)        */
     uint32_t total_iterations; /* fixed-point iterations in last eval   */
@@ -2087,6 +2098,10 @@ tdd_stratum_mixed_slice_candidate(const wl_plan_stratum_t *sp);
 int
 col_stratum_step_with_delta(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
     uint32_t stratum_idx);
+void
+wl_columnar_delta_events_clear(wl_col_session_t *sess);
+void
+wl_columnar_delta_events_publish(wl_col_session_t *sess);
 bool
 stratum_has_preseeded_delta(const wl_plan_stratum_t *sp,
     wl_col_session_t *sess);

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1304,6 +1304,7 @@ col_session_destroy(wl_session_t *session)
     if (!session)
         return;
     wl_col_session_t *sess = COL_SESSION(session);
+    wl_columnar_delta_events_clear(sess);
 
     /* Issue #959: report the join-output high-water mark before teardown.
      *
@@ -1623,6 +1624,7 @@ col_worker_session_destroy(wl_col_session_t *worker)
 {
     if (!worker)
         return;
+    wl_columnar_delta_events_clear(worker);
 
     /* Free mat_cache entries (all worker-owned since zeroed at create) */
     col_mat_cache_clear(&worker->mat_cache);
@@ -2178,6 +2180,10 @@ col_session_step(wl_session_t *session)
         }
     }
 
+    if (sess->delta_cb) {
+        wl_columnar_delta_events_clear(sess);
+        sess->delta_event_transaction = true;
+    }
     for (uint32_t si = 0; si < plan->stratum_count; si++) {
         /* Skip strata not affected by the last incremental insertion */
         if (!col_affected_mask_contains(affected_mask, si))
@@ -2186,8 +2192,18 @@ col_session_step(wl_session_t *session)
         const wl_plan_stratum_t *sp = &plan->strata[si];
         int rc = sess->delta_cb ? col_stratum_step_with_delta(sp, sess, si)
                                 : col_eval_stratum_tdd(sp, sess, si);
-        if (rc != 0)
+        if (rc != 0) {
+            if (sess->delta_cb) {
+                sess->delta_event_transaction = false;
+                wl_columnar_delta_events_clear(sess);
+            }
             return rc;
+        }
+    }
+    if (sess->delta_cb) {
+        sess->delta_event_transaction = false;
+        wl_columnar_delta_events_publish(sess);
+        wl_columnar_delta_events_clear(sess);
     }
 
     /* Issue #158: Cleanup retraction state and delta relations after step */

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1450,6 +1450,10 @@ col_worker_session_create(wl_col_session_t *coordinator,
     out_worker->coordinator = coordinator;
     out_worker->extension_expr_status = 0;
     out_worker->callback_session_key = coordinator->callback_session_key;
+    out_worker->delta_events = NULL;
+    out_worker->delta_event_count = 0;
+    out_worker->delta_event_capacity = 0;
+    out_worker->delta_event_transaction = false;
 
     /* Prevent accidental wl_session_destroy on stack-allocated worker */
     out_worker->base.backend = NULL;


### PR DESCRIPTION
## Summary
- stage delta callback rows across all affected strata
- discard staged events when evaluation, consolidation, or allocation fails
- publish callbacks only after the session evaluation succeeds
- add a multi-relation scalar callback failure regression test

Part of #1254

## Validation
- meson test -C builddir delta_callback delta_retraction side_compound_delta --print-errorlogs
- meson test -C builddir-san delta_callback --print-errorlogs