### PR TITLE
fix: preserve scalar addon optimizer semantics

### DIFF
--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -36,6 +36,14 @@ An addon callback cannot change the engine's relational, differential, or
 aggregate semantics. In particular, callback errors are not silently converted
 to false predicates.
 
+The `DETERMINISTIC` and `PURE` capability bits are addon attestations; Wirelog
+does not independently prove them. Until an optimizer pass has access to the
+extension snapshot that carries those declarations, optimizer passes preserve
+the source order and expression structure of rules containing scalar addon
+calls. This conservative boundary prevents callback duplication, elimination,
+or movement based on an unverified capability declaration. A future optimizer
+contract may enable specific transformations for callbacks with both bits.
+
 ---
 
 ## Inline `.dl` facts (Status: Current)

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -362,8 +362,8 @@ test_jpp_extension_tree_is_conservative(void)
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(
         ".decl a(x: int32, y: int32)\n"
-        ".decl b(x: int32, z: int32)\n"
-        ".decl c(x: int32, w: int32)\n"
+        ".decl b(z: int32, w: int32)\n"
+        ".decl c(x: int32, z: int32)\n"
         ".decl out(x: int32)\n"
         "out(x) :- a(x, y), b(x, z), c(x, w), @call(\"test.fn\", x).\n",
         &err);
@@ -373,7 +373,8 @@ test_jpp_extension_tree_is_conservative(void)
     }
     wl_jpp_stats_t stats = { 0, 0, 0 };
     int rc = wl_jpp_apply(prog, &stats);
-    if (rc != 0 || stats.joins_reordered != 0) {
+    if (rc != 0 || stats.joins_reordered != 0
+        || stats.projections_inserted != 0) {
         FAIL("extension-containing tree was reordered");
         wirelog_program_free(prog);
         return;

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -362,10 +362,10 @@ test_jpp_extension_tree_is_conservative(void)
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(
         ".decl a(x: int32, y: int32)\n"
-        ".decl b(z: int32, w: int32)\n"
-        ".decl c(x: int32, z: int32)\n"
+        ".decl c(w: int32, z: int32)\n"
+        ".decl b(y: int32, w: int32)\n"
         ".decl out(x: int32)\n"
-        "out(x) :- a(x, y), b(x, z), c(x, w), @call(\"test.fn\", x).\n",
+        "out(x) :- a(x, y), c(w, z), b(y, w), @call(\"test.fn\", x).\n",
         &err);
     if (!prog) {
         FAIL("parse failed");

--- a/tests/test_jpp.c
+++ b/tests/test_jpp.c
@@ -355,6 +355,33 @@ test_jpp_no_ir_trees(void)
     PASS();
 }
 
+static void
+test_jpp_extension_tree_is_conservative(void)
+{
+    TEST("jpp: scalar extension trees are not reordered");
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(
+        ".decl a(x: int32, y: int32)\n"
+        ".decl b(x: int32, z: int32)\n"
+        ".decl c(x: int32, w: int32)\n"
+        ".decl out(x: int32)\n"
+        "out(x) :- a(x, y), b(x, z), c(x, w), @call(\"test.fn\", x).\n",
+        &err);
+    if (!prog) {
+        FAIL("parse failed");
+        return;
+    }
+    wl_jpp_stats_t stats = { 0, 0, 0 };
+    int rc = wl_jpp_apply(prog, &stats);
+    if (rc != 0 || stats.joins_reordered != 0) {
+        FAIL("extension-containing tree was reordered");
+        wirelog_program_free(prog);
+        return;
+    }
+    wirelog_program_free(prog);
+    PASS();
+}
+
 /* ======================================================================== */
 /* No-op Tests                                                              */
 /* ======================================================================== */
@@ -2782,6 +2809,7 @@ main(void)
     test_jpp_null_program();
     test_jpp_null_stats();
     test_jpp_no_ir_trees();
+    test_jpp_extension_tree_is_conservative();
 
     /* No-op cases */
     test_jpp_single_atom_noop();

--- a/wirelog/passes/jpp.c
+++ b/wirelog/passes/jpp.c
@@ -480,6 +480,44 @@ scan_is_idb(const wirelog_ir_node_t *scan, const char *const *idb_names,
     return false;
 }
 
+static bool
+expr_contains_extension_call(const wl_ir_expr_t *expr)
+{
+    if (!expr)
+        return false;
+    if (expr->type == WL_IR_EXPR_EXTENSION_CALL)
+        return true;
+    for (uint32_t i = 0; i < expr->child_count; i++)
+        if (expr_contains_extension_call(expr->children[i]))
+            return true;
+    return false;
+}
+
+/* JPP has no registry snapshot at optimizer time, so it cannot distinguish
+* a trusted PURE/DETERMINISTIC attestation from a legacy or partial one.
+* Keep extension-containing trees in source order until an optimizer pass
+* with capability metadata exists.  This prevents join reordering and
+* projection changes from duplicating, moving, or eliminating callbacks. */
+static bool
+node_contains_extension_call(const wirelog_ir_node_t *node)
+{
+    if (!node)
+        return false;
+    if (expr_contains_extension_call(node->filter_expr)
+        || expr_contains_extension_call(node->agg_expr)
+        || expr_contains_extension_call(node->compound_side.handle_expr))
+        return true;
+    if (node->project_exprs) {
+        for (uint32_t i = 0; i < node->project_count; i++)
+            if (expr_contains_extension_call(node->project_exprs[i]))
+                return true;
+    }
+    for (uint32_t i = 0; i < node->child_count; i++)
+        if (node_contains_extension_call(node->children[i]))
+            return true;
+    return false;
+}
+
 /* ======================================================================== */
 /* Internal: greedy reorder a join chain                                    */
 /* ======================================================================== */
@@ -1461,6 +1499,9 @@ optimize_tree(wirelog_ir_node_t *ir, uint32_t *chains_examined,
     const char *const *idb_names, uint32_t idb_count)
 {
     if (!ir)
+        return;
+
+    if (node_contains_extension_call(ir))
         return;
 
     /* UNION: recurse into each child */


### PR DESCRIPTION
## Summary
- treat DETERMINISTIC/PURE as addon attestations rather than runtime proofs
- keep JPP from reordering or projecting rules containing scalar addon calls
- document the conservative optimizer boundary and add regression coverage

Closes #1264

## Validation
- meson test -C builddir jpp optimizer_equivalence plan_gen extension_filter extension_registry --print-errorlogs