### PR TITLE
docs: add arithmetic operations example 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ done
 | `11-time-evolution` | Per-epoch delta isolation |
 | `12-snapshot-vs-delta` | Snapshot vs streaming API comparison |
 | `13-daemon-style` | Long-running daemon rotation pattern |
+| `14-arithmetic-operations` | Arithmetic expressions and aggregate functions |
 
 ## Build & Test
 

--- a/examples/14-arithmetic-operations/README.md
+++ b/examples/14-arithmetic-operations/README.md
@@ -1,0 +1,93 @@
+# Example 14: Arithmetic Operations
+
+## Overview
+
+This example evaluates arithmetic expressions in a rule head. Each input row
+contains three integers, and the derived `result` relation shows addition,
+subtraction, multiplication, integer division, remainder, and the evaluation
+order of chained operators. It also uses separate rules to demonstrate the
+`min`, `max`, `average`, and `count` aggregate functions.
+
+The Datalog program is:
+
+```datalog
+.decl sample(label: symbol, a: int64, b: int64, c: int64)
+.decl result(label: symbol, added: int64, difference: int64,
+            product: int64, quotient: int64, remainder: int64,
+            precedence: int64)
+
+result(Label, A + B, A - B, A * B, A / B, A % B, A + B * C)
+    :- sample(Label, A, B, C), B != 0.
+```
+
+Arithmetic expressions are parsed left-associatively: `A + B * C` means
+`(A + B) * C` in this language, not conventional multiplication-first
+precedence. The `precedence` input row makes that behavior visible (`22`, not
+`14`). Use explicit intermediate relations when conventional grouping is
+needed.
+
+Each aggregate is in its own rule because a rule head accepts at most one
+aggregate. `min` and `max` operate on the integer column, `average` requires a
+declared `float` operand, and `count` returns the number of input rows. The
+aggregate program used by the demo is:
+
+```datalog
+.decl sample(a: int64, value: float)
+.decl zero_input(value: float)
+.decl zero_observed(value: float)
+.decl minimum(value: int64)
+.decl maximum(value: int64)
+.decl average_value(value: float)
+.decl sample_count(value: int64)
+
+minimum(min(A)) :- sample(A, _).
+maximum(max(A)) :- sample(A, _).
+average_value(average(Value)) :- sample(_, Value).
+sample_count(count(A)) :- sample(A, _).
+zero_observed(Value) :- zero_input(Value).
+```
+
+## Build & Run
+
+```sh
+meson compile -C build arithmetic_demo
+./build/examples/14-arithmetic-operations/arithmetic_demo
+meson test -C build example_14_arithmetic_golden
+```
+
+## Expected Output
+
+```text
+Example 14: Arithmetic Operations
+=================================
+
+average_value(2.500000)
+maximum(17)
+minimum(-17)
+result("negative", -12, -22, -85, -3, -2, -24)
+result("positive", 22, 12, 85, 3, 2, 44)
+result("precedence", 11, 5, 24, 2, 2, 22)
+sample_count(3)
+zero_observed(+0.0)
+
+Done.
+```
+
+## Integer and Error Semantics
+
+- The arithmetic expression columns are all `int64`; the separate `average`
+  aggregate intentionally produces a `float` result.
+- Division truncates toward zero. For example, `-17 / 5` is `-3`.
+- The remainder keeps the dividend's sign: `-17 % 5` is `-2`.
+- The typed float ingress canonicalizes both `-0.0` and `+0.0` to the same
+  `+0.0` value. The demo inserts both spellings and prints the one observed
+  relation row as `zero_observed(+0.0)`.
+- The rule filters out rows with `B == 0`, so it never attempts division or
+  remainder by zero. Do not treat that guard as a default value for invalid
+  arithmetic; invalid operations should be rejected or handled explicitly by
+  the surrounding rule logic.
+
+See [Arithmetic Operators](../../docs/SYNTAX.md#expressions) in the syntax
+reference for the complete expression grammar and supported operators.
+The aggregate restrictions and `average` type requirement are described in
+the same syntax reference.

--- a/examples/14-arithmetic-operations/arithmetic_demo.c
+++ b/examples/14-arithmetic-operations/arithmetic_demo.c
@@ -1,0 +1,263 @@
+/*
+ * arithmetic_demo.c - Example 14: Arithmetic Operations
+ *
+ * Copyright (C) CleverPlant
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include "wirelog/wirelog.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *ARITHMETIC_SRC =
+    ".decl sample(label: symbol, a: int64, b: int64, c: int64)\n"
+    ".decl result(label: symbol, added: int64, difference: int64, "
+    "product: int64, quotient: int64, remainder: int64, precedence: int64)\n"
+    "result(Label, A + B, A - B, A * B, A / B, A % B, A + B * C) "
+    ":- sample(Label, A, B, C), B != 0.\n";
+
+static const char *AGGREGATE_SRC =
+    ".decl sample(a: int64, value: float)\n"
+    ".decl zero_input(value: float)\n"
+    ".decl zero_observed(value: float)\n"
+    ".decl minimum(value: int64)\n"
+    ".decl maximum(value: int64)\n"
+    ".decl average_value(value: float)\n"
+    ".decl sample_count(value: int64)\n"
+    "minimum(min(A)) :- sample(A, _).\n"
+    "maximum(max(A)) :- sample(A, _).\n"
+    "average_value(average(Value)) :- sample(_, Value).\n"
+    "sample_count(count(A)) :- sample(A, _).\n"
+    "zero_observed(Value) :- zero_input(Value).\n";
+
+typedef struct {
+    int64_t id;
+    const char *name;
+} symbol_t;
+
+typedef struct {
+    char lines[12][256];
+    size_t count;
+    bool invalid;
+    const char *wanted;
+    const symbol_t *symbols;
+    size_t symbol_count;
+} output_t;
+
+static const char *
+lookup_symbol(const output_t *out, int64_t id)
+{
+    for (size_t i = 0; i < out->symbol_count; i++) {
+        if (out->symbols[i].id == id)
+            return out->symbols[i].name;
+    }
+    return NULL;
+}
+
+static void
+on_result(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    output_t *out = (output_t *)user_data;
+    const char *label;
+
+    if (strcmp(relation, "result") == 0 && ncols == 7) {
+        if (out->count >= 8 || !(label = lookup_symbol(out, row[0]))) {
+            fprintf(stderr, "unexpected arithmetic result\n");
+            abort();
+        }
+        snprintf(out->lines[out->count++], sizeof(out->lines[0]),
+            "result(\"%s\", %" PRId64 ", %" PRId64 ", %" PRId64
+            ", %" PRId64 ", %" PRId64 ", %" PRId64 ")", label,
+            row[1], row[2], row[3], row[4], row[5], row[6]);
+        return;
+    }
+    return;
+}
+
+static void
+on_typed_aggregate(const char *relation, const wirelog_typed_row_v1_t *row,
+    int32_t diff, void *user_data)
+{
+    output_t *out = (output_t *)user_data;
+    uint64_t lane;
+    double value;
+
+    (void)diff;
+    if (!out->wanted || strcmp(relation, out->wanted) != 0
+        || !row || row->logical_ncols != 1 || out->count >= 12)
+        return;
+    lane = row->lanes[row->lane_offsets[0]];
+    if (strcmp(relation, "average_value") == 0
+        || strcmp(relation, "zero_observed") == 0) {
+        memcpy(&value, &lane, sizeof(value));
+        if (strcmp(relation, "zero_observed") == 0) {
+            if (lane != UINT64_C(0)) {
+                out->invalid = true;
+                return;
+            }
+            snprintf(out->lines[out->count++], sizeof(out->lines[0]),
+                "zero_observed(%s0.0)",
+                (lane >> 63) == 0 ? "+" : "-");
+        } else {
+            snprintf(out->lines[out->count++], sizeof(out->lines[0]),
+                "average_value(%.6f)", value);
+        }
+    } else {
+        int64_t integer_value;
+
+        memcpy(&integer_value, &lane, sizeof(integer_value));
+        snprintf(out->lines[out->count++], sizeof(out->lines[0]),
+            "%s(%" PRId64 ")", relation, integer_value);
+    }
+}
+
+static int
+line_compare(const void *left, const void *right)
+{
+    return strcmp((const char *)left, (const char *)right);
+}
+
+static int
+insert_sample(wirelog_easy_session_t *session, int64_t label, int64_t a,
+    int64_t b, int64_t c)
+{
+    int64_t row[] = { label, a, b, c };
+    return wirelog_easy_insert(session, "sample", row, 4) == WIRELOG_OK
+        ? 0 : -1;
+}
+
+static int
+collect_aggregate(const char *relation, output_t *output)
+{
+    wirelog_error_t error = WIRELOG_OK;
+    wirelog_program_t *program = wirelog_parse_string(AGGREGATE_SRC, &error);
+    wirelog_session_t *advanced = NULL;
+    const int64_t values[] = { -17, 17, 8 };
+    const double measurements[] = { 1.5, 2.5, 3.5 };
+
+    if (!program || !wirelog_optimize(program, &error)
+        || wirelog_session_create(program, WIRELOG_BACKEND_DEFAULT, 1,
+        &advanced) != WIRELOG_OK) {
+        fprintf(stderr, "%s aggregate setup failed: %s\n", relation,
+            wirelog_error_string(error));
+        wirelog_program_free(program);
+        return -1;
+    }
+    const bool zero_demo = strcmp(relation, "zero_observed") == 0;
+    for (size_t i = 0; i < (zero_demo ? 2u : 3u); i++) {
+        uint64_t lanes[2] = { 0, 0 };
+        double value = zero_demo ? (i == 0 ? -0.0 : +0.0) : measurements[i];
+        memcpy(&lanes[0], &values[i], sizeof(values[i]));
+        memcpy(&lanes[1], &value, sizeof(value));
+        uint32_t sample_types[2] = {
+            WIRELOG_TYPE_INT64, WIRELOG_TYPE_FLOAT
+        };
+        uint32_t sample_offsets[2] = { 0, 1 };
+        uint32_t zero_type = WIRELOG_TYPE_FLOAT;
+        uint32_t zero_offset = 0;
+        wirelog_typed_row_v1_t row = zero_demo
+            ? (wirelog_typed_row_v1_t) {
+            sizeof(row), 1, 0, 1, 1, 1, &zero_type, &zero_offset,
+            &zero_type, &lanes[1]
+        }
+            : (wirelog_typed_row_v1_t) {
+            sizeof(row), 1, 0, 2, 2, 2, sample_types, sample_offsets,
+            sample_types, lanes
+        };
+        wirelog_typed_error_v1_t typed_error = {
+            sizeof(typed_error), WIRELOG_TYPED_ERROR_NONE,
+            UINT32_MAX, UINT32_MAX, NULL, 0
+        };
+        const char *input = zero_demo ? "zero_input" : "sample";
+        if (wirelog_session_insert_typed(advanced, input, &row, 1,
+            &typed_error) != WIRELOG_OK) {
+            fprintf(stderr, "%s aggregate input failed\n", relation);
+            wirelog_session_destroy(advanced);
+            wirelog_program_free(program);
+            return -1;
+        }
+        if (zero_demo) {
+            uint64_t expected = i == 0 ? UINT64_C(0x8000000000000000)
+                                       : UINT64_C(0);
+            if (lanes[1] != expected) {
+                fprintf(stderr, "signed-zero input encoding failed\n");
+                wirelog_session_destroy(advanced);
+                wirelog_program_free(program);
+                return -1;
+            }
+        }
+    }
+    output->wanted = relation;
+    wirelog_error_t rc = wirelog_session_snapshot_typed(advanced,
+            on_typed_aggregate, output);
+    wirelog_session_destroy(advanced);
+    wirelog_program_free(program);
+    if (rc != WIRELOG_OK) {
+        fprintf(stderr, "%s aggregate failed: %s\n", relation,
+            wirelog_error_string(rc));
+        return -1;
+    }
+    return 0;
+}
+
+int
+main(void)
+{
+    static const char *names[] = { "negative", "positive", "precedence" };
+    symbol_t symbols[3];
+    output_t output = { .count = 0, .wanted = "result", .symbols = symbols,
+                        .symbol_count = 3 };
+    wirelog_easy_session_t *session = NULL;
+
+    printf("Example 14: Arithmetic Operations\n");
+    printf("=================================\n\n");
+
+    if (wirelog_easy_open(ARITHMETIC_SRC, &session) != WIRELOG_OK) {
+        fprintf(stderr, "wirelog_easy_open failed\n");
+        return 1;
+    }
+    for (size_t i = 0; i < 3; i++) {
+        symbols[i].name = names[i];
+        symbols[i].id = wirelog_easy_intern(session, names[i]);
+        if (symbols[i].id < 0) {
+            wirelog_easy_close(session);
+            return 1;
+        }
+    }
+
+    /* B is non-zero for every row: division and remainder are defined. */
+    wirelog_error_t rc = WIRELOG_OK;
+    if (insert_sample(session, symbols[0].id, -17, 5, 2) != 0
+        || insert_sample(session, symbols[1].id, 17, 5, 2) != 0
+        || insert_sample(session, symbols[2].id, 8, 3, 2) != 0
+        || (rc = wirelog_easy_snapshot(session, "result", on_result, &output))
+        != WIRELOG_OK) {
+        fprintf(stderr, "arithmetic evaluation failed: %s\n",
+            wirelog_error_string(rc));
+        wirelog_easy_close(session);
+        return 1;
+    }
+    wirelog_easy_close(session);
+
+    if (collect_aggregate("minimum", &output) != 0
+        || collect_aggregate("maximum", &output) != 0
+        || collect_aggregate("average_value", &output) != 0
+        || collect_aggregate("sample_count", &output) != 0
+        || collect_aggregate("zero_observed", &output) != 0
+        || output.invalid) {
+        fprintf(stderr, "aggregate evaluation failed\n");
+        return 1;
+    }
+
+    qsort(output.lines, output.count, sizeof(output.lines[0]), line_compare);
+    for (size_t i = 0; i < output.count; i++)
+        printf("%s\n", output.lines[i]);
+    printf("\nDone.\n");
+    return output.count == 8 ? 0 : 1;
+}

--- a/examples/14-arithmetic-operations/expected.txt
+++ b/examples/14-arithmetic-operations/expected.txt
@@ -1,0 +1,13 @@
+Example 14: Arithmetic Operations
+=================================
+
+average_value(2.500000)
+maximum(17)
+minimum(-17)
+result("negative", -12, -22, -85, -3, -2, -24)
+result("positive", 22, 12, 85, 3, 2, 44)
+result("precedence", 11, 5, 24, 2, 2, 22)
+sample_count(3)
+zero_observed(+0.0)
+
+Done.

--- a/examples/14-arithmetic-operations/meson.build
+++ b/examples/14-arithmetic-operations/meson.build
@@ -1,0 +1,24 @@
+# Example 14: Arithmetic Operations
+
+arithmetic_demo = executable(
+  'arithmetic_demo',
+  files('arithmetic_demo.c'),
+  wirelog_sources,
+  config_h_file,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep, mbedtls_dep, math_dep],
+  install: false,
+)
+
+py3 = find_program('python3', 'python', required: true)
+test(
+  'example_14_arithmetic_golden',
+  py3,
+  args: [
+    files('../09-retraction-basics/golden_diff.py')[0],
+    arithmetic_demo.full_path(),
+    meson.current_source_dir() / 'expected.txt',
+  ],
+  depends: arithmetic_demo,
+  suite: 'examples',
+)

--- a/meson.build
+++ b/meson.build
@@ -608,6 +608,7 @@ if not mobile_cross
   subdir('examples/11-time-evolution')
   subdir('examples/12-snapshot-vs-delta')
   subdir('examples/13-daemon-style')
+  subdir('examples/14-arithmetic-operations')
 endif
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==


### PR DESCRIPTION
## Summary
- add Example 14 covering arithmetic expressions, integer division/remainder, and left-associative evaluation
- demonstrate min, max, average, and count aggregates
- document typed float signed-zero canonicalization and verify -0.0/+0.0 behavior
- register the example and golden test in Meson

Closes #1273

## Validation
- meson compile -C build-example14 arithmetic_demo
- meson test -C build-example14 example_14_arithmetic_golden --print-errorlogs
- git diff --check