### PR TITLE
ci: read the project version without a pipe

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev uncrustify abigail-tools
+          sudo apt-get install -y meson ninja-build libmbedtls-dev uncrustify abigail-tools b3sum
 
       - name: Configure
         run: meson setup builddir -Dtests=true -DmbedTLS=disabled
@@ -291,7 +291,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev uncrustify abigail-tools
+          sudo apt-get install -y meson ninja-build libmbedtls-dev uncrustify abigail-tools b3sum
 
       - name: Configure
         run: meson setup builddir -Dtests=true -DmbedTLS=disabled
@@ -342,7 +342,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev uncrustify abigail-tools
+          sudo apt-get install -y meson ninja-build libmbedtls-dev uncrustify abigail-tools b3sum
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             sudo apt-get install -y clang
           fi

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build
+          sudo apt-get install -y meson ninja-build b3sum
       - name: Build and test default suite
         run: |
           meson setup build-default -Dtests=true --buildtype=debug
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build abigail-tools
+          sudo apt-get install -y meson ninja-build abigail-tools b3sum
       - name: Build and test ABI suite
         run: |
           meson setup build-abi -Dtests=true --buildtype=debug

--- a/scripts/ci/test-version-extraction.sh
+++ b/scripts/ci/test-version-extraction.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Regression test for make-tarball.sh's project-version extraction.
+#
+# Issue #1312. The version was read with `... | sed -n '...p' | head -1` under
+# `set -euo pipefail`. head exits after the first line; once sed crosses its
+# first 4 KiB stdout flush it writes into a closed pipe, takes SIGPIPE, and
+# pipefail turns the release build into a bare exit 141 with no message.
+#
+# The threshold is far lower than it looks: about 700 matching `version:`
+# lines, roughly 14 KB. This meson.build is already 25 KB, so the fixture below
+# is not an exotic size -- it is smaller than the real file.
+set -euo pipefail
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux|Darwin) ;;
+    *) echo "test-version-extraction: SKIP: needs a POSIX host"; exit 77 ;;
+esac
+for t in git sha256sum b3sum gzip sed; do
+    command -v "$t" >/dev/null 2>&1 || {
+        echo "test-version-extraction: SKIP: $t not available"; exit 77
+    }
+done
+
+# make-tarball.sh resolves its repo with `git rev-parse --show-toplevel`, so
+# these would otherwise point it at the caller's repository.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_COMMON_DIR GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_CEILING_DIRECTORIES \
+      GIT_TEMPLATE_DIR GIT_NAMESPACE GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM \
+      GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS \
+      GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_AUTHOR_DATE \
+      GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL GIT_COMMITTER_DATE
+
+root=$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+tmp=$(CDPATH= cd -- "$(mktemp -d "${TMPDIR:-/tmp}/wirelog-version-extract.XXXXXX")" && pwd)
+trap 'rm -rf "$tmp"' EXIT
+
+failures=0
+check() {
+    local name=$1 ok=$2
+    if [[ "$ok" == 0 ]]; then printf 'test-version-extraction: ok %s\n' "$name"
+    else printf 'test-version-extraction: FAIL %s\n' "$name" >&2; failures=$((failures + 1)); fi
+}
+# The condition runs inside the helper. `cond; check $?` aborts under set -e
+# before check runs, which silently truncates the suite at the first failure.
+assert() { local n=$1 ok=0; shift; "$@" || ok=1; check "$n" "$ok"; }
+
+mkdir -p "$tmp/nohooks" "$tmp/notmpl"
+mkrepo() {
+    local dir=$1
+    mkdir -p "$dir"
+    printf 'int main(void) { return 0; }\n' > "$dir/main.c"
+    git -C "$dir" -c init.templateDir="$tmp/notmpl" init -q
+    git -C "$dir" -c user.email=t@example.com -c user.name=Test \
+        -c commit.gpgsign=false -c core.hooksPath="$tmp/nohooks" \
+        -c core.excludesFile=/dev/null -c core.attributesFile=/dev/null \
+        -c core.autocrlf=false -c core.safecrlf=false add -A
+    git -C "$dir" -c user.email=t@example.com -c user.name=Test \
+        -c commit.gpgsign=false -c core.hooksPath="$tmp/nohooks" \
+        commit -qm fixture --no-verify
+}
+# GIT_CEILING_DIRECTORIES is SET, not merely unset: unsetting removes a guard,
+# whereas setting it makes `git rev-parse --show-toplevel` fail loudly rather
+# than walk up into the caller's repository if the fixture's `git init` ever
+# silently no-ops.
+build() {
+    ( CDPATH= cd -- "$1" \
+      && GIT_CEILING_DIRECTORIES="$tmp" "$root/scripts/release/make-tarball.sh" "$2" )
+}
+
+# Sized to cross BOTH thresholds, because the two rejected forms fail at
+# different ones:
+#
+#   sed | head -1   dies once sed crosses its first 4 KiB stdout flush after
+#                   head exits -- about 700 matching lines, ~14 KB.
+#   git show | sed ...q   dies once the whole blob exceeds ~70 KB -- the
+#                   64 KiB pipe capacity plus sed's 4 KiB read block, which it
+#                   drains before quitting -- independent of how many lines
+#                   match. Measured: 0/10 failures at 68,046 B, 10/10 at
+#                   72,046 B. Do not shrink this fixture toward 64 KiB; it
+#                   would pass vacuously.
+#
+# 5000 lines is ~100 KB, past both. A 40 KB fixture caught the first form and
+# silently missed the second, which is the trap this file exists to close.
+big="$tmp/big"
+{ printf "project('wirelog', 'c',\n  version: '1.2.3',\n"
+  for i in $(seq 1 5000); do printf "  version: '9.9.9',\n"; done
+  printf ')\n'; } > "$tmp/big-meson.build"
+mkdir -p "$big"; cp "$tmp/big-meson.build" "$big/meson.build"; mkrepo "$big"
+assert 'a meson.build past the SIGPIPE threshold still builds' build "$big" "$tmp/out-big"
+assert 'and produces the FIRST version, not a later one' \
+    test -f "$tmp/out-big/wirelog-1.2.3.tar.gz"
+
+# The ordinary case must keep working: the version is not on line 1, so a form
+# that quits after the first line processed returns empty.
+small="$tmp/small"
+mkdir -p "$small"
+printf "project('wirelog', 'c',\n  default_options: [],\n  version: '4.5.6',\n)\n" > "$small/meson.build"
+mkrepo "$small"
+assert 'a version below line 1 is found' build "$small" "$tmp/out-small"
+assert 'the archive carries that version' test -f "$tmp/out-small/wirelog-4.5.6.tar.gz"
+
+# A tree with no version at all must fail with the named error, not silently.
+none="$tmp/none"
+mkdir -p "$none"
+printf "project('wirelog', 'c')\n" > "$none/meson.build"
+mkrepo "$none"
+no_version() { ! build "$none" "$tmp/out-none" >/dev/null 2>&1; }
+assert 'a meson.build with no version fails' no_version
+
+if ((failures)); then
+    printf 'test-version-extraction: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test-version-extraction: all cases passed\n'

--- a/scripts/release/make-tarball.sh
+++ b/scripts/release/make-tarball.sh
@@ -6,8 +6,28 @@ repo_root=$(git rev-parse --show-toplevel)
 out_dir=${1:-"$repo_root/dist"}
 ref=${2:-HEAD}
 commit=$(git -C "$repo_root" rev-parse --verify "$ref^{commit}")
-version=$(git -C "$repo_root" show "$commit:meson.build" \
-  | sed -n "s/^  version: '\([^']*\)'.*/\1/p" | head -1)
+# Read the file into a variable, then match it: no pipeline, so nothing can
+# stop reading early and SIGPIPE its producer.
+#
+# Two forms were tried and rejected, and the thresholds are much lower than
+# they look. `sed ... | head -1` dies once sed crosses its first 4 KiB stdout
+# flush after head has exited -- about 700 matching `version:` lines, measured
+# 4/5 at 700 and 5/5 at 800, not the 10^5 first assumed. Replacing head with
+# sed's own `q` moves the early exit one stage left, and its threshold is the
+# whole blob against ~70 KB -- the 64 KiB pipe capacity plus sed's 4 KiB read
+# block -- rather than a match count: this meson.build is already 25 KiB, so
+# that form becomes reachable at under 3x growth of the file. Removing the pipe
+# is the only form with no threshold.
+#
+# The `q` stays inside the address block. A bare `s/.../p;q` quits after the
+# FIRST LINE rather than the first match, and the version is on line 4 -- that
+# form returns empty and fails the check below with "invalid project version:".
+# The narrowing this accepts: block-`q` stops at the first line matching the
+# ADDRESS even if the substitution fails, so a malformed `  version: '` with no
+# closing quote now masks a valid line below it. That is invalid meson and it
+# fails closed, but it is a behaviour change from the piped form.
+meson_build=$(git -C "$repo_root" show "$commit:meson.build")
+version=$(sed -n "/^  version: '/{s/^  version: '\([^']*\)'.*/\1/p;q;}" <<<"$meson_build")
 version=${version%%-*}
 [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
   echo "invalid project version: $version" >&2

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -746,6 +746,17 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #1312: make-tarball.sh read the project version through a pipe whose
+# consumer exits early, so once sed crossed its first stdout flush it took
+# SIGPIPE and pipefail turned the release build into a bare exit 141.  The
+# fixture is sized past both that threshold (~14 KB) and the 64 KiB pipe buffer,
+# because the two rejected forms fail at different ones.
+if sh.found()
+  test('version_extraction', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-version-extraction.sh'],
+       suite: 'abi')
+endif
+
 # Issue #747 B18: RC changelog selftest for changelog-freeze checker.
 # Shell gate uses the same shared `sh` handle to keep skip behavior
 # consistent on platforms without bash.


### PR DESCRIPTION
Refs #1312. Based on `main` — no stacking; no open PR touches `make-tarball.sh`.

## The defect

```sh
version=$(git show "$commit:meson.build" | sed -n "s/^  version: '\([^']*\)'.*/\1/p" | head -1)
```

under `set -euo pipefail`. `head` exits after the first line; once `sed` crosses its first 4 KiB stdout flush it writes into a closed pipe, takes SIGPIPE, and `pipefail` turns the release build into **a bare exit 141 with no message**.

## The threshold is much lower than the issue claimed

Measured against the real script:

| matching `version:` lines | bytes | result |
|---|---|---|
| 400 | 8,039 | ok |
| **700** | 14,039 | **4/5 fail** |
| 800 | 16,039 | **5/5 fail** |
| 40,000 | 800,039 | 5/5 fail |

So ~700 lines / 14 KB, not the 10⁵ I first asserted. **Both of my earlier numbers were wrong** — the issue claimed a second `version:` line suffices, and I then claimed 40,000 was safe. The second was an artefact of a probe whose trailing `[ -n "$v" ]` masked the assignment's status. #1312 carries the correction.

## Two rejected forms, each failing differently

| form | why rejected |
|---|---|
| `s/.../p;q` (no address block) | `q` fires after the first **line**, and the version is on **line 4** — returns empty, so every release fails `invalid project version:` |
| `git show \| sed ...;q` | moves the early exit one stage left: sed quits, **git show** takes the signal. Threshold is the blob against **~70 KB** (64 KiB pipe capacity + sed's 4 KiB read block), which this 25 KB `meson.build` reaches at under 3× growth |

Reading into a variable first is the only form with no threshold.

## The fixture is sized past *both* bars, deliberately

My first fixture was 2000 lines / 40 KB. It caught the piped-`head` form and **silently missed** the piped-`q` one, because they fail at different thresholds. Now 5000 lines / ~100 KB, and the comment says not to shrink it — 68 KB passes vacuously (0/10), 72 KB fails 10/10.

All three rejected forms are caught, in 0.16 s:

```
original | head -1   → exit 1
bare s/.../p;q       → exit 1  (also "a version below line 1 is found")
piped  ... | sed ;q  → exit 1
```

Also covers the ordinary case (version below line 1) and a `meson.build` with no version, which must fail with the named error.

## b3sum

`b3sum` is not on `ubuntu-latest` and was installed only in a job that runs no tests — so as first written this test **SKIPped in 100% of CI**, the same defect PR #1310 had. It is now installed in the jobs that run the suite. #1310 makes the identical edit on its branch; verified the two merge cleanly without double-applying.

Reviewed; no blocking issue. The reviewer refuted my original threshold, and its finding that a 40 KB fixture misses variant C is what produced the current sizing.