### PR TITLE
fix(release): test and cross-check the owned-soname derivation

### DIFF
--- a/scripts/ci/test-derive-owned-sonames.sh
+++ b/scripts/ci/test-derive-owned-sonames.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Self-test for derive-owned-sonames.sh.
+#
+# Issue #1285. The release closure gate (#1272) can only verify libraries the
+# owned-soname set names; one that drops out of the set stops being checked,
+# silently, while the gate keeps reporting PASS. The derivation was inline in
+# scripts/upgrade/run-upgrade-matrix.sh and therefore only ever executed on a
+# release tag. Extracted so it can be exercised here, from fixtures, in
+# milliseconds.
+set -euo pipefail
+
+# meson hands this script a native path; on Windows that is a drive-letter path
+# bash cannot use. See bb4ca712 for the same fix on the downstream self-test.
+normalize_root() {
+    local supplied=$1
+    case "$supplied" in
+        [[:alpha:]]:[\\/]* )
+            if ! command -v cygpath >/dev/null 2>&1; then
+                echo "derive-owned-sonames self-test: cygpath is required to normalize Windows root: $supplied" >&2
+                return 2
+            fi
+            if ! supplied=$(cygpath -u -- "$supplied"); then
+                echo "derive-owned-sonames self-test: cygpath could not normalize Windows root: $supplied" >&2
+                return 2
+            fi
+            ;;
+    esac
+    printf '%s\n' "$supplied"
+}
+
+root=${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}
+if (($#)); then
+    root=$(normalize_root "$root")
+fi
+derive="$root/scripts/release/derive-owned-sonames.sh"
+[[ -x "$derive" ]] || {
+    echo "derive-owned-sonames self-test: not executable: $derive" >&2
+    exit 1
+}
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-owned-selftest.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+failures=0
+check() {
+    local name=$1 status=$2
+    if [[ "$status" == 0 ]]; then
+        printf 'derive-owned-sonames self-test: ok %s\n' "$name"
+    else
+        printf 'derive-owned-sonames self-test: FAIL %s\n' "$name" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+assert() {
+    local name=$1 status=0
+    shift
+    "$@" || status=1
+    check "$name" "$status"
+}
+
+# A build tree shaped like meson's: a versioned soname with its symlink chain,
+# a subproject library nested deeper, the .p object directories that match
+# '*.so.*' but are directories, and a .symbols by-product that matches too.
+build="$tmp/build"
+mkdir -p "$build/subprojects/nanoarrow" "$build/libwirelog.so.0.60.0.p" \
+         "$build/subprojects/nanoarrow/libnanoarrow.so.p"
+: >"$build/libwirelog.so.0.60.0"
+ln -s libwirelog.so.0.60.0 "$build/libwirelog.so.0"
+ln -s libwirelog.so.0 "$build/libwirelog.so"
+: >"$build/libwirelog.so.0.60.0.symbols"
+: >"$build/subprojects/nanoarrow/libnanoarrow.so"
+: >"$build/subprojects/nanoarrow/libnanoarrow.so.symbols"
+: >"$build/libwirelog.so.0.60.0.p/some.o"
+# A directory named exactly like a library: excluded only by `! -type d`,
+# unlike the .p directories, which the grep would reject anyway.
+mkdir -p "$build/libdecoy.so.1"
+# A duplicate basename across two locations: exercises sort -u.
+mkdir -p "$build/subprojects/other"
+: >"$build/subprojects/other/libnanoarrow.so"
+# macOS forms, on a platform this repository supports.
+: >"$build/libwirelog.1.dylib"
+# A static library, which must not be collected.
+: >"$build/libwirelog.a"
+
+expected=$'libnanoarrow.so\nlibwirelog.1.dylib\nlibwirelog.so\nlibwirelog.so.0\nlibwirelog.so.0.60.0'
+actual=$("$derive" "$build")
+
+[[ "$actual" == "$expected" ]]
+check "derives exactly the library names, sorted" $?
+if [[ "$actual" != "$expected" ]]; then
+    printf 'expected:\n%s\ngot:\n%s\n' "$expected" "$actual" >&2
+fi
+
+not_listed() { ! printf '%s\n' "$actual" | grep -qx "$1"; }
+listed() { printf '%s\n' "$actual" | grep -qx "$1"; }
+
+assert 'a versioned soname is included' listed 'libwirelog.so.0.60.0'
+assert 'both symlinks in the chain are included' listed 'libwirelog.so.0'
+assert 'a nested subproject library is found without -maxdepth' \
+    listed 'libnanoarrow.so'
+assert 'a .symbols by-product is excluded' not_listed 'libwirelog.so.0.60.0.symbols'
+assert 'a .p object directory is excluded' not_listed 'libwirelog.so.0.60.0.p'
+assert 'an object inside a .p directory is excluded' not_listed 'some.o'
+assert 'a directory named exactly like a library is excluded' not_listed 'libdecoy.so.1'
+assert 'a versioned .dylib is included' listed 'libwirelog.1.dylib'
+assert 'a static library is excluded' not_listed 'libwirelog.a'
+dedupes() { [[ "$(printf '%s\n' "$actual" | grep -cx 'libnanoarrow.so')" == 1 ]]; }
+assert 'a basename appearing twice is emitted once' dedupes
+
+# A tree with no shared libraries must fail rather than emit an empty set: an
+# empty set makes the closure check vacuous, because no loaded library can
+# match it.
+empty="$tmp/empty"
+mkdir -p "$empty/subprojects"
+: >"$empty/README"
+empty_fails() { ! "$derive" "$empty" >/dev/null 2>&1; }
+assert 'an empty build tree fails rather than yielding an empty set' empty_fails
+
+# A tree holding only by-products is the same case, and is the one a naive
+# `find` would get wrong by reporting success.
+byproducts="$tmp/byproducts"
+mkdir -p "$byproducts/libwirelog.so.0.p"
+: >"$byproducts/libwirelog.so.0.symbols"
+byproducts_fail() { ! "$derive" "$byproducts" >/dev/null 2>&1; }
+assert 'a tree of only by-products fails' byproducts_fail
+
+# Locale independence: the output feeds a comparison, so its order must not
+# depend on the operator (#1291).
+locale_name=""
+for candidate in en_US.utf8 en_US.UTF-8; do
+    if locale -a 2>/dev/null | grep -Fxq "$candidate"; then
+        locale_name=$candidate
+        break
+    fi
+done
+if [[ -n "$locale_name" ]]; then
+    # A colliding pair: en_US ignores the hyphen, so libmethod-modifier sorts
+    # as libmethodmodifier and lands after libmethodhandle, while C sorts the
+    # hyphen (0x2D) first. Without a pair that collides, the set orders
+    # identically either way and this passes whether or not the pin exists.
+    : >"$build/libmethod-modifier.so"
+    : >"$build/libmethodhandle.so"
+    fixture_discriminates() {
+        [[ "$(printf 'libmethod-modifier.so\nlibmethodhandle.so\n' | LC_ALL=C sort)" != \
+           "$(printf 'libmethod-modifier.so\nlibmethodhandle.so\n' | LC_ALL="$locale_name" sort)" ]]
+    }
+    assert 'the locale fixture actually distinguishes the two collations' \
+        fixture_discriminates
+    locale_stable() {
+        [[ "$(LC_ALL=C "$derive" "$build")" == \
+           "$(LC_ALL="$locale_name" "$derive" "$build")" ]]
+    }
+    assert 'output does not depend on the ambient locale' locale_stable
+    rm -f "$build/libmethod-modifier.so" "$build/libmethodhandle.so"
+else
+    printf 'derive-owned-sonames self-test: ok locale (en_US absent, skipped)\n'
+fi
+
+missing_arg() { ! "$derive" >/dev/null 2>&1; }
+assert 'no argument exits non-zero' missing_arg
+bad_dir() { ! "$derive" "$tmp/does-not-exist" >/dev/null 2>&1; }
+assert 'a missing build directory exits non-zero' bad_dir
+
+if ((failures)); then
+    printf 'derive-owned-sonames self-test: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'derive-owned-sonames self-test: all cases passed\n'

--- a/scripts/release/derive-owned-sonames.sh
+++ b/scripts/release/derive-owned-sonames.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Print the basenames of the shared libraries a build tree produces for itself.
+#
+# Issue #1272 introduced this set; #1285 extracted it so it can be tested. The
+# release upgrade matrix uses it to tell "the consumer loaded a library this
+# release installs" apart from "the consumer loaded whatever the host had
+# lying around". Everything the closure gate asserts rests on this set being
+# right, so it is worth being able to exercise it without a release tag.
+#
+# usage: derive-owned-sonames.sh BUILD_DIR
+#
+# Prints one basename per line, LC_ALL=C sorted and de-duplicated. Exits 1 if
+# the tree yields none -- an empty set would make the closure check vacuous,
+# since no loaded library could ever match it.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo 'usage: derive-owned-sonames.sh BUILD_DIR' >&2
+    exit 2
+fi
+
+build=$1
+[[ -d "$build" ]] || {
+    echo "derive-owned-sonames: not a directory: $build" >&2
+    exit 1
+}
+
+# No -maxdepth: a subproject that relocates its build output must not drop
+# silently out of the set. `! -type d` keeps meson's libwirelog.so.N.p object
+# directories, which match '*.so.*', from being mistaken for libraries. The
+# grep keeps the match to real library names -- '*.so.*' also catches build
+# by-products such as libnanoarrow.so.symbols. LC_ALL=C so the output does not
+# depend on the operator's locale (#1291).
+owned=$(find "$build" ! -type d \
+    \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' \) -print |
+    sed 's|.*/||' |
+    { grep -E '\.(so|dylib)(\.[0-9]+)*$' || true; } |
+    LC_ALL=C sort -u)
+
+[[ -n "$owned" ]] || {
+    echo "derive-owned-sonames: $build produced no shared libraries" >&2
+    exit 1
+}
+
+printf '%s\n' "$owned"

--- a/scripts/upgrade/run-upgrade-matrix.sh
+++ b/scripts/upgrade/run-upgrade-matrix.sh
@@ -61,24 +61,63 @@ build_tree() {
     # plus the subproject libraries it carries as DT_NEEDED.  The closure
     # check in compile_and_run uses these basenames to tell "loaded from the
     # release prefix" apart from "loaded from whatever the host had lying
-    # around"; see scripts/ci/check-shared-library-closure.sh.  No -maxdepth:
-    # a subproject that relocates its build output must not drop silently out
-    # of the set.  ! -type d keeps meson's libwirelog.so.N.p object
-    # directories, which match *.so.*, from being mistaken for libraries.
-    # The grep keeps the match to real library names: '*.so.*' also catches
-    # build by-products such as libnanoarrow.so.symbols.
+    # around"; see scripts/ci/check-shared-library-closure.sh for the consumer
+    # and scripts/release/derive-owned-sonames.sh for what counts as owned.
+    # build_tree runs inside a command substitution and this script does not
+    # set inherit_errexit, so a failing *external* command does not abort it
+    # the way the previous inline `exit` did -- and the redirection truncates
+    # $owned regardless. Without the explicit `|| exit 1` the derivation could
+    # fail, leave an empty set, and have every installed library reported
+    # missing below: a real failure reported as the wrong one.
     local owned="$tmp/owned-$name.txt"
-    find "$build" ! -type d \
-        \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' \) -print |
-        sed 's|.*/||' |
-        { grep -E '\.(so|dylib)(\.[0-9]+)*$' || true; } |
-        LC_ALL=C sort -u >"$owned"
+    "$root/scripts/release/derive-owned-sonames.sh" "$build" >"$owned" || exit 1
     [[ -s "$owned" ]] || {
-        echo "upgrade matrix: $name built no shared libraries to verify" >&2
+        echo "upgrade matrix: $name derived an empty owned-soname set" >&2
         exit 1
     }
     cp "$owned" "$log_dir/$name-owned-sonames.txt"
-    printf '%s\n' "$prefix|$(dirname "$lib")"
+
+    # The closure check is only as good as this set: a library that drops out
+    # of it stops being checked, silently, and the gate keeps reporting PASS
+    # while the consumer loads a host copy (#1285).  Anything installed into
+    # the prefix but missing from the set is a derivation bug, so say so here
+    # rather than letting the closure check pass vacuously later.
+    #
+    # Only that direction is checked.  The reverse -- a name in the set that
+    # the prefix does not install -- is not a derivation bug, because the build
+    # tree legitimately holds more than the prefix.  It is not harmless either:
+    # check-shared-library-closure.sh classifies an owned basename resolving
+    # outside the prefix as FOREIGN, so such a name would fail the gate for a
+    # library this release does not ship.  That case is empty today, since the
+    # matrix builds with -Dtests=false and every library it produces is
+    # installed -- but nothing here proves it: the check below is comm -13,
+    # which establishes installed-subset-of-owned, and the reverse would need
+    # comm -23.
+    local libdir installed missing
+    libdir=$(dirname "$lib")
+    installed=$(find "$libdir" -maxdepth 1 ! -type d \
+        \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' \) -print |
+        sed 's|.*/||' |
+        { grep -E '\.(so|dylib)(\.[0-9]+)*$' || true; } |
+        LC_ALL=C sort -u)
+    # LC_ALL=C on comm as well as on the sorts: comm respects LC_COLLATE, so
+    # with C-sorted inputs and an en_US comparison it reports spurious
+    # differences and warns "file 2 is not in sorted order" -- accusing the
+    # derivation of a bug that does not exist. Latent while every library
+    # basename here is collation-invariant, live the day a hyphenated one
+    # appears (#1291, #1294).
+    missing=$(LC_ALL=C comm -13 "$owned" <(printf '%s\n' "$installed") || true)
+    if [[ -n "$missing" ]]; then
+        {
+            echo "upgrade matrix: $name installs shared libraries the owned-soname set does not name:"
+            sed 's/^/  /' <<<"$missing"
+            echo 'The closure check would not verify these, so a host copy could be'
+            echo 'loaded instead and the gate would still pass.'
+        } >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$prefix|$libdir"
 }
 
 compile_and_run() {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -791,6 +791,21 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #1285: the closure gate below can only verify libraries the
+# owned-soname set names, and the derivation of that set only ever ran on a
+# release tag.  Extracted to scripts/release/derive-owned-sonames.sh so its
+# edge cases -- symlink chains, .p object directories, .symbols by-products,
+# an empty tree -- are exercised on every PR.
+# Linux-gated: the fixture builds a symlink chain with `ln -s`, which on
+# MSYS/Git-Bash copies instead of linking, so the symlink assertions would pass
+# for a different reason there rather than exercising what they name.
+if host_machine.system() == 'linux' and sh.found()
+  test('owned_sonames', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-derive-owned-sonames.sh',
+              meson.project_source_root()],
+       suite: 'abi')
+endif
+
 # Issue #1272: the release upgrade matrix must prove the consumer loaded the
 # libraries this release installs, not whatever the host had installed.  The
 # matrix itself only runs on a release tag, so this self-test is the only


### PR DESCRIPTION
Closes **#1285**, filed during the #1272 review as a condition of approving the
closure gate.

## The hole

The closure gate can only verify libraries the owned-soname set names. Its
coverage guard is deliberately set-level — it catches the list going *wholly*
stale, not one library leaving it. So a library dropping out stops being checked
while the gate keeps reporting PASS and the consumer loads a host copy: exactly
the defect the gate exists to catch.

The derivation was inline in `run-upgrade-matrix.sh`, so it only ever executed
on a release tag.

## Two changes

**Extracted** to `scripts/release/derive-owned-sonames.sh`, with 17 fixture
cases: symlink chain, versioned soname, nested subproject found without
`-maxdepth`, `.p` object directory, a directory named *exactly* like a library,
`.symbols` by-product, static `.a`, versioned `.dylib`, duplicate basenames,
empty tree, by-products-only tree, and locale independence.

**Cross-check** in `build_tree` — anything installed into the prefix but not
named by the derived set fails immediately with a named reason. This is the
`comm` anchor proposed during the #1272 review: no `readelf`, no
system-library classification, no platform branch, because the defect's
precondition is precisely "a library in the prefix fell out of the set".

Verified against the real gate, not fixtures: making the derivation drop
`libnanoarrow` now produces

```
upgrade matrix: old installs shared libraries the owned-soname set does not name:
  libnanoarrow.so
```

where previously it passed.

## Two defects found in review, both worth flagging

**Extraction moved a failure mode rather than removing one.** `build_tree` runs
inside a command substitution and the script doesn't set `inherit_errexit`, so
the external script's `exit 1` stopped propagating where the previous inline
builtin `exit` did — and the redirection truncated the file regardless. A
failing derivation reported *every* installed library as missing: a real error
attributed to the wrong cause. Fixed locally with `|| exit 1`;
`shopt -s inherit_errexit` would be broader but changes every substitution in a
release gate and deserves its own change.

**The two halves were covering for each other by accident.** An empty owned set
only failed to reach the closure check because the cross-check happened to
intercept it. Separating them later would have silently reopened the defect.
The explicit guard makes that a property rather than a coincidence of scope.

**`comm` is pinned to `LC_ALL=C`** alongside the sorts — it respects
`LC_COLLATE`, and C-sorted inputs compared under `en_US` produce spurious
differences. Fuzzed at ~16% false positives over randomised hyphenated names
with **zero false negatives**, so it could only ever have caused a false
accusation, never a missed one. Latent today, live the day a hyphenated basename
appears.

## Testing

Seven mutations of the derivation, all caught — including three that survived an
earlier revision. `--suite abi` 42/42. Full `run-upgrade-matrix.sh` exit 0 under
both `C` and `en_US`.

Every defect this went through review for was an **assertion passing for a
reason other than the one it named**: `! -type d` shadowed by the grep that
already rejected `.p` directories; a locale check whose fixture couldn't
distinguish the collations; symlink assertions that would have passed on MSYS
where `ln -s` copies (now Linux-gated); and a comment claiming a containment
`comm -13` doesn't establish. Each is now falsifiable or explicitly disclaimed.
