### PR TITLE
fix(release): harden make-tarball's manifest writing the way #1311 hardened reading

### DIFF
--- a/scripts/ci/test-release-roundtrip.sh
+++ b/scripts/ci/test-release-roundtrip.sh
@@ -346,6 +346,55 @@ assert 'an archive whose name contains a space verifies' \
 assert 'a name containing a literal backslash-n verifies' \
     verifies_awkward_name 'a\nb.tar.gz' backslash_n
 
+# --- #1316: make-tarball.sh's manifest-writing hardening ----------------------
+#
+# Three hardenings, each with its own fixture, because a fixture that passes
+# with any one of them removed is not covering it. Verified: each mutant below
+# is killed by exactly one of these three and by no other.
+#
+#   CDPATH=  a RELATIVE out_dir found through CDPATH sends `cd` to whichever
+#            directory CDPATH matched, so the manifest is written in the wrong
+#            place -- or, in the current form, the resolved path `cd` echoes is
+#            captured into archive_dir and the next cd fails.
+#   -P       an out_dir of the form `x/dir/link/..` resolves to the link
+#            target's PARENT for the kernel that writes the archive, but to
+#            `x/dir` for a logical `cd`.
+#   --       an out_dir beginning with `-` is parsed as options. Note this is
+#            caught at `mkdir -p --`, which runs BEFORE the manifest subshells;
+#            hardening only those two would leave this case unreachable and the
+#            `--` untestable.
+harden_dir="$tmp/harden"
+
+# Everything runs in ONE subshell at $outer_cd, because make-tarball.sh prints
+# paths as given -- a relative out_dir yields relative paths, which only resolve
+# from the directory it was invoked in.
+builds_manifest_naming_archive() {
+    local out=$1 outer_cd=$2 cdpath=$3
+    (
+        cd "$outer_cd" || exit 1
+        local lines arch man
+        lines=$( CDPATH="$cdpath" "$mt" "$out" ) || exit 1
+        arch=$(printf '%s\n' "$lines" | sed -n 1p)
+        man=$(printf '%s\n' "$lines" | sed -n 2p)
+        [ -f "$man" ] || exit 1
+        [ "$(sed -n 's/^[0-9a-f]*  //p' -- "$man")" = "$(basename -- "$arch")" ]
+    )
+}
+
+# All three run from inside $repo: make-tarball.sh derives its repo root from
+# the working directory, so a relative out_dir must be relative to that.
+mkdir -p "$harden_dir/decoy/dist-rel"
+assert 'a relative out_dir is unaffected by CDPATH' \
+    builds_manifest_naming_archive dist-rel "$repo" "$harden_dir/decoy"
+
+mkdir -p "$harden_dir/x/dir" "$harden_dir/y/target"
+ln -sfn "$harden_dir/y/target" "$harden_dir/x/dir/link"
+assert 'an out_dir reached through a symlink and .. writes beside its archive' \
+    builds_manifest_naming_archive "$harden_dir/x/dir/link/.." "$repo" ''
+
+assert 'an out_dir beginning with a dash is not parsed as options' \
+    builds_manifest_naming_archive -outdir "$repo" ''
+
 if ((failures)); then
     printf 'test-release-roundtrip: %d case(s) failed\n' "$failures" >&2
     exit 1

--- a/scripts/release/make-tarball.sh
+++ b/scripts/release/make-tarball.sh
@@ -36,7 +36,10 @@ version=${version%%-*}
 command -v sha256sum >/dev/null || { echo 'sha256sum is required' >&2; exit 1; }
 command -v b3sum >/dev/null || { echo 'b3sum is required' >&2; exit 1; }
 
-mkdir -p "$out_dir"
+# `--`: an out_dir beginning with `-` is otherwise parsed as options here, and
+# mkdir fails before the manifest subshells below are ever reached -- which is
+# why hardening only those two would have left `--` untestable. (#1316)
+mkdir -p -- "$out_dir"
 archive="$out_dir/wirelog-$version.tar.gz"
 prefix="wirelog-$version/"
 
@@ -44,7 +47,31 @@ prefix="wirelog-$version/"
 # gzip -n removes wall-clock metadata so repeated builds are byte-identical.
 git -C "$repo_root" archive --format=tar --prefix="$prefix" "$commit" \
   | gzip -n -9 > "$archive"
-(cd "$(dirname "$archive")" && sha256sum "$(basename "$archive")" > "$(basename "$archive").sha256")
-(cd "$(dirname "$archive")" && b3sum "$(basename "$archive")" > "$(basename "$archive").blake3")
+# Write each manifest from inside the archive's directory, against the bare
+# basename, so no path is embedded in the hash line. Three hardenings, each with
+# a distinct failure this repository has already seen on the reading side
+# (#1311):
+#
+#   CDPATH=  With CDPATH set, `cd` on a RELATIVE path searches CDPATH and lands
+#            in whichever entry matched first, not the intended directory -- so
+#            the manifest is written in the wrong place, or sha256sum finds no
+#            archive there and the run aborts. It also echoes the resolved path
+#            on ITS OWN stdout, which the archive_dir capture below would take
+#            as part of the value. Note it does NOT corrupt the manifest: the
+#            redirection binds to sha256sum, not to cd. release-tag.yml:274,344
+#            pass a relative out_dir, so this is the production shape.
+#   --       An out_dir beginning with `-` is parsed as options -- first by the
+#            mkdir above, which is why that line needs it too, then by dirname,
+#            basename and cd here -- all three receive the value.
+#   -P       `cd` is logical, so an out_dir reached through a symlink followed
+#            by `..` resolves differently for the shell than for the kernel:
+#            with `link -> y/target`, `x/dir/link/..` is `y` (the link target's
+#            PARENT) where the archive is written, but `x/dir` to a logical cd.
+#            The manifest would land beside a different file, or the subshell
+#            fails outright.
+archive_dir=$(CDPATH= cd -P -- "$(dirname -- "$archive")" && pwd -P)
+archive_base=$(basename -- "$archive")
+(CDPATH= cd -P -- "$archive_dir" && sha256sum -- "$archive_base" > "$archive_base.sha256")
+(CDPATH= cd -P -- "$archive_dir" && b3sum -- "$archive_base" > "$archive_base.blake3")
 
 printf '%s\n' "$archive" "$archive.sha256" "$archive.blake3"


### PR DESCRIPTION
Closes #1316. Stacked on #1330 (`fix/1315-manifest-unescape`) — review that first.

## The change

`make-tarball.sh` wrote its checksum manifests missing the three hardenings #1311 applied to
the reading side. Each has a distinct failure, and each now has a fixture no other kills:

| hardening | failure |
|---|---|
| `CDPATH=` | `cd` on a **relative** path lands in whichever CDPATH entry matched first — manifest written in the wrong place, or `sha256sum` finds no archive and the run aborts. `release-tag.yml:274,344` pass a relative `out_dir`, so this is production shape. |
| `--` | an `out_dir` beginning with `-` is parsed as options by `mkdir`, `dirname`, `basename` and `cd`. |
| `-P` | `cd` is logical: with `link -> y/target`, `x/dir/link/..` is `y` — the link target's **parent** — for the kernel that writes the archive, but `x/dir` for a logical `cd`. |

## Scope note: `mkdir -p --`

Line 22 is hardened although the issue's criterion 1 names only the two subshells. Without it
the `--` hardening is **unreachable** — `mkdir` fails first with `invalid option -- 'o'`, so no
fixture could kill it, while criterion 3 separately requires each hardening to be individually
killable. Those two criteria conflict as written.

Verified both directions: the mkdir-only mutant and the subshells-only mutant are each caught
by the dash fixture, so neither substitutes for the other.

## Mutation matrix

| mutant | FAILs |
|---|---|
| this PR | **0** |
| no `CDPATH=` | CDPATH case only |
| no `-P` | symlink case only |
| no `--` (all) | dash case only |
| no `--` (subshells only) | dash case only |
| no `--` (mkdir only) | dash case only |
| pre-change | all three |

Byte-identity holds (criterion 4): archive, `.sha256` and `.blake3` are `cmp`-identical to
pre-change output for an ordinary `out_dir`, and `verify-release.sh` round-trips them. Suite
passes under GNU bash 3.2.57 as well as 5.3.

## What I got wrong, since it shaped the result

**Two of my three fixtures were wrong before I measured them**, and both passed against the
*unhardened* script while covering nothing: for `-P` I first used `link/sub/..`, where logical
and physical `cd` agree; for `--` I used `./-outdir`, whose dirname is `.`.

**I described the CDPATH mechanism incorrectly in three places, and wrote a test assertion for
it.** I claimed `cd`'s CDPATH chatter is captured into the manifest. It is not — in
`(cd DIR && sha256sum NAME > NAME.sha256)` the redirection binds to `sha256sum`, not to `cd`.
The reviewer caught it and showed that the assertion I added for that mechanism
(`[ "$(grep -c . -- "$man")" = 1 ]`) can never fire. Both the claim and the dead assertion are
gone, and the comment now states the binding explicitly so the error is not re-derived.

**The `-P` example was off by one path component** — I wrote "where the link points" when my
own measurement had shown the link target's *parent*.

## Left out deliberately

`make-tarball.sh:8`'s `git rev-parse --verify "$ref^{commit}"` also lacks `--`. Filed as
**#1331** rather than folded in: the `mkdir` widening was *forced* by the criteria conflict
above, this one is not required by anything, and widening twice on my own judgment in one
change is how scope creep gets rationalised.
