### PR TITLE
fix(release): replace declare -A with a bash-3.2-portable workload dedup

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -415,6 +415,16 @@ jobs:
           $env:CXX = 'cl'
           meson compile -C builddir
 
+      # Record which bash meson will use. The suite's portability floor is the
+      # macOS runner's bash 3.2.57, and scripts have broken against it before
+      # (#1320, #1324). meson resolves the interpreter with
+      # find_program('bash') -- PATH, not /bin/bash -- so if the image ever adds
+      # a Homebrew bash 5 ahead of it, that runtime coverage disappears silently
+      # and nothing else would say so. One line, printed every run.
+      - name: Record bash version
+        if: runner.os != 'Windows'
+        run: bash --version | head -1
+
       - name: Test (Linux / macOS)
         if: runner.os != 'Windows'
         run: meson test -C builddir --print-errorlogs
@@ -550,6 +560,16 @@ jobs:
 
       - name: Build with sanitizers
         run: meson compile -C builddir-san
+
+      # See the note in build-matrix: this job also runs the abi suite on macOS.
+      # These are the two macOS jobs in THIS workflow; ci-main.yml and
+      # tier1-sanitizers.yml have four more that lack the probe. Those are
+      # ungated while these two are gated on build-required, but a PR that skips
+      # the build also skips the abi suite, so there is nothing to observe then.
+      # One observation point on the workflow that runs per-PR is enough for a
+      # diagnostic that fails nothing; six copies would be noise.
+      - name: Record bash version
+        run: bash --version | head -1
 
       - name: Test with sanitizers
         run: meson test -C builddir-san --print-errorlogs

--- a/scripts/release/run-downstream-matrix.sh
+++ b/scripts/release/run-downstream-matrix.sh
@@ -199,7 +199,26 @@ validate_acquisition() {
     esac
 }
 
-declare -A seen_workloads=()
+# A newline-delimited string, not an associative array: `declare -A` is bash
+# 4.0+, and this script is reachable from scripts/ci/test-downstream-matrix.sh,
+# which meson registers as `downstream_matrix_contract` in suite abi
+# (tests/meson.build:788) -- ungated, so it runs on the macOS runners under
+# bash 3.2.57.
+#
+# No macOS invocation reaches this line today: every call the contract test
+# makes exits at or before archive validation, so that suite is green on 3.2.57
+# with or without this change. The hazard is latent, not active, and it is what
+# happens when some future call DOES reach here -- bash 3.2 aborts with
+# `declare: -A: invalid option` and status 2, which is also this script's status
+# for bad usage (line 41) and exactly what test-downstream-matrix.sh:42 asserts.
+# The abort would read as a normal usage exit rather than a failure: a green
+# contract test whose oracle loop never ran.
+#
+# The workload field arrives via IFS=$'\t' read, so it cannot contain a newline,
+# which makes newline a safe delimiter. A quoted needle in [[ ]] is literal in
+# 3.2, so a workload named `a*b` matches literally rather than as a pattern.
+# (#1321)
+seen_workloads=$'\n'
 workload_count=0
 while IFS=$'\t' read -r workload expected_tuples expected_iterations data_path expected_manifest provenance acquisition extra; do
     [[ -z "$workload" || "$workload" == \#* ]] && continue
@@ -219,8 +238,8 @@ while IFS=$'\t' read -r workload expected_tuples expected_iterations data_path e
     validate_provenance "$provenance"
     validate_provenance_path "$provenance" "$data_path"
     validate_acquisition "$acquisition"
-    [[ -z "${seen_workloads[$workload]+x}" ]] || { echo "duplicate workload: $workload" >&2; exit 1; }
-    seen_workloads[$workload]=1
+    [[ "$seen_workloads" != *$'\n'"$workload"$'\n'* ]] || { echo "duplicate workload: $workload" >&2; exit 1; }
+    seen_workloads="$seen_workloads$workload"$'\n'
     workload_count=$((workload_count + 1))
     data_dir=$(realpath -e -- "$candidate_root/$data_path") || {
         echo "missing data path: $data_path" >&2


### PR DESCRIPTION
Closes #1321. Based on `main` — independent of every other open PR.

**This PR does not build the gate #1321 proposed.** Implementing that issue's corrected
acceptance criteria falsified its own premise, so the outcome is: close the issue, do the two
things worth doing, and file a narrow successor (#1327).

## Why the gate died

#1321's design argument was that scoping a bash-4.0+ denylist to the *transitive closure* of
meson-run scripts avoids the exemption list a blanket scan would need. Measured:

| scope | files | violations |
|---|---|---|
| blanket `scripts/**.sh` + `bench/**.sh` | 53 | 2 |
| transitive closure | 33 | 2 |
| meson direct invocations only | 21 | 0 |

The closure — the entire novel part of the proposal — finds the same two lines as the blanket
denylist it was designed to beat, at higher complexity.

And one of those two was an artifact of my own closure implementation:
`scripts/upgrade/run-upgrade-matrix.sh` entered it through a **comment** at
`scripts/ci/test-check-shared-library-closure.sh:5`. Excluding comment lines: 33 → 30 files,
2 → 1 violation. Its real invoker is `release-tag.yml:220` on `ubuntu-latest`. It is tier 2
under every correct reading and is untouched here.

## 1. `declare -A` → portable dedup

The remaining violation, and a latent **false pass** rather than a break.

`run-downstream-matrix.sh` is reachable from `test-downstream-matrix.sh`, registered as
`downstream_matrix_contract` in suite `abi` with no platform gate — so macOS, bash 3.2.57.
No macOS invocation reaches line 202 today; every call the contract test makes exits at or
before archive validation, and the suite is green on 3.2.57 with or without this change.

What makes it worth removing rather than commenting: on 3.2 `declare -A` aborts with
`declare: -A: invalid option` and status **2**, which is also this script's status for bad
usage and exactly what `test-downstream-matrix.sh:42` asserts. Verified by hoisting the
declaration above the argument validation — the probe returned 2 from `declare`, satisfying
the oracle **by the wrong cause**. A green contract test whose oracle loop never ran, macOS
only.

The replacement is a newline-delimited string. The workload field arrives via `IFS=$'\t' read`
so it cannot contain a newline; a quoted needle in `[[ ]]` is literal in 3.2, so a workload
named `a*b` matches literally — which the associative form did *not* guarantee, since a
non-associative subscript arithmetic-evaluates.

Verified on real bash **3.2.57** (built from the tarball with all 57 official patches, the
macOS version) and 5.3: identical behaviour across 40 adversarial names including
prefix/suffix collisions (`zxing`/`zxin`/`xing`), glob metacharacters, backslashes, brackets
and whitespace; duplicate guard proven live against a synthetic oracle carrying a real
duplicate; contract test passing on both shells.

## 2. `bash --version` in the two macOS jobs

`tests/meson.build:709` is `find_program('bash')` — PATH, not `/bin/bash`. If the runner image
ever puts a newer bash ahead of it, the 3.2 runtime coverage several scripts depend on
disappears with nothing to say so. Diagnostic only; fails nothing.

Scoped to `ci-pr.yml` deliberately: `ci-main.yml` and `tier1-sanitizers.yml` have four more
macOS jobs without it, and one observation point on the per-PR workflow is enough for a line
that fails nothing.

## Review

Reviewer and Architect disagreed, and the disagreement improved the outcome.

The Architect ruled "close #1321, don't build it" on the table above. The Reviewer **dissented**:
the ruling compares file counts, not yield. The meson-direct scope (0 violations) does not
contain `run-downstream-matrix.sh` at all, and macOS runtime demonstrably did *not* catch this
defect — runtime coverage is **line**-bounded while a static scan is **file**-bounded.

Then it supplied the fact that settles it against its own dissent: #1320 and #1324, the two
bash-3.2 defects that actually shipped, are `set -u` *behaviour* differences, not 4.0+
*constructs*. A construct denylist catches neither. Same conclusion as the Architect, by a
route that explains why. #1327 carries both halves so the next person knows what the ratchet
does and does not buy.

It also blocked an earlier candidate on four false claims in my own comments — a wrong line
number, a mechanism described in the present tense that has never occurred, a backwards
attribution of #1320/#1324, and an overstated scope claim. All corrected; the code never
changed.

Local: **304 Ok / 0 Fail / 12 Skipped**, serialized, dedicated build dir. Contract test passes
under both 3.2.57 and 5.3.
