### PR TITLE
release: retry the attestation download, and say why when it fails

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -363,11 +363,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          (cd dist && gh attestation download "wirelog-"*.tar.gz \
-            --repo "$GITHUB_REPOSITORY" --limit 1)
-          attestation=$(find dist -maxdepth 1 -type f -name 'sha256*.jsonl' -print -quit)
-          test -n "$attestation"
-          mv "$attestation" "dist/wirelog-${TAG_REF#v}.intoto.jsonl"
+          scripts/release/download-attestation.sh dist "${TAG_REF#v}"
       - name: Install cosign
         # Pinned to a commit rather than a floating major, deliberately against
         # the convention used elsewhere in this repository: this is the only job

--- a/scripts/ci/test-attestation-download.sh
+++ b/scripts/ci/test-attestation-download.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Self-test for download-attestation.sh.
+#
+# Issue #1290. The attestation download had no retry, and the path it guards
+# runs for the first time on a real release tag -- which cannot be rebuilt if
+# it fails. gh is stubbed here so the retry behaviour is exercised without
+# cutting one.
+set -euo pipefail
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux|Darwin) ;;
+    *) echo "test-attestation-download: SKIP: needs a POSIX host"; exit 77 ;;
+esac
+
+root=$(CDPATH= cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)
+tmp=$(CDPATH= cd -P -- "$(mktemp -d "${TMPDIR:-/tmp}/wirelog-attest.XXXXXX")" && pwd -P)
+trap 'rm -rf "$tmp"' EXIT
+dl="$root/scripts/release/download-attestation.sh"
+
+failures=0
+last_case=""
+expect_status() {
+    local name=$1 want=$2 got=0
+    shift 2
+    last_case=$name
+    "$@" >"$tmp/out" 2>"$tmp/err" || got=$?
+    if [[ "$got" == "$want" ]]; then printf 'test-attestation-download: ok %s\n' "$name"
+    else
+        printf 'test-attestation-download: FAIL %s (want exit %s, got %s)\n' "$name" "$want" "$got" >&2
+        sed 's/^/    /' "$tmp/out" "$tmp/err" >&2; failures=$((failures + 1))
+    fi
+}
+expect_says() {
+    local name=$1 needle=$2
+    if grep -qF -e "$needle" "$tmp/out" "$tmp/err"; then
+        printf 'test-attestation-download: ok %s (output of: %s)\n' "$name" "$last_case"
+    else
+        printf 'test-attestation-download: FAIL %s (no %q in output of: %s)\n' "$name" "$needle" "$last_case" >&2
+        failures=$((failures + 1))
+    fi
+}
+check() { local n=$1 ok=$2; if [[ "$ok" == 0 ]]; then printf 'test-attestation-download: ok %s\n' "$n"
+    else printf 'test-attestation-download: FAIL %s\n' "$n" >&2; failures=$((failures + 1)); fi; }
+# The condition runs inside the helper: `cond; check $?` aborts under set -e
+# before check runs, truncating the suite at the first failure.
+assert() { local n=$1 ok=0; shift; "$@" || ok=1; check "$n" "$ok"; }
+refute() { local n=$1 ok=0; shift; "$@" && ok=1; check "$n" "$ok"; }
+
+bin="$tmp/bin"; mkdir -p "$bin"
+# A gh that succeeds only on the Nth call, writing the bundle the real one
+# would. GH_STUB_SUCCEED_ON=0 never succeeds. The counter is a file because
+# each invocation is a fresh process.
+cat > "$bin/gh" <<'EOS'
+#!/usr/bin/env bash
+n=$(( $(cat "$GH_STUB_COUNT" 2>/dev/null || echo 0) + 1 ))
+printf '%s' "$n" > "$GH_STUB_COUNT"
+if [ "${GH_STUB_SUCCEED_ON:-1}" != 0 ] && [ "$n" -ge "${GH_STUB_SUCCEED_ON:-1}" ]; then
+    printf '{"bundle":"stub"}\n' > "sha256:deadbeef.jsonl"
+    exit 0
+fi
+echo "no attestations found for subject" >&2
+exit 1
+EOS
+chmod +x "$bin/gh"
+
+newdist() {
+    local d="$tmp/$1"; rm -rf "$d"; mkdir -p "$d"
+    printf 'archive\n' > "$d/wirelog-9.9.9.tar.gz"
+    printf '%s\n' "$d"
+}
+run() {
+    local d=$1 on=$2
+    GH_STUB_COUNT="$d/.count" GH_STUB_SUCCEED_ON="$on" \
+    WIRELOG_ATTESTATION_ATTEMPTS=3 WIRELOG_ATTESTATION_DELAY=0 \
+    PATH="$bin:$PATH" "$dl" "$d" 9.9.9 owner/repo
+}
+
+# First attempt succeeds: the ordinary path.
+d=$(newdist first)
+expect_status 'a first-attempt download succeeds' 0 run "$d" 1
+assert 'the bundle is renamed to the release name' test -f "$d/wirelog-9.9.9.intoto.jsonl"
+refute 'the raw sha256 bundle name is gone' test -f "$d/sha256:deadbeef.jsonl"
+refute 'no download log is left behind' test -f "$d/.attestation-download.log"
+
+# The case this issue exists for: the first call finds nothing, a later one
+# succeeds. Without a retry this was a hard failure on an unrebuildable tag.
+d=$(newdist lag)
+expect_status 'a download that only succeeds on the third attempt still succeeds' 0 run "$d" 3
+assert 'and produces the bundle' test -f "$d/wirelog-9.9.9.intoto.jsonl"
+attempts_made() { [[ "$(cat "$d/.count")" == 3 ]]; }
+assert 'it actually retried rather than succeeding by luck' attempts_made
+
+# Never succeeds: must fail with a diagnosis, not a bare non-zero.
+d=$(newdist never)
+expect_status 'a download that never succeeds fails' 1 run "$d" 0
+expect_says 'the failure names replication lag as the usual cause' 'replication lag'
+# Needle chosen against the stub's own stderr: the stub says "no attestations
+# found for subject", so a needle of 'attestations' was satisfied by the quoted
+# gh output and gave false credit for the diagnosis. Deleting both URL lines
+# left the suite green. This matches text only the script can produce.
+expect_says 'it points at the attestations page' 're-running this job alone'
+expect_says "it quotes gh rather than guessing" 'no attestations found'
+exhausted() { [[ "$(cat "$d/.count")" == 3 ]]; }
+assert 'it used every attempt before giving up' exhausted
+refute 'and cleans up its log' test -f "$d/.attestation-download.log"
+
+# A bundle left by an earlier run must not be mistaken for this run's download.
+# With gh failing every time, the stale file would otherwise satisfy the
+# existence check on the first attempt and be published as this release's
+# provenance.
+d=$(newdist stale)
+printf 'STALE-LEFTOVER\n' > "$d/sha256:cafebabe.jsonl"
+expect_status 'a stale bundle does not mask a failing download' 1 run "$d" 0
+refute 'and the stale bundle is not renamed into place' test -f "$d/wirelog-9.9.9.intoto.jsonl"
+
+# A zero or non-numeric attempt count must be rejected, not silently run the
+# loop zero times and then report the replication-lag diagnosis.
+d=$(newdist badattempts)
+bad_attempts() {
+    GH_STUB_COUNT="$d/.count" GH_STUB_SUCCEED_ON=1 \
+    WIRELOG_ATTESTATION_ATTEMPTS=0 WIRELOG_ATTESTATION_DELAY=0 \
+    PATH="$bin:$PATH" "$dl" "$d" 9.9.9 owner/repo
+}
+expect_status 'a zero attempt count is a usage error' 2 bad_attempts
+expect_says   'and says what was wrong' 'positive integer'
+
+# Argument handling.
+expect_status 'no arguments is a usage error' 2 "$dl"
+expect_status 'a missing dist directory is a usage error' 2 "$dl" "$tmp/nope" 9.9.9 o/r
+d=$(newdist norepo)
+no_repo() { GH_STUB_COUNT="$d/.count" PATH="$bin:$PATH" GITHUB_REPOSITORY= "$dl" "$d" 9.9.9; }
+expect_status 'a missing repository is a usage error' 2 no_repo
+expect_says 'and says so' 'repository is required'
+
+# No archive to attest: distinct from "no attestation for the archive".
+d="$tmp/empty"; rm -rf "$d"; mkdir -p "$d"
+no_archive() { GH_STUB_COUNT="$d/.count" PATH="$bin:$PATH" "$dl" "$d" 9.9.9 o/r; }
+expect_status 'a dist with no archive fails' 1 no_archive
+expect_says 'and names the missing archive, not a missing attestation' 'no wirelog-*.tar.gz'
+
+if ((failures)); then
+    printf 'test-attestation-download: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test-attestation-download: all cases passed\n'

--- a/scripts/release/download-attestation.sh
+++ b/scripts/release/download-attestation.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Download the SLSA provenance attestation bundle for a release archive.
+#
+# Issue #1290. The workflow attested the archive and then downloaded the bundle
+# in the next step, back to back, with no delay and no retry. Those are two
+# separate API operations: if the attestations API is not read-your-writes
+# consistent, the download returns nothing, and the job died on a bare
+# `test -n` with no indication of why -- after every verification job had
+# already passed, on a tag that cannot be rebuilt.
+#
+# This lives in a script rather than inline in the workflow so it can be
+# exercised without cutting a release. That is the point: the path it guards
+# runs for the first time on a real one.
+#
+# usage: download-attestation.sh DIST_DIR VERSION [REPO]
+#
+# Exit codes:
+#    0 - the bundle was downloaded and renamed.
+#    1 - it could not be, with a diagnosis.
+#    2 - usage error.
+set -euo pipefail
+
+usage() {
+    echo "usage: download-attestation.sh DIST_DIR VERSION [REPO]" >&2
+    exit 2
+}
+[[ $# -ge 2 && $# -le 3 ]] || usage
+dist=$1
+version=$2
+repo=${3:-${GITHUB_REPOSITORY:-}}
+[[ -n "$repo" ]] || { echo 'download-attestation: repository is required (argument or GITHUB_REPOSITORY)' >&2; exit 2; }
+[[ -d "$dist" ]] || { echo "download-attestation: not a directory: $dist" >&2; exit 2; }
+
+command -v gh >/dev/null 2>&1 || {
+    echo 'download-attestation: gh is required' >&2
+    exit 1
+}
+
+# Bounded, and short. Replication lag on a read-after-write is the failure this
+# exists for, so seconds are the right scale; a long backoff would only delay a
+# genuine outage. Overridable so the self-test does not sleep.
+attempts=${WIRELOG_ATTESTATION_ATTEMPTS:-5}
+delay=${WIRELOG_ATTESTATION_DELAY:-3}
+
+archive=$(find "$dist" -maxdepth 1 -type f -name 'wirelog-*.tar.gz' -print -quit)
+[[ -n "$archive" ]] || {
+    echo "download-attestation: no wirelog-*.tar.gz in $dist" >&2
+    echo '  the attestation is for the archive; build it first.' >&2
+    exit 1
+}
+archive_name=$(basename -- "$archive")
+
+# Clear any bundle left by an earlier run BEFORE the loop. Success below is
+# decided by "a sha256*.jsonl exists", and with `|| true` swallowing gh's
+# status a stale file would satisfy that on the first attempt -- one gh call,
+# its failure discarded, and last release's provenance renamed and published as
+# this one's. The inline version this replaces could not do that, because gh's
+# exit aborted the step; the retry loop is what makes the guard necessary.
+rm -f -- "$dist"/sha256*.jsonl
+
+# A non-numeric or zero attempt count would run the loop zero times, never call
+# gh, and still print the full replication-lag diagnosis -- a confidently wrong
+# answer.
+[[ "$attempts" =~ ^[1-9][0-9]*$ ]] || {
+    echo "download-attestation: attempts must be a positive integer, got: $attempts" >&2
+    exit 2
+}
+
+found=""
+for attempt in $(seq 1 "$attempts"); do
+    # `|| true`: a failed download is the expected transient case, not a reason
+    # to abort before the retry loop has had its say. The output is kept so the
+    # final diagnosis can quote gh rather than guess.
+    ( CDPATH= cd -P -- "$dist" \
+      && gh attestation download "$archive_name" --repo "$repo" --limit 1 ) \
+      >"$dist/.attestation-download.log" 2>&1 || true
+    found=$(find "$dist" -maxdepth 1 -type f -name 'sha256*.jsonl' -print -quit)
+    [[ -n "$found" ]] && break
+    if [[ "$attempt" -lt "$attempts" ]]; then
+        echo "download-attestation: attempt $attempt/$attempts found no bundle; retrying in ${delay}s" >&2
+        sleep "$delay"
+    fi
+done
+
+if [[ -z "$found" ]]; then
+    echo "download-attestation: no attestation bundle for $archive_name after $attempts attempts" >&2
+    echo '  The attest step and this download are separate API operations, so the' >&2
+    echo '  usual cause is replication lag rather than a missing attestation.' >&2
+    echo "  Check https://github.com/$repo/attestations before re-running; if the" >&2
+    echo '  attestation is listed there, re-running this job alone is enough.' >&2
+    echo '  gh said:' >&2
+    # Order matters: >&2 first duplicates the real stderr into stdout, THEN
+    # 2>/dev/null silences sed's own errors. Reversed, stdout follows fd2 to
+    # /dev/null and the gh output this line exists to show is swallowed.
+    sed 's/^/    /' "$dist/.attestation-download.log" >&2 2>/dev/null || true
+    rm -f "$dist/.attestation-download.log"
+    exit 1
+fi
+
+rm -f "$dist/.attestation-download.log"
+mv -- "$found" "$dist/wirelog-$version.intoto.jsonl"
+echo "download-attestation: OK; wirelog-$version.intoto.jsonl"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -766,6 +766,18 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #1290: the release job attested the archive and downloaded the bundle
+# back to back with no retry.  Those are separate API operations, so replication
+# lag killed the job on a bare `test -n` -- after every verification job had
+# passed, on a tag that cannot be rebuilt.  The retry now lives in a script so
+# it can be exercised without cutting a release, which is the point: the path it
+# guards runs for the first time on a real one.
+if sh.found()
+  test('attestation_download', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-attestation-download.sh'],
+       suite: 'abi')
+endif
+
 # Issue #747 B18: RC changelog selftest for changelog-freeze checker.
 # Shell gate uses the same shared `sh` handle to keep skip behavior
 # consistent on platforms without bash.


### PR DESCRIPTION
Refs #1290. **Stacked on #1289**, which owns `release-tag.yml`.

## The defect

The workflow attested the archive and downloaded the bundle in the next step, back to back, with no delay and no retry:

```yaml
(cd dist && gh attestation download "wirelog-"*.tar.gz --repo "$GITHUB_REPOSITORY" --limit 1)
attestation=$(find dist -maxdepth 1 -type f -name 'sha256*.jsonl' -print -quit)
test -n "$attestation"
```

Those are separate API operations. Without read-your-writes consistency the download returns nothing and the job dies on a bare `test -n` — **after every verification job has passed, on a tag that cannot be rebuilt.**

## Extracted, not just patched

The retry lives in `scripts/release/download-attestation.sh` so it can be exercised without cutting a release. That is the point rather than a side benefit: this is code whose first real execution is a release. Same reasoning #1293 established for `generate-sbom.sh`.

The failure path now diagnoses:

```
no attestation bundle for wirelog-9.9.9.tar.gz after 5 attempts
  The attest step and this download are separate API operations, so the
  usual cause is replication lag rather than a missing attestation.
  Check https://github.com/<repo>/attestations before re-running; if the
  attestation is listed there, re-running this job alone is enough.
  gh said: ...
```

## Two problems the retry itself created

Both found in review, both regressions against the inline original:

| problem | why it exists |
|---|---|
| a **stale bundle** from an earlier run satisfied the existence check on attempt 1, and would be renamed and published as this release's provenance | swallowing `gh`'s status (needed so a transient failure doesn't abort before the loop runs) means success is decided by "a bundle exists", not "this download produced one". The inline form couldn't do this — `gh`'s exit aborted the step |
| a zero/non-numeric attempt count ran the loop **zero times**, never called `gh`, and still printed the full replication-lag diagnosis | a confidently wrong answer |

Both guarded and pinned. Currently unreachable in CI (fresh VM per job), but the guard is now the code rather than runner ephemerality.

Also fixed in review: an assertion that gave **false credit** for the diagnosis text — the needle `attestations` was satisfied by the stub's own stderr (`no attestations found for subject`), so deleting the URL and re-run guidance left the suite green. It now matches text only the script can produce.

## Validation

- 23 assertions, suite `abi`. Confirmed by the reviewer to **actually run** in `release-tag.yml`'s ABI job and `ci-pr.yml` — needs only bash and a stubbed `gh`, no `b3sum`. (I have shipped two tests this session that skipped in 100% of CI; this one was checked.)
- Mutations killed: removing the retry (the original bug), removing the stale-bundle guard, removing the attempts validation, removing the URL guidance, `cp` instead of `mv`, dropping the `gh` quote, leaving the log behind
- The test asserts it *actually retried*, by counting stub invocations, rather than inferring it from success
- No pipelines in the new script, so the `pipefail` early-exit class this repo has hit seven times is structurally absent
- Full suite 306 Ok / 0 Fail / 12 Skipped

One redirection-order bug of mine was caught by the suite itself: `2>/dev/null >&2` sends stdout to `/dev/null`, swallowing the `gh` output that line exists to print.