### PR TITLE
fix(release): read checksum manifests the way coreutils writes them

### DIFF
--- a/scripts/ci/test-release-roundtrip.sh
+++ b/scripts/ci/test-release-roundtrip.sh
@@ -307,6 +307,45 @@ expect_says   'the pairing requirement is explained' 'must be supplied together'
 expect_status '--tag without a value is a usage error' 2 "$vr" "$archive" --tag
 expect_status 'an unknown option is a usage error' 2 "$vr" "$archive" --nope
 
+# --- #1315: names coreutils escapes, and one it does not ----------------------
+#
+# Built from REAL sha256sum/b3sum output, not hand-written manifests: a
+# hand-written unescaped manifest would pin the parsing code without exercising
+# the escaping condition at all, which is the whole point of these cases.
+#
+# `a\nb.tar.gz` is the discriminator. Unescaping the manifest name -- the
+# obvious fix, and the one #1315 suggested -- is ambiguous here: coreutils
+# writes it `a\\nb.tar.gz`, and replacing `\\` then `\n` in sequence yields a
+# newline. Verifying by ESCAPING the expected name instead has no such case.
+# `has space.tar.gz` needs no escaping at all and was broken separately, by
+# reading the name as awk's `$2`.
+# Under $tmp, which line 46's trap already removes. A second mktemp with its
+# own trap would REPLACE that trap and orphan $tmp every run.
+escaping_dir="$tmp/escaping"
+
+verifies_awkward_name() {
+    local name=$1 dir="$escaping_dir/$2"
+    mkdir -p "$dir"
+    printf 'payload' >"$dir/$name"
+    ( cd "$dir" && sha256sum -- "$name" >"$name.sha256" && b3sum -- "$name" >"$name.blake3" )
+    "$vr" "$dir/$name" "$dir/$name.sha256" "$dir/$name.blake3" >/dev/null 2>&1
+}
+
+# No `command -v b3sum` guard here: the tool check near the top already exits 77
+# for the whole suite when b3sum is absent, so a guard would be dead code whose
+# else-branch printed a fake `ok` outside this file's SKIP protocol.
+assert 'an archive whose name contains a backslash verifies' \
+    verifies_awkward_name 'back\slash.tar.gz' backslash
+assert 'an archive whose name contains a newline verifies' \
+    verifies_awkward_name "$(printf 'new\nline.tar.gz')" newline
+assert 'an archive whose name contains a carriage return verifies' \
+    verifies_awkward_name "$(printf 'car\rriage.tar.gz')" carriage
+assert 'an archive whose name contains a space verifies' \
+    verifies_awkward_name 'has space.tar.gz' space
+# The one that would pass under a naive unescape while being wrong.
+assert 'a name containing a literal backslash-n verifies' \
+    verifies_awkward_name 'a\nb.tar.gz' backslash_n
+
 if ((failures)); then
     printf 'test-release-roundtrip: %d case(s) failed\n' "$failures" >&2
     exit 1

--- a/scripts/release/verify-release.sh
+++ b/scripts/release/verify-release.sh
@@ -131,20 +131,58 @@ command -v b3sum >/dev/null || { echo 'b3sum is required' >&2; exit 1; }
 # run to detect tampering, that is the wrong direction to be wrong in.
 archive_dir=$(CDPATH= cd -P -- "$(dirname -- "$archive")" && pwd -P)
 archive_name=$(basename -- "$archive")
+# Compare against the ESCAPED form of the expected name rather than unescaping
+# the manifest's. GNU coreutils escapes exactly three characters in a name --
+# backslash as `\\`, newline as `\n`, carriage return as `\r` -- and marks the
+# whole line with a leading `\`. Determined by scanning all 254 legal filename
+# bytes through sha256sum, not from documentation: tab, other control bytes and
+# UTF-8 are NOT escaped, and neither is a space. b3sum escapes the same three
+# and uses the same marker, which is why both manifests parse identically.
+# Unescaping is ambiguous in the wrong direction: a file genuinely named
+# `a\nb.tar.gz` is written `a\\nb.tar.gz`, and sequential replacement of `\\`
+# then `\n` turns it into a newline. Measured -- the naive form corrupts that
+# name; this one does not. Escaping is a one-way transform with no such case.
+#
+# The name is also taken as everything after the two-character separator, not
+# as awk's `$2`. coreutils does NOT escape spaces, so `$2` silently truncated
+# `has space.tar.gz` to `has` and reported a name mismatch on a correct
+# archive. (#1315)
+nl=$'\n'
+cr=$'\r'
+escaped_form() {
+  local s=$1
+  s=${s//\\/\\\\}      # backslash FIRST: the two rules below each emit one
+  s=${s//$nl/\\n}
+  s=${s//$cr/\\r}
+  printf '%s' "$s"
+}
+expected_name=$(escaped_form "$archive_name")
+
+# Split one coreutils line into hash and name. The leading marker is stripped
+# before the hash is read, or the comparison would face `\<hash>`.
+parse_manifest_line() {
+  local line=$1 rest
+  case $line in \\*) line=${line#\\} ;; esac
+  parsed_hash=${line%% *}
+  rest=${line#"$parsed_hash"}
+  parsed_name=${rest:2}
+}
+
 for manifest in "$sha_file" "$b3_file"; do
-  manifest_name=$(awk 'NF { print $2; exit }' "$manifest")
-  test "$manifest_name" = "$archive_name" || {
-    echo "checksum manifest does not name $archive_name: $manifest_name" >&2
+  parse_manifest_line "$(awk 'NF { print; exit }' "$manifest")"
+  test "$parsed_name" = "$expected_name" || test "$parsed_name" = "$archive_name" || {
+    echo "checksum manifest does not name $archive_name: $parsed_name" >&2
     exit 1
   }
 done
-expected_sha=$(awk 'NF { print $1; exit }' "$sha_file")
-expected_b3=$(awk 'NF { print $1; exit }' "$b3_file")
+parse_manifest_line "$(awk 'NF { print; exit }' "$sha_file")"; expected_sha=$parsed_hash
+parse_manifest_line "$(awk 'NF { print; exit }' "$b3_file")"; expected_b3=$parsed_hash
 # Hash from inside the archive's directory, against the bare basename, rather
 # than passing the full path.
 #
-# GNU coreutils escapes a filename containing a backslash or a newline: it
-# prefixes the WHOLE line with a literal `\` and escapes the character. Passing
+# GNU coreutils escapes a filename containing a backslash, a newline or a
+# carriage return: it prefixes the WHOLE line with a literal `\` and escapes
+# the character. Passing
 # a full path therefore yielded `\<hash>` for any archive under such a path, the
 # comparison below could never match, and this reported "SHA256 mismatch" on a
 # byte-perfect archive -- to a third party following the published verification
@@ -156,15 +194,12 @@ expected_b3=$(awk 'NF { print $1; exit }' "$b3_file")
 # the marker, and stripping it is what makes the hash comparable. Neither stage
 # stops reading early, so there is no SIGPIPE here.
 #
-# It is deliberately UNPINNED by any test, and that is worth stating rather than
-# hiding. Reaching it needs a backslash in the archive's NAME, and such an
-# archive cannot get this far: the manifest-name check above reads `$2` raw, so
-# a coreutils-written manifest (which escapes the name) fails there first with
-# "checksum manifest does not name". Only a hand-written unescaped manifest
-# would exercise this line, and make-tarball.sh never produces one. A fixture
-# for that would pin the line via a scenario that cannot occur end to end, which
-# is worse than saying so. Closing the class means unescaping on the
-# manifest-reading side too; tracked separately.
+# This line is now REACHABLE and pinned. It was not when #1311 wrote it: the
+# manifest-name check above read `$2` raw, so a coreutils-written manifest for
+# such a name failed there first with "checksum manifest does not name", and no
+# archive could get this far. #1315 fixed that side, so an archive whose
+# basename contains a backslash now reaches the hash comparison, and
+# test-release-roundtrip.sh exercises it.
 hash_of() {
     ( CDPATH= cd -P -- "$archive_dir" && "$1" -- "$archive_name" \
         | sed 's/^\\//' | awk '{print $1}' )


### PR DESCRIPTION
Closes #1315. Stacked on #1314 (`fix/1311-checksum-escaping`) — review that first.

## The bug

`verify-release.sh` rejected any archive whose name coreutils escapes, before comparing a
single hash:

```
checksum manifest does not name back\slash.tar.gz: back\\slash.tar.gz
```

GNU coreutils escapes exactly **three** characters in a name — `\` → `\\`, newline → `\n`,
carriage return → `\r` — and prefixes the whole line with a literal `\`.

**The escape set came from scanning all 254 legal filename bytes through `sha256sum`, not
from documentation.** My first version had only two: I'd derived the set from the two cases
the issue happened to name, and missed CR. The reviewer caught it by running the scan I
should have run — an incomplete set treated as complete, which is the same defect as the bug
being fixed, reproduced inside the fix. Tab, other control bytes and UTF-8 are *not* escaped;
`b3sum` escapes the same three with the same marker.

**A third failure had nothing to do with escaping.** The name was read as `awk '$2'`, and
coreutils does not escape spaces, so `has space.tar.gz` was truncated to `has`. The name is
now taken as everything after the two-character separator, which is also correct for binary
mode (`hash *name`).

## Why escaping the expected name, not unescaping the manifest's

The issue suggested unescaping. That direction is ambiguous, and I only found out by
measuring it: a file genuinely named `a\nb.tar.gz` is written `a\\nb.tar.gz`, and replacing
`\\` then `\n` in sequence **corrupts it** to `a<newline>b.tar.gz`. Escaping is one-way and
has no such case — which is why `a\nb.tar.gz` is one of the regression cases rather than an
incidental one.

## Fail-closed, verified

The name check only selects *which* manifest line is trusted; the hash is recomputed
independently. Reviewer confirmed no input produces a false "verified" — corrupt archive with
an escaped name, a forged name field carrying another file's hash, multi-line manifests with a
wrong first line, empty and hash-only manifests are all rejected. It also checked that
escaping stays injective across all three rules, so a manifest for an LF-named file is
correctly rejected against a CR-named archive.

## Tests

Five cases in `scripts/ci/test-release-roundtrip.sh`, built from **real** `sha256sum`/`b3sum`
output — a hand-written unescaped manifest would pin the parsing without exercising the
escaping condition at all.

| variant | suite result |
|---|---|
| this PR | 0 FAIL |
| minus the `\r` rule | 1 FAIL — carriage return only |
| minus the `\n` rule | 1 FAIL — newline only |
| minus the `\\` rule | 2 FAIL — backslash, literal `\n` |
| backslash rule moved **last** | 2 FAIL — newline, carriage return |
| unfixed `verify-release.sh` | 5 FAIL — all five |

Each rule is independently pinned, and the *ordering* the comment asserts is executable
rather than prose. Verified on real bash 3.2.57 (the macOS floor) as well as 5.3, with no
temp-directory leftovers.

This also makes #1311's leading-backslash strip in `hash_of` reachable for the first time and
pins it, so the comment declaring it deliberately unpinned is replaced.

## Left out deliberately

- `make-tarball.sh`'s missing `--`/`CDPATH=` hardening → that is **#1316**, open and
  unassigned. It has no matching escaping defect: the archive name is machine-generated behind
  a version regex, so nothing escapable can reach its manifests.
- An archive name *ending* in a newline is still truncated, by `basename` inside a command
  substitution — a different line and a different fix. Filed as **#1329** rather than folded
  into #1316, on the reviewer's argument that #1316 is scoped to the writing side and could be
  closed while leaving this unfixed and untracked.

Local: **306 Ok / 0 Fail / 12 Skipped**, serialized, dedicated build dir.
