### PR TITLE
ci: report gate skips as SKIP, and a deleted baseline as a failure

### DIFF
--- a/scripts/ci/check-abi-manifest.sh
+++ b/scripts/ci/check-abi-manifest.sh
@@ -29,22 +29,27 @@
 # link).
 #
 # Exit codes:
+#    0 - manifest matches the committed baseline.
+#    1 - incompatible ABI change, or the committed baseline is missing.
+#        The baseline is tracked, so its absence means it was deleted --
+#        an error, not an inability to check.
+#   77 - SKIP; this host or build cannot check: no libwirelog.so, no
+#        abidiff, or a non-x86_64 host (the baseline is x86_64-only).
+#        Reported to meson as a skip rather than a pass (#1301).
 #
-#   0   - manifest matches baseline (or SKIPped gracefully).
-#   1   - incompatible-change finding (or missing baseline / inputs).
-#
-# SKIP conditions (exit 0 with diagnostic):
-#
-#   - `libwirelog.so` absent (Windows, static-only, cross builds).
-#   - `abidiff` not on PATH (libabigail not installed).
-#   - Baseline `abi/libwirelog-1.0.abi.json` absent (first-time setup;
-#     run `scripts/release/regenerate-abi-manifest.sh` to seed).
-#   - Host architecture is not x86_64.  The v1.0 libabigail baseline is
-#     intentionally x86_64-only; Linux arm64 ABI coverage is symbol-only
-#     unless and until a per-architecture baseline policy is added after
-#     v1.0 (issue #824).
+#        77 is safe only under meson.  A bare workflow `run:` step uses
+#        `bash -e`, where it would fail the job.
 
 set -euo pipefail
+
+# Meson reads exit 77 as SKIP and exit 0 as a pass, so a branch that cannot
+# check anything must exit 77 or the gate is recorded as having asserted
+# something it never looked at (#1301).  Matches SKIP_EXIT in
+# check-clang-tidy-backlog-monotonic.sh and SKIP in run-doop-perf-gate.sh.
+#
+# 77 is only safe under meson: a bare workflow `run:` step uses `bash -e`,
+# where 77 fails the job.  Do not invoke this from one.
+SKIP_EXIT=77
 
 if [ $# -lt 1 ]; then
     echo "usage: $0 <build_root>" >&2
@@ -70,20 +75,25 @@ done
 if [ -z "$lib" ]; then
     echo "check-abi-manifest: SKIP: libwirelog.so not found in $build_root" >&2
     echo "  (expected on Windows / static-only / cross builds)" >&2
-    exit 0
+    exit "$SKIP_EXIT"
 fi
 
 if ! command -v abidiff >/dev/null 2>&1; then
     echo "check-abi-manifest: SKIP: abidiff not on PATH" >&2
     echo "  install libabigail (Ubuntu: apt-get install -y abigail-tools)" >&2
-    exit 0
+    exit "$SKIP_EXIT"
 fi
 
+# Not a skip: abi/libwirelog-1.0.abi.json is committed, so its absence means
+# it was deleted rather than that this build cannot answer.  Reporting that as
+# "nothing to check" retires the gate silently.  check-abi-symbols.sh has
+# always treated a missing allowlist as a hard failure; this matches it.
 if [ ! -f "$baseline" ]; then
-    echo "check-abi-manifest: SKIP: baseline missing: $baseline" >&2
+    echo "check-abi-manifest: FAIL: baseline missing: $baseline" >&2
+    echo "  it is committed, so this means it was deleted." >&2
     echo "  first-time setup: run scripts/release/regenerate-abi-manifest.sh" >&2
     echo "  and commit the resulting abi/libwirelog-1.0.abi.json." >&2
-    exit 0
+    exit 1
 fi
 
 # The committed baseline is generated on Linux x86_64.  abidiff treats
@@ -100,7 +110,7 @@ if [ "$host_arch" != "x86_64" ]; then
     echo "  issue #824 scopes v1.0 Linux arm64 ABI coverage to" >&2
     echo "  abi/libwirelog-1.0.symbols; per-arch libabigail baselines" >&2
     echo "  require a separate post-v1.0 policy and regeneration flow." >&2
-    exit 0
+    exit "$SKIP_EXIT"
 fi
 
 # `--suppr` is optional; pass it only if the suppression file exists so

--- a/scripts/ci/check-abi-symbols-locale.sh
+++ b/scripts/ci/check-abi-symbols-locale.sh
@@ -7,6 +7,15 @@
 
 set -euo pipefail
 
+# Meson reads exit 77 as SKIP and exit 0 as a pass, so a branch that cannot
+# check anything must exit 77 or the gate is recorded as having asserted
+# something it never looked at (#1301).  Matches SKIP_EXIT in
+# check-clang-tidy-backlog-monotonic.sh and SKIP in run-doop-perf-gate.sh.
+#
+# 77 is only safe under meson: a bare workflow `run:` step uses `bash -e`,
+# where 77 fails the job.  Do not invoke this from one.
+SKIP_EXIT=77
+
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 
@@ -20,7 +29,7 @@ done
 
 if [ -z "$locale_name" ]; then
     echo "check-abi-symbols-locale: SKIP: en_US UTF-8 locale not installed"
-    exit 0
+    exit "$SKIP_EXIT"
 fi
 
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/wirelog-abi-locale.XXXXXX")"

--- a/scripts/ci/check-abi-symbols-macos.sh
+++ b/scripts/ci/check-abi-symbols-macos.sh
@@ -1,10 +1,24 @@
 #!/usr/bin/env bash
 # Issue #788: advisory macOS/Mach-O export-surface check.
 #
-# This gate is warning-only for v1.0.  It reports drift against the
-# platform-specific allowlist but always exits 0 unless the script itself is
-# invoked incorrectly.
+# This gate is warning-only for v1.0.  Symbol drift against the platform-
+# specific allowlist is reported as a warning and exits 0, and so is a missing
+# allowlist -- unlike the enforcing gates, which fail on that.
+#
+# It does exit 77 when it cannot check at all (host is not macOS, or no dylib
+# was built), so meson records those runs as skipped rather than passed
+# (#1301).  That is a reporting change, not an enforcement one: nothing this
+# gate can actually check has become a failure.
 set -euo pipefail
+
+# Meson reads exit 77 as SKIP and exit 0 as a pass, so a branch that cannot
+# check anything must exit 77 or the gate is recorded as having asserted
+# something it never looked at (#1301).  Matches SKIP_EXIT in
+# check-clang-tidy-backlog-monotonic.sh and SKIP in run-doop-perf-gate.sh.
+#
+# 77 is only safe under meson: a bare workflow `run:` step uses `bash -e`,
+# where 77 fails the job.  Do not invoke this from one.
+SKIP_EXIT=77
 
 if [ $# -lt 1 ]; then
     echo "usage: $0 <build_root>" >&2
@@ -13,7 +27,7 @@ fi
 
 if [ "$(uname -s)" != "Darwin" ]; then
     echo "check-abi-symbols-macos: SKIP: host is not macOS" >&2
-    exit 0
+    exit "$SKIP_EXIT"
 fi
 
 build_root="$1"
@@ -40,11 +54,29 @@ done
 
 if [ -z "$lib" ]; then
     echo "check-abi-symbols-macos: SKIP: libwirelog dylib not found in $build_root" >&2
-    exit 0
+    exit "$SKIP_EXIT"
 fi
 
+# An advisory pass, not a skip, and deliberately still exit 0.
+#
+# The rule this file follows: 77 means the environment cannot supply the input
+# (not macOS, no dylib built); once the environment can, the gate's own
+# severity applies -- exit 1 for the enforcing gates, warn-and-0 for this
+# advisory one.  That is why the no-dylib branch above became 77 while this one
+# did not.
+#
+# Neither alternative survives contact with the gate's own behaviour.  Real
+# symbol drift is reported as a warning and exits 0, so a missing allowlist --
+# strictly less informative than drift -- cannot correctly carry a harsher
+# status than the drift itself.  And 77 would mean meson shows SKIP for "no
+# allowlist" but OK for "the symbols actually diverged": the worse outcome
+# getting the better status.
+#
+# Note that #1301 is self-contradictory here.  It lists this branch as
+# out-of-scope by its `if` line (:46) and as needing exit 1 by that same
+# branch's `exit` line (:48).  The out-of-scope reading is the coherent one.
 if [ ! -f "$allowlist" ]; then
-    warn "allowlist missing: $allowlist"
+    warn "allowlist missing: $allowlist (advisory gate: not a failure)"
     exit 0
 fi
 

--- a/scripts/ci/check-abi-symbols.sh
+++ b/scripts/ci/check-abi-symbols.sh
@@ -26,7 +26,9 @@
 # Where <build_root> contains `libwirelog.so` (or a SOVERSION-
 # qualified link).
 #
-# Exit codes: 0 on match, 1 on diff or missing inputs.
+# Exit codes: 0 on match, 1 on diff or a missing allowlist, 77 on SKIP
+#             (no libwirelog.so, or a Windows POSIX layer) -- reported to
+#             meson as a skip rather than a pass (#1301).
 #
 # To regenerate the allowlist after a deliberate API addition:
 #
@@ -36,6 +38,15 @@
 #       > abi/libwirelog-1.0.symbols
 
 set -euo pipefail
+
+# Meson reads exit 77 as SKIP and exit 0 as a pass, so a branch that cannot
+# check anything must exit 77 or the gate is recorded as having asserted
+# something it never looked at (#1301).  Matches SKIP_EXIT in
+# check-clang-tidy-backlog-monotonic.sh and SKIP in run-doop-perf-gate.sh.
+#
+# 77 is only safe under meson: a bare workflow `run:` step uses `bash -e`,
+# where 77 fails the job.  Do not invoke this from one.
+SKIP_EXIT=77
 
 if [ $# -lt 1 ]; then
     echo "usage: $0 <build_root>" >&2
@@ -50,7 +61,7 @@ allowlist="$repo_root/abi/libwirelog-1.0.symbols"
 case "$(uname -s)" in
   MSYS*|MINGW*|CYGWIN*)
     echo "check-abi-symbols: SKIP: Windows POSIX layer ($(uname -s)) detected" >&2
-    exit 0
+    exit "$SKIP_EXIT"
     ;;
 esac
 
@@ -71,7 +82,7 @@ done
 if [ -z "$lib" ]; then
     echo "check-abi-symbols: SKIP: libwirelog.so not found in $build_root" >&2
     echo "  (expected on Windows / static-only / cross builds)" >&2
-    exit 0
+    exit "$SKIP_EXIT"
 fi
 
 if [ ! -f "$allowlist" ]; then

--- a/scripts/ci/check-sbom-snapshot.sh
+++ b/scripts/ci/check-sbom-snapshot.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 # Issue #744: SBOM snapshot CI gate.
 # Diffs the detected dependency list against the committed baseline.
-# SKIPs when syft is not on PATH or baseline file is absent.
+# SKIPs (exit 77) when syft is not on PATH.  A missing baseline is a
+# FAILURE, not a skip: sbom/snapshot.txt is committed, so its absence
+# means it was deleted (#1301).
 
 set -euo pipefail
+
+# Meson reads exit 77 as SKIP and exit 0 as a pass, so a branch that cannot
+# check anything must exit 77 or the gate is recorded as having asserted
+# something it never looked at (#1301).  Matches SKIP_EXIT in
+# check-clang-tidy-backlog-monotonic.sh and SKIP in run-doop-perf-gate.sh.
+#
+# 77 is only safe under meson: a bare workflow `run:` step uses `bash -e`,
+# where 77 fails the job.  Do not invoke this from one.
+SKIP_EXIT=77
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
@@ -12,14 +23,17 @@ baseline="$repo_root/sbom/snapshot.txt"
 # SKIP if syft not available
 if ! command -v syft >/dev/null 2>&1; then
     echo "check-sbom-snapshot: SKIP: syft not on PATH" >&2
-    exit 0
+    exit "$SKIP_EXIT"
 fi
 
-# SKIP if baseline file doesn't exist (first time; regenerate via scripts/release/generate-sbom.sh)
+# NOT a skip: the baseline is committed, so its absence means deletion.
 if [ ! -f "$baseline" ]; then
-    echo "check-sbom-snapshot: SKIP: baseline missing: $baseline" >&2
+    # Not a skip: sbom/snapshot.txt is committed, so its absence means it was
+    # deleted, not that this build cannot answer.
+    echo "check-sbom-snapshot: FAIL: baseline missing: $baseline" >&2
+    echo "  it is committed, so this means it was deleted." >&2
     echo "  first-time: run scripts/release/generate-sbom.sh <build_root>" >&2
-    exit 0
+    exit 1
 fi
 
 tmpdir=$(mktemp -d)

--- a/scripts/ci/test-gate-skip-exit-codes.sh
+++ b/scripts/ci/test-gate-skip-exit-codes.sh
@@ -85,6 +85,8 @@ check-threading-doc.sh
 check-wl-easy-opts-symbol.sh
 check-wrap-revisions.sh
 check_log_header_not_public.sh
+check-manifest-collation.sh
+check-sbom-snapshot-locale.sh
 "
 
 # Gates deliberately outside the contract, each with the reason. A gate belongs
@@ -187,7 +189,17 @@ for name in $COVERED; do
     # scripts/, which is why the scan above matches on basename.
     f="$root/scripts/ci/$name"
     [[ -f "$f" ]] || f="$root/scripts/$name"
-    [[ -f "$f" ]] || { check "$name exists" 1; continue; }
+    if [[ ! -f "$f" ]]; then
+        # Absent AND unregistered: it belongs to a branch not merged here, which
+        # is expected while these land separately. Absent BUT registered is a
+        # moved or deleted gate, and that still fails.
+        if grep -qE "scripts/[A-Za-z0-9_/-]*$name" "$root/tests/meson.build"; then
+            check "$name exists" 1
+        else
+            printf 'test-gate-skip-exit-codes: SKIPPED %s (not present on this branch)\n' "$name"
+        fi
+        continue
+    fi
     if skip_then_zero "$f"; then
         check "$name has no SKIP branch exiting 0" 1
     else

--- a/scripts/ci/test-gate-skip-exit-codes.sh
+++ b/scripts/ci/test-gate-skip-exit-codes.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# Shared self-test for the meson-registered shell gates' skip contract.
+#
+# Issue #1301. meson reads exit 0 as a pass and 77 as a skip, so a gate that
+# prints "SKIP:" and then exits 0 is recorded as having asserted something it
+# never checked. #1288 fixed one such gate; this covers the rest, and is shared
+# rather than per-gate so that a gate added later cannot quietly reintroduce the
+# defect -- the coverage assertion below fails if a meson-registered check
+# script is neither covered here nor explicitly exempted with a reason.
+#
+# Two kinds of assertion, deliberately:
+#
+#   - behavioural, where the skip can be provoked (no library, wrong host, a
+#     tool absent from PATH). These are the real ones: they run the gate.
+#   - source-level, as a backstop for branches that cannot be provoked from
+#     here (a missing en_US locale on a host that has it). These only catch a
+#     literal `exit 0`, which is stated where it matters.
+set -euo pipefail
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux|Darwin) ;;
+    *) echo "test-gate-skip-exit-codes: SKIP: needs a POSIX host"; exit 77 ;;
+esac
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-gate-skip.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+failures=0
+last_case=""
+expect_status() {
+    local name=$1 want=$2 got=0
+    shift 2
+    last_case=$name
+    "$@" >"$tmp/out" 2>"$tmp/err" || got=$?
+    if [[ "$got" == "$want" ]]; then
+        printf 'test-gate-skip-exit-codes: ok %s\n' "$name"
+    else
+        printf 'test-gate-skip-exit-codes: FAIL %s (want exit %s, got %s)\n' "$name" "$want" "$got" >&2
+        sed 's/^/    /' "$tmp/out" "$tmp/err" >&2
+        failures=$((failures + 1))
+    fi
+}
+# Asserts against the output of the most recent expect_status, whose name it
+# prints so that a misordered pair is visible rather than silently checking the
+# wrong command's output.
+expect_says() {
+    local name=$1 needle=$2
+    if grep -qF -e "$needle" "$tmp/out" "$tmp/err"; then
+        printf 'test-gate-skip-exit-codes: ok %s (output of: %s)\n' "$name" "$last_case"
+    else
+        printf 'test-gate-skip-exit-codes: FAIL %s (no %q in output of: %s)\n' "$name" "$needle" "$last_case" >&2
+        failures=$((failures + 1))
+    fi
+}
+check() {
+    local name=$1 ok=$2
+    if [[ "$ok" == 0 ]]; then
+        printf 'test-gate-skip-exit-codes: ok %s\n' "$name"
+    else
+        printf 'test-gate-skip-exit-codes: FAIL %s\n' "$name" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# Gates whose skip contract this file owns.
+# The five this issue fixes, plus every other meson-registered check script
+# that is already clean. Listing the clean ones is the point: the backstop then
+# guards them against acquiring the defect, which a list of only the broken ones
+# could not do.
+COVERED="
+check-abi-manifest.sh
+check-abi-symbols.sh
+check-abi-symbols-locale.sh
+check-abi-symbols-macos.sh
+check-sbom-snapshot.sh
+check-advanced-header.sh
+check-clang-tidy-backlog-monotonic.sh
+check-doop-catalogue.sh
+check-log-erasure.sh
+check-perf-gate-execution.sh
+check-phase-labels.sh
+check-semantics-future.sh
+check-threading-doc.sh
+check-wl-easy-opts-symbol.sh
+check-wrap-revisions.sh
+check_log_header_not_public.sh
+"
+
+# Gates deliberately outside the contract, each with the reason. A gate belongs
+# here only when exit 77 would be wrong for it, not merely inconvenient.
+#
+#   check-changelog-rc.sh   invoked as a bare `run:` step at ci-pr.yml, where
+#                           GitHub uses `bash -e` and 77 fails the job. Its skip
+#                           branch is taken on every PR to main, and the job
+#                           gates `lint` and therefore every build. Only its
+#                           self-test is meson-registered.
+#   check-no-testhook-in-libwirelog.sh
+#                           its NOTICE follows an assertion that already ran and
+#                           passed, so reporting 77 would discard a real result.
+#                           This is a genuine exemption: 77 would be wrong here.
+#   check-release-template.sh
+#                           NOT a genuine exemption -- a merge-order carve-out.
+#                           This gate has the defect, and #1288 fixes it on a
+#                           separate branch that also adds its own self-test.
+#                           Covering it here would make this file's result
+#                           depend on which branch merges first.
+#                           TODO: move to COVERED once #1288 has landed; until
+#                           then this entry is the one thing in this file that
+#                           does not meet the rule stated above.
+EXEMPT="
+check-changelog-rc.sh
+check-no-testhook-in-libwirelog.sh
+check-release-template.sh
+"
+
+# --- coverage: a gate added later cannot slip through -----------------------
+# Every check-*.sh that tests/meson.build runs must be listed above. Without
+# this the file silently stops covering the tree it claims to.
+uncovered=""
+found=0
+while IFS= read -r script; do
+    found=$((found + 1))
+    # The one pipeline left in this file, and safe in the direction that
+    # matters: the list is ~20 short lines, printf is a builtin, and a spurious
+    # non-zero adds to $uncovered and FAILS. Fail-closed, unlike skip_then_zero,
+    # which was fail-open and is why that one has no pipeline at all.
+    printf '%s\n' "$COVERED$EXEMPT" | grep -qxF "$script" || uncovered="$uncovered $script"
+done < <(grep -oE "scripts/[A-Za-z0-9_/-]+\.sh" "$root/tests/meson.build" \
+             | sed 's|.*/||' | grep -Ei '^check[_-]' | sort -u)
+# A floor, because "nothing uncovered" and "scanned nothing" are otherwise the
+# same result: replacing every path in tests/meson.build with a spelling the
+# scan cannot match made this report ok with rc 0. A restructure of how those
+# paths are written would have retired the guard silently.
+if (( found < 15 )); then
+    printf 'test-gate-skip-exit-codes: FAIL coverage scan found only %d check scripts in tests/meson.build (expected at least 15); the scan or the file has changed shape\n' "$found" >&2
+    failures=$((failures + 1))
+elif [[ -n "$uncovered" ]]; then
+    printf 'test-gate-skip-exit-codes: FAIL meson runs check scripts absent from COVERED/EXEMPT:%s\n' "$uncovered" >&2
+    failures=$((failures + 1))
+else
+    printf 'test-gate-skip-exit-codes: ok every meson-registered check script is covered or exempted (%d scanned)\n' "$found"
+fi
+
+# --- source-level backstop --------------------------------------------------
+# A branch that prints SKIP and then exits 0 within the next SIX lines. Matches
+# a literal `exit 0` only: an indirect zero (`exit $((0))`) escapes, which is
+# inherent to reading source with grep and is why the behavioural cases below
+# carry the real weight.
+#
+# TWO margins, and they are not the same size. Against false positives there
+# are 18 lines of slack: the nearest unrelated `exit 0` after any SKIP echo in
+# a covered gate is check-abi-symbols.sh:83, 18 lines away. Against false
+# NEGATIVES there is exactly ONE line: the largest live SKIP-to-exit gap is 5
+# (check-abi-manifest.sh's arm64 branch), and a 7-line gap evades this window
+# silently. Adding one diagnostic echo to that branch drops it out of coverage.
+# Quote the one-line figure, not the eighteen, when judging whether this is
+# still safe -- and prefer adding a behavioural case over widening again.
+# -A6, not -A2: check-abi-manifest.sh's arm64 arch-skip prints five diagnostic
+# lines between its SKIP echo and its exit, and that branch is the one live on
+# the ubuntu-24.04-arm required check. Two other branches sit at exactly the
+# old two-line limit, so the window had no margin and any added `echo` would
+# have silently dropped a branch out of coverage.
+#
+# Captured, not piped into `grep -q`: grep -q exits at the first match, the
+# upstream grep dies writing to the closed pipe, and `set -o pipefail`
+# propagates that -- so the `if` read false and this reported "ok" for a file
+# that had the defect. Silently open, which is the failure this file exists to
+# catch. Reproduced at 60k lines.
+skip_then_zero() {
+    local f=$1 window hits
+    # echo with either quote style, and printf: a single-quoted `echo 'SKIP: x'`
+    # or a `printf 'SKIP: ...'` is ordinary shell and evaded a double-quote-only
+    # pattern completely, giving a new gate a vacuously passing line here.
+    window=$(grep -A6 -nE "^[^#]*(echo|printf)[[:space:]]+[\"']?[^\"']*SKIP" "$f" 2>/dev/null || true)
+    # No pipeline at all. `printf ... | grep -q` and `printf ... | grep -c` are
+    # both unsafe here: the consumer stops reading (or the producer outruns the
+    # 64 KB buffer), printf takes SIGPIPE, and pipefail turns that into a
+    # non-zero status which this function reports as "no defect found" --
+    # silently open, the failure this file exists to catch. Measured at 1.5 MB:
+    # the piped forms return 1 and 141 respectively, both wrong.
+    hits=$(grep -cE '^[0-9]+-[[:space:]]*exit 0[[:space:]]*(#.*)?$' <<<"$window" || true)
+    [[ "$hits" != 0 ]]
+}
+for name in $COVERED; do
+    # Not all gates live under scripts/ci: check_log_header_not_public.sh is in
+    # scripts/, which is why the scan above matches on basename.
+    f="$root/scripts/ci/$name"
+    [[ -f "$f" ]] || f="$root/scripts/$name"
+    [[ -f "$f" ]] || { check "$name exists" 1; continue; }
+    if skip_then_zero "$f"; then
+        check "$name has no SKIP branch exiting 0" 1
+    else
+        check "$name has no SKIP branch exiting 0" 0
+    fi
+    # If a gate names the constant, it must be meson's skip code.
+    # (check-abi-symbols-macos.sh's allowlist branch is an advisory pass, not a
+    # skip: it says so and does not print "SKIP", so the scan above ignores it.)
+    if grep -qE '^[[:space:]]*SKIP_EXIT=' "$f"; then
+        if grep -qE '^[[:space:]]*SKIP_EXIT=77[[:space:]]*(#.*)?$' "$f"; then
+            check "$name defines SKIP_EXIT as 77" 0
+        else
+            check "$name defines SKIP_EXIT as 77" 1
+        fi
+    fi
+done
+
+# --- behavioural: provoke a real skip and read the status -------------------
+empty="$tmp/empty-build"; mkdir -p "$empty"
+
+# No libwirelog in the build dir: both ABI gates must skip, not pass.
+expect_status 'check-abi-symbols skips on a build tree with no library' 77 \
+    "$root/scripts/ci/check-abi-symbols.sh" "$empty"
+expect_status 'check-abi-manifest skips on a build tree with no library' 77 \
+    "$root/scripts/ci/check-abi-manifest.sh" "$empty"
+
+# syft absent: the SBOM gate must skip. PATH is rebuilt from the tools the gate
+# needs so that syft is genuinely absent without breaking anything else.
+bare="$tmp/bare"; mkdir -p "$bare"
+missing=""
+# Only what the gate touches before its syft probe. A wider list made the
+# assertion silently opt out on a minimal host for tools it never reaches;
+# `git` was needed only by the fixture that has since been deleted.
+for tool in bash sh grep sed cat dirname uname; do
+    p=$(command -v "$tool" 2>/dev/null) || { missing="$missing $tool"; continue; }
+    ln -sf "$p" "$bare/$tool"
+done
+if [[ -n "$missing" ]]; then
+    printf 'test-gate-skip-exit-codes: SKIPPED syft case (%s unavailable)\n' "${missing# }"
+else
+    no_syft() { PATH="$bare" "$root/scripts/ci/check-sbom-snapshot.sh" "$empty"; }
+    expect_status 'check-sbom-snapshot skips when syft is absent' 77 no_syft
+fi
+
+# The macOS gate on a non-macOS host, and vice versa.
+if [[ "$(uname -s)" != Darwin ]]; then
+    expect_status 'check-abi-symbols-macos skips on a non-macOS host' 77 \
+        "$root/scripts/ci/check-abi-symbols-macos.sh" "$empty"
+else
+    expect_status 'check-abi-symbols-macos skips with no dylib present' 77 \
+        "$root/scripts/ci/check-abi-symbols-macos.sh" "$empty"
+fi
+
+# A missing committed baseline is NOT a skip: those files are in the tree, so
+# their absence means one was deleted. The sibling check-abi-symbols.sh has
+# always treated the same condition as a hard failure.
+fake_build="$tmp/fake-build"; mkdir -p "$fake_build"
+: >"$fake_build/libwirelog.so"
+
+# No git fixture here, deliberately. An earlier draft built one with
+# `( cd "$d" && git init && git add -A && git commit )`, which is unsafe and was
+# also unnecessary: check-abi-manifest.sh invokes git zero times. GIT_DIR and
+# GIT_WORK_TREE override `cd` rather than supplementing it, and git exports both
+# inside hooks, `git bisect run` and `git rebase --exec` -- so under any of
+# those the fixture committed the CALLER's uncommitted work to their real
+# repository while this suite printed "all cases passed". Verified against a
+# victim repo. The #1288 commit message documents the same hazard; do not
+# reintroduce a git fixture here without a reason the gate itself requires.
+if [[ "$(uname -s)" == Linux ]] && command -v abidiff >/dev/null 2>&1; then
+    no_baseline() {
+        local d="$tmp/nobase"; rm -rf "$d"; mkdir -p "$d/abi" "$d/scripts/ci"
+        cp "$root/scripts/ci/check-abi-manifest.sh" "$d/scripts/ci/"
+        "$d/scripts/ci/check-abi-manifest.sh" "$fake_build"
+    }
+    expect_status 'a deleted ABI baseline fails rather than skipping' 1 no_baseline
+else
+    printf 'test-gate-skip-exit-codes: SKIPPED baseline case (needs Linux + abidiff)\n'
+fi
+
+# A deleted SBOM baseline must fail, not skip -- the counterpart of the ABI
+# baseline case above, and the other half of this change. Without it, mutating
+# that exit 1 to exit 0 passes the entire suite: the source backstop cannot see
+# it (the branch prints FAIL:, not SKIP:) and nothing else reaches the branch.
+sbom_no_baseline() {
+    local d="$tmp/sbom-nobase"; rm -rf "$d"; mkdir -p "$d/scripts/ci" "$d/bin"
+    cp "$root/scripts/ci/check-sbom-snapshot.sh" "$d/scripts/ci/"
+    # A syft that need not work: the gate must reach the baseline check, which
+    # sits immediately after the `command -v syft` probe.
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$d/bin/syft"
+    chmod +x "$d/bin/syft"
+    # No sbom/ directory here, so the committed baseline is "deleted".
+    PATH="$d/bin:$PATH" "$d/scripts/ci/check-sbom-snapshot.sh"
+}
+expect_status 'a deleted SBOM baseline fails rather than skipping' 1 sbom_no_baseline
+expect_says   'the SBOM baseline failure says it was deleted' 'it was deleted'
+
+if ((failures)); then
+    printf 'test-gate-skip-exit-codes: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test-gate-skip-exit-codes: all cases passed\n'

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -611,6 +611,15 @@ if not is_windows
   test('log_abi_header_not_public',
        find_program(meson.project_source_root() / 'scripts/check_log_header_not_public.sh'),
        suite: 'abi')
+  # Issue #1301: meson reads exit 0 as a pass, so a gate that prints "SKIP:"
+  # and exits 0 is recorded as having asserted something it never checked.
+  # This is shared rather than per-gate so a gate added later cannot quietly
+  # reintroduce it: the test fails if a meson-registered check script is
+  # neither covered nor explicitly exempted with a reason.
+  test('gate_skip_exit_codes',
+       find_program(meson.project_source_root() / 'scripts/ci/test-gate-skip-exit-codes.sh'),
+       suite: 'abi')
+
   # Issue #1302: the two claims are registered separately.  A provenance skip
   # (stripped or non-debug build, or a BSD nm with no --line-numbers) must not
   # be reported as the verdict for the symbol-leak check, which is unaffected by
@@ -879,8 +888,9 @@ test('scalar_function_addon_design_fixtures', py3,
 # Issue #733 K2 (cross-link #690 B3): pin the dynamic-symbol table of
 # libwirelog.so against `abi/libwirelog-1.0.symbols`.  Any new public
 # symbol must update the allowlist in the same PR; any accidental loss
-# of an exported symbol fails the gate.  Linux/ELF-focused; SKIPs
-# cleanly on platforms without `libwirelog.so` (Windows, static-only).
+# of an exported symbol fails the gate.  Linux/ELF-focused; SKIPs with
+# exit 77 on platforms without `libwirelog.so` (Windows, static-only),
+# so meson records those runs as skipped rather than passed (#1301).
 if sh.found()
   test('abi_symbols', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-abi-symbols.sh',
@@ -929,9 +939,11 @@ endif
 # Where abi_symbols only checks the dynamic-symbol set, abi_manifest uses
 # `abidiff` to catch struct member offsets, function signature changes,
 # and visibility/linkage drift that nm -D cannot see.  Linux/ELF-focused;
-# SKIPs cleanly when libwirelog.so is missing (Windows, static-only),
-# when abidiff is not on PATH, or when the baseline has not been seeded
-# yet (run scripts/release/regenerate-abi-manifest.sh to seed).  Per
+# SKIPs with exit 77 when libwirelog.so is missing (Windows,
+# static-only), when abidiff is not on PATH, or on a non-x86_64 host.
+# A missing committed baseline is a FAILURE, not a skip: it is tracked,
+# so its absence means deletion (#1301); run
+# scripts/release/regenerate-abi-manifest.sh to seed a new one.  Per
 # issue #824, the committed v1.0 libabigail baseline is x86_64-only;
 # Linux arm64 v1.0 ABI coverage is symbol-only via abi_symbols.
 if sh.found()
@@ -943,8 +955,9 @@ endif
 
 # Issue #744: SBOM snapshot gate.  Diffs the detected dependency list
 # (packages + versions) against the committed baseline (sbom/snapshot.txt).
-# SKIPs when syft is not on PATH or when the baseline has not been seeded yet
-# (run scripts/release/generate-sbom.sh to seed).  Fails when dependencies
+# SKIPs with exit 77 when syft is not on PATH (#1301).  A missing committed
+# baseline is a FAILURE, not a skip -- it is tracked, so its absence means
+# deletion; run scripts/release/generate-sbom.sh to seed.  Fails when dependencies
 # change without a baseline update (enforces explicit review of dependency drift).
 if sh.found()
   test('sbom_snapshot', sh,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -608,9 +608,6 @@ if not is_windows
 
   # Header must not leak into public surface; testhook symbols must not
   # appear in libwirelog.
-  test('log_abi_header_not_public',
-       find_program(meson.project_source_root() / 'scripts/check_log_header_not_public.sh'),
-       suite: 'abi')
   # Issue #1301: meson reads exit 0 as a pass, so a gate that prints "SKIP:"
   # and exits 0 is recorded as having asserted something it never checked.
   # This is shared rather than per-gate so a gate added later cannot quietly
@@ -618,6 +615,9 @@ if not is_windows
   # neither covered nor explicitly exempted with a reason.
   test('gate_skip_exit_codes',
        find_program(meson.project_source_root() / 'scripts/ci/test-gate-skip-exit-codes.sh'),
+       suite: 'abi')
+  test('log_abi_header_not_public',
+       find_program(meson.project_source_root() / 'scripts/check_log_header_not_public.sh'),
        suite: 'abi')
 
   # Issue #1302: the two claims are registered separately.  A provenance skip


### PR DESCRIPTION
Refs #1301. Third instance of this defect class (#1288 fixed `check-release-template.sh`, #1302 the `wl_log_emit` provenance check), so the guard here is **shared** rather than per-gate.

## The defect

Five meson-registered gates printed `SKIP: …` and exited 0. Meson reads exit 0 as a pass, so each was recorded as having asserted something it never looked at.

`check-abi-manifest.sh` · `check-abi-symbols.sh` · `check-abi-symbols-locale.sh` · `check-abi-symbols-macos.sh` · `check-sbom-snapshot.sh`

All five are reached **only** through `tests/meson.build`. 77 is safe under meson and *not* under a bare workflow `run:` step, where GitHub's `bash -e` fails the job — each header now says so.

## Two branches go the other way, to exit 1

`abi/libwirelog-1.0.abi.json` and `sbom/snapshot.txt` are committed, so absence means a baseline was **deleted**, not that the build can't answer. `check-abi-symbols.sh` has always treated a missing allowlist as a hard failure — three gates were giving three verdicts for one condition.

Both sit behind their tool probes, so exit 1 is only reachable on a host that could otherwise have checked; the release tarball ships both files; and every downstream/upgrade consumer builds `-Dtests=false`, so these gates aren't even registered there.

In `check-abi-manifest.sh` the baseline check deliberately **precedes** the arm64 arch skip: a deleted baseline is true on every architecture at once, so severity outranks environment, and the order makes the arm64 leg a second detector rather than a blind spot.

## One deliberate inconsistency

`check-abi-symbols-macos.sh` keeps exit 0 for a missing allowlist. That gate reports real symbol drift as a *warning*, so a missing allowlist — strictly less informative than drift — cannot carry a harsher status than the drift itself; and 77 would show SKIP for "no allowlist" beside OK for "the symbols diverged."

The rule the file now states: **77 means the environment cannot supply the input; once it can, the gate's own severity applies.**

**#1301 contradicts itself here**: its out-of-scope section names `:46` and `:70` as advisory by design, its exit-1 section names `:48` — the same branch's `exit`. The out-of-scope reading is coherent, and that adjudication is recorded next to the branch.

## The shared guard

Partitions every meson-registered check script into COVERED (16) or EXEMPT (3, each with a reason) and fails when one is neither. Listing the ten already-clean gates is the point — a list of only the broken ones couldn't guard them.

One exemption is honest rather than principled: `check-release-template.sh` **has** the defect and is exempted only because #1288 fixes it on another branch. It's labelled as the one entry failing the file's own rule, with a TODO to promote it.

## Four defects found in the guard itself

Three are the same class this PR exists to fix:

| defect | consequence |
|---|---|
| git fixture used `cd`, but `GIT_DIR` **overrides** it | committed the caller's uncommitted work while printing "all cases passed"; with `GIT_DIR` alone, **deletes the tracked tree**. It fired against this worktree during review. Also unnecessary — the gate invokes `git` zero times |
| `grep -A \| grep -q` under `pipefail` | `grep -q` kills its producer; reported "no defect" on a large file |
| the obvious repair, `printf \| grep -c` | failed identically — `grep -c` returns 1 on a zero count, and `\|\| true` can't distinguish that from a producer dying at 141. **Removing** the pipeline, not hardening it, was the fix |
| the coverage guard was **fail-open** | a scan matching nothing reported success — this PR's own defect one level up |

Each now has a mutation that kills it.

## Validation

- abi suite **42 Ok / 0 Fail / 0 Skipped** on Linux x86_64 with `abidiff` and `syft` present — nothing that could enforce was downgraded; a patch turning everything into 77 would show up here
- full suite 305 Ok / 0 Fail / 12 Skipped (all skips pre-existing)
- 30 assertions; mutation-tested including both exit-1 conversions, the arm64 arch-skip, three quote/`printf` evasion shapes, uppercase and underscore gate names, and an empty scan
- the backstop's window has 18 lines of false-positive slack but only **one** line against false negatives; the comment states the one-line figure, verified empirically (gap=6 caught, gap=7 evades)

Three review rounds; final verdicts Reviewer, Architect and Critic all approving.