### PR TITLE
fix(ci): stop check-threading-doc aborting on bash 3.2 when a citation misses

### DIFF
--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -71,6 +71,15 @@ resolve_reference_source() {
         while IFS= read -r candidate; do candidates+=("$candidate"); done \
             < <(find "$repo_root/wirelog" -type f -name "$basename" -print | sort)
     fi
+    # Return before iterating when nothing matched. On bash 3.2 -- which the
+    # macOS CI runners ship, and this script is suite-registered with no
+    # platform gate -- `for x in "${arr[@]}"` over an EMPTY array is an
+    # unbound-variable error under `set -u`; bash 4.4 changed that, 3.2
+    # predates it. Without this the script aborts with `candidates[@]: unbound
+    # variable` instead of letting the caller report the citation that did not
+    # resolve. `${#arr[@]}` on an assigned array is safe at 3.2, so the guard
+    # itself is portable.
+    [ "${#candidates[@]}" -gt 0 ] || return 1
     for candidate in "${candidates[@]}"; do
         [ -f "$candidate" ] || continue
         line_count=$(wc -l <"$candidate")
@@ -86,6 +95,15 @@ while IFS= read -r citation; do
     citation=${citation#\`}; citation=${citation%\`}
     basename=${citation%%:*}; locations=${citation#*:}
     IFS=',' read -ra location_list <<<"$locations"
+    # Same bash 3.2 hazard as resolve_reference_source above: `read -ra` over an
+    # empty string yields an assigned-empty array, and iterating one under
+    # `set -u` aborts there. Unreachable today -- the grep below guarantees a
+    # non-empty post-colon part -- but it is one pattern edit away from being
+    # live, and the guard costs a line.
+    [ "${#location_list[@]}" -gt 0 ] || {
+        echo "check-threading-doc: FAIL: prose citation '$citation' has no locations" >&2
+        exit 1
+    }
     for location in "${location_list[@]}"; do
         if [[ "$location" =~ ^([0-9]+)-([0-9]+)$ ]]; then
             start=${BASH_REMATCH[1]}; end=${BASH_REMATCH[2]}

--- a/scripts/ci/test-threading-doc.sh
+++ b/scripts/ci/test-threading-doc.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 checker="$script_dir/check-threading-doc.sh"
+# Invoke the checker with "$BASH", not via its shebang. The shebang resolves to
+# the first bash on PATH, which need not be the interpreter running this suite
+# -- so a portability defect that only appears under the runner's bash (macOS
+# ships 3.2.57) would be masked here by a newer bash from the environment. This
+# is what makes the #1320 case below able to fail.
 fixture=$(mktemp -d)
 trap 'rm -rf "$fixture"' EXIT
 
@@ -14,7 +19,7 @@ make_fixture() {
 
 run_checker() {
     WIRELOG_THREADING_DOC_ROOT="$fixture" \
-        WIRELOG_THREADING_EXPECTED_ROWS=3 "$checker"
+        WIRELOG_THREADING_EXPECTED_ROWS=3 "$BASH" "$checker"
 }
 
 expect_failure() {
@@ -54,7 +59,7 @@ run_checker >/dev/null
 
 # A header-like cell is not an audit row, while the macro continuation is.
 grep -q '3 audit rows' <(WIRELOG_THREADING_DOC_ROOT="$fixture" \
-    WIRELOG_THREADING_EXPECTED_ROWS=3 "$checker" 2>/dev/null) || exit 1
+    WIRELOG_THREADING_EXPECTED_ROWS=3 "$BASH" "$checker" 2>/dev/null) || exit 1
 
 # A duplicated anchor cannot hide an omitted source site.
 sed 's/intern.c:LOAD/foo.c:foo/' "$fixture/docs/THREADING.md" \
@@ -93,6 +98,53 @@ cat >"$fixture/docs/THREADING.md" <<'EOF'
 | `foo.c:real` | value | `atomic_load_explicit` | relaxed | test |
 EOF
 WIRELOG_THREADING_EXPECTED_ROWS=1 WIRELOG_THREADING_DOC_ROOT="$fixture" \
-    "$checker" >/dev/null
+    "$BASH" "$checker" >/dev/null
+
+# #1320: a prose citation naming a file that does not exist must be REPORTED,
+# not abort the checker. On bash 3.2 -- which the macOS CI runners ship, and
+# this suite has no platform gate -- iterating an empty array under `set -u` is
+# an unbound-variable error, so resolve_reference_source died before its caller
+# could name the citation. bash 4.4 changed that, so on any modern bash this
+# case passes with or without the guard: what it pins is the DIAGNOSTIC, and
+# the portability guard is verified by the assertion below it.
+#
+# Verified by hand against a real GNU bash 3.2.57 (the macOS version, built
+# from source with all 57 official patches): unfixed, this fixture dies with
+# `candidates[@]: unbound variable`; fixed, it prints the message asserted here.
+# Note for anyone repeating that: unpatched 3.2.0 additionally rejects this
+# repository's inline `=~ ^([0-9]+)-(...)$` as a syntax error, which 3.2.57
+# accepts -- 3.2.0 is not a faithful proxy for the runner.
+make_fixture
+printf '%s\n' '#include <stdatomic.h>' 'static _Atomic int value;' \
+    'int real(void) {' \
+    '    atomic_load_explicit(&value, memory_order_relaxed);' \
+    '}' >"$fixture/wirelog/foo.c"
+cat >"$fixture/docs/THREADING.md" <<'EOF'
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
+|---|---|---|---|---|
+| `foo.c:real` | value | `atomic_load_explicit` | relaxed | test |
+
+Prose citing `absent.c:1-5`, which does not exist under wirelog/.
+EOF
+missing_out=$(WIRELOG_THREADING_EXPECTED_ROWS=1 WIRELOG_THREADING_DOC_ROOT="$fixture" \
+    "$BASH" "$checker" 2>&1 || true)
+case "$missing_out" in
+    *"prose citation 'absent.c:1-5' does not resolve"*) ;;
+    *)
+        echo "test-threading-doc: FAIL: expected the unresolvable-citation diagnostic" >&2
+        printf 'got: %s\n' "$missing_out" >&2
+        exit 1
+        ;;
+esac
+# The abort this replaced named the array, not the citation. Assert its absence
+# directly, so a future edit that reintroduces the bare iteration is caught here
+# on bash 3.2 rather than only on a macOS runner.
+case "$missing_out" in
+    *'unbound variable'*)
+        echo "test-threading-doc: FAIL: checker aborted on an empty candidate set" >&2
+        printf 'got: %s\n' "$missing_out" >&2
+        exit 1
+        ;;
+esac
 
 echo 'test-threading-doc: OK'


### PR DESCRIPTION
Closes #1320. Based on `main` — independent of the other open PRs.

## The bug

`resolve_reference_source` iterated `"${candidates[@]}"` without checking the array was
non-empty. On bash 3.2 that is an unbound-variable error under `set -u`; bash 4.4 changed it.
So a prose citation naming a file that does not exist under `wirelog/` killed the checker
with

```
check-threading-doc.sh: line 65: candidates[@]: unbound variable
```

instead of letting the caller report *which* citation failed to resolve.

It cannot cause a false pass — the path is only reachable when the run was going to fail
anyway. It replaces the diagnostic with one naming an internal array.

`threading_doc` and `threading_doc_selftest` are registered in suite `abi` with no platform
gate; `ci-pr.yml` runs bare `meson test` on `macos-latest` in two jobs; those runners ship
bash 3.2.57.

## Verified against real bash 3.2.57, not by reasoning

I built GNU bash 3.2 from the tarball with all 57 official patches — `3.2.57(4)-release`, the
version macOS ships — and ran everything against it.

```
unfixed checker + self-test, bash 3.2.57  → exit 1, "candidates[@]: unbound variable"
fixed   checker + self-test, bash 3.2.57  → exit 0
fixed   checker + self-test, bash 5.3     → exit 0
```

**Caveat worth recording for anyone repeating this:** unpatched bash **3.2.0** additionally
rejects this repository's inline `[[ x =~ ^([0-9]+)-([0-9]+)$ ]]` as a syntax error, which
3.2.**57** accepts. I initially concluded from a 3.2.0 build that the checker did not parse
on macOS at all — that was an artifact of the unpatched build, not a real CI failure. 3.2.0
is not a faithful proxy for the runner.

## The change

**`check-threading-doc.sh`** — guard both empty-array iterations. The `candidates` loop is
the live bug. The `location_list` loop four lines below is the identical shape; it is
unreachable today because the driving `grep -oE` guarantees a non-empty post-colon part, but
it is one pattern edit from being live and the guard costs a line. Verified on 3.2.57 that
the unguarded form aborts with `location_list[@]: unbound variable` and the guarded form
reports intelligibly.

**`test-threading-doc.sh`** — a case asserting an unresolvable citation produces the
diagnostic and not an abort, plus every `"$checker"` invocation changed to
`"$BASH" "$checker"`.

That second part is what makes the new case able to fail at all. The shebang resolves to the
first `bash` on `PATH`, which need not be the interpreter running the suite — so with the
shebang, **deleting the guard leaves the new case passing under 3.2.57**. My first version of
this test was decoration and I only found that by mutating it. It also makes the self-test
agree with `tests/meson.build:735`, which already runs the checker under
`find_program('bash')`; before, the self-test's inner checker used the *runtime* PATH bash
while the sibling test used the *configure-time* bash, and the two could diverge.

## Review

Reviewer approved, verifying against the same 3.2.57 binary. It confirmed the `"$BASH"`
change is strictly more faithful rather than merely different, that `return 1` on an empty
candidate set is *equivalent* to the old fall-through and not merely similar, and that four
independent mutations each kill the new case.

Two things it found that are fixed here: a temp-directory leak I introduced (my new case
reassigned `fixture` and replaced the EXIT trap, orphaning the first `mktemp -d` every run —
now reuses the file's own `make_fixture` idiom, verified 0 leftovers under a controlled
`TMPDIR` on both shells), and the latent `location_list` twin above.

It also found the same shape in `scripts/ci/check-abi-manifest.sh:124`, where
`abi/libwirelog-1.0.suppr` does not exist so the array is empty in the *default*
configuration — masked only by libabigail being unavailable on macOS. Filed as **#1324**.

Local: **304 Ok / 0 Fail / 12 Skipped**, serialized, dedicated build dir.
