### PR TITLE
fix(release): anchor the Sigstore certificate identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ All notable changes to wirelog are documented in this file.
 
 ### Security
 
+- **Release signature verification now names the release workflow.** cosign
+  matches `--certificate-identity-regexp` unanchored, and the pattern was a bare
+  prefix, so it accepted a certificate minted by any workflow in this repository
+  granted `id-token: write`. It is now anchored to `release-tag.yml` and
+  constrained to `refs/heads/main` or a tag — a run mints a certificate for the
+  workflow file as it exists at the ref being run, so an unconstrained ref would
+  let anyone with write access run a modified `release-tag.yml` and mint an
+  accepted certificate. Both refs are admitted deliberately: the manual
+  immutable-rerun path dispatches from `main` while checking out the tag.
+  Two residuals are documented rather than closed, because no identity pattern
+  can close either: the certificate names the workflow file and not the job
+  (#1319), and `refs/tags/` accepts any tag name (#1318). No published artifact
+  is affected — signing landed after v0.60.0, so no release certificate has been
+  minted yet (#1287).
+
 - **Sigstore keyless signing of release artifacts** (#750): the release-tag
   workflow now signs the source archive with `cosign sign-blob`, emitting a
   detached signature, the Fulcio certificate, and a bundle carrying the Rekor

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -113,7 +113,7 @@ Requires `cosign` on `PATH`. Under the hood this runs:
 ```bash
 cosign verify-blob \
     --certificate wirelog-X.Y.Z.tar.gz.pem \
-    --certificate-identity-regexp 'https://github.com/semantic-reasoning/wirelog/.github/workflows/' \
+    --certificate-identity-regexp '^https://github\.com/semantic-reasoning/wirelog/\.github/workflows/release-tag\.yml@refs/(heads/main$|tags/)' \
     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
     --signature wirelog-X.Y.Z.tar.gz.sig \
     wirelog-X.Y.Z.tar.gz
@@ -122,19 +122,39 @@ cosign verify-blob \
 Use the raw form if you do not have the repository checked out, or do not have
 the checksum files.
 
-Note the identity pattern is a bare prefix and cosign matches it unanchored, so
-it currently accepts a certificate minted by *any* workflow in this repository
-rather than only the release workflow. In practice that means any workflow
-granted `id-token: write`, which today is only `release-tag.yml`. Anchoring the
-pattern is tracked in
-[#1287](https://github.com/semantic-reasoning/wirelog/issues/1287).
+Note the identity pattern is anchored and names the release workflow, because
+cosign matches `--certificate-identity-regexp` unanchored: a bare prefix would
+accept a certificate minted by *any* workflow in this repository granted
+`id-token: write`. It also constrains the ref, because a workflow run mints a
+certificate for the workflow file **as it exists at the ref being run** — so an
+unconstrained ref would let anyone with write access run a modified
+`release-tag.yml` and mint a certificate this recipe accepts. Both `refs/tags/`
+and `refs/heads/main` are admitted deliberately: the manual immutable-rerun path
+dispatches from `main` while checking out the tag, so requiring a tag ref would
+reject it ([#1287](https://github.com/semantic-reasoning/wirelog/issues/1287)).
+
+Two things the pattern deliberately does **not** bound, so that you can judge
+what this signature is worth rather than assume:
+
+- **Which job minted it.** The certificate identifies the workflow file, not the
+  job — there is no job discriminator in the SAN or in the GitHub OID extensions
+  — and `release-tag.yml` currently grants `id-token: write` to all of its jobs.
+  No identity pattern can separate them; only the workflow's `permissions:` block
+  can ([#1319](https://github.com/semantic-reasoning/wirelog/issues/1319)).
+- **Which tag.** `refs/tags/` accepts any tag name, and the attacker picks the
+  name, so no regex closes this. It needs tag protection or a protected Actions
+  environment ([#1318](https://github.com/semantic-reasoning/wirelog/issues/1318)).
+
+Both require repository write access. Neither affects any published artifact
+today: signing landed after `v0.60.0`, so no release certificate has been minted
+in this repository yet.
 
 ### With the bundle — the recipe that keeps working
 
 ```bash
 cosign verify-blob \
     --bundle wirelog-X.Y.Z.tar.gz.cosign.bundle \
-    --certificate-identity-regexp 'https://github.com/semantic-reasoning/wirelog/.github/workflows/' \
+    --certificate-identity-regexp '^https://github\.com/semantic-reasoning/wirelog/\.github/workflows/release-tag\.yml@refs/(heads/main$|tags/)' \
     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
     wirelog-X.Y.Z.tar.gz
 ```
@@ -180,7 +200,7 @@ gh attestation verify wirelog-X.Y.Z.tar.gz \
     --repo semantic-reasoning/wirelog \
     --bundle wirelog-X.Y.Z.intoto.jsonl \
     --predicate-type https://slsa.dev/provenance/v1 \
-    --cert-identity-regex 'https://github.com/semantic-reasoning/wirelog/.github/workflows/' \
+    --cert-identity-regex '^https://github\.com/semantic-reasoning/wirelog/\.github/workflows/release-tag\.yml@refs/(heads/main$|tags/)' \
     --cert-oidc-issuer 'https://token.actions.githubusercontent.com'
 ```
 

--- a/scripts/ci/test-identity-pattern.sh
+++ b/scripts/ci/test-identity-pattern.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# Self-test for the Sigstore certificate-identity pattern.
+#
+# Issue #1287. cosign matches --certificate-identity-regexp UNANCHORED, and the
+# pattern was a bare prefix, so it accepted a SAN from any workflow in this
+# repository. The signer and the verifier each carry a copy, and the docs carry
+# three more; nothing checked that they agreed or that the pattern rejected
+# anything.
+#
+# Every candidate below is a LITERAL SAN string, written out in full. The issue
+# warns why: a test that builds a candidate by concatenating the pattern with a
+# workflow name is a tautology -- the constructed string begins with the pattern
+# text and matching is unanchored, so it passes for every input, including for a
+# pattern that rejects nothing.
+set -euo pipefail
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux|Darwin) ;;
+    *) echo "test-identity-pattern: SKIP: needs a POSIX host"; exit 77 ;;
+esac
+
+root=$(CDPATH= cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)
+failures=0
+check() {
+    local name=$1 ok=$2
+    if [[ "$ok" == 0 ]]; then printf 'test-identity-pattern: ok %s\n' "$name"
+    else printf 'test-identity-pattern: FAIL %s\n' "$name" >&2; failures=$((failures + 1)); fi
+}
+assert() { local n=$1 ok=0; shift; "$@" || ok=1; check "$n" "$ok"; }
+refute() { local n=$1 ok=0; shift; "$@" && ok=1; check "$n" "$ok"; }
+
+# Read the pattern from each script the way a reader would: the DEFAULT
+# assignment at the start of the file, not the `identity_regexp=$2` in the
+# argument parser. The issue flags that trap explicitly -- a naive match on
+# `identity_regexp=` finds the parser line and tests nothing.
+# Exactly one top-level assignment, not the first of several: a second one
+# would be the effective value while this validated the first. The sibling
+# test-release-signing.sh takes the same care for the same reason.
+constant_from() {
+    local file=$1 name=$2 hits
+    hits=$(grep -c "^$name='" "$file")
+    [[ "$hits" == 1 ]] || {
+        echo "test-identity-pattern: expected exactly one $name= in $file, found $hits" >&2
+        return 1
+    }
+    grep -m1 "^$name='" "$file" | sed "s/^$name='//; s/'\$//"
+}
+pattern_from() { constant_from "$1" identity_regexp; }
+
+# Reject any escape other than \. : the two engines disagree about what an
+# escape MEANS. `\d` is a digit class to Go and a literal `d` to POSIX ERE, and
+# some sequences Go rejects outright. Either way, a pattern that passed this
+# suite could behave differently under cosign on tag day -- the failure mode
+# these tests exist to prevent. A whitelist, so it covers constructs not
+# enumerated here.
+only_dot_escapes() { ! grep -qE '\\[^.]' <<<"$1"; }
+verify_pat=$(pattern_from "$root/scripts/release/verify-release.sh")
+sign_pat=$(pattern_from "$root/scripts/release/sign-artifacts.sh")
+
+shaped() { [[ "$1" =~ ^\^https ]]; }
+assert 'the verifier pattern was read, and is anchored' shaped "$verify_pat"
+assert 'the signer pattern was read, and is anchored' shaped "$sign_pat"
+assert 'the verifier pattern uses no escape the two engines read differently' \
+    only_dot_escapes "$verify_pat"
+# Also the signer: same() covers this transitively, but only while same() holds.
+assert 'the signer pattern uses no escape the two engines read differently' \
+    only_dot_escapes "$sign_pat"
+
+# The signer and verifier must agree, or an artifact signs under one policy and
+# verifies under another.
+same() { [[ "$verify_pat" == "$sign_pat" ]]; }
+assert 'the signer and verifier use the same pattern' same
+
+# The rationale ABOVE the constant must match too. release_signing_contract
+# asserts sign_identity == verify_identity -- the value, not the prose -- so a
+# correction applied to one script and not the other survives every other gate,
+# and the two files then publish different accounts of the same policy. That is
+# not hypothetical: in this change the docs fell two rounds behind the scripts
+# for exactly this reason, in a file nothing compared.
+rationale_of() {
+    sed -n '/^# Anchored at the start/,/^identity_regexp=/p' "$1"
+}
+rationale_same() {
+    local a b
+    a=$(rationale_of "$root/scripts/release/verify-release.sh")
+    b=$(rationale_of "$root/scripts/release/sign-artifacts.sh")
+    # Two empty extractions compare equal, so require the block to be found
+    # before believing the agreement -- the same trap check-manifest-collation.sh
+    # hit when its sed range stopped matching.
+    if [[ "$(printf '%s\n' "$a" | grep -c .)" -lt 10 ]]; then
+        printf 'rationale block not found in verify-release.sh\n' >&2
+        return 1
+    fi
+    [[ "$a" == "$b" ]]
+}
+assert 'the signer and verifier carry the same rationale' rationale_same
+
+# cosign uses Go's regexp, whose syntax grep -E follows closely enough for the
+# constructs here (anchors, escaped dots, literals). No early-exit consumer.
+matches() { printf '%s\n' "$2" | grep -qE -- "$1"; }
+
+# --- accepted: the real release workflow, on the refs it actually runs from ---
+assert 'a tag-push SAN is accepted' matches "$verify_pat" \
+  'https://github.com/semantic-reasoning/wirelog/.github/workflows/release-tag.yml@refs/tags/v1.0.0'
+# release-tag.yml is dispatchable as well as tag-triggered, and a dispatch's
+# OIDC ref claim names the dispatched ref rather than the tag the job checks
+# out, so rejecting this would break the manual immutable-rerun path from
+# #1272. Derived from the workflow's triggers: no certificate has ever been
+# minted in this repository, so there is no observed SAN behind this case.
+assert 'a workflow_dispatch SAN on main is accepted' matches "$verify_pat" \
+  'https://github.com/semantic-reasoning/wirelog/.github/workflows/release-tag.yml@refs/heads/main'
+
+# --- rejected -----------------------------------------------------------------
+# Most of these the old bare prefix accepted; the two owner cases it already
+# rejected, since owner and repo cannot contain a slash. They are kept because
+# they are still killable (widening the owner to [^/]+ fails them), not because
+# they discriminate old from new.
+refute 'a different workflow in this repository is rejected' matches "$verify_pat" \
+  'https://github.com/semantic-reasoning/wirelog/.github/workflows/ci-pr.yml@refs/heads/main'
+refute 'a lookalike workflow filename is rejected' matches "$verify_pat" \
+  'https://github.com/semantic-reasoning/wirelog/.github/workflows/release-tag.yml.evil@refs/heads/main'
+refute 'a prefixed workflow filename is rejected' matches "$verify_pat" \
+  'https://github.com/semantic-reasoning/wirelog/.github/workflows/not-release-tag.yml@refs/heads/main'
+refute 'another repository is rejected' matches "$verify_pat" \
+  'https://github.com/attacker/wirelog/.github/workflows/release-tag.yml@refs/heads/main'
+refute 'another owner with a matching suffix is rejected' matches "$verify_pat" \
+  'https://github.com/evil-semantic-reasoning/wirelog/.github/workflows/release-tag.yml@refs/tags/v1.0.0'
+# The leading ^ is what stops a SAN that merely CONTAINS the expected identity.
+refute 'a SAN with the identity embedded later is rejected' matches "$verify_pat" \
+  'https://github.com/attacker/evil/x?u=https://github.com/semantic-reasoning/wirelog/.github/workflows/release-tag.yml@refs/tags/v1.0.0'
+# The escaped dots matter: an unescaped . would accept any character there.
+refute 'a host with a different character where a dot belongs is rejected' matches "$verify_pat" \
+  'https://githubXcom/semantic-reasoning/wirelog/.github/workflows/release-tag.yml@refs/tags/v1.0.0'
+# The filename dot needs escaping too, and separately: unescaping only that one
+# was caught by the docs comparison alone, with no SAN case to name it.
+refute 'a workflow filename with a different character where the dot belongs is rejected' \
+  matches "$verify_pat" \
+  'https://github.com/semantic-reasoning/wirelog/.github/workflows/release-tagXyml@refs/tags/v1.0.0'
+# The trailing @ forces the match to end at the filename.
+refute 'the workflow path without an @ref is rejected' matches "$verify_pat" \
+  'https://github.com/semantic-reasoning/wirelog/.github/workflows/release-tag.yml'
+# A workflow file NAMED release-tag.yml@evil.yml is legal in git and satisfies
+# the .yml extension, so a bare trailing @ was not a sufficient right-hand bound.
+refute 'a filename containing @ does not defeat the bound' matches "$verify_pat" \
+  'https://github.com/semantic-reasoning/wirelog/.github/workflows/release-tag.yml@evil.yml@refs/heads/main'
+# A run mints a certificate for the workflow file AS IT EXISTS AT THE REF BEING
+# RUN, so an unconstrained ref lets a branch carrying a modified release-tag.yml
+# mint a certificate this accepts. (refs/tags/ still admits the same thing; see
+# the RESIDUAL note in verify-release.sh and #1318.)
+refute 'a dispatch from a non-main branch is rejected' matches "$verify_pat" \
+  'https://github.com/semantic-reasoning/wirelog/.github/workflows/release-tag.yml@refs/heads/attacker-branch'
+refute 'a branch whose name merely starts with main is rejected' matches "$verify_pat" \
+  'https://github.com/semantic-reasoning/wirelog/.github/workflows/release-tag.yml@refs/heads/main-evil'
+
+# --- the docs must publish the same policy they tell consumers to trust -------
+# Enumerate the flag USAGES and require each to carry $verify_pat, rather than
+# counting occurrences of the correct pattern. Counting the correct pattern is
+# satisfied by a fourth site publishing a WEAKER one -- the count stays at 3 and
+# the gate passes -- which is the realistic drift here: someone adds a
+# verification recipe to SIGNING.md with a hand-typed pattern. Prose mentions of
+# the flag name carry no quoted argument, so they are not usages.
+# One mechanism for every "the docs must publish what the code implements"
+# check, rather than a bespoke extractor per flag. Five rounds of review found
+# the same defect one shape over each time -- the count vs the value, one quote
+# style vs the other, a space vs `=`, the scripts vs the docs, the identity flag
+# vs the issuer -- because every fix was scoped to the instance. Adding a flag
+# here is a call, not a new extractor, so the next one inherits the guard.
+#
+# Quoted values only, for regexp- and URL-valued flags: an unquoted alternative
+# would match prose like "the `--cert-identity-regex` flag" and turn a security
+# gate into a wording gate. The backtick after a prose mention is neither a
+# space nor `=`, which keeps SIGNING.md's flag-naming paragraph out of the
+# results. grep is line-oriented, so this also assumes flag and value sit on
+# ONE line; a value moved to a continuation line would not be enumerated. Write
+# them on one line.
+flag_values() {
+    grep -oE -- "$1[ =]+('[^']*'|\"[^\"]*\")" "$2" |
+        sed "s/^[^\"']*.//; s/.\$//"
+}
+
+# --repo and --predicate-type take a bare slug or URL, not a regexp, so the
+# recipes leave them unquoted. The charset includes `:` for the URL form -- it
+# was omitted at first, and the predicate guard failed on its own first run
+# with the value truncated to "https", which is the failure direction this
+# whole change is about. Be honest about what excludes prose here: NOT the charset, which
+# happily matches "--repo with" in a sentence, but the convention that prose
+# backticks the flag -- and a backtick is neither a space nor `=`. The failure
+# direction is safe either way, since a prose hit raises the count and fails
+# loudly. Its three sites include SIGNING.md's `gh release download` example,
+# which is counted deliberately: a download pointed at another fork is as wrong
+# as a verification pointed there. A benign fourth gh example will fail this
+# with "expected 3, found 4"; update the count.
+bare_values() {
+    grep -oE -- "$1[ =]+[A-Za-z0-9._:/-]+" "$2" | sed -E "s/^$1[ =]+//"
+}
+
+# label, expected value, expected count, then the command that emits the sites.
+sites_agree() {
+    local label=$1 expected=$2 want=$3 v n=0 bad=0
+    shift 3
+    while IFS= read -r v; do
+        n=$((n + 1))
+        if [[ "$v" != "$expected" ]]; then
+            printf '%s: a site publishes a different value:\n  %s\n' "$label" "$v" >&2
+            bad=1
+        fi
+    done < <("$@")
+    if [[ "$n" -ne "$want" ]]; then
+        printf '%s: expected %d sites in SIGNING.md, found %d\n' "$label" "$want" "$n" >&2
+        return 1
+    fi
+    return "$bad"
+}
+
+docs=$root/docs/SIGNING.md
+verify_issuer=$(constant_from "$root/scripts/release/verify-release.sh" oidc_issuer)
+verify_repo=$(constant_from "$root/scripts/release/verify-release.sh" repository)
+
+assert 'every identity flag site in docs/SIGNING.md carries the pattern' \
+    sites_agree identity "$verify_pat" 3 \
+    flag_values '--cert(ificate)?-identity-regexp?' "$docs"
+# The issuer pins WHICH OIDC provider minted the certificate. A recipe naming
+# the wrong one verifies against the wrong trust root, and fails as silently as
+# a weak identity pattern did -- the same defect, on the same command lines,
+# with no guard until now.
+assert 'every issuer flag site in docs/SIGNING.md names the GitHub OIDC issuer' \
+    sites_agree issuer "$verify_issuer" 3 \
+    flag_values '--cert(ificate)?-oidc-issuer' "$docs"
+assert 'every --repo site in docs/SIGNING.md names this repository' \
+    sites_agree repo "$verify_repo" 3 \
+    bare_values '--repo' "$docs"
+# The attestation predicate type: same command line as the three above, and the
+# only value on it the script did not name until now. A docs/script mismatch
+# fails verification loudly rather than accepting something it should not --
+# the opposite direction from the identity and issuer holes -- but it is the
+# same missing comparison, so it gets the same mechanism.
+verify_predicate=$(constant_from "$root/scripts/release/verify-release.sh" predicate_type)
+assert 'the attestation predicate type in docs/SIGNING.md matches the script' \
+    sites_agree predicate "$verify_predicate" 1 \
+    bare_values '--predicate-type' "$docs"
+
+# Every check above compares a NAMED constant's value. None asserts the name is
+# USED -- so re-inlining a literal into the gh/cosign invocation, while leaving
+# the constant assigned, passes everything: the constant goes dead, the docs
+# still agree with it, and the script sends the literal. Nothing breaks while
+# the two happen to match, and the next edit to either one is the hazard. That
+# is precisely the shape --predicate-type was in before it was named, so guard
+# against its return rather than only against the instance.
+# [ =] so a benign reformat to --flag="$const" is not reported as a re-inline;
+# the assertion name would not explain that failure.
+flag_uses_constant() {
+    grep -qE -- "$1[ =]\"\\\$$2\"" "$root/scripts/release/$3"
+}
+v=verify-release.sh
+assert 'verifier cosign --certificate-identity-regexp uses the constant' \
+    flag_uses_constant --certificate-identity-regexp identity_regexp "$v"
+assert 'verifier cosign --certificate-oidc-issuer uses the constant' \
+    flag_uses_constant --certificate-oidc-issuer oidc_issuer "$v"
+assert 'verifier gh --cert-identity-regex uses the constant' \
+    flag_uses_constant --cert-identity-regex identity_regexp "$v"
+assert 'verifier gh --cert-oidc-issuer uses the constant' \
+    flag_uses_constant --cert-oidc-issuer oidc_issuer "$v"
+assert 'verifier gh --repo uses the constant' \
+    flag_uses_constant --repo repository "$v"
+assert 'verifier gh --predicate-type uses the constant' \
+    flag_uses_constant --predicate-type predicate_type "$v"
+# The signer's post-signing self-check, for the same reason. Its blast radius is
+# smaller -- cosign sign-blob uses the ambient OIDC identity regardless, so what
+# gets signed is unchanged, and release-tag.yml round-trips through the verifier
+# before publishing -- but a re-inline there turns the self-check into a rubber
+# stamp silently, which is the failure mode this whole issue is about, in the
+# file documented as needing to match the verifier byte-for-byte.
+a=sign-artifacts.sh
+assert 'signer cosign --certificate-identity-regexp uses the constant' \
+    flag_uses_constant --certificate-identity-regexp identity_regexp "$a"
+assert 'signer cosign --certificate-oidc-issuer uses the constant' \
+    flag_uses_constant --certificate-oidc-issuer oidc_issuer "$a"
+
+refute 'and no longer publishes the old bare prefix' \
+    grep -qF -- "'https://github.com/semantic-reasoning/wirelog/.github/workflows/'" "$root/docs/SIGNING.md"
+
+if ((failures)); then
+    printf 'test-identity-pattern: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test-identity-pattern: all cases passed\n'

--- a/scripts/ci/test-release-signing.sh
+++ b/scripts/ci/test-release-signing.sh
@@ -103,7 +103,17 @@ assert 'OIDC issuer is the GitHub Actions issuer' \
 # is #1287's business.
 repository=$(extract_one "$verifier" repository) || repository='<unextractable>'
 identity_names_repository() {
-    [[ "$sign_identity" == *"https://github.com/$repository/.github/workflows/"* ]]
+    # Compare against the pattern with regex escapes removed: since #1287 the
+    # identity is an anchored regexp with escaped dots (github\.com), so a
+    # literal substring test for github.com no longer matches even though the
+    # repository is named correctly. This assertion is about the repository
+    # name, not the regexp syntax -- anchoring is #1287's business and is
+    # asserted in test-identity-pattern.sh.
+    # Unescape only `\.` -- a blanket strip of every backslash also erases an
+    # INVALID escape, so a pattern like `g\ithub\.com` (which GNU grep accepts
+    # silently and Go refuses to compile) would pass this assertion. Verified.
+    local plain=${sign_identity//\\./.}
+    [[ "$plain" == *"https://github.com/$repository/.github/workflows/"* ]]
 }
 assert "certificate identity names the repository the verifier expects ($repository)" \
     identity_names_repository

--- a/scripts/release/sign-artifacts.sh
+++ b/scripts/release/sign-artifacts.sh
@@ -30,7 +30,54 @@ set -euo pipefail
 
 # Must match scripts/release/verify-release.sh byte-for-byte. The
 # release_signing_contract test asserts that they do.
-identity_regexp='https://github.com/semantic-reasoning/wirelog/.github/workflows/'
+# Anchored at the start and naming the release workflow file.  cosign matches
+# --certificate-identity-regexp UNANCHORED (pkg/cosign/verify.go compiles the
+# pattern and calls MatchString), so a bare prefix accepts a SAN from any
+# workflow in this repository.  GitHub's documented job_workflow_ref claim is
+# https://github.com/<owner>/<repo>/.github/workflows/<file>@<ref>, and neither
+# owner nor repo can contain a slash, so this was never a cross-repository
+# weakness -- the exposure is within-repository workflow confusion: any workflow
+# granted `id-token: write` could mint a certificate this accepts as a release
+# signature.  release-tag.yml is the only such workflow today, but that bounds
+# the impact far less than it sounds: job_workflow_ref names the WORKFLOW FILE,
+# not the job, and release-tag.yml grants id-token: write at workflow level, so
+# every job that does not re-declare permissions: inherits it.  No identity
+# pattern can separate them -- the certificate carries no job discriminator at
+# all -- so this is bounded by workflow permissions or not at all.  The one
+# exception is instructive: the sanitizers job is `uses:` a reusable workflow,
+# which declares its own contents: read AND would mint a SAN naming the CALLED
+# file, so the anchor already excludes it.  Tracked in #1319, the higher
+# priority of the two residuals here because it is a four-line YAML edit.
+#
+# The ref is constrained, but not to tags alone.  release-tag.yml is reachable
+# by workflow_dispatch as well as by a tag push, and a dispatch's OIDC ref
+# claim names the dispatched ref rather than the tag the job checks out, so
+# requiring @refs/tags/ would reject the manual immutable-rerun path #1272
+# exists to provide.  The accepted set is derived from the workflow's triggers,
+# not from an observed certificate: signing landed after v0.60.0, so no SAN has
+# ever been minted here to read.  Accepting ANY ref is also wrong:
+# workflow_dispatch runs the workflow file from the dispatched ref, so a
+# write-access actor could push a branch carrying a modified release-tag.yml,
+# dispatch it, and mint a certificate this would accept -- bypassing whatever
+# review protects main.  refs/heads/main anchored at the end, or any
+# refs/tags/, admits both real cases and neither of those.
+#
+# RESIDUAL 2, and deliberate: refs/tags/ still admits the same forgery, and by
+# an even shorter route than dispatch.  `on: push: tags:` runs the workflow file as
+# it exists AT THE PUSHED TAG, so pushing v1.99.0 with a modified
+# release-tag.yml needs no dispatch at all; dispatching at a tag is the second
+# route.  No pattern over the tag name closes either, because the attacker
+# chooses the name -- tightening to tags/v[01]\. only invites v1.99.0.  Bounding
+# it needs tag protection or a protected Actions environment, which this script
+# can neither express nor observe.  Tracked in #1318; do not "fix" it here by
+# narrowing the regex.
+#
+# @refs/ is also the right-hand bound.  A bare trailing @ is not: a workflow
+# file named release-tag.yml@evil.yml is legal in git, satisfies the .yml
+# extension, and defeats the anchor entirely.  Every ref in that documented
+# claim begins refs/, so requiring it costs nothing.  Both facts come from
+# GitHub's OIDC documentation, not from a certificate observed here.
+identity_regexp='^https://github\.com/semantic-reasoning/wirelog/\.github/workflows/release-tag\.yml@refs/(heads/main$|tags/)'
 oidc_issuer='https://token.actions.githubusercontent.com'
 
 usage() {

--- a/scripts/release/verify-release.sh
+++ b/scripts/release/verify-release.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: $0 ARCHIVE [ARCHIVE.sha256] [ARCHIVE.blake3] [--tag TAG] [--signature FILE --certificate FILE] [--attestation FILE --repo OWNER/REPO]" >&2
+  echo "usage: $0 ARCHIVE [ARCHIVE.sha256] [ARCHIVE.blake3] [--tag TAG] [--signature FILE --certificate FILE] [--attestation FILE --repo OWNER/REPO] [--identity-regexp RE] [--oidc-issuer URL]" >&2
   exit 2
 }
 [[ $# -ge 1 ]] || usage
@@ -18,8 +18,62 @@ signature=''
 certificate=''
 attestation=''
 repository='semantic-reasoning/wirelog'
-identity_regexp='https://github.com/semantic-reasoning/wirelog/.github/workflows/'
+# Anchored at the start and naming the release workflow file.  cosign matches
+# --certificate-identity-regexp UNANCHORED (pkg/cosign/verify.go compiles the
+# pattern and calls MatchString), so a bare prefix accepts a SAN from any
+# workflow in this repository.  GitHub's documented job_workflow_ref claim is
+# https://github.com/<owner>/<repo>/.github/workflows/<file>@<ref>, and neither
+# owner nor repo can contain a slash, so this was never a cross-repository
+# weakness -- the exposure is within-repository workflow confusion: any workflow
+# granted `id-token: write` could mint a certificate this accepts as a release
+# signature.  release-tag.yml is the only such workflow today, but that bounds
+# the impact far less than it sounds: job_workflow_ref names the WORKFLOW FILE,
+# not the job, and release-tag.yml grants id-token: write at workflow level, so
+# every job that does not re-declare permissions: inherits it.  No identity
+# pattern can separate them -- the certificate carries no job discriminator at
+# all -- so this is bounded by workflow permissions or not at all.  The one
+# exception is instructive: the sanitizers job is `uses:` a reusable workflow,
+# which declares its own contents: read AND would mint a SAN naming the CALLED
+# file, so the anchor already excludes it.  Tracked in #1319, the higher
+# priority of the two residuals here because it is a four-line YAML edit.
+#
+# The ref is constrained, but not to tags alone.  release-tag.yml is reachable
+# by workflow_dispatch as well as by a tag push, and a dispatch's OIDC ref
+# claim names the dispatched ref rather than the tag the job checks out, so
+# requiring @refs/tags/ would reject the manual immutable-rerun path #1272
+# exists to provide.  The accepted set is derived from the workflow's triggers,
+# not from an observed certificate: signing landed after v0.60.0, so no SAN has
+# ever been minted here to read.  Accepting ANY ref is also wrong:
+# workflow_dispatch runs the workflow file from the dispatched ref, so a
+# write-access actor could push a branch carrying a modified release-tag.yml,
+# dispatch it, and mint a certificate this would accept -- bypassing whatever
+# review protects main.  refs/heads/main anchored at the end, or any
+# refs/tags/, admits both real cases and neither of those.
+#
+# RESIDUAL 2, and deliberate: refs/tags/ still admits the same forgery, and by
+# an even shorter route than dispatch.  `on: push: tags:` runs the workflow file as
+# it exists AT THE PUSHED TAG, so pushing v1.99.0 with a modified
+# release-tag.yml needs no dispatch at all; dispatching at a tag is the second
+# route.  No pattern over the tag name closes either, because the attacker
+# chooses the name -- tightening to tags/v[01]\. only invites v1.99.0.  Bounding
+# it needs tag protection or a protected Actions environment, which this script
+# can neither express nor observe.  Tracked in #1318; do not "fix" it here by
+# narrowing the regex.
+#
+# @refs/ is also the right-hand bound.  A bare trailing @ is not: a workflow
+# file named release-tag.yml@evil.yml is legal in git, satisfies the .yml
+# extension, and defeats the anchor entirely.  Every ref in that documented
+# claim begins refs/, so requiring it costs nothing.  Both facts come from
+# GitHub's OIDC documentation, not from a certificate observed here.
+identity_regexp='^https://github\.com/semantic-reasoning/wirelog/\.github/workflows/release-tag\.yml@refs/(heads/main$|tags/)'
 oidc_issuer='https://token.actions.githubusercontent.com'
+# Named rather than inlined in the gh call below, so that the docs-agreement
+# check can see it. That mechanism compares SIGNING.md against values this
+# script assigns to a NAME; a value hardcoded inside an invocation is not a flag
+# it forgot, it is a shape it structurally cannot read. Everything else on that
+# command line already had a name, which is exactly why this was the one that
+# drifted unguarded.
+predicate_type='https://slsa.dev/provenance/v1'
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --tag)
@@ -149,7 +203,7 @@ if [[ -n "$attestation" ]]; then
   gh attestation verify "$archive" \
     --repo "$repository" \
     --bundle "$attestation" \
-    --predicate-type https://slsa.dev/provenance/v1 \
+    --predicate-type "$predicate_type" \
     --cert-identity-regex "$identity_regexp" \
     --cert-oidc-issuer "$oidc_issuer"
   echo "verified SLSA provenance attestation $attestation"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -778,6 +778,18 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #1287: cosign matches --certificate-identity-regexp unanchored, and the
+# pattern was a bare prefix, so it accepted a SAN from any workflow in this
+# repository.  The signer, the verifier and the docs each carried a copy and
+# nothing checked they agreed.  Candidates in the test are literal SAN strings:
+# building one by concatenating the pattern is a tautology that passes even for
+# a pattern rejecting nothing.
+if sh.found()
+  test('identity_pattern', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-identity-pattern.sh'],
+       suite: 'abi')
+endif
+
 # Issue #747 B18: RC changelog selftest for changelog-freeze checker.
 # Shell gate uses the same shared `sh` handle to keep skip behavior
 # consistent on platforms without bash.


### PR DESCRIPTION
Closes #1287. Stacked on #1317 (`fix/1290-attestation-retry`) — review that first.

## The bug

cosign matches `--certificate-identity-regexp` **unanchored**: `pkg/cosign/verify.go`
compiles the pattern and calls `MatchString`. The release scripts passed a bare prefix, so
any SAN merely *containing*
`https://github.com/semantic-reasoning/wirelog/.github/workflows/` satisfied it.

Neither owner nor repo can contain a slash, so this was never a cross-repository weakness.
The exposure is within-repository workflow confusion, plus any SAN embedding the string
elsewhere.

## The pattern

```
^https://github\.com/semantic-reasoning/wirelog/\.github/workflows/release-tag\.yml@refs/(heads/main$|tags/)
```

| SAN | before | after |
|---|---|---|
| `release-tag.yml@refs/tags/v1.0.0` | accept | accept |
| `release-tag.yml@refs/heads/main` | accept | accept |
| `release-tag.yml@refs/heads/attacker-branch` | accept | **reject** |
| `release-tag.yml@evil.yml@refs/heads/main` | accept | **reject** |
| `.../x?u=<the real identity>` | accept | **reject** |

The ref is constrained but **not to tags alone**: a dispatch's OIDC ref claim names the
dispatched ref rather than the tag the job checks out, so requiring `@refs/tags/` would
reject #1272's manual immutable-rerun path. Accepting *any* ref is also wrong — a run mints
a certificate for the workflow file as it exists at the ref being run. And `@refs/` is the
right-hand bound, because a workflow file named `release-tag.yml@evil.yml` is legal in git
and defeats a bare trailing `@`.

Verified against a Go `regexp.Compile` + `MatchString` oracle — cosign's actual call — not
just `grep -E`. The two engines agreed on all 22 SANs tested, and the reviewers confirmed
`$` binds to `heads/main` alone inside the alternation.

## What this does not close

Two residuals are documented in the scripts and in `docs/SIGNING.md` rather than fixed,
because **no identity pattern can close either**:

- **Which job minted it (#1319, p1).** `job_workflow_ref` names the workflow *file*, not the
  job — there is no job discriminator in the SAN or the OID extensions — and `release-tag.yml`
  grants `id-token: write` at workflow level. Bounded by the permissions block or not at all.
  Four-line YAML fix, higher priority than the below.
- **Which tag (#1318).** `refs/tags/` accepts any tag name and the attacker chooses the name,
  so tightening to `tags/v[01]\.` only invites `v1.99.0`. Needs tag protection or a protected
  Actions environment.

Both need repository write access. **No published artifact is affected**: signing landed in
`98ff98d1`, after `v0.60.0` — no certificate has ever been minted in this repository.

## Tests

`scripts/ci/test-identity-pattern.sh` (new, suite `abi`, 33 assertions) asserts behaviour,
not presence. Every candidate is a full literal SAN, so mutating the pattern in **both**
scripts kills specific named cases — mutating one alone was masked by the signer/verifier
equality assertion, which is why they are mutated together.

It also guards, through one mechanism, the four values `docs/SIGNING.md` publishes:
identity, OIDC issuer, `--repo`, predicate type. Adding a flag is a call, not a new
extractor. Each is additionally asserted to be **used** at its call site, not merely
assigned — a re-inlined literal otherwise leaves the constant dead while the docs still
agree with it.

`--predicate-type` is promoted to a named constant for exactly that reason: the agreement
check compares values the script assigns to a *name*, so a value hardcoded inside an
invocation is not a flag the mechanism forgot, it is a shape it cannot read.

Mutation-tested throughout. Local: **307 Ok / 0 Fail / 12 Skipped**.

## Review

Ten rounds across an independent Reviewer, Architect and Critic, which found six defect
shapes in my own fixes, each more structural than the last: the quote-style extractor, the
`--flag=value` separator, docs left two rounds behind the scripts, the unguarded issuer, the
unguarded `--repo`, a value with no name for the mechanism to read, and a name with no use.
The generalized helper is what stops the seventh.

Also corrected during review: a claim that prior release-tag runs carried a `refs/heads/main`
ref claim (no certificate existed to have carried anything), and a claim that all eleven jobs
inherit `id-token: write` (`sanitizers` delegates to a reusable workflow declaring
`contents: read`, and its SAN would name the *called* file, which the anchor already rejects).

A blocking `mapfile` was caught before merge: it is bash 4.0+, and the macOS runners ship
3.2.57 with the `abi` suite running there in two jobs. The Critic built bash 3.2 from source
to settle a follow-on question and re-ran the full mutation battery under it.

Follow-ups filed: #1318, #1319, #1320, #1321.

Constraint from #1154 held throughout: no key, fingerprint, or secret-consuming step is
introduced anywhere in this change. Signing remains keyless OIDC.
