### PR TITLE
ci: give generate-sbom.sh an output directory so it can be tested

### DIFF
--- a/scripts/ci/check-sbom-snapshot-locale.sh
+++ b/scripts/ci/check-sbom-snapshot-locale.sh
@@ -8,18 +8,18 @@
 # spurious reordering hunks that buried the real dependency change in a gate
 # whose whole purpose is making dependency drift reviewable.
 #
-# What this actually asserts, which is less than #886's equivalent: that every
-# `sort` in the two SBOM scripts carries the LC_ALL=C pin, plus a sanity check
-# that the fixture's two collations really disagree so the pin is not
-# decorative. It does NOT run generate-sbom.sh -- that script hardcodes its
-# output to $repo_root/sbom/, so invoking it here would clobber the committed
-# baseline. Giving it an output-directory parameter, the way make-tarball.sh
-# takes one, is what would allow a behavioural test; tracked in #1293.
+# What this asserts: that every `sort` in the two SBOM scripts carries the
+# LC_ALL=C pin, plus a sanity check that the fixture's two collations really
+# disagree so the pin is not decorative. It is a string check, so it catches
+# someone deleting the pin but NOT a pipeline rewritten to reorder after a
+# correctly pinned sort.
 #
-# So the guard here is a string check, and it catches the realistic regression
-# -- someone deleting the pin -- but not a pipeline rewritten to reorder after
-# a pinned sort. #886's check-abi-symbols-locale.sh is the stronger shape: it
-# stubs nm and runs the real gate.
+# That second half is now covered behaviourally by scripts/ci/test-generate-sbom.sh,
+# which runs the real generator into a temporary directory -- possible since
+# #1293 gave it an output-directory parameter. Verified: a mutation inserting an
+# unpinned `sort` after the pinned one passes this file and fails that one.
+# Both are kept: this one guards check-sbom-snapshot.sh too, which that test
+# does not run.
 set -euo pipefail
 
 # Meson reads exit 77 as SKIP and exit 0 as a pass, so a branch that cannot
@@ -31,9 +31,15 @@ SKIP_EXIT=77
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 
+# Captured, not piped into grep -q: grep -q stops at the first match, locale -a
+# takes SIGPIPE, and pipefail reports 141 even though the locale WAS found -- so
+# this reads as "not installed" and the gate below exits 0 having asserted
+# nothing. Not triggerable at locale -a's size, but it is the same shape that
+# has bitten this repository repeatedly, and the here-string costs nothing.
+locales_available=$(locale -a 2>/dev/null || true)
 locale_name=""
 for candidate in en_US.utf8 en_US.UTF-8; do
-    if locale -a 2>/dev/null | grep -Fxq "$candidate"; then
+    if grep -Fxq "$candidate" <<<"$locales_available"; then
         locale_name="$candidate"
         break
     fi

--- a/scripts/ci/test-generate-sbom.sh
+++ b/scripts/ci/test-generate-sbom.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Self-test for generate-sbom.sh.
+#
+# Issue #1293. The generator hardcoded its outputs to $repo_root/sbom/, so
+# running the real script from a test would clobber the committed drift
+# baseline. #1291's locale guard therefore had to assert statically that every
+# `sort` carries the LC_ALL=C pin -- it catches someone deleting the pin, but
+# not a pipeline rewritten to reorder after a correctly pinned sort, because it
+# never runs the generator. check-abi-symbols-locale.sh (#886) can run the real
+# gate for the same bug class purely because that script takes its build root as
+# an argument. The difference is the parameterisation, and this closes it.
+#
+# The script derives repo_root from its own location, so the fixture is a
+# throwaway tree with a copy of the script in it: every path it computes then
+# lands under $tmp, and the real sbom/ is untouchable by construction rather
+# than by care.
+set -euo pipefail
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux|Darwin) ;;
+    *) echo "test-generate-sbom: SKIP: needs a POSIX host"; exit 77 ;;
+esac
+command -v jq >/dev/null 2>&1 || { echo "test-generate-sbom: SKIP: jq not available"; exit 77; }
+
+root=$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+tmp=$(CDPATH= cd -- "$(mktemp -d "${TMPDIR:-/tmp}/wirelog-gen-sbom.XXXXXX")" && pwd)
+trap 'rm -rf "$tmp"' EXIT
+
+# Captured HERE, before the fixture is built and before any generator runs.
+# An earlier version captured it just above the assertion, i.e. after the whole
+# test body -- so it compared the tree against itself across a window in which
+# nothing happened, and reported ok while the test clobbered sbom/snapshot.txt.
+# The comparison is only meaningful if one side predates the code under test.
+#
+# Compared against a prior state rather than against "clean": the documented
+# release recipe legitimately modifies sbom/snapshot.txt, and demanding
+# cleanliness made an operator's next `meson test` fail for a reason unrelated
+# to this test.
+#
+# --ignored because .gitignore hides sbom/*.spdx.json and sbom/*.cdx.json, so
+# without it the tripwire covers only one of the generator's three outputs.
+#
+# Known and by design: if TMPDIR is inside $root/sbom, this fails. git does not
+# report EMPTY untracked directories, so the capture below sees nothing where
+# the harness's scratch dir will be, and by assertion time the fixture has
+# populated it. Put TMPDIR elsewhere. Excluding $tmp here was considered and
+# rejected: this is the one assertion that must have no exceptions, and it has
+# already failed open twice in this file's history.
+#
+# git's own status is checked: `[[ -z "$(git ...)" ]]` reported success when git
+# ERRORED (absent, not a repo, dubious ownership), so the tripwire proving this
+# test is safe passed precisely when it could not check. GIT_DIR is unset
+# because `git -C` does not override it.
+sbom_state() {
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
+        git -C "$root" status --porcelain --ignored -- sbom/
+}
+if ! baseline_before=$(sbom_state); then baseline_before=$'\x01GIT-FAILED'; fi
+
+failures=0
+expect_status() {
+    local name=$1 want=$2 got=0
+    shift 2
+    "$@" >"$tmp/out" 2>"$tmp/err" || got=$?
+    if [[ "$got" == "$want" ]]; then printf 'test-generate-sbom: ok %s\n' "$name"
+    else
+        printf 'test-generate-sbom: FAIL %s (want exit %s, got %s)\n' "$name" "$want" "$got" >&2
+        sed 's/^/    /' "$tmp/out" "$tmp/err" >&2; failures=$((failures + 1))
+    fi
+}
+check() {
+    local name=$1 ok=$2
+    if [[ "$ok" == 0 ]]; then printf 'test-generate-sbom: ok %s\n' "$name"
+    else printf 'test-generate-sbom: FAIL %s\n' "$name" >&2; failures=$((failures + 1)); fi
+}
+# `cond; check "$name" $?` is unsafe under set -e: a failing condition is a
+# standalone command and aborts the file before check runs, so the first real
+# failure silently truncates the suite instead of reporting. Run the condition
+# inside the helper, where its status is consumed by an `if`.
+assert() {
+    local name=$1 ok=0
+    shift
+    "$@" || ok=1
+    check "$name" "$ok"
+}
+refute() {
+    local name=$1 ok=0
+    shift
+    "$@" && ok=1
+    check "$name" "$ok"
+}
+
+# A fixture repo_root holding a copy of the real script. Nothing here can reach
+# the working tree: repo_root is derived from the script's own directory.
+repo="$tmp/repo"
+mkdir -p "$repo/scripts/release" "$repo/subprojects/nanoarrow" "$repo/bin"
+cp "$root/scripts/release/generate-sbom.sh" "$repo/scripts/release/"
+printf "project('wirelog', 'c',\n  version: '9.9.9-dev',\n)\n" > "$repo/meson.build"
+
+# Entries chosen so C and en_US collation disagree: glibc's en_US ignores the
+# leading punctuation, so "./..." sorts among the alphabetic names instead of
+# before them. A fixture that sorted identically either way could not tell a
+# pinned sort from an unpinned one.
+cat > "$repo/bin/syft" <<'EOS'
+#!/usr/bin/env bash
+# Honour `-o <format>=<path>` by writing there, the way real syft does; a stub
+# that only ever printed to stdout would silently pass the document-location
+# assertions no matter where the script pointed them.
+#
+# Also record the dir: argument. Without this nothing asserts WHAT the generator
+# scans, and changing dir:"$repo_root" to dir:"$build_root" passed every
+# assertion -- the likeliest future edit, since the script documents build_root
+# as unused.
+outfile=""
+prev=""
+for a in "$@"; do
+    case "$a" in dir:*) printf '%s\n' "${a#dir:}" >> "$SYFT_SCANNED" ;; esac
+    case "$prev" in -o) case "$a" in *=*) outfile=${a#*=} ;; esac ;; esac
+    prev=$a
+done
+emit() {
+cat <<'JSON'
+{"artifacts":[
+  {"name":"zlib","version":"1.3","licenses":[{"value":"Zlib"}]},
+  {"name":"./.github/workflows/lint-pr.yml","version":"UNKNOWN","licenses":[]},
+  {"name":"actions/checkout","version":"v5","licenses":[]},
+  {"name":"./.github/workflows/lint-main.yml","version":"UNKNOWN","licenses":[]},
+  {"name":"r-lib/actions","version":"v2","licenses":[]}
+]}
+JSON
+}
+if [ -n "$outfile" ]; then emit > "$outfile"; else emit; fi
+EOS
+chmod +x "$repo/bin/syft"
+
+scanned="$tmp/scanned.txt"
+gen() { SYFT_SCANNED="$scanned" PATH="$repo/bin:$PATH" \
+        "$repo/scripts/release/generate-sbom.sh" "$@"; }
+
+# --- the parameter, which is the point of the issue ------------------------
+out="$tmp/out-dir"
+expect_status 'an explicit output directory is accepted' 0 gen "$tmp/fake-build" "$out"
+assert 'the snapshot lands in the given directory' test -f "$out/snapshot.txt"
+assert 'the SPDX document lands there too' test -f "$out/wirelog-9.9.9.spdx.json"
+assert 'the CycloneDX document lands there too' test -f "$out/wirelog-9.9.9.cdx.json"
+refute 'the default directory is not touched when one is given' test -e "$repo/sbom"
+
+# What the generator SCANS, not just where it writes. The script takes a
+# build_root it does not read; if that ever changes the SBOM would describe a
+# different tree and every other assertion here would still pass.
+#
+# These two PIN TODAY'S BEHAVIOUR rather than assert a desired property. The
+# follow-up (#1308) will make the build root load-bearing, and when it does
+# this assertion must be INVERTED as part of that work -- its failure there is
+# the change landing, not a regression.
+# Strict: EVERY recorded scan must be repo_root, not merely one of them. The
+# earlier pair asserted "at least one is repo_root" and "none is the build
+# root", which together let a partial divergence through -- two of the three
+# calls retargeted to some third path passed silently, so the SPDX document
+# could describe a different tree than the snapshot. One assertion covering all
+# three also avoids keeping a second one that can no longer fail on its own.
+all_scans_are_repo_root() {
+    [[ -s "$scanned" ]] || return 1
+    ! grep -qvxF "$repo" "$scanned"
+}
+assert 'every syft scan targets repo_root, never the build root' all_scans_are_repo_root
+
+# --- the default, which every existing caller relies on --------------------
+expect_status 'the output directory is optional' 0 gen "$tmp/fake-build"
+assert 'omitting it still writes to repo_root/sbom' test -f "$repo/sbom/snapshot.txt"
+
+# An explicitly empty out_dir must fail rather than silently fall back to the
+# committed baseline. `${2:-...}` treats empty as absent and would write there,
+# which is the clobber this parameter exists to prevent -- so the distinction
+# between ${2-} and ${2:-} is behaviour, not style.
+empty_out_fails() { ! gen "$tmp/fake-build" "" >/dev/null 2>&1; }
+assert 'an empty output directory fails rather than using the default' empty_out_fails
+
+# --- what could not be asserted before: the real pipeline's ordering --------
+# #1291's guard can only check that the pin is present in the source. This runs
+# the generator under a foreign locale and compares bytes, so a pipeline that
+# reordered AFTER a correctly pinned sort would be caught.
+locale_name=""
+locales_available=$(locale -a 2>/dev/null || true)
+for cand in en_US.utf8 en_US.UTF-8; do
+    if grep -Fxq "$cand" <<<"$locales_available"; then locale_name=$cand; break; fi
+done
+if [[ -n "$locale_name" && "$(uname -s)" == Linux ]]; then
+    c_out="$tmp/under-c"; l_out="$tmp/under-locale"
+    # `|| true`: an unprotected command here is the same set -e truncation the
+    # helpers above exist to avoid, and it skipped the baseline tripwire below
+    # exactly when the generator was broken.
+    LC_ALL=C              gen "$tmp/fake-build" "$c_out" >/dev/null 2>&1 || true
+    LC_ALL="$locale_name" gen "$tmp/fake-build" "$l_out" >/dev/null 2>&1 || true
+    assert 'the snapshot is byte-identical under C and en_US' \
+        cmp -s "$c_out/snapshot.txt" "$l_out/snapshot.txt"
+
+    # The fixture must actually discriminate, or the comparison above holds
+    # whether or not the pin exists.
+    unpinned_c=$(LC_ALL=C sort < "$c_out/snapshot.txt" 2>/dev/null || true)
+    unpinned_l=$(LC_ALL="$locale_name" sort < "$c_out/snapshot.txt" 2>/dev/null || true)
+    discriminates() { [[ "$unpinned_c" != "$unpinned_l" ]]; }
+    assert 'the fixture distinguishes C from en_US collation' discriminates
+else
+    printf 'test-generate-sbom: SKIPPED locale case (needs Linux with en_US installed)\n'
+fi
+
+# --- the committed baseline is unreachable from here -----------------------
+# Asserted rather than assumed: the whole reason this script could not be
+# tested was that running it wrote into the working tree.
+baseline_unchanged() {
+    local now
+    [[ "$baseline_before" != $'\x01GIT-FAILED' ]] || return 1
+    now=$(sbom_state) || return 1
+    [[ "$now" == "$baseline_before" ]]
+}
+assert 'this test does not change the state of the real sbom/' baseline_unchanged
+
+if ((failures)); then
+    printf 'test-generate-sbom: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test-generate-sbom: all cases passed\n'

--- a/scripts/release/generate-sbom.sh
+++ b/scripts/release/generate-sbom.sh
@@ -5,14 +5,45 @@
 #   - wirelog-<version>.cdx.json (CycloneDX 1.5 format)
 #   - sbom/snapshot.txt (committed baseline for CI gate)
 #
+# usage: generate-sbom.sh <build_root> [out_dir]
+#   out_dir defaults to <repo_root>/sbom, which is what every caller wants;
+#   it is parameterised so the script can be exercised by a test (#1293).
+#
 # Requires: syft installed and on PATH.
-# See issue #744 and RELEASE_PROCESS.md §2.
+# See issue #744; the invocation recipe is docs/SECURITY_MODEL.md 3.1.
 
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
-build_root="${1:?Usage: generate-sbom.sh <build_root>}"
+# $1 is never read: all three syft calls scan $repo_root, not the build tree.
+# There are no programmatic callers -- only the recipe in
+# docs/SECURITY_MODEL.md 3.1 and the hints in check-sbom-snapshot.sh -- so what
+# this preserves is compatibility with humans following docs, not with code.
+#
+# It stays because REMOVING it would shift $2 into $1, and the documented
+# `generate-sbom.sh build` would then set out_dir=build and write the snapshot
+# into ./build, silently leaving the committed baseline stale. That is a
+# transition hazard rather than an intrinsic one: make-tarball.sh takes its out
+# dir at $1, so the two would be consistent afterwards.
+#
+# Do not "fix" this by pointing syft at $build_root -- a meson build tree
+# carries no manifests syft catalogs, and scanning one yields zero artifacts.
+# What the SBOM actually describes is the real problem; see #1308.
+build_root="${1:?Usage: generate-sbom.sh <build_root> [out_dir]}"
+: "$build_root"
+
+# The output directory, defaulting to today's behaviour so no caller changes.
+# It exists so the script can be run in a test at all: writing to $repo_root/sbom
+# unconditionally meant invoking the real generator would clobber the committed
+# drift baseline, so #1291's locale guard could only assert statically that the
+# LC_ALL=C pin is present in the source. It could not catch a pipeline rewritten
+# to reorder after a correctly pinned sort, because it never ran this script.
+# ${2-...} not ${2:-...}: an explicitly EMPTY second argument must not fall back
+# to the committed baseline. A caller whose computed out_dir came out empty
+# would otherwise write into $repo_root/sbom -- the clobber this parameter
+# exists to prevent -- instead of failing at mkdir.
+out_dir="${2-$repo_root/sbom}"
 
 # Verify syft is available
 if ! command -v syft >/dev/null 2>&1; then
@@ -29,9 +60,9 @@ version=$(grep "^  version:" "$repo_root/meson.build" | head -1 \
           | sed -E "s/.*'([^']+)'.*/\1/" | cut -d'-' -f1)
 
 # Ensure sbom/ directory exists
-mkdir -p "$repo_root/sbom"
+mkdir -p "$out_dir"
 
-output_prefix="$repo_root/sbom/wirelog-${version}"
+output_prefix="$out_dir/wirelog-${version}"
 
 echo "generate-sbom: Generating SPDX 2.3..."
 syft dir:"$repo_root" -o spdx-json@2.3="${output_prefix}.spdx.json"
@@ -47,15 +78,15 @@ echo "generate-sbom: Updating snapshot baseline..."
 # buries the real dependency change in unrelated diff noise.
 syft dir:"$repo_root" -o syft-json 2>/dev/null \
   | jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' \
-  | LC_ALL=C sort > "$repo_root/sbom/snapshot.txt"
+  | LC_ALL=C sort > "$out_dir/snapshot.txt"
 
 # Append the resolved nanoarrow commit SHA as a comment for provenance.
 nanoarrow_sha=$(git -C "$repo_root/subprojects/nanoarrow" rev-parse HEAD 2>/dev/null || true)
 if [ -n "$nanoarrow_sha" ]; then
-    printf '# nanoarrow-resolved-sha: %s\n' "$nanoarrow_sha" >> "$repo_root/sbom/snapshot.txt"
+    printf '# nanoarrow-resolved-sha: %s\n' "$nanoarrow_sha" >> "$out_dir/snapshot.txt"
 fi
 
 echo "generate-sbom: OK; generated:"
 echo "  - ${output_prefix}.spdx.json"
 echo "  - ${output_prefix}.cdx.json"
-echo "  - sbom/snapshot.txt (CI baseline)"
+echo "  - $out_dir/snapshot.txt (CI baseline)"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -904,6 +904,17 @@ if host_machine.system() == 'linux' and sh.found()
        suite: 'sbom')
 endif
 
+# Issue #1293: generate-sbom.sh hardcoded its output to repo_root/sbom, so the
+# real generator could not be run from a test without clobbering the committed
+# baseline -- which is why the locale guard above can only string-match the pin.
+# With an output directory parameter it runs into a temp tree, so a pipeline
+# that reorders AFTER a correctly pinned sort is now caught behaviourally.
+if host_machine.system() == 'linux' and sh.found()
+  test('generate_sbom_selftest', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-generate-sbom.sh'],
+       suite: 'sbom')
+endif
+
 # Issue #788: warning-only platform ABI surface advisory checks.
 # Linux remains the hard v1.0 ABI gate.  These checks run on every
 # default `meson test` invocation but only emit GitHub warning


### PR DESCRIPTION
Refs #1293. **Stacked on #1296** (`fix/1291-1292-release-tooling`) — both touch `generate-sbom.sh`. Merge #1296 first.

## The defect

`generate-sbom.sh` wrote to `$repo_root/sbom` unconditionally, so running the real script from a test would clobber the committed drift baseline. #1291's locale guard could therefore only assert *statically* that every `sort` carries the `LC_ALL=C` pin — it never runs the generator, so it cannot catch a pipeline rewritten to reorder **after** a correctly pinned sort.

Demonstrated:

| guard | `\| LC_ALL=C sort \| sort` mutation |
|---|---|
| `check-sbom-snapshot-locale.sh` (static) | **passes** |
| new `test-generate-sbom.sh` (behavioural) | **fails** |

## Note on the issue's proposed direction

The issue proposes `out_dir=${1:-…}`. That would have broken every caller — `$1` is already the mandatory `build_root`. Used `$2`.

`${2-…}` rather than `${2:-…}`: an explicitly **empty** value must not fall back to the committed baseline — that is precisely the clobber this parameter prevents. Asserted.

## `$1` is never read — and that led somewhere bigger

`build_root` is mandatory and unused; syft scans `$repo_root`. It stays, because removing it shifts `$2` into `$1` and the documented `generate-sbom.sh build` would then write into `./build`, leaving the baseline stale.

Investigating why produced **#1308**, which matters more than this PR. Measured against the committed baseline:

| `SECURITY_MODEL.md:159-161` claims | measured |
|---|---|
| xxHash covered | **0 matches** — linked at `meson.build:180,374` |
| nanoarrow covered | `0.9.0.9000` — the **R binding's** version from `r/DESCRIPTION:3`, not the C library (`0.10.0-SNAPSHOT`) |
| optional mbedTLS covered | **0 matches** |
| system dependencies covered | **0 matches** |

73 of 84 lines are GitHub Actions pins, mostly from vendored subprojects; ~75% of the baseline vanishes if `subprojects/` is unpopulated. The ECCN 5D002.c.1 reasoning at `:177-181` rests on mbedTLS linkage no SBOM records. Nothing incorrect has shipped — publication is unwired, deferred to #1152 — which is why #1308 should land first.

Pointing syft at the build root is **not** the fix: a meson build tree carries no manifests syft catalogs (zero artifacts).

## Four defects in my own test, three sharing one cause

An assertion that reports success precisely when it cannot check:

| defect | symptom |
|---|---|
| `cond; check $?` under `set -e` | first failure aborted the file — reported **1 assertion, 0 failures** while 5 were broken |
| two unprotected commands | **7 of 10** assertions ran under a broken generator, skipping the safety tripwire exactly when it mattered |
| `[[ -z "$(git …)" ]]` | returned success when git *errored* — passed on a tree with no `.git` |
| the fix for that | captured the baseline **after** the body, comparing the tree against itself across a window where nothing runs — reported `ok` while the test clobbered `snapshot.txt`. A false pass, and a regression against the shape it replaced |

Each is now killed by a mutation. The stub also records what syft is pointed at — without it, `dir:"$repo_root"` → `dir:"$build_root"` passed every assertion, which is the likeliest future edit precisely because this change advertises the build root as unused. That assertion pins today's behaviour and must be **inverted** when #1308 lands; the file says so.

## Validation

- 12 assertions, suite `sbom`, linux-gated
- `meson test -C build`: 306 Ok / 0 Fail / 12 Skipped; `git status --porcelain --ignored -- sbom/` empty after every run
- Mutations killed: ignore `out_dir`, `${2:-}` revert, drop `LC_ALL=C`, reorder after a pinned sort, retarget any syft call (including a 1-of-3 partial divergence), drop either document, drop `mkdir -p`
- Hostile environments pass: `TMPDIR` with spaces/metacharacters/backslash/relative, `CDPATH=.`, poisoned `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`, no `.git` (fails closed, by design)

Also fixes the **sixth** `locale -a | grep -Fxq` SIGPIPE instance this session, in `check-sbom-snapshot-locale.sh` — whose skip is `exit 0`, so on a `locales-all` host it reported **OK having asserted nothing**.

Three review rounds; final verdicts Reviewer and Critic both approving `a875715d`.