### PR TITLE
fix(release): test and cross-check the owned-soname derivation

### DIFF
--- a/scripts/ci/test-derive-owned-sonames.sh
+++ b/scripts/ci/test-derive-owned-sonames.sh
@@ -9,29 +9,10 @@
 # milliseconds.
 set -euo pipefail
 
-# meson hands this script a native path; on Windows that is a drive-letter path
-# bash cannot use. See bb4ca712 for the same fix on the downstream self-test.
-normalize_root() {
-    local supplied=$1
-    case "$supplied" in
-        [[:alpha:]]:[\\/]* )
-            if ! command -v cygpath >/dev/null 2>&1; then
-                echo "derive-owned-sonames self-test: cygpath is required to normalize Windows root: $supplied" >&2
-                return 2
-            fi
-            if ! supplied=$(cygpath -u -- "$supplied"); then
-                echo "derive-owned-sonames self-test: cygpath could not normalize Windows root: $supplied" >&2
-                return 2
-            fi
-            ;;
-    esac
-    printf '%s\n' "$supplied"
-}
-
+# No Windows path normalization: tests/meson.build gates this test to Linux
+# (see the two reasons recorded there), so the drive-letter form the sibling
+# test-downstream-matrix.sh handles cannot reach here.
 root=${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}
-if (($#)); then
-    root=$(normalize_root "$root")
-fi
 derive="$root/scripts/release/derive-owned-sonames.sh"
 [[ -x "$derive" ]] || {
     echo "derive-owned-sonames self-test: not executable: $derive" >&2
@@ -86,9 +67,17 @@ mkdir -p "$build/subprojects/other"
 expected=$'libnanoarrow.so\nlibwirelog.1.dylib\nlibwirelog.so\nlibwirelog.so.0\nlibwirelog.so.0.60.0'
 actual=$("$derive" "$build")
 
-[[ "$actual" == "$expected" ]]
-check "derives exactly the library names, sorted" $?
-if [[ "$actual" != "$expected" ]]; then
+# `status=...; check` rather than a bare `[[ ]]` followed by `check $?`: under
+# errexit a standalone `[[ ]]` aborts the script on failure, so the FAIL line
+# and the diagnostic below it never printed and the remaining cases never ran.
+# Measured -- with the derivation mutated, this file exited 1 having produced
+# NO output at all. Worse on the platform that matters: bash 3.2 does not apply
+# errexit there, and tests/meson.build gates this test to Linux, so the
+# diagnostics were dead exactly where they run.
+headline_status=0
+[[ "$actual" == "$expected" ]] || headline_status=1
+check "derives exactly the library names, sorted" "$headline_status"
+if [[ "$headline_status" != 0 ]]; then
     printf 'expected:\n%s\ngot:\n%s\n' "$expected" "$actual" >&2
 fi
 
@@ -109,8 +98,9 @@ dedupes() { [[ "$(printf '%s\n' "$actual" | grep -cx 'libnanoarrow.so')" == 1 ]]
 assert 'a basename appearing twice is emitted once' dedupes
 
 # A tree with no shared libraries must fail rather than emit an empty set: an
-# empty set makes the closure check vacuous, because no loaded library can
-# match it.
+# empty set is also caught by the `-s` guards in
+# check-shared-library-closure.sh and run-upgrade-matrix.sh, so this asserts the
+# derivation names the cause itself rather than deferring to them.
 empty="$tmp/empty"
 mkdir -p "$empty/subprojects"
 : >"$empty/README"
@@ -128,11 +118,19 @@ assert 'a tree of only by-products fails' byproducts_fail
 # Locale independence: the output feeds a comparison, so its order must not
 # depend on the operator (#1291).
 locale_name=""
+# Read the list once, then test membership without a pipeline. `locale -a |
+# grep -Fxq` would be a SIGPIPE-under-pipefail hazard, and the failure mode is
+# the bad one: this is an `if` CONDITION, so errexit does not apply and a
+# SIGPIPE would merely make it false -- silently taking the else branch and
+# printing `ok locale (en_US absent, skipped)` while dropping both locale
+# assertions. Stopping-to-assert-while-reporting-PASS is the exact shape this
+# whole change exists to prevent. Measured threshold is far above any real
+# locale list, so this is prevention, not a live fix.
+available_locales=$(locale -a 2>/dev/null || true)
 for candidate in en_US.utf8 en_US.UTF-8; do
-    if locale -a 2>/dev/null | grep -Fxq "$candidate"; then
-        locale_name=$candidate
-        break
-    fi
+    case $'\n'"$available_locales"$'\n' in
+        *$'\n'"$candidate"$'\n'*) locale_name=$candidate; break ;;
+    esac
 done
 if [[ -n "$locale_name" ]]; then
     # A colliding pair: en_US ignores the hyphen, so libmethod-modifier sorts
@@ -157,10 +155,22 @@ else
     printf 'derive-owned-sonames self-test: ok locale (en_US absent, skipped)\n'
 fi
 
-missing_arg() { ! "$derive" >/dev/null 2>&1; }
-assert 'no argument exits non-zero' missing_arg
-bad_dir() { ! "$derive" "$tmp/does-not-exist" >/dev/null 2>&1; }
-assert 'a missing build directory exits non-zero' bad_dir
+# Assert the SPECIFIC outcome, not merely non-zero. `! "$derive"` passed even
+# with the argument check or the -d check deleted, because `set -u` and the
+# empty-set guard produce a non-zero exit by other routes -- the cases held
+# while pinning nothing they named.
+usage_exit_2() { local st=0; "$derive" >/dev/null 2>&1 || st=$?; [[ "$st" == 2 ]]; }
+assert 'no argument exits 2 (usage), distinct from a derivation failure' usage_exit_2
+
+# Deliberately not `"$derive" ... | grep -q`: derive exits 1 by design here, and
+# pipefail would make the function fail even when grep matched -- the same trap
+# as the locale probe above.
+bad_dir_names_itself() {
+    local msg
+    msg=$("$derive" "$tmp/does-not-exist" 2>&1 || true)
+    [[ "$msg" == *'not a directory'* ]]
+}
+assert 'a missing build directory names itself, not an empty tree' bad_dir_names_itself
 
 if ((failures)); then
     printf 'derive-owned-sonames self-test: %d case(s) failed\n' "$failures" >&2

--- a/scripts/release/derive-owned-sonames.sh
+++ b/scripts/release/derive-owned-sonames.sh
@@ -10,8 +10,11 @@
 # usage: derive-owned-sonames.sh BUILD_DIR
 #
 # Prints one basename per line, LC_ALL=C sorted and de-duplicated. Exits 1 if
-# the tree yields none -- an empty set would make the closure check vacuous,
-# since no loaded library could ever match it.
+# the tree yields none. Not because that would otherwise go unnoticed --
+# check-shared-library-closure.sh and run-upgrade-matrix.sh each carry their own
+# `-s` guard, both predating this script -- but because failing at the point of
+# derivation names the real cause, where the downstream guards can only report
+# that the set was empty by the time they saw it.
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then

--- a/scripts/upgrade/run-upgrade-matrix.sh
+++ b/scripts/upgrade/run-upgrade-matrix.sh
@@ -66,9 +66,12 @@ build_tree() {
     # build_tree runs inside a command substitution and this script does not
     # set inherit_errexit, so a failing *external* command does not abort it
     # the way the previous inline `exit` did -- and the redirection truncates
-    # $owned regardless. Without the explicit `|| exit 1` the derivation could
-    # fail, leave an empty set, and have every installed library reported
-    # missing below: a real failure reported as the wrong one.
+    # $owned regardless. The `|| exit 1` makes the derivation's own diagnostic
+    # the one that surfaces. It is belt-and-braces, not load-bearing: the
+    # `-s` guard on the next line already catches an empty set, so the
+    # every-library-reported-missing outcome is unreachable while that guard
+    # sits there. Keep both -- the first names the cause, the second is the
+    # backstop if the first is ever relaxed.
     local owned="$tmp/owned-$name.txt"
     "$root/scripts/release/derive-owned-sonames.sh" "$build" >"$owned" || exit 1
     [[ -s "$owned" ]] || {
@@ -93,20 +96,43 @@ build_tree() {
     # installed -- but nothing here proves it: the check below is comm -13,
     # which establishes installed-subset-of-owned, and the reverse would need
     # comm -23.
-    local libdir installed missing
+    local libdir missing
     libdir=$(dirname "$lib")
-    installed=$(find "$libdir" -maxdepth 1 ! -type d \
-        \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' \) -print |
-        sed 's|.*/||' |
-        { grep -E '\.(so|dylib)(\.[0-9]+)*$' || true; } |
-        LC_ALL=C sort -u)
+    # Call the extracted derivation rather than re-inlining its classifier.
+    # This scan and derive-owned-sonames.sh must agree on what counts as a
+    # library, and a second copy here would be exactly the untested,
+    # release-only duplicate that #1285 exists to remove -- if the two drifted,
+    # the cross-check below would raise false accusations on a path that runs
+    # only at release time.
+    #
+    # No -maxdepth, matching the derivation's own rule for the same reason: a
+    # library installed under a subdirectory of libdir would otherwise be
+    # invisible here, which is the silent-drop shape this cross-check exists to
+    # catch.
+    #
+    # `|| exit 1`, not `|| true`: an empty result here is not tolerable, it is
+    # IMPOSSIBLE. libdir is dirname("$lib") and $lib is the installed
+    # libwirelog located above, so the directory provably holds at least one
+    # shared library. The only way this yields nothing is a real failure, and
+    # swallowing it would add a silent-pass route to the check whose whole job
+    # is to prevent silent passes. Nothing guards an empty `installed` -- the
+    # `-s` guard above is on $owned, the build side.
+    #
+    # Materialized to a file rather than a variable so comm reads it directly:
+    # `printf '%s\n' "$installed"` on an empty value feeds comm a blank line,
+    # which it reports as only-in-file-2 and the substitution then strips --
+    # right by accident rather than by design. And `|| exit 1` on comm rather
+    # than `|| true`: comm fails only on error or unsorted input here, never on
+    # a legitimate difference, so it cannot cause a false failure.
+    local installed_file="$tmp/installed-$name.txt"
+    "$root/scripts/release/derive-owned-sonames.sh" "$libdir" >"$installed_file" || exit 1
     # LC_ALL=C on comm as well as on the sorts: comm respects LC_COLLATE, so
     # with C-sorted inputs and an en_US comparison it reports spurious
     # differences and warns "file 2 is not in sorted order" -- accusing the
     # derivation of a bug that does not exist. Latent while every library
     # basename here is collation-invariant, live the day a hyphenated one
     # appears (#1291, #1294).
-    missing=$(LC_ALL=C comm -13 "$owned" <(printf '%s\n' "$installed") || true)
+    missing=$(LC_ALL=C comm -13 "$owned" "$installed_file") || exit 1
     if [[ -n "$missing" ]]; then
         {
             echo "upgrade matrix: $name installs shared libraries the owned-soname set does not name:"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -824,9 +824,21 @@ endif
 # release tag.  Extracted to scripts/release/derive-owned-sonames.sh so its
 # edge cases -- symlink chains, .p object directories, .symbols by-products,
 # an empty tree -- are exercised on every PR.
-# Linux-gated: the fixture builds a symlink chain with `ln -s`, which on
-# MSYS/Git-Bash copies instead of linking, so the symlink assertions would pass
-# for a different reason there rather than exercising what they name.
+# Linux-gated, for two reasons rather than the one first recorded here:
+#   Windows -- the fixture builds a symlink chain with `ln -s`, which on
+#     MSYS/Git-Bash copies instead of linking, so the symlink assertions would
+#     pass for a different reason rather than exercising what they name.
+#   macOS -- the locale case ASSERTS that en_US collation orders a hyphenated
+#     pair differently from C. That is glibc applying the UCA rule of ignoring
+#     punctuation at the primary level; Darwin's en_US.UTF-8 is not known to,
+#     and the candidate loop tries `en_US.UTF-8` precisely because macOS has
+#     it. So the branch would be taken and `fixture_discriminates` would fail
+#     -- a false failure, not a real one.
+# Widening to darwin therefore needs `fixture_discriminates` turned from an
+# assertion into a skip-guard first, and confirming on a real macOS host.
+# `normalize_root` is deliberately absent from the test: the sibling
+# test-downstream-matrix.sh carries it because a bare `if sh.found()` really
+# does run it on Windows, and this gate does not.
 if host_machine.system() == 'linux' and sh.found()
   test('owned_sonames', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-derive-owned-sonames.sh',


### PR DESCRIPTION
Closes #1285. Based on `main` — independent of every other open PR.

## The problem

The release upgrade matrix (#1272) derived its owned-soname set inline in
`run-upgrade-matrix.sh`, so the derivation only ever executed on a release tag and had no
test. Everything the closure gate asserts rests on that set being right: a library that drops
out of it stops being checked, **silently**, while the gate keeps reporting PASS.

## The change

Extract to `scripts/release/derive-owned-sonames.sh`, exercise it from fixtures in
milliseconds, and have the cross-check call it rather than re-inlining its classifier.

Every property the derivation relies on is falsifiable and killed by a named case: no
`-maxdepth`, `! -type d` for meson's `.p` object directories, the suffix grep for `.symbols`
by-products, `sort -u`, `LC_ALL=C`, and the empty-set exit.

## What review found

This was written in an earlier session, committed, and **never pushed** — no remote branch, no
PR. I picked it up with no review record and handed it over as unreviewed third-party code.
That was the right call; four substantive defects came out of it.

**The headline assertion produced no diagnostic on the platform it runs.** It used a bare
`[[ ]]` followed by `check $?`. Under errexit that aborts before its own FAIL line, before the
expected/got dump, and before any remaining case runs. Measured: a mutated derivation exited 1
having produced **zero output**. Worse in direction — bash 3.2 does *not* apply errexit there,
and this test is gated to Linux, so the diagnostics were dead exactly where they execute.

**The extraction left a second copy of the classifier ten lines below the call** — the very
untested, release-only duplicate the change exists to remove. And the two did not agree: the
inline form used `-maxdepth 1`, so a library installed under a subdirectory of `libdir` was
invisible to the check whose job is catching libraries the owned set doesn't name.

**My fix for that introduced a silent-pass route into the function whose purpose is preventing
silent passes.** I wrote `2>/dev/null || true` and justified it with two false sentences. Both
a derivation failure and a `comm` failure previously yielded an empty result that `comm`
reported as a clean subset:

```
old form, derivation fails:  exit 0, missing=''   ← passes having asserted nothing
new form, derivation fails:  exit 1, diagnostic on stderr
```

Empty there is not tolerable, it is *impossible* — `libdir` is `dirname "$lib"` where `$lib`
was located four lines earlier.

**The "empty set makes the closure check vacuous" rationale was false in three places.**
`owned soname list is empty` exists at `HEAD~1` in `check-shared-library-closure.sh`, and
`[[ -s "$owned" ]]` sits directly below the `|| exit 1` whose comment described an unreachable
outcome.

## The Linux gate

Recorded with both reasons, where only one was written down. Windows: MSYS `ln -s` copies, so
the symlink assertions would pass for the wrong reason. **macOS: the locale case *asserts* that
en_US collation orders a hyphenated pair differently from C — that is glibc ignoring
punctuation at the primary level, and Darwin's `en_US.UTF-8` is not known to.** Since the
candidate loop tries `en_US.UTF-8` precisely because macOS has it, widening the gate would
produce a hard **false** failure. The prerequisite for ever widening (turn
`fixture_discriminates` into a skip-guard, confirm on a real macOS host) is stated. 17 lines of
Windows path handling that a Linux-only gate makes unreachable are deleted, with the divergence
from the sibling test explained.

The locale probe is also now pipeline-free. Not because the SIGPIPE was reachable — measured
headroom is large — but because it is an `if` **condition**, so errexit doesn't apply: a
SIGPIPE would silently take the else branch and print `ok locale (… skipped)` while dropping
both assertions. Reporting PASS while having stopped asserting is the exact shape this change
exists to prevent.

Verified on real GNU bash 3.2.57 as well as 5.3. Local: **305 Ok / 0 Fail / 12 Skipped**.
