### PR TITLE
fix: pin SBOM sort collation and report a missing sha256sum by name

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -243,7 +243,7 @@ jobs:
             head -20 sbom/snapshot.txt
             echo "..."
             echo "=== Current scan (first 20):"
-            syft dir:. -o syft-json 2>/dev/null | jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' | sort | head -20
+            syft dir:. -o syft-json 2>/dev/null | jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' | LC_ALL=C sort | head -20
             exit 1
           }
 

--- a/scripts/ci/check-sbom-snapshot-locale.sh
+++ b/scripts/ci/check-sbom-snapshot-locale.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# check-sbom-snapshot-locale.sh - Regression for issue #1291.
+#
+# The SBOM snapshot baseline is a committed artifact, so its order must not
+# depend on the locale of whoever regenerates it. Under glibc's en_US
+# collation, leading punctuation is ignored, so entries beginning "./" sort
+# among the alphabetic names instead of before them -- regenerating produced
+# spurious reordering hunks that buried the real dependency change in a gate
+# whose whole purpose is making dependency drift reviewable.
+#
+# What this actually asserts, which is less than #886's equivalent: that every
+# `sort` in the two SBOM scripts carries the LC_ALL=C pin, plus a sanity check
+# that the fixture's two collations really disagree so the pin is not
+# decorative. It does NOT run generate-sbom.sh -- that script hardcodes its
+# output to $repo_root/sbom/, so invoking it here would clobber the committed
+# baseline. Giving it an output-directory parameter, the way make-tarball.sh
+# takes one, is what would allow a behavioural test; tracked in #1293.
+#
+# So the guard here is a string check, and it catches the realistic regression
+# -- someone deleting the pin -- but not a pipeline rewritten to reorder after
+# a pinned sort. #886's check-abi-symbols-locale.sh is the stronger shape: it
+# stubs nm and runs the real gate.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+locale_name=""
+for candidate in en_US.utf8 en_US.UTF-8; do
+    if locale -a 2>/dev/null | grep -Fxq "$candidate"; then
+        locale_name="$candidate"
+        break
+    fi
+done
+
+if [ -z "$locale_name" ]; then
+    echo "check-sbom-snapshot-locale: SKIP: en_US UTF-8 locale not installed"
+    exit 0
+fi
+
+command -v jq >/dev/null 2>&1 || {
+    echo "check-sbom-snapshot-locale: SKIP: jq not available"
+    exit 0
+}
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/wirelog-sbom-locale.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Entries chosen so C and en_US collation disagree: "./..." sorts first under
+# C and mid-list under en_US, which is exactly the drift observed on #1291.
+cat > "$tmpdir/artifacts.json" <<'EOF'
+{"artifacts":[
+  {"name":"zlib","version":"1.3","licenses":[{"value":"Zlib"}]},
+  {"name":"./.github/workflows/lint-pr.yml","version":"UNKNOWN","licenses":[]},
+  {"name":"actions/checkout","version":"v5","licenses":[]},
+  {"name":"./.github/workflows/lint-main.yml","version":"UNKNOWN","licenses":[]},
+  {"name":"r-lib/actions","version":"v2","licenses":[]}
+]}
+EOF
+
+extract() {
+    jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' \
+        "$tmpdir/artifacts.json"
+}
+
+# Reproduce the generator's pipeline tail under both collations, purely to
+# confirm the fixture discriminates. A fixture whose entries sort identically
+# either way would make the check below meaningless.
+extract | LC_ALL=C sort > "$tmpdir/under-c.txt"
+extract | LC_ALL="$locale_name" sort > "$tmpdir/under-locale-unpinned.txt"
+
+# Sanity: the two collations must actually disagree on this fixture, or the
+# test would pass regardless of whether the pin exists.
+if cmp -s "$tmpdir/under-c.txt" "$tmpdir/under-locale-unpinned.txt"; then
+    echo "check-sbom-snapshot-locale: FAIL: fixture does not distinguish collations under $locale_name" >&2
+    exit 1
+fi
+
+# The scripts must actually carry the pin. This is the assertion that guards
+# the repository; the comparison above only establishes that the fixture can
+# tell the two collations apart.
+# \bsort\b catches the forms a narrower pattern misses -- `sort -o`,
+# `$(sort f)`, `< <(sort f)` -- and whole-line comments are dropped afterwards
+# rather than by an `^[^#]*` prefix, which could not cross the `'^#'` literal
+# in check-sbom-snapshot.sh's own comment-stripping line and so skipped the
+# very sort it was meant to check. Trailing comments after code are still
+# scanned; a false positive names its line and is the safe direction.
+sort_lines() { grep -n '\bsort\b' "$repo_root/$1" | grep -v '^[0-9]*:[[:space:]]*#' || true; }
+
+for target in scripts/release/generate-sbom.sh scripts/ci/check-sbom-snapshot.sh; do
+    total=$(sort_lines "$target" | grep -c . || true)
+    # Absence must not pass: a script with no `sort` at all would otherwise
+    # satisfy an unpinned-count check by having nothing to count, and the pin
+    # this guards would have gone with it.
+    if [ "$total" -eq 0 ]; then
+        echo "check-sbom-snapshot-locale: FAIL: no sort found in $target; the pipeline this guards has changed shape" >&2
+        exit 1
+    fi
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        echo "check-sbom-snapshot-locale: FAIL: unpinned sort in $target: $line" >&2
+        exit 1
+    done < <(sort_lines "$target" | grep -v 'LC_ALL=C sort' || true)
+done
+
+echo "check-sbom-snapshot-locale: OK under LC_ALL=$locale_name"

--- a/scripts/ci/check-sbom-snapshot-locale.sh
+++ b/scripts/ci/check-sbom-snapshot-locale.sh
@@ -22,6 +22,12 @@
 # stubs nm and runs the real gate.
 set -euo pipefail
 
+# Meson reads exit 77 as SKIP and exit 0 as a pass, so a branch that cannot
+# check anything must exit 77, or this gate is recorded as having asserted
+# something it never looked at.  Same defect class as #1301, in a gate added
+# while fixing a different one.
+SKIP_EXIT=77
+
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 
@@ -35,12 +41,12 @@ done
 
 if [ -z "$locale_name" ]; then
     echo "check-sbom-snapshot-locale: SKIP: en_US UTF-8 locale not installed"
-    exit 0
+    exit "$SKIP_EXIT"
 fi
 
 command -v jq >/dev/null 2>&1 || {
     echo "check-sbom-snapshot-locale: SKIP: jq not available"
-    exit 0
+    exit "$SKIP_EXIT"
 }
 
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/wirelog-sbom-locale.XXXXXX")"

--- a/scripts/ci/check-sbom-snapshot.sh
+++ b/scripts/ci/check-sbom-snapshot.sh
@@ -28,14 +28,14 @@ trap 'rm -rf "$tmpdir"' EXIT
 # Extract current dependency list as "name@version:license"
 syft dir:"$repo_root" -o syft-json 2>/dev/null \
   | jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' \
-  | sort > "$tmpdir/current.txt"
+  | LC_ALL=C sort > "$tmpdir/current.txt"
 
 # Compare against baseline (exclude comment lines starting with #)
-grep -v '^#' "$baseline" | sort > "$tmpdir/baseline_clean.txt"
+grep -v '^#' "$baseline" | LC_ALL=C sort > "$tmpdir/baseline_clean.txt"
 
 # Compare against baseline
 if diff -u "$tmpdir/baseline_clean.txt" "$tmpdir/current.txt"; then
-    n=$(wc -l < "$baseline")
+    n=$(wc -l < "$tmpdir/baseline_clean.txt")
     echo "check-sbom-snapshot: OK; $n packages in snapshot match baseline"
     exit 0
 else

--- a/scripts/release/generate-sbom.sh
+++ b/scripts/release/generate-sbom.sh
@@ -40,10 +40,14 @@ echo "generate-sbom: Generating CycloneDX 1.5..."
 syft dir:"$repo_root" -o cyclonedx-json@1.5="${output_prefix}.cdx.json"
 
 echo "generate-sbom: Updating snapshot baseline..."
-# Extract normalized dependency list: name@version:license
+# Extract normalized dependency list: name@version:license.
+# LC_ALL=C so the committed baseline has one canonical order regardless of the
+# operator's locale: glibc's en_US collation ignores leading punctuation, so
+# regenerating under it reorders the "./.github/workflows/..." entries and
+# buries the real dependency change in unrelated diff noise.
 syft dir:"$repo_root" -o syft-json 2>/dev/null \
   | jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' \
-  | sort > "$repo_root/sbom/snapshot.txt"
+  | LC_ALL=C sort > "$repo_root/sbom/snapshot.txt"
 
 # Append the resolved nanoarrow commit SHA as a comment for provenance.
 nanoarrow_sha=$(git -C "$repo_root/subprojects/nanoarrow" rev-parse HEAD 2>/dev/null || true)

--- a/scripts/release/run-downstream-matrix.sh
+++ b/scripts/release/run-downstream-matrix.sh
@@ -53,7 +53,6 @@ command -v tar >/dev/null || { echo 'tar is required' >&2; exit 2; }
 command -v timeout >/dev/null || { echo 'timeout is required' >&2; exit 2; }
 command -v gzip >/dev/null || { echo 'gzip is required' >&2; exit 2; }
 command -v git >/dev/null || { echo 'git is required' >&2; exit 2; }
-command -v gcc >/dev/null || { echo 'gcc is required' >&2; exit 2; }
 command -v curl >/dev/null || { echo 'curl is required' >&2; exit 2; }
 command -v unzip >/dev/null || { echo 'unzip is required' >&2; exit 2; }
 command -v realpath >/dev/null || { echo 'realpath is required' >&2; exit 2; }
@@ -116,7 +115,7 @@ metadata="$output_dir/host-metadata.txt"
     echo "memory_bytes=$(awk '/MemTotal:/ {print $2 * 1024}' /proc/meminfo)"
     echo "meson_version=$(meson --version)"
     echo "ninja_version=$(ninja --version)"
-    echo "gcc_version=$(gcc --version | head -1)"
+    echo "gcc_version=$(gcc --version 2>/dev/null | head -1 || echo unavailable)"
     echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 } > "$metadata"
 printf 'workload\texpected_manifest\tactual_manifest\n' > "$output_dir/data-manifests.tsv"

--- a/scripts/release/verify-release.sh
+++ b/scripts/release/verify-release.sh
@@ -65,6 +65,7 @@ done
   exit 1
 }
 
+command -v sha256sum >/dev/null || { echo 'sha256sum is required' >&2; exit 1; }
 command -v b3sum >/dev/null || { echo 'b3sum is required' >&2; exit 1; }
 archive_dir=$(cd "$(dirname "$archive")" && pwd)
 archive_name=$(basename "$archive")

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -839,6 +839,16 @@ if host_machine.system() == 'linux' and sh.found()
        suite: 'abi')
 endif
 
+# Issue #1291: sbom/snapshot.txt is a committed artifact, so its order must not
+# depend on the locale of whoever regenerates it.  Same bug class as #886 and
+# the same shape of guard: a pin without a regression test is a pin that gets
+# deleted later.  SKIPs without an en_US locale or jq; needs no syft.
+if host_machine.system() == 'linux' and sh.found()
+  test('sbom_snapshot_locale', sh,
+       args: [meson.project_source_root() / 'scripts/ci/check-sbom-snapshot-locale.sh'],
+       suite: 'sbom')
+endif
+
 # Issue #788: warning-only platform ABI surface advisory checks.
 # Linux remains the hard v1.0 ABI gate.  These checks run on every
 # default `meson test` invocation but only emit GitHub warning


### PR DESCRIPTION
Two independent one-issue fixes, both found while writing #750's consumer
documentation. Closes **#1291** and **#1292**.

## `fix(sbom): pin sort collation so the snapshot baseline is reproducible` — #1291

`sbom/snapshot.txt` is a committed artifact, but nothing pinned the collation of
the sort producing it. Under glibc's `en_US` collation, leading punctuation is
ignored, so the three `./.github/workflows/*.yml` entries sort among the
alphabetic names instead of before them. Regenerating on a non-C-locale machine
produced three spurious reordering hunks alongside the real dependency change —
in a gate whose whole purpose is making dependency drift reviewable.

**The gate itself was never locale-broken.** `check-sbom-snapshot.sh` re-sorts
both sides in the same process, so its verdict is order-insensitive even fully
unpinned. The defect is confined to `generate-sbom.sh`, whose output is
committed. The pins on the gate are defence in depth — load-bearing for the new
test, never for detection.

`scripts/ci/check-sbom-snapshot-locale.sh` follows the shape **#886** established
for this same bug class: a pin without a regression test is a pin somebody
deletes later. It is honest about being weaker than #886's, which stubs `nm` and
runs the real gate — `generate-sbom.sh` hardcodes its output to `sbom/`, so
running it here would clobber the baseline. **#1293** tracks the
output-directory parameter that would allow the stronger form.

Two details worth flagging for review, both found by mutation testing:

- The guard matches `\bsort\b` and drops whole-line comments *afterwards*. An
  `^[^#]*` prefix cannot cross the `'^#'` literal in `check-sbom-snapshot.sh`'s
  own comment-stripping line, and so skipped the very sort it was meant to check.
- It requires `LC_ALL=C` specifically. An inherited `LC_ALL` overrides an
  `LC_COLLATE` prefix, so `LC_COLLATE=C` is silently ineffective on exactly the
  machines this fixes — verified, and it is a correctness requirement rather than
  a style rule.

Also pins `ci-pr.yml`'s SBOM debug path, which printed an unpinned scan directly
beneath a C-ordered baseline: two windows that disagreed only on an off-locale
runner, and only while someone was reading them to diagnose a failure.

## `fix(release): report a missing sha256sum by name` — #1292

`verify-release.sh` guarded `b3sum`, `cosign` and `gh` but invoked `sha256sum`
bare, so a consumer without GNU coreutils hit `sha256sum: command not found` on
the first verification recipe. `make-tarball.sh:16-17` already guards both, so
the verifier was the one place diverging from the repo's own pattern.

**This is a diagnostics fix, not a correctness or portability one.** The old
behaviour was never a false pass — `set -euo pipefail` aborted at exit 127 — and
a macOS consumer still cannot run the script afterwards; they get a named
prerequisite error instead of an internal-looking failure.

## Testing

`--suite sbom` goes 1 → 2. The locale guard runs in 0.05s, needs no `syft`, and
skips cleanly without an `en_US` locale or `jq`. Between the three review gates,
**twelve mutations** were run against the final tree; all are caught, and the two
whole-line-comment cases correctly pass.

The `sha256sum` guard was verified with a stub `PATH`: `sha256sum is required`,
exit 1, before any digest — versus `command not found`, exit 127, previously.

## Found while doing this, filed rather than folded in

- **#1294** — two *worse* instances of the same class, where an unpinned sort
  feeds a hash compared against a **pinned** value. `run-doop-perf-gate.sh:69`
  fails with `DOOP dataset manifest ... != pinned ...`, which accuses the
  dataset; `run-downstream-matrix.sh:141,149` feeds committed oracles from a job
  `release-tag.yml:279` invokes, so it gates GA. The issue also warns that the
  fix must first confirm the existing pinned constants were computed under C
  collation, or it converts an intermittent failure into a permanent one.
- **#1293** — `generate-sbom.sh` cannot be tested because it hardcodes its output.
- **#1295** — `verify-release.sh` and `make-tarball.sh` have no coverage at all,
  and the former is the only script third parties are told to run.
