### PR TITLE
ci: make the wl_log_emit provenance check actually run

### DIFF
--- a/scripts/ci/check-no-testhook-in-libwirelog.sh
+++ b/scripts/ci/check-no-testhook-in-libwirelog.sh
@@ -1,11 +1,54 @@
 #!/usr/bin/env bash
 # Issue #287: libwirelog must NOT contain testhook symbols, and its wl_log_emit
-# must originate from log_emit.c (not log_testhook.c). Soft NOTICE on stripped
-# builds (no debug info).
+# must originate from log_emit.c (not log_testhook.c).
+#
+# The two claims are separate tests (#1302).  They fail for different reasons
+# and, more importantly, one of them can be unanswerable on a build where the
+# other still holds: a stripped or release build carries no line numbers, so
+# provenance cannot be determined, while the symbol-leak check is unaffected.
+# Reporting one status for both meant a provenance skip would have masked a real
+# leak verdict, so meson registers them separately.
+#
+# usage: check-no-testhook-in-libwirelog.sh [--check=leak|provenance|both] [BUILD_DIR]
+#
+# Exit codes:
+#    0 - the selected check passed.
+#    1 - violation: testhook symbols present, or wl_log_emit does not come from
+#        log_emit.c.
+#    2 - usage error; libwirelog is not built under BUILD_DIR; or nm cannot
+#        read it / reports no symbols at all.  The last is distinct from a
+#        clean library: silence from nm must not read as "nothing to find".
+#   77 - SKIP; provenance cannot be determined on this build or with this nm.
+#        Reported to meson as a skip, not a pass -- see #1288.
 set -euo pipefail
 
-ROOT="$(git rev-parse --show-toplevel)"
-BUILD_DIR="${1:-$ROOT/build}"
+SKIP_EXIT=77
+
+usage() {
+    echo "usage: check-no-testhook-in-libwirelog.sh [--check=leak|provenance|both] [BUILD_DIR]" >&2
+}
+
+CHECK=both
+BUILD_DIR=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --check=*) CHECK="${1#--check=}" ;;
+        -h|--help) usage 2>&1; exit 0 ;;
+        --*)       echo "unknown option: $1" >&2; usage; exit 2 ;;
+        *)         BUILD_DIR="$1" ;;
+    esac
+    shift
+done
+case "$CHECK" in
+    leak|provenance|both) ;;
+    *) echo "unknown --check value: $CHECK" >&2; usage; exit 2 ;;
+esac
+
+# Only consult git when we actually need the default; `git rev-parse` outside a
+# checkout exits 128 and would abort the script under set -e even though the
+# caller supplied an explicit build directory.
+[ -n "$BUILD_DIR" ] || BUILD_DIR="$(git rev-parse --show-toplevel)/build"
+
 LIB=""
 for candidate in "$BUILD_DIR/libwirelog.so" "$BUILD_DIR"/libwirelog.so.* \
                  "$BUILD_DIR/libwirelog.dylib" "$BUILD_DIR"/libwirelog.*.dylib \
@@ -27,31 +70,124 @@ nm_defined() {
     nm "$1" 2>/dev/null | awk '$2 != "U" && $2 != "u"'
 }
 
-# (a) No testhook-branded symbols may be defined in production.
-if nm_defined "$LIB" | grep -qE 'wl_log_test_last|wl_log_test_count|wl_log_testhook|__log_testhook'; then
-    echo "LEAK: testhook symbols present in $LIB" >&2
-    nm_defined "$LIB" | grep -E 'wl_log_test_last|wl_log_test_count|wl_log_testhook|__log_testhook' >&2 || true
-    exit 1
-fi
+TESTHOOK_RE='wl_log_test_last|wl_log_test_count|wl_log_testhook|__log_testhook'
 
-# (b) wl_log_emit provenance = log_emit.c. GNU binutils --line-numbers only;
-# BSD nm has no equivalent, so this degrades to a soft NOTICE on macOS.
-PROV="$(nm --line-numbers --defined-only "$LIB" 2>/dev/null \
-        | awk '$NF ~ /:[0-9]+$/ && $0 ~ / wl_log_emit$/ {print $NF; exit}')"
-if [[ -z "$PROV" ]]; then
-    echo "NOTICE: wl_log_emit symbol not resolvable or stripped build; provenance check skipped"
-    exit 0
-fi
-case "$PROV" in
-    *log_emit.c*)
-        echo "OK: wl_log_emit provenance = $PROV"
-        ;;
-    *log_testhook.c*)
-        echo "LEAK: wl_log_emit in $LIB originates from log_testhook.c ($PROV)" >&2
-        exit 1
-        ;;
-    *)
-        echo "NOTICE: wl_log_emit provenance unverifiable ($PROV)"
+# Capture once, then match the variable.  `nm_defined "$LIB" | grep -q ...` is
+# not equivalent: grep -q exits at the first match, nm takes SIGPIPE and exits
+# 141, and `set -o pipefail` makes the `if` false -- so a library that DOES leak
+# is reported "OK: no testhook symbols".  Silent green on the one check that
+# exists to keep a test hook out of a shipped artifact.  Reproduced 5/5 at
+# 20,000 symbols; today's .so is under the pipe-buffer threshold, but the
+# library grows and this gate also accepts libwirelog.a.
+check_leak() {
+    local syms hits
+    syms=$(nm_defined "$LIB" || true)
+    # An unreadable or non-object file makes nm print nothing and exit non-zero
+    # into 2>/dev/null, which is indistinguishable from a library with no
+    # matching symbols -- so silence has to be an error, not a pass.
+    if [ -z "$syms" ]; then
+        echo "ERROR: nm produced no symbols for $LIB; not an object file, or unreadable" >&2
+        return 2
+    fi
+    hits=$(grep -E "$TESTHOOK_RE" <<<"$syms" || true)
+    if [ -n "$hits" ]; then
+        echo "LEAK: testhook symbols present in $LIB" >&2
+        printf '%s\n' "$hits" >&2
+        return 1
+    fi
+    echo "OK: no testhook symbols in $LIB"
+    return 0
+}
+
+# `nm --line-numbers` prints "<addr> <type> <name>\t<file>:<line>".
+#
+# The predicate this replaces was `$NF ~ /:[0-9]+$/ && $0 ~ / wl_log_emit$/`,
+# which can never hold: when the location is present $0 ends with it rather
+# than with the symbol name, and when it is absent $NF *is* the symbol name.
+# So the provenance check never ran, on any platform, and always reported a
+# pass it had not earned (#1302).
+#
+# The TAB is the field separator, not whitespace: a build path containing a
+# space would otherwise truncate the location.  The type column is deliberately
+# NOT examined: wl_log_emit is a local symbol ('t') in this library rather than
+# an exported one ('T'), so a predicate keyed on an uppercase type would match
+# every hand-written fixture and still miss the shipped library.
+provenance_of() {
+    awk -F'\t' '
+        NF < 2 { next }
+        {
+            split($1, f, /[ \t]+/)
+            # ^_? for Mach-O, where symbols carry a leading underscore.  The
+            # optional dotted tail accepts GCC clone suffixes such as
+            # wl_log_emit.constprop.0: an optimised build can emit only the
+            # clone, and a clone of wl_log_emit still originates from the file
+            # we are asking about.  The dot matters -- it keeps this from
+            # matching a different symbol like wl_log_emit_v2.
+            if (f[3] ~ /^_?wl_log_emit(\.[A-Za-z0-9_.]+)?$/ && $NF ~ /:[0-9]+$/) { print $NF; exit }
+        }'
+}
+
+check_provenance() {
+    local nm_out prov
+    if ! nm_out=$(nm --line-numbers --defined-only "$LIB" 2>/dev/null); then
+        # Two different causes, and calling both "BSD nm" would file an
+        # unreadable file under a benign skip with the wrong reason.
+        if ! nm "$LIB" >/dev/null 2>&1; then
+            echo "ERROR: nm cannot read $LIB; not an object file, or unreadable" >&2
+            return 2
+        fi
+        echo "SKIP: this nm does not support --line-numbers (BSD nm); cannot verify wl_log_emit provenance in $LIB" >&2
+        return "$SKIP_EXIT"
+    fi
+    if [ -z "$nm_out" ]; then
+        echo "ERROR: nm produced no symbols for $LIB; not an object file, or unreadable" >&2
+        return 2
+    fi
+    # Here-string, not a pipe: provenance_of's awk stops at the first match, and
+    # a pipe would SIGPIPE the producer once the output exceeds the pipe buffer
+    # -- making the exit status depend on where the linker happened to place
+    # wl_log_emit.  Verified: with the symbol first in 20k lines of real nm
+    # output, the piped form exits 141.
+    prov=$(provenance_of <<<"$nm_out")
+    if [ -z "$prov" ]; then
+        echo "SKIP: no line-number information for wl_log_emit in $LIB (stripped or non-debug build); cannot verify provenance" >&2
+        return "$SKIP_EXIT"
+    fi
+    case "$prov" in
+        *log_testhook.c*)
+            echo "LEAK: wl_log_emit in $LIB originates from log_testhook.c ($prov)" >&2
+            return 1
+            ;;
+        *log_emit.c*)
+            echo "OK: wl_log_emit provenance = $prov"
+            return 0
+            ;;
+        *)
+            # Reaching a verdict, not falling through to 0. An unrecognized
+            # origin means either a rename this gate has not been taught about
+            # or a genuinely unexpected definition; both need a human, and
+            # passing silently is what #1302 is about.
+            echo "FAIL: wl_log_emit in $LIB resolves to an unrecognized source ($prov); expected log_emit.c" >&2
+            return 1
+            ;;
+    esac
+}
+
+case "$CHECK" in
+    leak)       check_leak ;;
+    provenance) check_provenance ;;
+    both)
+        # Run both and report the stronger verdict. A provenance SKIP does not
+        # mask the leak result, which is why meson registers them separately;
+        # this mode exists for running the gate by hand.
+        leak_rc=0; check_leak || leak_rc=$?
+        prov_rc=0; check_provenance || prov_rc=$?
+        # Propagate the actual status rather than folding everything into 1.
+        # Testing `prov_rc = 1` would have treated 2 (unreadable) and 141 as
+        # passes -- the same "anything I did not name is fine" mistake as the
+        # predicate this issue fixes.
+        [ "$leak_rc" = 0 ] || exit "$leak_rc"
+        [ "$prov_rc" = 0 ] || [ "$prov_rc" = "$SKIP_EXIT" ] || exit "$prov_rc"
+        exit 0
         ;;
 esac
-exit 0

--- a/scripts/ci/test-check-no-testhook.sh
+++ b/scripts/ci/test-check-no-testhook.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+# Self-test for check-no-testhook-in-libwirelog.sh.
+#
+# Issue #1302. The gate makes two claims: (a) no testhook-branded symbols are
+# defined in libwirelog, and (b) wl_log_emit originates from log_emit.c rather
+# than log_testhook.c. Claim (a) ran. Claim (b) never did, on any platform,
+# because its awk predicate could not be satisfied:
+#
+#   $NF ~ /:[0-9]+$/ && $0 ~ / wl_log_emit$/
+#
+# `nm --line-numbers` prints "<addr> T wl_log_emit\t<file>:<line>". With the
+# location present $NF matches but $0 no longer ends in the symbol name; with it
+# absent $0 matches but $NF is the symbol name. The two are mutually exclusive,
+# so PROV was always empty and the gate always took its "provenance check
+# skipped; exit 0" branch -- a security-adjacent check reporting success without
+# ever running.
+#
+# nm is stubbed here rather than built against, so every branch is reachable in
+# milliseconds; the one case that needs a real library is guarded on the build
+# tree existing.
+set -euo pipefail
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux|Darwin) ;;
+    *) echo "test-check-no-testhook: SKIP: needs a POSIX host"; exit 77 ;;
+esac
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+gate="$root/scripts/ci/check-no-testhook-in-libwirelog.sh"
+[[ -x "$gate" ]] || { echo "test-check-no-testhook: not executable: $gate" >&2; exit 1; }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-testhook.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+failures=0
+# Exact status: `!` would conflate 1 (a real leak) with 77 (could not check),
+# which is the distinction this issue exists to restore.
+expect_status() {
+    local name=$1 want=$2 got=0
+    shift 2
+    "$@" >"$tmp/out" 2>"$tmp/err" || got=$?
+    if [[ "$got" == "$want" ]]; then
+        printf 'test-check-no-testhook: ok %s\n' "$name"
+    else
+        printf 'test-check-no-testhook: FAIL %s (want exit %s, got %s)\n' "$name" "$want" "$got" >&2
+        sed 's/^/    /' "$tmp/out" "$tmp/err" >&2
+        failures=$((failures + 1))
+    fi
+}
+expect_says() {
+    local name=$1 needle=$2
+    if grep -qF -e "$needle" "$tmp/out" "$tmp/err"; then
+        printf 'test-check-no-testhook: ok %s\n' "$name"
+    else
+        printf 'test-check-no-testhook: FAIL %s (no %q in output)\n' "$name" "$needle" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# A stub nm driven by two files: NM_PLAIN is what `nm --defined-only` prints,
+# NM_LINES what `nm --line-numbers --defined-only` prints. Writing NM_NO_LINES
+# makes the stub reject --line-numbers the way BSD nm does.
+bin="$tmp/bin"; mkdir -p "$bin"
+cat > "$bin/nm" <<'EOS'
+#!/usr/bin/env bash
+# NM_FAIL models the real failure -- nm exiting non-zero with no output, which
+# is what an unreadable or non-object file produces. Reading an empty file
+# instead exits 0 and only models "nm ran and found nothing", a different case.
+[ -n "${NM_FAIL:-}" ] && { echo "nm: could not read file" >&2; exit 1; }
+want_lines=0
+for a in "$@"; do [ "$a" = --line-numbers ] && want_lines=1; done
+if [ "$want_lines" = 1 ]; then
+    [ -n "${NM_NO_LINES:-}" ] && { echo "nm: unrecognized option '--line-numbers'" >&2; exit 1; }
+    cat "$NM_LINES"
+else
+    cat "$NM_PLAIN"
+fi
+EOS
+chmod +x "$bin/nm"
+
+build="$tmp/build"; mkdir -p "$build"
+: >"$build/libwirelog.so"          # presence is all the gate checks
+
+clean_syms="$tmp/clean.txt"
+cat > "$clean_syms" <<'EOF'
+0000000000001100 T wl_log_init
+0000000000001119 T wl_log_emit
+EOF
+
+run() { PATH="$bin:$PATH" NM_PLAIN="$1" NM_LINES="$2" "$gate" "${@:3}" "$build"; }
+
+# --- (a) the leak check ------------------------------------------------------
+leaky="$tmp/leaky.txt"
+cat > "$leaky" <<'EOF'
+0000000000001100 T wl_log_init
+0000000000001180 T wl_log_test_last
+EOF
+expect_status 'a testhook symbol is a leak' 1 run "$leaky" "$clean_syms" --check=leak
+expect_says   'the leak names the symbol' 'wl_log_test_last'
+expect_status 'a clean library passes the leak check' 0 run "$clean_syms" "$clean_syms" --check=leak
+
+# --- (b) the provenance check ------------------------------------------------
+# The regression itself: with line info present the check must reach a verdict.
+# Under the old predicate PROV was empty here and the gate exited 0 without
+# checking, so this case is what proves the fix.
+good="$tmp/good.txt"
+printf '0000000000001119 T wl_log_emit\t%s/wirelog/util/log_emit.c:42\n' "$root" > "$good"
+expect_status 'provenance in log_emit.c passes' 0 run "$clean_syms" "$good" --check=provenance
+expect_says   'the pass names the file' 'log_emit.c'
+
+# The case the gate exists for, and which has never run.
+bad="$tmp/bad.txt"
+printf '0000000000001119 T wl_log_emit\t%s/wirelog/util/log_testhook.c:17\n' "$root" > "$bad"
+expect_status 'provenance in log_testhook.c FAILS' 1 run "$clean_syms" "$bad" --check=provenance
+# The specific diagnosis, not just the filename: deleting the log_testhook.c
+# case makes it fall through to the "unrecognized source" branch, which also
+# exits 1 and also happens to print the path -- so a needle of "log_testhook.c"
+# alone cannot tell a correct leak diagnosis from an accidental one. For a gate
+# whose purpose is naming this exact leak, that distinction is the point.
+expect_says   'it is diagnosed as a testhook leak, not merely unrecognized' \
+    'originates from log_testhook.c'
+
+# No line info: a stripped or release build genuinely cannot answer. That is a
+# skip, not a pass -- meson must not record it as a verdict (#1288).
+nolines="$tmp/nolines.txt"
+printf '0000000000001119 T wl_log_emit\n' > "$nolines"
+expect_status 'a build without line info SKIPs' 77 run "$clean_syms" "$nolines" --check=provenance
+expect_says   'the skip says why' 'no line-number information'
+
+# BSD nm has no --line-numbers at all. Same verdict, different cause.
+bsd_skips() {
+    PATH="$bin:$PATH" NM_PLAIN="$clean_syms" NM_LINES="$good" NM_NO_LINES=1 \
+        "$gate" --check=provenance "$build"
+}
+expect_status 'an nm without --line-numbers SKIPs' 77 bsd_skips
+
+# Provenance somewhere unexpected must reach a verdict, not fall through to 0.
+odd="$tmp/odd.txt"
+printf '0000000000001119 T wl_log_emit\t/somewhere/else/mystery.c:3\n' > "$odd"
+expect_status 'unrecognized provenance FAILS rather than passing' 1 run "$clean_syms" "$odd" --check=provenance
+expect_says   'the unrecognized verdict names the file' 'mystery.c'
+
+# --- parsing edge cases ------------------------------------------------------
+# The location is tab-separated, so a path containing spaces must still parse.
+# Splitting on whitespace and taking $NF would truncate it.
+spaced="$tmp/spaced.txt"
+printf '0000000000001119 T wl_log_emit\t/build dir/wirelog/util/log_emit.c:42\n' > "$spaced"
+expect_status 'a path containing spaces still resolves' 0 run "$clean_syms" "$spaced" --check=provenance
+
+# A longer symbol that merely starts with the name must not be mistaken for it.
+prefix="$tmp/prefix.txt"
+printf '0000000000001119 T wl_log_emit_v2\t/x/log_testhook.c:1\n' > "$prefix"
+expect_status 'a prefix symbol is not mistaken for wl_log_emit' 77 run "$clean_syms" "$prefix" --check=provenance
+
+# --- independence (criterion 5) ---------------------------------------------
+# A provenance skip must not hide the leak check's real result, and a leak must
+# not be reported as a skip.
+# --check=both composes the two, and had no coverage: its exit logic could be
+# deleted entirely and every other assertion still passed. It is also the mode a
+# developer types by hand.
+expect_status 'both: a leak fails even when provenance cannot be checked' 1 \
+    run "$leaky" "$nolines" --check=both
+expect_status 'both: a provenance skip alone is not a failure' 0 \
+    run "$clean_syms" "$nolines" --check=both
+expect_status 'both: bad provenance fails even with no leak' 1 \
+    run "$clean_syms" "$bad" --check=both
+expect_status 'both: all clear passes' 0 run "$clean_syms" "$good" --check=both
+
+# A readable symbol table but an unusable line-number listing: the leak check
+# passes and provenance returns 2. This is the case that distinguishes
+# propagating the real status from the older "anything that is not 1 is fine",
+# which would report success on a status it never considered.
+both_prov_error() {
+    local e="$tmp/empty-lines.txt"; : >"$e"
+    run "$clean_syms" "$e" --check=both
+}
+expect_status 'both: a non-1 provenance error is not treated as a pass' 2 both_prov_error
+
+# An unreadable or non-object file makes nm print nothing, which used to be
+# indistinguishable from a clean library -- the gate said "OK: no testhook
+# symbols" about a file it could not read.
+empty_syms="$tmp/empty.txt"; : >"$empty_syms"
+expect_status 'nm producing nothing is an error, not a clean bill of health' 2 \
+    run "$empty_syms" "$empty_syms" --check=leak
+expect_says   'the unreadable case says why' 'not an object file'
+expect_status 'nm producing nothing is an error for provenance too' 2 \
+    run "$empty_syms" "$empty_syms" --check=provenance
+
+# ...and the case that actually occurs: nm exits non-zero having printed
+# nothing. The empty-file fixtures above exercise a stub that exits 0, so they
+# never reached the code that handles a genuine nm failure -- the gate got this
+# wrong in the meson-registered mode while every assertion here passed.
+nm_fails() { PATH="$bin:$PATH" NM_PLAIN="$clean_syms" NM_LINES="$good" NM_FAIL=1 "$gate" "$@" "$build"; }
+expect_status 'nm failing outright is an error (leak)' 2 nm_fails --check=leak
+expect_status 'nm failing outright is an error (provenance)' 2 nm_fails --check=provenance
+expect_says   'the provenance failure blames the file, not BSD nm' 'cannot read'
+expect_status 'nm failing outright is an error (both)' 2 nm_fails --check=both
+
+# Mach-O symbols carry a leading underscore.
+macho="$tmp/macho.txt"
+printf '0000000000001119 t _wl_log_emit\t/x/wirelog/util/log_emit.c:51\n' > "$macho"
+expect_status 'a Mach-O underscored symbol resolves' 0 run "$clean_syms" "$macho" --check=provenance
+
+# An optimised build can emit only a clone. build-erasure-check contains
+# wl_log_emit.constprop.0 and no plain wl_log_emit, so without this the gate
+# silently SKIPs there -- a registered check that can never reach a verdict,
+# which is the shape of the bug this issue is about.
+clone="$tmp/clone.txt"
+printf '0000000000001119 t wl_log_emit.constprop.0\t/x/wirelog/util/log_emit.c:51\n' > "$clone"
+expect_status 'a GCC clone suffix resolves' 0 run "$clean_syms" "$clone" --check=provenance
+
+# ...but a different symbol that merely shares the prefix must not. The dot is
+# what separates a clone from an unrelated function.
+notclone="$tmp/notclone.txt"
+printf '0000000000001119 t wl_log_emit_v2\t/x/wirelog/util/log_testhook.c:1\n' > "$notclone"
+expect_status 'a prefix symbol is still not mistaken for a clone' 77 \
+    run "$clean_syms" "$notclone" --check=provenance
+
+# A tab-separated trailing field that is not a file:line must not be taken as a
+# location; without the :<line> guard this would be reported as provenance.
+notloc="$tmp/notloc.txt"
+printf '0000000000001119 t wl_log_emit\tsome trailing note\n' > "$notloc"
+expect_status 'a trailing field that is not file:line is not a location' 77 \
+    run "$clean_syms" "$notloc" --check=provenance
+
+# --- output larger than the pipe buffer -------------------------------------
+# Every fixture above is one or two lines, which cannot reach the failure these
+# cover. A consumer that stops reading early -- `grep -q`, or awk's `exit` --
+# SIGPIPEs its producer once the output passes the pipe buffer (~64 KB); under
+# `set -o pipefail` that surfaces as 141, and in the leak check it silently
+# inverted the verdict. Both were live in this gate: the leak check reported
+# "OK: no testhook symbols" on a leaking library 5/5 times at this size, and the
+# provenance check exited 141. Whether either fired depended only on where the
+# linker placed the symbol, so a relink was enough to change the answer.
+big_leak="$tmp/big-leak.txt"
+big_prov="$tmp/big-prov.txt"
+{
+    # The interesting symbol FIRST: that is what makes the consumer stop while
+    # the producer still has ~1 MB to write.
+    printf '0000000000001180 T wl_log_test_last\n'
+    awk 'BEGIN { for (i = 1; i <= 20000; i++)
+        printf "00000000000%05d t filler_%d\t/some/path/file_%d.c:%d\n", i, i, i, i }'
+} > "$big_leak"
+{
+    printf '0000000000001119 t wl_log_emit\t/x/wirelog/util/log_emit.c:51\n'
+    awk 'BEGIN { for (i = 1; i <= 20000; i++)
+        printf "00000000000%05d t filler_%d\t/some/path/file_%d.c:%d\n", i, i, i, i }'
+} > "$big_prov"
+
+# Sanity: the fixtures must actually exceed the pipe buffer, or these assertions
+# hold vacuously and would keep passing after the guard was removed.
+big_enough() { [[ "$(wc -c <"$big_leak")" -gt 262144 && "$(wc -c <"$big_prov")" -gt 262144 ]]; }
+expect_status 'the large fixtures exceed the pipe buffer' 0 big_enough
+
+expect_status 'a leak is still caught in output larger than the pipe buffer' 1 \
+    run "$big_leak" "$clean_syms" --check=leak
+expect_says   'the large-output leak is named, not swallowed' 'wl_log_test_last'
+expect_status 'provenance still resolves in output larger than the pipe buffer' 0 \
+    run "$clean_syms" "$big_prov" --check=provenance
+
+# --- argument handling -------------------------------------------------------
+missing_lib() { PATH="$bin:$PATH" NM_PLAIN="$clean_syms" NM_LINES="$good" "$gate" "$tmp/nonexistent"; }
+expect_status 'a missing library is an error, not a skip' 2 missing_lib
+bad_flag() { PATH="$bin:$PATH" NM_PLAIN="$clean_syms" NM_LINES="$good" "$gate" --check=bogus "$build"; }
+expect_status 'an unknown --check value is rejected' 2 bad_flag
+
+# --- against the real library (criterion 1) ---------------------------------
+# The stubs above prove the parsing; this proves the parsing matches what this
+# platform's nm actually emits, which is the part a stub cannot establish.
+# meson passes its build root as $1 so this does not depend on a directory
+# guessed by name; without it a CI build dir called anything else silently
+# skipped the only assertion a stub cannot substitute for.
+# Try each candidate and keep going until one actually carries line info: meson
+# passes its build root, which defaults to buildtype=release and cannot answer,
+# and stopping there would skip the assertions a stub cannot substitute for.
+# The dylib name is used, not just found -- the previous version located a
+# dylib and then ran nm on a hardcoded libwirelog.so, so the macOS path could
+# never run.
+real=""
+real_lib=""
+real_nm=""
+for d in ${1:+"$1"} "$root/build-debug" "$root/build"; do
+    # Mirror the gate's own search order and take the FIRST match, rather than
+    # the first that happens to carry line info. Picking a different library
+    # than the gate would makes the assertions below judge an artifact the gate
+    # never looks at: on a tree holding a stripped .so and a debug .dylib, the
+    # probe chose the dylib, the gate chose the .so, and they disagreed.
+    cand=""
+    for c in "$d"/libwirelog.so "$d"/libwirelog.so.* \
+             "$d"/libwirelog.dylib "$d"/libwirelog.*.dylib "$d"/libwirelog.a; do
+        [[ -f "$c" ]] && { cand=$c; break; }
+    done
+    if [[ -n "$cand" ]]; then
+        probe=$(nm --line-numbers --defined-only "$cand" 2>/dev/null || true)
+        # Same clone-aware match the gate uses; a stricter probe here would opt
+        # out of exactly the builds the gate handles correctly.
+        if [[ -n "$probe" ]] && awk -F'\t' 'NF >= 2 {
+                split($1, f, /[ \t]+/)
+                if (f[3] ~ /^_?wl_log_emit(\.[A-Za-z0-9_.]+)?$/ && $NF ~ /:[0-9]+$/) found = 1
+            } END { exit found ? 0 : 1 }' <<<"$probe"; then
+            real=$d; real_lib=$cand; real_nm=$probe
+            break
+        fi
+    fi
+done
+# real_nm is the probe's own output, captured in the loop above -- not re-read
+# here. An earlier version re-read a hardcoded libwirelog.so at this point,
+# which discarded the candidate the loop had just chosen and reintroduced the
+# "find a dylib, then run nm on a .so" mismatch it exists to avoid.
+#
+# It is captured rather than piped for the reason that cost the most time here:
+# `nm | grep -q` looks equivalent but is not -- grep -q exits at the first
+# match, nm takes SIGPIPE and returns 141, and `set -o pipefail` propagates it,
+# so the guard read "no line info" on a library that has it and silently
+# downgraded this case to a skip.
+if [[ -n "$real_lib" ]]; then
+    real_ok() { "$gate" --check=provenance "$real"; }
+    expect_status 'the real library resolves its own provenance' 0 real_ok
+    expect_says   'the real provenance is log_emit.c' 'log_emit.c'
+    # A stub cannot establish this: the symbol is local ('t'), not exported
+    # ('T'). The parser deliberately ignores the type column; this asserts the
+    # fact that makes that deliberate, so a future "tighten it to ^T$" cannot
+    # look harmless -- it would pass every fixture here and still miss the
+    # shipped library.
+    # Here-string, and no early `exit` in awk: any consumer that stops reading
+    # early SIGPIPEs its producer, which under pipefail surfaces as 141. That is
+    # what the comment above is about, and it bites here too.
+    local_type() {
+        local t
+        t=$(awk '$3 ~ /^_?wl_log_emit(\.[A-Za-z0-9_.]+)?$/ && !seen { print $2; seen = 1 }' <<<"$real_nm")
+        [[ "$t" == t ]]
+    }
+    expect_status 'wl_log_emit is local, so the parser must not require ^T$' 0 local_type
+else
+    printf 'test-check-no-testhook: SKIPPED real-library case (no debug build present)\n'
+fi
+
+if ((failures)); then
+    printf 'test-check-no-testhook: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test-check-no-testhook: all cases passed\n'

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -611,8 +611,22 @@ if not is_windows
   test('log_abi_header_not_public',
        find_program(meson.project_source_root() / 'scripts/check_log_header_not_public.sh'),
        suite: 'abi')
+  # Issue #1302: the two claims are registered separately.  A provenance skip
+  # (stripped or non-debug build, or a BSD nm with no --line-numbers) must not
+  # be reported as the verdict for the symbol-leak check, which is unaffected by
+  # either.  One test for both meant the weaker outcome spoke for the stronger.
   test('log_abi_no_testhook_in_libwirelog',
        find_program(meson.project_source_root() / 'scripts/ci/check-no-testhook-in-libwirelog.sh'),
+       args: ['--check=leak', meson.project_build_root()],
+       suite: 'abi')
+  test('log_abi_testhook_provenance',
+       find_program(meson.project_source_root() / 'scripts/ci/check-no-testhook-in-libwirelog.sh'),
+       args: ['--check=provenance', meson.project_build_root()],
+       suite: 'abi')
+  # Its awk predicate was unsatisfiable, so the provenance claim above had never
+  # once been evaluated; this drives both checks from stubbed nm output.
+  test('testhook_gate_selftest',
+       find_program(meson.project_source_root() / 'scripts/ci/test-check-no-testhook.sh'),
        args: [meson.project_build_root()],
        suite: 'abi')
   test('wirelog_easy_abi_opts_symbol',


### PR DESCRIPTION
Refs #1302. **Does not close it** — see Scope.

## The defect

`check-no-testhook-in-libwirelog.sh` asserts two things: (a) no testhook symbols in libwirelog, (b) `wl_log_emit` comes from `log_emit.c`, not `log_testhook.c`. **(b) has never executed, on any platform.**

```awk
$NF ~ /:[0-9]+$/ && $0 ~ / wl_log_emit$/
```

`nm --line-numbers` prints `<addr> <type> <name>\t<file>:<line>`. With the location present `$0` ends with it, not the symbol name; without it, `$NF` *is* the symbol name. Mutually exclusive → `PROV` always empty → always `exit 0`. The check that exists to keep a test hook out of a shipped library reported success without looking.

## Two worse defects the fix exposed

Both from a consumer stopping early under `set -o pipefail`:

| | before | now |
|---|---|---|
| `nm_defined \| grep -qE "$TESTHOOK_RE"` | `grep -q` exits at first match → `nm` SIGPIPEs → 141 → `pipefail` inverts the `if` → **`OK: no testhook symbols` on a leaking library**, 5/5 at 20k symbols | captures once, matches a variable |
| `printf \| provenance_of` | awk's `exit` SIGPIPEs `printf` → **exit 141**, no diagnostic | here-string |

Which one fired depended on where the linker placed the symbol — a relink could change the answer.

An unreadable artifact was also misreported: leak mode exited **1 with no output** (meson renders that as a testhook leak in a file `nm` could not open), and provenance blamed BSD nm. Both now exit 2.

## Design

- **Two meson tests**, not one. The claims are independently unanswerable — a build without DWARF cannot answer provenance while the leak check is unaffected — and one status meant the weaker outcome spoke for the stronger.
- **Exit codes**: 0 checked and holds · 1 checked and violated · 77 could not check, legitimately for this build/toolchain · 2 could not check, and that is an error.
- The type column is deliberately **not** examined: `wl_log_emit` is local (`t`), so a predicate keyed on `T` matches every fixture and misses the real library. Mach-O `_` prefix and GCC clone suffixes (`build-erasure-check` has only `wl_log_emit.constprop.0`) are accepted; the required dot keeps `wl_log_emit_v2` out.

## Scope — this makes the claim checkable, not checked everywhere

`meson.build` defaults to `buildtype=release`, so the provenance test **SKIPs in routine per-PR CI** and genuinely runs only where DWARF exists: `release-tag` Tag/ABI and Tag/default, the sanitizer matrix, tsan. On macOS it lands in the **BSD-nm branch** — Apple's `nm` has no `--line-numbers`, so it never reaches the question. Escalation is #1303.

**Known consequence:** adding `-Dstrip=true`, or pointing the gate at an install tree, turns the leak test red rather than yellow. For a security-adjacent gate that is intended.

## Testing

39 assertions. The stub can **fail outright**, not merely print nothing — an empty file exits 0, which models "nm found nothing" and never "nm failed", and that gap is why the unreadable-artifact bugs survived two review rounds. Fixtures exceed the pipe buffer (with a sanity assertion that they do) to cover the SIGPIPE pair. Three assertions run against the real library — the part a stub cannot establish.

- `meson test -C build`: 305 Ok / 0 Fail / 13 Skipped
- 12 input shapes swept (dylib-only, stripped `.so` + debug dylib, versioned `.so`, `.a`-only, clone-only, empty/garbage/nonexistent trees): all exit 0
- Mutation-tested: both SIGPIPE reverts, the original predicate, `--check=both` composition, clone-regex loosening and tightening, `f[2]=="T"`, the `:[0-9]+$` guard, and both unreadable-artifact regressions all fail

The 12-shape sweep is a **manual** matrix; `meson test` does not rerun it. Re-run after touching the self-test's library probe, which mirrors the gate's own search order so the two cannot judge different artifacts.

Three review rounds; final verdicts Reviewer, Architect and Critic all approving tree `92304786`.