### PR TITLE
ci(release): assert the upgrade matrix loads its own libraries

### DIFF
--- a/scripts/ci/check-shared-library-closure.sh
+++ b/scripts/ci/check-shared-library-closure.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Assert that a consumer's runtime shared-library closure resolved entirely
+# from the release prefix it was built against.
+#
+# Issue #1272.  The release upgrade matrix builds a small consumer against an
+# installed wirelog prefix and runs it.  The consumer is linked with
+# -Wl,-rpath, which emits DT_RUNPATH -- and DT_RUNPATH is *not* transitive: it
+# is consulted only for the direct DT_NEEDED entries of the object carrying
+# it.  The installed libwirelog.so carries no RUNPATH of its own (meson strips
+# the build rpath on install), so its own DT_NEEDED libnanoarrow.so and
+# libxxhash.so.0 fall through to LD_LIBRARY_PATH and then to the host's
+# system directories.
+#
+# On a clean CI runner that silently became "cannot open shared object file"
+# and the job died with exit 127.  On a developer machine that happens to have
+# the libraries installed it is worse: the consumer runs green against the
+# *host's* copies, so the gate certifies a release prefix it never tested.
+# Both outcomes are invisible to an exit-status check, which is why this runs
+# on the loader's own record of what it opened rather than on the exit code.
+#
+# The trace is captured from the real run (LD_DEBUG=libs on glibc,
+# DYLD_PRINT_LIBRARIES=1 on macOS), not from a separate ldd prediction: ldd
+# re-resolves in its own environment, so it can disagree with the run it is
+# supposed to be describing.
+#
+# usage: check-shared-library-closure.sh TRACE PREFIX OWNED-SONAMES REPORT
+#
+#   TRACE          loader trace captured from the consumer's real execution
+#   PREFIX         install prefix the consumer was built against
+#   OWNED-SONAMES  basenames of the shared libraries this build produces
+#   REPORT         written with one line per loaded object (release evidence)
+#
+# Exits 0 when every owned library resolved from PREFIX, 1 otherwise.
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+    echo 'usage: check-shared-library-closure.sh TRACE PREFIX OWNED-SONAMES REPORT' >&2
+    exit 2
+fi
+
+trace=$1
+prefix=$2
+owned_file=$3
+report=$4
+
+fail() {
+    echo "shared library closure: $*" >&2
+    exit 1
+}
+
+[[ -r "$trace" ]] || fail "cannot read loader trace: $trace"
+[[ -r "$owned_file" ]] || fail "cannot read owned soname list: $owned_file"
+
+# An empty owned set would make the whole check vacuous: no loaded library
+# could ever match it, so the gate would pass without asserting anything.
+[[ -s "$owned_file" ]] || fail \
+    "owned soname list is empty: the build produced no shared libraries to check ($owned_file)"
+
+# Strip a trailing slash so the "$path" == "$p"/* tests below anchor on a real
+# path separator.  Without that anchor /opt/rel would also accept /opt/rel-old.
+prefix=${prefix%/}
+[[ -n "$prefix" ]] || fail 'prefix must not be empty'
+
+# Compare against both the literal and the physically resolved prefix.  The
+# loader prints the search directory it was handed, uncanonicalised, so on a
+# host where the prefix sits under a symlinked parent (macOS /var -> /private/var,
+# or a symlinked TMPDIR) exactly one of the two forms matches, and which one
+# differs by platform.
+prefix_real=$prefix
+if [[ -d "$prefix" ]]; then
+    prefix_real=$(cd "$prefix" && pwd -P) || fail "cannot resolve prefix: $prefix"
+fi
+
+inside_prefix() {
+    local path=$1
+    [[ "$path" == "$prefix"/* || "$path" == "$prefix_real"/* ]]
+}
+
+# Extract the absolute path of every object the loader actually mapped.
+#
+# glibc LD_DEBUG=libs emits one "calling init: <path>" line per loaded object.
+# It also emits "trying file=<path>" for every *candidate* it probes, including
+# ones that do not exist, so keying on "calling init:" is what distinguishes
+# what was loaded from what was merely searched.
+loaded=$(sed -n 's/.*calling init: \(\/.*\)$/\1/p' "$trace" || true)
+shape=glibc
+
+if [[ -z "$loaded" ]]; then
+    # macOS DYLD_PRINT_LIBRARIES.  Classic dyld prints "dyld: loaded: <path>";
+    # dyld4 prints "dyld[<pid>]: <uuid> <path>".  Both end in the path, which
+    # must be captured to end of line: macOS paths routinely contain spaces
+    # ("Application Support"), and a capture that stopped at the first space
+    # would drop the library from the report entirely -- passing the very
+    # substitution this gate exists to catch.
+    loaded=$(sed -n 's/^dyld[^ ]*:.*[ 	]\(\/.*\)$/\1/p' "$trace" || true)
+    shape=dyld
+fi
+
+[[ -n "$loaded" ]] || fail \
+    "no loader trace found in $trace: the run produced no LD_DEBUG=libs or DYLD_PRINT_LIBRARIES records, so the closure was never observed"
+
+: >"$report"
+printf '# shared library closure (%s trace: %s)\n' "$shape" "$trace" >>"$report"
+printf '# prefix: %s\n' "$prefix" >>"$report"
+
+owned_seen=0
+violations=()
+
+while IFS= read -r path; do
+    [[ -n "$path" ]] || continue
+    soname=${path##*/}
+    if grep -qxF "$soname" "$owned_file"; then
+        if inside_prefix "$path"; then
+            printf 'OWNED\t%s\t%s\n' "$soname" "$path" >>"$report"
+            owned_seen=$((owned_seen + 1))
+        else
+            printf 'FOREIGN\t%s\t%s\n' "$soname" "$path" >>"$report"
+            violations+=("$soname -> $path")
+        fi
+    else
+        printf 'EXTERNAL\t%s\t%s\n' "$soname" "$path" >>"$report"
+    fi
+done <<<"$loaded"
+
+if ((${#violations[@]})); then
+    {
+        echo 'shared library closure: libraries built by this release resolved outside the release prefix.'
+        echo "  prefix: $prefix"
+        for violation in "${violations[@]}"; do
+            echo "  $violation"
+        done
+        echo 'The consumer loaded host copies instead of the ones this release installs.'
+        echo 'On a machine without those host copies the same run fails to start.'
+        echo "  report: $report"
+    } >&2
+    exit 1
+fi
+
+# Coverage guard.  Every owned library resolving correctly is only meaningful
+# if at least one of them was actually loaded; an owned list that describes a
+# different build entirely would otherwise pass while asserting nothing.
+# This is deliberately set-level: it catches the list going wholly stale, not
+# a single library dropping out of it while the others still match.
+((owned_seen)) || fail \
+    "the trace in $trace loaded no owned library, so nothing was verified; the owned soname list in $owned_file does not describe this build"
+
+printf 'shared library closure: %d owned librar%s resolved from %s\n' \
+    "$owned_seen" "$( ((owned_seen == 1)) && echo y || echo ies)" "$prefix"

--- a/scripts/ci/test-check-shared-library-closure.sh
+++ b/scripts/ci/test-check-shared-library-closure.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Self-test for check-shared-library-closure.sh.
+#
+# The closure checker only ever runs inside the release upgrade matrix
+# (scripts/upgrade/run-upgrade-matrix.sh), which itself only runs on a release
+# tag.  Without this self-test the parser would have no pre-release coverage at
+# all, so every branch below is exercised from canned loader traces instead of
+# from a real build.  Runs in under a second and builds nothing.
+set -euo pipefail
+
+# meson hands this script a native path, which on Windows is a drive-letter
+# path bash cannot use directly; see bb4ca712 for the same fix on the sibling
+# downstream-matrix self-test.
+normalize_root() {
+    local supplied=$1
+    case "$supplied" in
+        [[:alpha:]]:[\\/]* )
+            if ! command -v cygpath >/dev/null 2>&1; then
+                echo "closure self-test: cygpath is required to normalize Windows root: $supplied" >&2
+                return 2
+            fi
+            if ! supplied=$(cygpath -u -- "$supplied"); then
+                echo "closure self-test: cygpath could not normalize Windows root: $supplied" >&2
+                return 2
+            fi
+            ;;
+    esac
+    printf '%s\n' "$supplied"
+}
+
+root=${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}
+if (($#)); then
+    root=$(normalize_root "$root")
+fi
+checker="$root/scripts/ci/check-shared-library-closure.sh"
+[[ -x "$checker" ]] || {
+    echo "closure self-test: checker not executable: $checker" >&2
+    exit 1
+}
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-closure-selftest.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+failures=0
+case_no=0
+
+# Run the checker and assert its exit status.  On an unexpected status the
+# captured output is echoed, because a parser that fails for the wrong reason
+# is indistinguishable from one that fails for the right reason.
+expect() {
+    local name=$1 want=$2 trace=$3 prefix=$4 owned=$5
+    local report="$tmp/report.$((++case_no))" out status=0
+    out=$("$checker" "$trace" "$prefix" "$owned" "$report" 2>&1) || status=$?
+    if [[ "$status" != "$want" ]]; then
+        printf 'closure self-test: FAIL %s (want exit %s, got %s)\n' \
+            "$name" "$want" "$status" >&2
+        printf '%s\n' "$out" | sed 's/^/    /' >&2
+        failures=$((failures + 1))
+        return
+    fi
+    printf 'closure self-test: ok %s\n' "$name"
+}
+
+# As expect(), but also require a substring in the checker's diagnostics, so a
+# failing case cannot pass this test by failing for an unrelated reason.
+expect_message() {
+    local name=$1 want=$2 needle=$3 trace=$4 prefix=$5 owned=$6
+    local report="$tmp/report.$((++case_no))" out status=0
+    out=$("$checker" "$trace" "$prefix" "$owned" "$report" 2>&1) || status=$?
+    if [[ "$status" != "$want" ]] || [[ "$out" != *"$needle"* ]]; then
+        printf 'closure self-test: FAIL %s (want exit %s and %q)\n' \
+            "$name" "$want" "$needle" >&2
+        printf 'got exit %s:\n' "$status" >&2
+        printf '%s\n' "$out" | sed 's/^/    /' >&2
+        failures=$((failures + 1))
+        return
+    fi
+    printf 'closure self-test: ok %s\n' "$name"
+}
+
+owned_full="$tmp/owned-full.txt"
+cat >"$owned_full" <<'EOF'
+libnanoarrow.so
+libwirelog.so
+libwirelog.so.0
+libxxhash.so.0
+EOF
+
+owned_empty="$tmp/owned-empty.txt"
+: >"$owned_empty"
+
+# glibc LD_DEBUG=libs shape, closure fully inside the prefix.  Includes the
+# noise lines ("trying file=", search paths) that a real trace carries, so the
+# parser is proven to key on "calling init:" and not on incidental matches.
+cat >"$tmp/glibc-clean.trace" <<'EOF'
+    12345:	find library=libwirelog.so.0 [0]; searching
+    12345:	  trying file=/opt/rel/lib/glibc-hwcaps/x86-64-v3/libwirelog.so.0
+    12345:	  trying file=/opt/rel/lib/libwirelog.so.0
+    12345:	find library=libnanoarrow.so [0]; searching
+    12345:	  trying file=/usr/lib/libnanoarrow.so
+    12345:	calling init: /lib64/ld-linux-x86-64.so.2
+    12345:	calling init: /usr/lib/libc.so.6
+    12345:	calling init: /usr/lib/libm.so.6
+    12345:	calling init: /opt/rel/lib/libxxhash.so.0
+    12345:	calling init: /opt/rel/lib/libnanoarrow.so
+    12345:	calling init: /opt/rel/lib/libwirelog.so.0
+EOF
+expect 'glibc closure inside prefix passes' 0 \
+    "$tmp/glibc-clean.trace" /opt/rel "$owned_full"
+
+# The #1272 defect itself: the consumer runs and exits 0, but an owned library
+# was served by the host instead of the release prefix.  On a clean runner the
+# same condition is a hard "cannot open shared object file".
+cat >"$tmp/glibc-host.trace" <<'EOF'
+    12345:	calling init: /lib64/ld-linux-x86-64.so.2
+    12345:	calling init: /usr/lib/libc.so.6
+    12345:	calling init: /opt/rel/lib/libxxhash.so.0
+    12345:	calling init: /usr/lib/libnanoarrow.so
+    12345:	calling init: /opt/rel/lib/libwirelog.so.0
+EOF
+expect_message 'owned library served by host fails' 1 'libnanoarrow.so' \
+    "$tmp/glibc-host.trace" /opt/rel "$owned_full"
+
+# An empty owned set would make the whole rule vacuous: nothing matches, so
+# nothing is ever asserted.  That must be a loud failure, not a silent pass.
+expect_message 'empty owned set fails' 1 'no shared libraries' \
+    "$tmp/glibc-clean.trace" /opt/rel "$owned_empty"
+
+# Coverage guard.  If the owned set stops naming the libraries that actually
+# load -- e.g. a subproject relocates its build output and drops out of the
+# set -- the rule silently stops covering anything.  Assert that at least one
+# owned library was observed.
+cat >"$tmp/glibc-nocoverage.trace" <<'EOF'
+    12345:	calling init: /lib64/ld-linux-x86-64.so.2
+    12345:	calling init: /usr/lib/libc.so.6
+EOF
+expect_message 'trace covering no owned library fails' 1 'no owned' \
+    "$tmp/glibc-nocoverage.trace" /opt/rel "$owned_full"
+
+# A prefix that is a string prefix of an unrelated directory must not be
+# accepted by a naive comparison: /opt/rel-old is outside /opt/rel.
+cat >"$tmp/glibc-sibling.trace" <<'EOF'
+    12345:	calling init: /usr/lib/libc.so.6
+    12345:	calling init: /opt/rel-old/lib/libnanoarrow.so
+    12345:	calling init: /opt/rel/lib/libwirelog.so.0
+EOF
+expect_message 'sibling directory is outside the prefix' 1 'libnanoarrow.so' \
+    "$tmp/glibc-sibling.trace" /opt/rel "$owned_full"
+
+# A trailing slash on the prefix is the same prefix.
+expect 'trailing slash on prefix is accepted' 0 \
+    "$tmp/glibc-clean.trace" /opt/rel/ "$owned_full"
+
+# dyld DYLD_PRINT_LIBRARIES shape.  Both the classic "dyld: loaded:" form and
+# the dyld4 "dyld[pid]: <uuid> /path" form appear in the wild; the parser must
+# take the trailing absolute path in either.
+cat >"$tmp/dyld-clean.trace" <<'EOF'
+dyld: loaded: /opt/rel/lib/libwirelog.dylib
+dyld[4321]: <A1B2C3D4-0000-0000-0000-000000000000> /opt/rel/lib/libnanoarrow.dylib
+dyld: loaded: /usr/lib/libSystem.B.dylib
+EOF
+owned_dyld="$tmp/owned-dyld.txt"
+printf 'libnanoarrow.dylib\nlibwirelog.dylib\n' >"$owned_dyld"
+expect 'dyld closure inside prefix passes' 0 \
+    "$tmp/dyld-clean.trace" /opt/rel "$owned_dyld"
+
+cat >"$tmp/dyld-host.trace" <<'EOF'
+dyld: loaded: /opt/rel/lib/libwirelog.dylib
+dyld: loaded: /usr/local/lib/libnanoarrow.dylib
+EOF
+expect_message 'dyld owned library served by host fails' 1 'libnanoarrow.dylib' \
+    "$tmp/dyld-host.trace" /opt/rel "$owned_dyld"
+
+# macOS paths routinely contain spaces.  A parser that captured only up to the
+# first space would drop this library from the report entirely and report a
+# clean closure -- the exact substitution this gate exists to catch, passing.
+cat >"$tmp/dyld-spaces.trace" <<'EOF'
+dyld: loaded: /opt/rel/lib/libwirelog.dylib
+dyld: loaded: /Users/ci/Application Support/lib/libnanoarrow.dylib
+EOF
+expect_message 'dyld path containing spaces is not dropped' 1 'Application Support' \
+    "$tmp/dyld-spaces.trace" /opt/rel "$owned_dyld"
+
+# A trace the parser does not recognise means the loader never produced one --
+# LD_DEBUG unsupported, output redirected elsewhere, a musl host.  That is an
+# unusable gate and must fail with a named reason rather than pass vacuously.
+printf 'some unrelated program output\n' >"$tmp/unknown.trace"
+expect_message 'unrecognised trace shape fails' 1 'no loader trace' \
+    "$tmp/unknown.trace" /opt/rel "$owned_full"
+
+: >"$tmp/empty.trace"
+expect_message 'empty trace fails' 1 'no loader trace' \
+    "$tmp/empty.trace" /opt/rel "$owned_full"
+
+expect_message 'missing trace file fails' 1 'cannot read' \
+    "$tmp/does-not-exist.trace" /opt/rel "$owned_full"
+
+# The report is the uploaded release evidence; a passing run must produce one
+# that names both the owned and the external resolutions.
+report="$tmp/report-content.txt"
+"$checker" "$tmp/glibc-clean.trace" /opt/rel "$owned_full" "$report" >/dev/null
+report_failures=0
+for needle in 'OWNED	libwirelog.so.0	/opt/rel/lib/libwirelog.so.0' \
+              'EXTERNAL	libc.so.6	/usr/lib/libc.so.6'; do
+    if ! grep -qF "$needle" "$report"; then
+        printf 'closure self-test: FAIL report missing %q\n' "$needle" >&2
+        report_failures=$((report_failures + 1))
+    fi
+done
+failures=$((failures + report_failures))
+((report_failures)) || printf 'closure self-test: ok report records owned and external\n'
+
+if ((failures)); then
+    printf 'closure self-test: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'closure self-test: all cases passed\n'

--- a/scripts/upgrade/run-upgrade-matrix.sh
+++ b/scripts/upgrade/run-upgrade-matrix.sh
@@ -57,23 +57,60 @@ build_tree() {
         echo "upgrade matrix: installed libwirelog not found for $name" >&2
         exit 1
     }
+    # Record the shared libraries this tree builds for itself -- libwirelog
+    # plus the subproject libraries it carries as DT_NEEDED.  The closure
+    # check in compile_and_run uses these basenames to tell "loaded from the
+    # release prefix" apart from "loaded from whatever the host had lying
+    # around"; see scripts/ci/check-shared-library-closure.sh.  No -maxdepth:
+    # a subproject that relocates its build output must not drop silently out
+    # of the set.  ! -type d keeps meson's libwirelog.so.N.p object
+    # directories, which match *.so.*, from being mistaken for libraries.
+    # The grep keeps the match to real library names: '*.so.*' also catches
+    # build by-products such as libnanoarrow.so.symbols.
+    local owned="$tmp/owned-$name.txt"
+    find "$build" ! -type d \
+        \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' \) -print |
+        sed 's|.*/||' |
+        { grep -E '\.(so|dylib)(\.[0-9]+)*$' || true; } |
+        LC_ALL=C sort -u >"$owned"
+    [[ -s "$owned" ]] || {
+        echo "upgrade matrix: $name built no shared libraries to verify" >&2
+        exit 1
+    }
+    cp "$owned" "$log_dir/$name-owned-sonames.txt"
     printf '%s\n' "$prefix|$(dirname "$lib")"
 }
 
 compile_and_run() {
-    local label=$1 prefix=$2 libdir=$3 source=$4 program=$5 output=$6
+    local label=$1 prefix=$2 libdir=$3 source=$4 program=$5 output=$6 owned=$7
     local exe="$tmp/$label"
     local runtime_log="$log_dir/$label-runtime.log"
+    local trace="$tmp/$label-loader.trace"
     "${CC:-cc}" -std=c11 -Wall -Wextra -Werror -I"$prefix/include" \
         "$source" -L"$libdir" -lwirelog -Wl,-rpath,"$libdir" -o "$exe" \
         >"$log_dir/$label-compile.log" 2>&1
+    # Ask the loader to record what it opens during the real run.  A separate
+    # ldd pass would re-resolve in its own environment and could describe a
+    # different closure than the one that actually executed.
     if [[ "$(uname -s)" == Darwin ]]; then
         DYLD_LIBRARY_PATH="$libdir${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" \
-            "$exe" "$program" >"$output" 2>"$runtime_log"
+            DYLD_PRINT_LIBRARIES=1 \
+            "$exe" "$program" >"$output" 2>"$trace"
+        # dyld shares stderr with the program, so keep the consumer's own
+        # diagnostics readable in the evidence artifact.
+        grep -v '^dyld' "$trace" >"$runtime_log" || true
     else
+        # glibc appends .PID to LD_DEBUG_OUTPUT; without it the trace would go
+        # to stderr and bury the consumer's diagnostics.
+        local trace_prefix="$tmp/$label-loader"
+        rm -f "$trace_prefix".[0-9]*
         LD_LIBRARY_PATH="$libdir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+            LD_DEBUG=libs LD_DEBUG_OUTPUT="$trace_prefix" \
             "$exe" "$program" >"$output" 2>"$runtime_log"
+        cat "$trace_prefix".[0-9]* >"$trace" 2>/dev/null || : >"$trace"
     fi
+    "$root/scripts/ci/check-shared-library-closure.sh" \
+        "$trace" "$prefix" "$owned" "$log_dir/$label-closure.txt"
     [[ -s "$output" ]] || {
         echo "upgrade matrix: $label produced no output" >&2
         exit 1
@@ -90,14 +127,16 @@ old_prefix=${old_install%%|*}
 old_libdir=${old_install#*|}
 candidate_prefix=${candidate_install%%|*}
 candidate_libdir=${candidate_install#*|}
+old_owned=$tmp/owned-old.txt
+candidate_owned=$tmp/owned-candidate.txt
 
 run_case() {
     local name=$1 old_program=$2 candidate_program=$3 old_consumer=$4 candidate_consumer=$5
     local old_out="$log_dir/$name-old.out" candidate_out="$log_dir/$name-candidate.out"
     compile_and_run "$name-old" "$old_prefix" "$old_libdir" \
-        "$old_consumer" "$old_program" "$old_out"
+        "$old_consumer" "$old_program" "$old_out" "$old_owned"
     compile_and_run "$name-candidate" "$candidate_prefix" "$candidate_libdir" \
-        "$candidate_consumer" "$candidate_program" "$candidate_out"
+        "$candidate_consumer" "$candidate_program" "$candidate_out" "$candidate_owned"
     cmp -s "$old_out" "$candidate_out" || {
         echo "upgrade matrix: $name output mismatch" >&2
         diff -u "$old_out" "$candidate_out" >&2 || true
@@ -110,7 +149,7 @@ run_executor_case() {
     local program=$1 consumer=$2 probe=$3 old_lib candidate_out old_lib_symbols
     candidate_out="$log_dir/executor-candidate.out"
     compile_and_run executor-candidate "$candidate_prefix" "$candidate_libdir" \
-        "$consumer" "$program" "$candidate_out"
+        "$consumer" "$program" "$candidate_out" "$candidate_owned"
 
     old_lib=$(find -L "$old_libdir" -maxdepth 1 -name 'libwirelog.so' -print -quit)
     [[ -n "$old_lib" ]] || { echo 'upgrade matrix: old library missing' >&2; exit 1; }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -791,6 +791,18 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #1272: the release upgrade matrix must prove the consumer loaded the
+# libraries this release installs, not whatever the host had installed.  The
+# matrix itself only runs on a release tag, so this self-test is the only
+# pre-release coverage the closure parser gets.
+if sh.found()
+  test('shared_library_closure', sh,
+       args: [meson.project_source_root() /
+              'scripts/ci/test-check-shared-library-closure.sh',
+              meson.project_source_root()],
+       suite: 'abi')
+endif
+
 # Issue #913: keep the weighted/semiring design proposal explicit about its
 # current Z-set baseline, future-only ABI, retraction contract, and links.
 test('weighted_semiring_design', py3,


### PR DESCRIPTION
Closes part of #1272. Follow-up tracked in #1285.

## Problem

The upgrade matrix builds a small consumer against an installed wirelog prefix
and runs it. The consumer is linked with `-Wl,-rpath`, which emits
`DT_RUNPATH` -- and `DT_RUNPATH` is **not transitive**: it is consulted only
for the direct `DT_NEEDED` entries of the object carrying it. The installed
`libwirelog.so` carries no RUNPATH of its own (meson strips the build rpath on
install), so its own `DT_NEEDED libnanoarrow.so` and `libxxhash.so.0` fall
through to `LD_LIBRARY_PATH` and then to the host's system directories.

Confirmed with `readelf -d` on a real v0.30.0 install:

```
consumer:            (NEEDED) libwirelog.so.0     (RUNPATH) <prefix>/lib
installed libwirelog: (NEEDED) libnanoarrow.so    -- no RUNPATH, no RPATH
                      (NEEDED) libxxhash.so.0
```

```
$ ldd ./easy-old                                    # no LD_LIBRARY_PATH
  libwirelog.so.0 => <prefix>/lib/libwirelog.so.0   # via RUNPATH
  libnanoarrow.so => /usr/lib/libnanoarrow.so       # HOST COPY
  libxxhash.so.0  => /usr/lib/libxxhash.so.0        # HOST COPY
```

This has two faces. On a clean runner the host copies do not exist, and the job
dies with `error while loading shared libraries: libnanoarrow.so` -- the exit
127 seen in the v0.60.0 release verification. `53996128` fixed that half by
setting `LD_LIBRARY_PATH`.

The other half is worse and was still open: on a host that *does* have those
libraries installed, the consumer runs green against the **host's** copies, so
the gate certifies a release prefix it never actually tested. Neither the exit
status nor the consumer's output distinguishes that from a correct run.

## Approach

Capture the loader's own record of the **real** run -- `LD_DEBUG=libs` on
glibc, `DYLD_PRINT_LIBRARIES` on macOS -- and assert that every shared library
this build produces resolved from the release prefix.

A separate `ldd` pre-check was considered and rejected: `ldd` re-resolves in
its own process environment, and `compile_and_run` sets `LD_LIBRARY_PATH` only
as a command prefix on the consumer invocation, so the checker would have
inherited nothing and failed every release run with a `not found` message
indistinguishable from the genuine defect.

The closure parser gets a self-test in the `abi` suite. The matrix itself only
runs on a release tag, so without one the parser would have no pre-release
coverage at all.

## Verification

Against a real v0.30.0 prefix, with `libnanoarrow.so` removed so it resolves
from `/usr/lib` instead:

```
consumer:  exit 0, output "reach 1 2 / reach 1 3 / reach 2 3"   <- gate says PASS today
checker:   exit 1
           libnanoarrow.so -> /usr/lib/libnanoarrow.so
```

The gate now fails on a developer machine in exactly the case where a clean
runner would die with exit 127.

- `scripts/ci/test-check-shared-library-closure.sh` -- 13/13
- `meson test -C build --suite abi` -- 41/41
- `meson test -C build` (full) -- 304 Ok / 0 Fail / 12 Skipped
- `scripts/upgrade/run-upgrade-matrix.sh --old-ref v0.30.0 --candidate-ref HEAD` -- exit 0

## Scope and risk

**Forward-looking.** `release-tag.yml` checks out `ref: ${{ env.TAG_REF }}`, so
a re-run of the immutable `v0.60.0` executes that tag's copy of the script and
cannot pick this up. It applies from the next tag onward. See the #1272
discussion for the proposed resolution.

**New coupling.** The `v0.30.0` tag pins its nanoarrow wrap to a floating
`revision = main`. An upstream change that stops installing that library will
now redden the gate rather than pass silently off host copies. The old half of
the matrix is immutable, so the remedy would have to be in the harness. Failing
loudly is the intended direction.

**Known limit, tracked in #1285.** The owned-soname derivation the gate depends
on is untested, and the coverage guard is deliberately set-level: it catches
the owned list going wholly stale, not a single library dropping out of it
while the others still match. #1285 carries the reproduction and the intended
fix (a `comm` cross-check against the install `$libdir`).
