### PR TITLE
fix(release): pin collation on the manifest hashes

### DIFF
--- a/scripts/ci/check-manifest-collation.sh
+++ b/scripts/ci/check-manifest-collation.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# check-manifest-collation.sh - Regression for issue #1294.
+#
+# Two release gates hash a sorted file list and compare the result against a
+# value that is pinned or committed:
+#
+#   scripts/ci/run-doop-perf-gate.sh     vs WIRELOG_DOOP_DATASET_MANIFEST_SHA256
+#   scripts/release/run-downstream-matrix.sh  vs downstream-matrix-oracles.tsv
+#
+# The sorts were unpinned. glibc's en_US collation ignores the hyphen in
+# Method-Modifier.facts, moving it after MethodHandleConstant.facts, so a
+# runner with a non-C locale produced a different manifest and the gate failed
+# with a message accusing the dataset of being substituted. Verified against
+# the real zxing dataset: C order reproduces the committed oracle
+# (215ddcc5...), en_US does not (472346fb...).
+#
+# Two halves, asserting different things:
+#
+#   1. The two manifest functions are lifted from run-downstream-matrix.sh with
+#      sed and run over a fixture of the real discriminating filenames under
+#      two locales. Because they are the real definitions, unpinning either one
+#      in that script makes this half fail -- verified. A retyped copy would
+#      instead assert that GNU sort honours an explicit prefix, which nothing
+#      here can break.
+#   2. check_pinned requires every sort in both scripts to carry the pin. That
+#      is what guards run-doop-perf-gate.sh, whose manifest is an inline
+#      expression and cannot be lifted.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+
+locale_name=""
+for candidate in en_US.utf8 en_US.UTF-8; do
+    if locale -a 2>/dev/null | grep -Fxq "$candidate"; then
+        locale_name="$candidate"
+        break
+    fi
+done
+
+if [ -z "$locale_name" ]; then
+    echo "check-manifest-collation: SKIP: en_US UTF-8 locale not installed"
+    exit 0
+fi
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/wirelog-manifest-collation.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# The real names from the zxing DOOP dataset that C and en_US order
+# differently. A fixture of alphabetic-only names would make this test pass
+# whether or not the pins existed.
+data="$tmpdir/data"
+mkdir -p "$data"
+for f in Method.facts Method-Modifier.facts MethodHandleConstant.facts \
+         MethodTypeConstant.facts; do
+    printf 'contents of %s\n' "$f" > "$data/$f"
+done
+
+# Sanity: the fixture must actually distinguish the two collations, or every
+# assertion below holds vacuously.
+c_order=$(find "$data" -maxdepth 1 -type f -name '*.facts' -print0 \
+    | LC_ALL=C sort -z | tr '\0' '\n')
+locale_order=$(find "$data" -maxdepth 1 -type f -name '*.facts' -print0 \
+    | LC_ALL="$locale_name" sort -z | tr '\0' '\n')
+if [ "$c_order" = "$locale_order" ]; then
+    echo "check-manifest-collation: FAIL: fixture does not distinguish C from $locale_name" >&2
+    exit 1
+fi
+
+# Lift manifest_for_doop out of the real script rather than retyping it: a
+# retyped copy keeps asserting the old pipeline's property after the original
+# changes. The script cannot be sourced whole -- it runs at top level under
+# `set -euo pipefail` -- but the function body extracts cleanly, and
+# check_pinned below fails loudly if the shape changes enough to break this.
+downstream=$repo_root/scripts/release/run-downstream-matrix.sh
+for fn in manifest_for_doop manifest_for_dir; do
+    extracted=$(sed -n "/^$fn()/,/^}/p" "$downstream")
+    # Syntax-check before eval: a corrupted range would otherwise die with a
+    # raw `eval: syntax error` before declare -F could name what went wrong.
+    printf '%s\n' "$extracted" | bash -n 2>/dev/null || {
+        echo "check-manifest-collation: FAIL: extracted $fn from $downstream does not parse; the function's shape has changed" >&2
+        exit 1
+    }
+    eval "$extracted"
+    declare -F "$fn" >/dev/null || {
+        echo "check-manifest-collation: FAIL: could not extract $fn from $downstream" >&2
+        exit 1
+    }
+done
+
+# run-doop-perf-gate.sh's dataset manifest is an inline expression, not a
+# function, so it cannot be lifted the same way. A retyped copy would only
+# assert that GNU sort honours an explicit LC_ALL=C prefix -- a coreutils
+# property nothing in this repository can break, and one that stays true no
+# matter what the real script does. check_pinned is what guards that site.
+for fn in manifest_for_doop manifest_for_dir; do
+    # "$BASH", not "$SHELL": $SHELL is the user's login shell, while these
+    # functions use `read -r -d ''` and are printed by `declare -f`, both
+    # bashisms. On a zsh or fish login this failed with a foreign error on a
+    # correct tree -- a gate blaming the wrong thing, which is the defect class
+    # this issue exists to remove. $BASH is the running interpreter.
+    under_c=$(LC_ALL=C "$BASH" -c "$(declare -f "$fn"); $fn '$data'")
+    under_locale=$(LC_ALL="$locale_name" "$BASH" -c "$(declare -f "$fn"); $fn '$data'")
+    # The comparison below is satisfied by two empty strings. If the sed range
+    # ever truncates at a column-0 `}` inside the body, the extraction still
+    # parses and declare -F still finds it, but the function returns nothing --
+    # so require a manifest-shaped result before believing the agreement.
+    [[ "$under_c" =~ ^[0-9a-f]{64}$ ]] || {
+        echo "check-manifest-collation: FAIL: extracted $fn produced no manifest; the extraction is not running the real body" >&2
+        exit 1
+    }
+    if [ "$under_c" != "$under_locale" ]; then
+        echo "check-manifest-collation: FAIL: $fn depends on the ambient locale" >&2
+        echo "  C:              $under_c" >&2
+        echo "  $locale_name: $under_locale" >&2
+        exit 1
+    fi
+done
+
+# The scripts must still carry the pin.
+#
+# Match `\bsort\b` rather than a specific flag spelling: `sort -z` and
+# `sort --zero-terminated` are the same thing, and a plain unpinned `sort`
+# added beside a pinned one would otherwise be invisible because the pinned
+# one keeps the count non-zero. Whole-line comments are dropped after matching,
+# not by an `^[^#]*` prefix, which cannot cross a `#` inside a quoted string.
+sort_lines() {
+    grep -n '\bsort\b' "$repo_root/$1" | grep -v '^[0-9]*:[[:space:]]*#' || true
+}
+
+check_pinned() {
+    local target=$1 total
+    total=$(sort_lines "$target" | grep -c . || true)
+    if [ "$total" -eq 0 ]; then
+        echo "check-manifest-collation: FAIL: no sort found in $target; the pipeline this guards has changed shape" >&2
+        exit 1
+    fi
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        echo "check-manifest-collation: FAIL: unpinned sort in $target: $line" >&2
+        exit 1
+    done < <(sort_lines "$target" | grep -v 'LC_ALL=C sort' || true)
+}
+
+check_pinned scripts/release/run-downstream-matrix.sh
+check_pinned scripts/ci/run-doop-perf-gate.sh
+
+echo "check-manifest-collation: OK under LC_ALL=$locale_name"

--- a/scripts/ci/check-manifest-collation.sh
+++ b/scripts/ci/check-manifest-collation.sh
@@ -27,6 +27,12 @@
 #      expression and cannot be lifted.
 set -euo pipefail
 
+# Meson reads exit 77 as SKIP and exit 0 as a pass, so a branch that cannot
+# check anything must exit 77, or this gate is recorded as having asserted
+# something it never looked at.  Same defect class as #1301, in a gate added
+# while fixing a different one.
+SKIP_EXIT=77
+
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 
@@ -40,7 +46,7 @@ done
 
 if [ -z "$locale_name" ]; then
     echo "check-manifest-collation: SKIP: en_US UTF-8 locale not installed"
-    exit 0
+    exit "$SKIP_EXIT"
 fi
 
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/wirelog-manifest-collation.XXXXXX")"

--- a/scripts/ci/run-doop-perf-gate.sh
+++ b/scripts/ci/run-doop-perf-gate.sh
@@ -66,7 +66,11 @@ bench_bin="${WIRELOG_DOOP_BENCH_BIN:-bench/bench_flowlog}"
 expected_manifest="${WIRELOG_DOOP_DATASET_MANIFEST_SHA256:-}"
 [[ -n "$expected_manifest" ]] || \
     skip "DOOP dataset manifest is not pinned; set WIRELOG_DOOP_DATASET_MANIFEST_SHA256"
-actual_manifest=$(sha256sum "$data_dir"/*.facts | sort -k2 | sha256sum | awk '{print $1}')
+# LC_ALL=C: en_US collation ignores the hyphen in Method-Modifier.facts and
+# reorders it against MethodHandleConstant.facts, so an unpinned sort yields a
+# different manifest on a non-C runner and this fails as if the dataset had
+# been substituted. See #1294.
+actual_manifest=$(sha256sum "$data_dir"/*.facts | LC_ALL=C sort -k2 | sha256sum | awk '{print $1}')
 [[ "$actual_manifest" == "$expected_manifest" ]] || \
     fail "DOOP dataset manifest $actual_manifest != pinned $expected_manifest"
 

--- a/scripts/release/run-downstream-matrix.sh
+++ b/scripts/release/run-downstream-matrix.sh
@@ -136,9 +136,17 @@ actual_oracle_sha256=$(sha256sum "$oracle_file" | awk '{print $1}')
     exit 1
 }
 
+# LC_ALL=C on both manifest sorts: the committed oracles in
+# downstream-matrix-oracles.tsv were computed under C collation, and the DOOP
+# file set genuinely discriminates -- en_US ignores the hyphen in
+# Method-Modifier.facts, moving it after MethodHandleConstant.facts and
+# yielding a different manifest. Unpinned, a runner with a non-C locale fails
+# with a manifest mismatch that reads as dataset tampering. Verified against
+# the real zxing dataset: C order reproduces the committed oracle, en_US does
+# not. See #1294.
 manifest_for_dir() {
     local dir=$1
-    find "$dir" -type f -print0 | sort -z \
+    find "$dir" -type f -print0 | LC_ALL=C sort -z \
         | while IFS= read -r -d '' path; do
             sha256sum "$path" | sed "s#  $dir/#  #"
         done | sha256sum | awk '{print $1}'
@@ -146,7 +154,7 @@ manifest_for_dir() {
 
 manifest_for_doop() {
     local dir=$1
-    find "$dir" -maxdepth 1 -type f -name '*.facts' -print0 | sort -z \
+    find "$dir" -maxdepth 1 -type f -name '*.facts' -print0 | LC_ALL=C sort -z \
         | while IFS= read -r -d '' path; do
             sha256sum "$path" | sed "s#  $dir/#  #"
         done | sha256sum | awk '{print $1}'

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -888,6 +888,15 @@ if sh.found()
        timeout: 120)
 endif
 
+# Issue #1294: two release gates hash a sorted file list and compare it against
+# a pinned or committed value.  Unpinned collation made a non-C runner produce a
+# different manifest, failing with a message that accuses the dataset.
+if host_machine.system() == 'linux' and sh.found()
+  test('manifest_collation', sh,
+       args: [meson.project_source_root() / 'scripts/ci/check-manifest-collation.sh'],
+       suite: 'abi')
+endif
+
 # Issue #1100: clang-tidy ratchet (suite 'tidy').  No CI job has run
 # clang-tidy since efbde27 removed it, and wirelog/ir/program.c regressed
 # after f1d2a2c with nothing failing.  The gate re-analyses every file in


### PR DESCRIPTION
Closes **#1294**. Two release gates hashed a sorted file list and compared the
result against a pinned or committed value, with the collation unpinned.

## The defect is live on the GA path, not latent

`run-downstream-matrix.sh` is invoked from `release-tag.yml:279`, so its
manifest check gates GA. glibc's `en_US` collation ignores the hyphen in
`Method-Modifier.facts`, moving it after `MethodHandleConstant.facts`. On a
runner with a non-C locale the manifest differs and the gate fails with

```
DOOP dataset manifest <x> != pinned <y>
```

— which reads as dataset tampering. The worst available message for the actual
cause.

## Verified against the real dataset, not reasoned about

Downloaded the zxing dataset through `bench/data/doop/download.sh` (archive
checksum confirmed) and computed the manifest both ways:

```
C      215ddcc50bca70c0089e0ced9298274aec4edb6741736d03cc3c4386b96f831c
en_US  472346fb234ac0610e2a0b83b7076e8279525aeeade628261fd98433d54d62b6
```

**The committed oracle is the C-order value**, so pinning is corrective rather
than a re-baseline.

The other five workloads were checked the same way before touching anything —
`cspa-fast`, `galen`, `polonius`, `ddisasm`, `crdt` all reproduce their
committed oracles under C *and* are collation-invariant. That check was the
precondition: pinning a sort whose oracle came from a different collation would
convert an intermittent failure into a permanent one, and would look like
silently re-baselining a security-relevant hash.

C is also the only collation a committed hash can safely depend on — it is byte
order and invariant, whereas en_US collation is **not stable across glibc
versions** (2.28 rewrote it), so an en_US-derived oracle is pinned to a moving
target.

## The guard

`check-manifest-collation.sh` **lifts the two manifest functions out of
`run-downstream-matrix.sh` with `sed`** rather than retyping them, so unpinning
either one in that script makes the test fail. A retyped copy would assert only
that GNU `sort` honours an explicit `LC_ALL=C` prefix — a coreutils property
nothing here can break. The perf gate's manifest is an inline expression and
cannot be lifted, so a static pin check covers that site.

Between the three review gates, **12 mutations, 12 caught**, each with its own
message: unpinning either function, unpinning or removing the perf-gate sort, a
partial rewrite to `--zero-terminated` with the sibling still pinned, a plain
unpinned `sort` added beside a pinned one, a renamed or deleted function, an
unparseable body, and a truncated extraction that parses but returns nothing.

That last one is worth flagging to reviewers: the guard passed three earlier
revisions while a truncating `}` would have left it comparing two empty strings.
Both the review and risk gates found it independently.

## Operator note

`WIRELOG_DOOP_DATASET_MANIFEST_SHA256` has **no committed value anywhere in this
repository**, so any existing pin is out-of-tree. Its owner must recompute it
under `LC_ALL=C` — otherwise this change flips that runner red.

Also: "C == en_US today" for the five non-discriminating workloads is an
accident of their filenames, not a property to rely on elsewhere.

## Follow-up

**#1297** — the perf gate's manifest embeds the directory path it is given, so
relative, absolute and trailing-slash forms yield three hashes from one dataset:
the same tampering-shaped message from a second cause. `manifest_for_doop` is
immune because it strips the prefix with `sed`, so the two computations have now
drifted twice — on collation and on path handling — which argues for one shared
helper taking the downstream matrix as reference.
