### PR TITLE
release: 0.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+### Security
+
+### Documentation
+
+## [0.60.0] - 2026-08-30
+
+### Added
+
 - **Parsed `.input` metadata query** (#1070): applications can use
   `wirelog_program_relation_has_input()` to inspect whether a relation has a
   parsed `.input` directive without opening its source or invoking an I/O

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.54.99',
+  version: '0.60.0',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
## Summary
- prepare the 0.60.0 changelog section
- bump the Meson project version to 0.60.0

## Validation
- `scripts/ci/check-changelog-format.py CHANGELOG.md`
- `scripts/ci/check-version-sync.py build-release`
- `meson compile -C build-release wirelog`
- local Meson tests passed through the available local run; CI will execute the full matrix