### PR TITLE
ci: fix Clang ASan fuzz linking

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -164,7 +164,7 @@ jobs:
           sudo apt-get install -y clang meson ninja-build
       - name: Build fuzz targets
         run: |
-          CC=clang meson setup build-fuzz -Denable_fuzz=true -Db_sanitize=address -Dtests=true
+          CC=clang meson setup build-fuzz -Denable_fuzz=true -Db_sanitize=address -Db_lundef=false -Dtests=true
           meson compile -C build-fuzz parser_fuzz csv_reader_fuzz intern_fuzz compound_arena_fuzz
       - name: Run 60-second seed campaign per target
         run: |


### PR DESCRIPTION
Fixes #1281

The v0.60.0 release-tag fuzz job failed while linking the ASan-instrumented xxHash shared library with undefined __asan_* symbols. The fuzz configure step did not disable the subproject's strict undefined-symbol check.

This change adds -Db_lundef=false only to the release-tag Clang ASan fuzz configure step. ASan and libFuzzer instrumentation, all four targets, and fatal failure handling remain enabled.

Validation:
- Clang ASan configure and link of parser_fuzz, csv_reader_fuzz, intern_fuzz, and compound_arena_fuzz
- Meson fuzz smoke: 4/4 passed
- 60-second libFuzzer campaign: all four targets exit 0
- actionlint and git diff --check passed

The ARM CSPA timeout is tracked separately in #1282.