### PR TITLE
fix(release): grant the certificate-minting scopes to the signing job only

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -16,10 +16,20 @@ on:
         required: true
         type: string
 
+# contents: read ONLY. The minting scopes -- id-token: write and
+# attestations: write -- are declared on release-artifacts alone, because a
+# workflow-level grant reaches every job that does not re-declare, and
+# job_workflow_ref names the WORKFLOW FILE rather than the job. The certificate
+# carries no job discriminator, so a SAN minted by any other job here is
+# indistinguishable from the signing job's and no
+# --certificate-identity-regexp can tell them apart (#1287). This block is the
+# only thing IN THIS FILE that can bound it -- a protected environment on the
+# signing job, or the tag protection tracked in #1318, constrain the same attack
+# from other directions. Do not add id-token or attestations here; put them on
+# the job that needs them. scripts/ci/test-release-signing.sh fails if you do
+# (#1319).
 permissions:
   contents: read
-  id-token: write
-  attestations: write
 
 env:
   EXPECTED_SHA: ${{ inputs.expected_sha || github.sha }}
@@ -302,6 +312,13 @@ jobs:
     # complete test graph in ASan/UBSan and TSan-configured build directories.
     # This is the repository's equivalent of the issue's --suite asan/tsan
     # requirement and keeps sanitizer coverage from silently narrowing.
+    # Explicit, though the called workflow declares contents: read itself: the
+    # docs are ambiguous about whether a calling job with no permissions block
+    # inherits the caller's workflow-level mapping or the repository default,
+    # and a called workflow can only DOWNGRADE what it is passed. Stating it
+    # here makes the ceiling independent of that ambiguity (#1319).
+    permissions:
+      contents: read
     uses: ./.github/workflows/tier1-sanitizers.yml
     with:
       ref: ${{ inputs.tag_ref || github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ All notable changes to wirelog are documented in this file.
 
 ### Security
 
+- **Only the signing job in `release-tag.yml` now holds the certificate-minting
+  scopes.** That workflow granted `id-token: write` at workflow level, so every
+  job that did not re-declare `permissions:` inherited it. The certificate
+  names the workflow file, not the job — there is no job discriminator in the
+  SAN or in the OID extensions — so any of those jobs could mint a certificate
+  indistinguishable from the signing job's, over an artifact of its choosing,
+  which a consumer following `docs/SIGNING.md` would verify as genuine. The
+  minting scopes are now declared on the `release-artifacts` job alone, and a
+  contract test asserts exactly one permissions mapping in the file grants each
+  of them. This bounds the workflow as committed, not an actor with repository
+  write access, who can still push a tag carrying their own copy of it — see the
+  next bullet, and #1318 for the remedy (#1319).
+
 - **Release signature verification now names the release workflow.** cosign
   matches `--certificate-identity-regexp` unanchored, and the pattern was a bare
   prefix, so it accepted a certificate minted by any workflow in this repository
@@ -36,11 +49,10 @@ All notable changes to wirelog are documented in this file.
   let anyone with write access run a modified `release-tag.yml` and mint an
   accepted certificate. Both refs are admitted deliberately: the manual
   immutable-rerun path dispatches from `main` while checking out the tag.
-  Two residuals are documented rather than closed, because no identity pattern
-  can close either: the certificate names the workflow file and not the job
-  (#1319), and `refs/tags/` accepts any tag name (#1318). No published artifact
-  is affected — signing landed after v0.60.0, so no release certificate has been
-  minted yet (#1287).
+  One residual is documented rather than closed, because no identity pattern can
+  close it: `refs/tags/` accepts any tag name, and the attacker chooses the name
+  (#1318). No published artifact is affected — signing landed after v0.60.0, so
+  no release certificate has been minted yet (#1287).
 
 - **Sigstore keyless signing of release artifacts** (#750): the release-tag
   workflow now signs the source archive with `cosign sign-blob`, emitting a

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -138,16 +138,19 @@ what this signature is worth rather than assume:
 
 - **Which job minted it.** The certificate identifies the workflow file, not the
   job — there is no job discriminator in the SAN or in the GitHub OID extensions
-  — and `release-tag.yml` currently grants `id-token: write` to all of its jobs.
-  No identity pattern can separate them; only the workflow's `permissions:` block
-  can ([#1319](https://github.com/semantic-reasoning/wirelog/issues/1319)).
+  — so no identity pattern can separate one job in `release-tag.yml` from
+  another. This is bounded by the workflow's `permissions:` block instead:
+  `id-token: write` is declared on the signing job alone, so no other job holds
+  a token that can mint this identity
+  ([#1319](https://github.com/semantic-reasoning/wirelog/issues/1319)).
 - **Which tag.** `refs/tags/` accepts any tag name, and the attacker picks the
   name, so no regex closes this. It needs tag protection or a protected Actions
   environment ([#1318](https://github.com/semantic-reasoning/wirelog/issues/1318)).
 
-Both require repository write access. Neither affects any published artifact
+Both require repository write access, and neither affects any published artifact
 today: signing landed after `v0.60.0`, so no release certificate has been minted
-in this repository yet.
+in this repository yet. The first is now bounded by the workflow's permissions
+block; the second remains open.
 
 ### With the bundle — the recipe that keeps working
 

--- a/scripts/ci/test-release-signing.sh
+++ b/scripts/ci/test-release-signing.sh
@@ -58,6 +58,26 @@ assert() {
     "$@" || status=1
     check "$name" "$status"
 }
+# The negative form. Same shape, so a refuted condition is recorded rather than
+# tripping `set -e` and truncating the suite at the first one.
+#
+# Unlike `assert`, this one has to check that the condition can RUN. `assert`
+# reads a missing command as a failure, which is correct. `refute` would read
+# the same 127 as "successfully refuted" and print ok -- so a renamed or
+# misspelled helper would silently turn every refutation in this file into a
+# pass, which is the failure mode these refutations exist to prevent.
+refute() {
+    local name=$1 status=0
+    shift
+    if ! declare -F "$1" >/dev/null 2>&1 && ! command -v "$1" >/dev/null 2>&1; then
+        printf 'release signing: FAIL %s (refute: no such command: %s)\n' \
+            "$name" "$1" >&2
+        failures=$((failures + 1))
+        return 0
+    fi
+    "$@" && status=1
+    check "$name" "$status"
+}
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-signing-selftest.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT
@@ -178,6 +198,71 @@ for scope in 'contents: write' 'id-token: write' 'attestations: write'; do
 done
 
 assert 'release-artifacts signs the archive' in_block 'sign-artifacts.sh'
+# --- #1319: the minting scopes must NOT be granted workflow-wide --------------
+#
+# job_workflow_ref names the WORKFLOW FILE, not the job, and the certificate
+# carries no job discriminator at all -- so every job holding id-token: write
+# mints a SAN indistinguishable from the signing job's, and no
+# --certificate-identity-regexp can separate them (#1287). The only thing that
+# can bound it is this permissions block. Granting the scopes at workflow level
+# hands them to every job that does not re-declare, which is what #1319 removes.
+#
+# Extracted from the top-level mapping specifically: the job-level block is a
+# different mapping at a deeper indent, and comments are stripped first because
+# this workflow discusses both scope names in prose.
+wf_nocomment="$tmp/workflow.nocomment.yml"
+sed 's/^[[:space:]]*#.*$//' "$workflow" >"$wf_nocomment"
+workflow_permissions() {
+    awk '/^permissions:$/ { inside = 1; next }
+         inside && /^[^ ]/ { exit }
+         inside { print }' "$wf_nocomment"
+}
+# A vacuous extraction would satisfy every refutation below, so require the
+# mapping to have been found before believing anything about its contents.
+wf_block_found() { [[ "$(workflow_permissions | grep -c .)" -ge 1 ]]; }
+assert 'the workflow-level permissions mapping was extracted' wf_block_found
+# Match the SCOPE, not one byte-spelling of it. `id-token: 'write'`,
+# `id-token:  write`, `attestations: "write"` and the flow form
+# `permissions: {contents: read, id-token: write}` all parse to exactly the same
+# grant, and a fixed-string match on `id-token: write` misses every one of them
+# -- so a re-added scope would sail past a green gate. The leading
+# (^|[{,[:space:]]) keeps `not-id-token:` and similar suffixes from matching.
+wf_grants() { workflow_permissions | grep -Eq -- "$1"; }
+scope_re() { printf "(^|[{,[:space:]])%s:[[:space:]]*['\"]?%s" "$1" "$2"; }
+for scope in id-token attestations; do
+    refute "workflow-level permissions does NOT grant $scope: write" \
+        wf_grants "$(scope_re "$scope" write)"
+done
+# It must still grant the read scope every job relies on, or removing the two
+# above would have been achieved by deleting the mapping and breaking checkout.
+assert 'workflow-level permissions still grants contents: read' \
+    wf_grants "$(scope_re contents read)"
+
+# The scopes have to live SOMEWHERE, and that somewhere is the signing job --
+# already asserted above. This pins the pairing: exactly one permissions mapping
+# in the file may grant id-token, so a future job cannot quietly re-add it.
+# No ^[[:space:]]+ anchor: that would miss the flow form, which is not at line
+# start. The trade is that a TRAILING comment naming the scope (sed strips only
+# whole-line comments) pushes the count to 2 and fails -- the safe direction.
+# The trailing (…|$) also catches the value on the CONTINUATION line --
+#     id-token:
+#       write
+# -- which YAML reads as an ordinary grant and which both line-based guards
+# would otherwise miss. Deliberately NOT added to scope_re: the positive
+# assertion wf_grants "$(scope_re contents read)" would then be satisfied by a
+# bare valueless `contents:`, which is the one place a loose match runs in the
+# UNSAFE direction. Loose here, strict there, for opposite reasons.
+sole_grant() {
+    [[ "$(grep -cE -- "$1:[[:space:]]*(['\"]?write|\$)" "$wf_nocomment")" -eq 1 ]]
+}
+# Both scopes, not just id-token: the workflow comment forbids adding either at
+# workflow level, and a guard that pins one while the comment names two is the
+# asymmetry this whole issue is about. attestations: write alone cannot obtain a
+# Fulcio certificate, so it is the lesser of the two -- but "lesser" is not a
+# reason for the assertion to be absent.
+assert 'exactly one permissions mapping grants id-token: write' sole_grant id-token
+assert 'exactly one permissions mapping grants attestations: write' \
+    sole_grant attestations
 
 ordered() {
     local sign_line publish_line upload_line

--- a/scripts/release/sign-artifacts.sh
+++ b/scripts/release/sign-artifacts.sh
@@ -38,16 +38,19 @@ set -euo pipefail
 # owner nor repo can contain a slash, so this was never a cross-repository
 # weakness -- the exposure is within-repository workflow confusion: any workflow
 # granted `id-token: write` could mint a certificate this accepts as a release
-# signature.  release-tag.yml is the only such workflow today, but that bounds
-# the impact far less than it sounds: job_workflow_ref names the WORKFLOW FILE,
-# not the job, and release-tag.yml grants id-token: write at workflow level, so
-# every job that does not re-declare permissions: inherits it.  No identity
-# pattern can separate them -- the certificate carries no job discriminator at
-# all -- so this is bounded by workflow permissions or not at all.  The one
-# exception is instructive: the sanitizers job is `uses:` a reusable workflow,
-# which declares its own contents: read AND would mint a SAN naming the CALLED
-# file, so the anchor already excludes it.  Tracked in #1319, the higher
-# priority of the two residuals here because it is a four-line YAML edit.
+# signature.  release-tag.yml is the only such workflow today.  Note what does
+# NOT bound this: job_workflow_ref names the WORKFLOW FILE, not the job, and the
+# certificate carries no job discriminator at all, so no identity pattern can
+# separate one job in that workflow from another.  What bounds it is the
+# permissions block -- id-token: write and attestations: write are declared on
+# release-artifacts alone rather than workflow-wide (#1319), so no other job
+# holds a token that can mint this identity.  Keep it that way; a scope added
+# back at workflow level re-opens this, and nothing in the PATTERN could notice
+# -- the contract test in scripts/ci/test-release-signing.sh is what does, and
+# it is the reason this is not silent.  The sanitizers job is excluded twice
+# over and is instructive: it is `uses:` a reusable workflow, which declares its
+# own contents: read AND would mint a SAN naming the CALLED file, so the anchor
+# excludes it too.
 #
 # The ref is constrained, but not to tags alone.  release-tag.yml is reachable
 # by workflow_dispatch as well as by a tag push, and a dispatch's OIDC ref

--- a/scripts/release/verify-release.sh
+++ b/scripts/release/verify-release.sh
@@ -26,16 +26,19 @@ repository='semantic-reasoning/wirelog'
 # owner nor repo can contain a slash, so this was never a cross-repository
 # weakness -- the exposure is within-repository workflow confusion: any workflow
 # granted `id-token: write` could mint a certificate this accepts as a release
-# signature.  release-tag.yml is the only such workflow today, but that bounds
-# the impact far less than it sounds: job_workflow_ref names the WORKFLOW FILE,
-# not the job, and release-tag.yml grants id-token: write at workflow level, so
-# every job that does not re-declare permissions: inherits it.  No identity
-# pattern can separate them -- the certificate carries no job discriminator at
-# all -- so this is bounded by workflow permissions or not at all.  The one
-# exception is instructive: the sanitizers job is `uses:` a reusable workflow,
-# which declares its own contents: read AND would mint a SAN naming the CALLED
-# file, so the anchor already excludes it.  Tracked in #1319, the higher
-# priority of the two residuals here because it is a four-line YAML edit.
+# signature.  release-tag.yml is the only such workflow today.  Note what does
+# NOT bound this: job_workflow_ref names the WORKFLOW FILE, not the job, and the
+# certificate carries no job discriminator at all, so no identity pattern can
+# separate one job in that workflow from another.  What bounds it is the
+# permissions block -- id-token: write and attestations: write are declared on
+# release-artifacts alone rather than workflow-wide (#1319), so no other job
+# holds a token that can mint this identity.  Keep it that way; a scope added
+# back at workflow level re-opens this, and nothing in the PATTERN could notice
+# -- the contract test in scripts/ci/test-release-signing.sh is what does, and
+# it is the reason this is not silent.  The sanitizers job is excluded twice
+# over and is instructive: it is `uses:` a reusable workflow, which declares its
+# own contents: read AND would mint a SAN naming the CALLED file, so the anchor
+# excludes it too.
 #
 # The ref is constrained, but not to tags alone.  release-tag.yml is reachable
 # by workflow_dispatch as well as by a tag push, and a dispatch's OIDC ref


### PR DESCRIPTION
Closes #1319. Stacked on #1322 (`fix/1287-identity-anchor`) — review that first.

## The bug

`release-tag.yml` granted `id-token: write` and `attestations: write` at **workflow level**,
so every job that did not re-declare `permissions:` inherited them. Only `release-artifacts`
re-declares.

```
$ grep -n 'permissions:' .github/workflows/release-tag.yml
19:permissions:          # ← contents: read, id-token: write, attestations: write
338:    permissions:      # ← release-artifacts
```

That matters because **`job_workflow_ref` names the workflow file, not the job.** There is
no job discriminator in the SAN or in the GitHub OID certificate extensions, so a
certificate minted by any inheriting job is byte-identical to the signing job's, and no
`--certificate-identity-regexp` can separate them. #1287 anchored that pattern; this is the
level below it, and the permissions block is the only thing that can bound it — the pattern
structurally cannot.

**Impact:** a certificate `scripts/release/verify-release.sh` accepts, over an artifact of
the minting job's choosing, which a consumer following `docs/SIGNING.md` verifies as
genuine. Two inheriting jobs execute externally-sourced input — `downstream` fetches and
runs corpora on `runs-on: [self-hosted, linux, x64, wirelog-ga]`, and `fuzz` runs generated
input.

## The fix

Workflow-level `permissions:` is now `contents: read` alone. Verified nothing else needed
the removed scopes: every other job runs only `actions/checkout@v5` and
`actions/upload-artifact@v7`, neither of which requires them — corroborated in-repo by
`perf-nightly.yml` and `fuzz-evidence.yml`, which already run `upload-artifact@v7` under
`contents: read` on a daily cron.

`sanitizers` now states `permissions: contents: read` explicitly. It delegates via `uses:`,
and the docs are genuinely ambiguous about whether a calling job with no block inherits the
caller's workflow-level mapping or the repository default. The called workflow declares
`contents: read` itself and can only *downgrade* what it is passed, so the result is
unchanged either way — stating it makes the ceiling independent of a question neither
reviewer could resolve from documentation.

## Tests

Five new assertions in `scripts/ci/test-release-signing.sh`, written before the fix and
confirmed failing against the unfixed workflow.

They match the **scope**, not one byte-spelling of it. `id-token: 'write'`, two spaces,
`"write"`, flow-style `permissions: {contents: read, id-token: write}`, and the value on a
continuation line all parse to the identical grant, and my first attempt — a fixed-string
match — missed **every one of them**. Three of those would have re-opened this in full,
silently, past a green gate.

The count check is deliberately loose where the positive check is strict: a bare valueless
`contents:` must *fail* the assertion that the read scope is granted. Unifying the two
matchers would make that mutation pass green while granting nothing. The comment records
the asymmetry, because it is invisible from the call sites.

`refute` is new. Unlike `assert` it has to verify its condition can *run*: a missing command
exits 127, which `assert` correctly reads as failure but `refute` would read as
"successfully refuted" — silently turning every refutation in the file into a pass.

Mutation-tested throughout: workflow-level re-add of each scope in every spelling, a second
job declaring either scope, flow form, continuation form, an emptied mapping, and a
false-positive probe (`attestations: read`). Local: **307 Ok / 0 Fail / 12 Skipped**,
serialized.

## What this does not close

`#1318`. An actor with repository write access can push `v1.99.0` carrying their own copy of
`release-tag.yml`, since `on: push: tags:` runs the file as it exists at the pushed tag. No
regex over the tag name closes that — the attacker picks the name. This change is
blast-radius reduction against supply-chain and non-adversarial failure, not adversary
exclusion, and the CHANGELOG entry is scoped to the file rather than the system for exactly
that reason.

## Review

Independent Reviewer and Critic, two rounds. Both blocked the first candidate. Findings:
the fixed-string scope matching (five evasions, three security-relevant); `CHANGELOG.md`
still declaring #1319 unclosed, which ships verbatim as the GitHub Release body via
`extract-changelog-section.sh`; the vacuous `refute`; a missing `attestations` counterpart to
the `id-token` count; and the continuation-line spelling.

One post-approval change: the Reviewer's suggested wording for a reference ambiguity in the
CHANGELOG bullet (`(#1318) — see the bullet below (#1319)` read as naming the wrong bullet).
Prose only; both gates had called it not worth another round.

#1154 holds: no key, fingerprint, or secret-consuming step anywhere. This strictly *reduces*
token scope.
