### PR TITLE
ci: bound pull request matrix duration

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -312,6 +312,7 @@ jobs:
     needs: [build-arm, build-mbedtls, build-scope]
     if: ${{ needs.build-scope.outputs.build-required == 'true' }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Add a 60-minute job-level timeout to the pull-request `build-matrix`.
- Apply the bound to every matrix combination, including Windows/MSVC.

Closes #1269

## Validation

- `actionlint .github/workflows/ci-pr.yml`
- `git diff --check`
