### PR TITLE
release: verify checksums without putting the path in the hash line

### DIFF
--- a/scripts/ci/test-release-roundtrip.sh
+++ b/scripts/ci/test-release-roundtrip.sh
@@ -251,6 +251,54 @@ no_b3() { PATH="$tmp/nob3" "$BASH" "$vr" "$archive"; }
 expect_status 'a missing b3sum is an error' 1 no_b3
 expect_says   'the missing b3sum is named' 'b3sum is required'
 
+# --- paths that make coreutils escape its output (#1311) --------------------
+# GNU sha256sum prefixes the whole line with a literal backslash when the
+# filename contains one, so passing a full path yielded "\<hash>" and the
+# comparison reported a mismatch on a byte-perfect archive. The fixture puts
+# the backslash in a PARENT directory with a plain archive name: that is the
+# shape the published recipe produces, and it is what distinguishes "the path
+# was escaped" from "the name was escaped".
+bs_dir="$tmp/bs/back\\slash"
+mkdir -p "$bs_dir"
+cp "$archive" "$archive.sha256" "$archive.blake3" "$bs_dir/"
+bs_archive="$bs_dir/wirelog-9.9.9.tar.gz"
+expect_status 'an archive under a backslash path verifies' 0 "$vr" "$bs_archive"
+expect_says   'and reports verification, not a mismatch' 'verified checksums for'
+
+# The same path must still reject a genuinely corrupt archive -- otherwise the
+# fix would have turned a false failure into a false pass.
+bs_bad="$tmp/bsbad/back\\slash"
+mkdir -p "$bs_bad"
+cp "$archive" "$archive.sha256" "$archive.blake3" "$bs_bad/"
+printf 'corruption' >> "$bs_bad/wirelog-9.9.9.tar.gz"
+expect_status 'a corrupt archive under a backslash path still fails' 1 \
+    "$vr" "$bs_bad/wirelog-9.9.9.tar.gz"
+expect_says   'and names the mismatch' 'SHA256 mismatch'
+
+# A symlinked parent followed by `..`: bash's `cd` resolves that LOGICALLY,
+# while the kernel -- and every other stage of verify-release.sh -- opens the
+# physical target. Hashing the logical path made the checksum describe a
+# different file than the one being verified, and reported success on a path
+# whose real target was tampered. This is the fail-OPEN direction, so it is
+# pinned in both directions.
+sym="$tmp/sym"; mkdir -p "$sym/a" "$sym/b"
+cp "$archive" "$sym/good.tar.gz"
+sed 's/wirelog-9\.9\.9\.tar\.gz/good.tar.gz/' "$archive.sha256" > "$sym/good.tar.gz.sha256"
+sed 's/wirelog-9\.9\.9\.tar\.gz/good.tar.gz/' "$archive.blake3" > "$sym/good.tar.gz.blake3"
+ln -s "$sym/b" "$sym/a/link"
+cp "$sym/good.tar.gz" "$sym/good.tar.gz.sha256" "$sym/good.tar.gz.blake3" "$sym/a/"
+logical_path="$sym/a/link/../good.tar.gz"
+
+expect_status 'a good archive reached through a symlinked parent verifies' 0 \
+    "$vr" "$logical_path"
+
+# Now tamper ONLY the physical target. The logical sibling stays good, so a
+# logical resolution would hash the good copy and report success.
+printf 'TAMPERED' >> "$sym/good.tar.gz"
+expect_status 'a tampered physical target is rejected, not masked by the logical path' 1 \
+    "$vr" "$logical_path"
+expect_says   'and the rejection names the mismatch' 'SHA256 mismatch'
+
 # --- argument handling ------------------------------------------------------
 expect_status 'no arguments is a usage error' 2 "$vr"
 expect_status '--signature without --certificate is a usage error' 2 \

--- a/scripts/release/verify-release.sh
+++ b/scripts/release/verify-release.sh
@@ -67,8 +67,16 @@ done
 
 command -v sha256sum >/dev/null || { echo 'sha256sum is required' >&2; exit 1; }
 command -v b3sum >/dev/null || { echo 'b3sum is required' >&2; exit 1; }
-archive_dir=$(cd "$(dirname "$archive")" && pwd)
-archive_name=$(basename "$archive")
+# -P on both cd and pwd, and physical resolution throughout: `cd` without -P is
+# LOGICAL, so a path like a/link/../f.tar.gz resolves to a/f.tar.gz for the
+# shell while the kernel -- and every other stage of this script, including
+# cosign, gh attestation and git get-tar-commit-id -- opens the physical
+# target. Hashing the logical path made the checksum describe a DIFFERENT FILE
+# than the one being verified, and reported "verified checksums for" on a path
+# whose real target was tampered. Measured. In the only script third parties
+# run to detect tampering, that is the wrong direction to be wrong in.
+archive_dir=$(CDPATH= cd -P -- "$(dirname -- "$archive")" && pwd -P)
+archive_name=$(basename -- "$archive")
 for manifest in "$sha_file" "$b3_file"; do
   manifest_name=$(awk 'NF { print $2; exit }' "$manifest")
   test "$manifest_name" = "$archive_name" || {
@@ -78,8 +86,37 @@ for manifest in "$sha_file" "$b3_file"; do
 done
 expected_sha=$(awk 'NF { print $1; exit }' "$sha_file")
 expected_b3=$(awk 'NF { print $1; exit }' "$b3_file")
-actual_sha=$(sha256sum "$archive" | awk '{print $1}')
-actual_b3=$(b3sum "$archive" | awk '{print $1}')
+# Hash from inside the archive's directory, against the bare basename, rather
+# than passing the full path.
+#
+# GNU coreutils escapes a filename containing a backslash or a newline: it
+# prefixes the WHOLE line with a literal `\` and escapes the character. Passing
+# a full path therefore yielded `\<hash>` for any archive under such a path, the
+# comparison below could never match, and this reported "SHA256 mismatch" on a
+# byte-perfect archive -- to a third party following the published verification
+# recipe, which passes an absolute path. Not embedding the path removes the
+# class; make-tarball.sh already writes its manifests this way, which is why
+# they were unaffected.
+#
+# The sed is the residue: a basename that itself needs escaping still produces
+# the marker, and stripping it is what makes the hash comparable. Neither stage
+# stops reading early, so there is no SIGPIPE here.
+#
+# It is deliberately UNPINNED by any test, and that is worth stating rather than
+# hiding. Reaching it needs a backslash in the archive's NAME, and such an
+# archive cannot get this far: the manifest-name check above reads `$2` raw, so
+# a coreutils-written manifest (which escapes the name) fails there first with
+# "checksum manifest does not name". Only a hand-written unescaped manifest
+# would exercise this line, and make-tarball.sh never produces one. A fixture
+# for that would pin the line via a scenario that cannot occur end to end, which
+# is worse than saying so. Closing the class means unescaping on the
+# manifest-reading side too; tracked separately.
+hash_of() {
+    ( CDPATH= cd -P -- "$archive_dir" && "$1" -- "$archive_name" \
+        | sed 's/^\\//' | awk '{print $1}' )
+}
+actual_sha=$(hash_of sha256sum)
+actual_b3=$(hash_of b3sum)
 test "$expected_sha" = "$actual_sha" || { echo "SHA256 mismatch for $archive" >&2; exit 1; }
 test "$expected_b3" = "$actual_b3" || { echo "BLAKE3 mismatch for $archive" >&2; exit 1; }
 


### PR DESCRIPTION
Refs #1311. **Stacked on #1310**, which stacks on #1296. Merge bottom-up.

## The defect

```sh
actual_sha=$(sha256sum "$archive" | awk '{print $1}')
```

GNU coreutils escapes a filename containing a backslash or newline by prefixing the **whole line** with a literal `\`, so `$1` became `\<hash>` and the comparison could never match:

```
before:  SHA256 mismatch for /tmp/back\slash-repro/wirelog-0.60.0.tar.gz
after:   verified checksums for /tmp/back\slash-repro/wirelog-0.60.0.tar.gz
```

`verify-release.sh` is the **only script here third parties run** — the docs publish it as the verification recipe, and that recipe passes an absolute path. So this was the project telling a downstream consumer their download was corrupt. `b3sum` uses the identical convention (verified on 1.8.7), so both halves were affected.

The fix hashes from inside the archive's directory against the bare basename — how `make-tarball.sh` already writes its manifests, and why those were unaffected.

## My first version of this fix was worse than the bug

`cd`/`pwd` without `-P` are **logical**. A path like `a/link/../f.tar.gz` resolves to `a/f.tar.gz` for the shell, while the kernel — and the `-f` test, `cosign`, `gh attestation`, `git get-tar-commit-id` — open the physical target:

```
first fix:  verified checksums for .../a/link/../f.tar.gz   exit 0   ← physical target TAMPERED
original:   SHA256 mismatch for  .../a/link/../f.tar.gz              ← correctly rejects
```

Turning a false failure into a **false pass, in a tamper-detection tool**, is the wrong direction to be wrong in. `-P` puts the checksum back in the same frame as every other stage. Both directions are now pinned; reverting to logical `cd` fails `a tampered physical target is rejected, not masked by the logical path`.

`--` on `dirname`/`basename` fixes a separate pre-existing bug: a relative archive named `-weird.tar.gz` died with `dirname: invalid option -- 'w'`.

## One line is deliberately untested, and says so

The leading-backslash strip cannot be reached end-to-end: a backslash in the archive's *name* fails the manifest-name check first, because that check reads its field raw. Only a hand-written unescaped manifest would exercise it. I wrote a fixture for it, found it couldn't pass, and **removed it** rather than pin a line through a scenario that cannot occur — the comment states the gap instead of leaving it looking covered.

Closing the class properly means unescaping on the manifest-reading side too. Filed separately.

## Validation

- 38 assertions; full suite 306 Ok / 0 Fail / 12 Skipped
- Mutations killed: logical `cd` (the fail-open regression), the original full-path hashing, and an always-pass hasher
- Reviewer independently probed relative paths, `./name`, `../ok/name`, symlinked archive *file*, symlinked parent without `..`, a **two-level** symlink chain, explicit relative manifests from a third cwd, spaces and newlines in the directory, poisoned `CDPATH`, execute-only ancestors, and `>PATH_MAX` — all agree with HEAD except the cases this fixes
- No residue; the symlink fixture lives under the harness `mktemp -d`

Reviewed twice; the blocking finding was the fail-open regression above, which I reproduced before fixing.