### PR TITLE
ci: distinguish why the provenance check declined to verify

### DIFF
--- a/scripts/ci/check-no-testhook-in-libwirelog.sh
+++ b/scripts/ci/check-no-testhook-in-libwirelog.sh
@@ -127,6 +127,17 @@ provenance_of() {
         }'
 }
 
+# Symbols matching the emitter pattern, WHETHER OR NOT they carry a location.
+# provenance_of answers "where is it defined"; this answers "is it defined at
+# all", and #1305 turns on the difference.
+emitter_symbols() {
+    awk -F'\t' '
+        {
+            split($1, f, /[ \t]+/)
+            if (f[3] ~ /^_?wl_log_emit(\.[A-Za-z0-9_.]+)?$/) { print f[3] }
+        }'
+}
+
 check_provenance() {
     local nm_out prov
     if ! nm_out=$(nm --line-numbers --defined-only "$LIB" 2>/dev/null); then
@@ -150,8 +161,92 @@ check_provenance() {
     # output, the piped form exits 141.
     prov=$(provenance_of <<<"$nm_out")
     if [ -z "$prov" ]; then
-        echo "SKIP: no line-number information for wl_log_emit in $LIB (stripped or non-debug build); cannot verify provenance" >&2
-        return "$SKIP_EXIT"
+        # Three causes, and they are not equally benign. Distinguishing them is
+        # the whole of #1305: before this, all three printed the stripped-build
+        # message, so a library with 1,261 lines of line-number information and
+        # wl_log_emit renamed away was byte-identical to a genuinely stripped
+        # build.
+        local any_loc emitter_syms
+        any_loc=$(grep -cE ':[0-9]+$' <<<"$nm_out" || true)
+        emitter_syms=$(emitter_symbols <<<"$nm_out")
+
+        if [ "$any_loc" -eq 0 ]; then
+            # (1) No locations anywhere: the build cannot answer. Unchanged.
+            echo "SKIP: no line-number information for wl_log_emit in $LIB (stripped or non-debug build); cannot verify provenance" >&2
+            return "$SKIP_EXIT"
+        fi
+        if [ -n "$emitter_syms" ]; then
+            # (2a) The emitter IS defined; this listing gives it no location.
+            # That is all that is observable -- deliberately not narrated as
+            # "the library is intact", because a substituted log_testhook.c
+            # compiled without -g produces exactly this shape, and a comment
+            # telling the maintainer to stop looking would be the same sin this
+            # change removes from the branch above. Skip because there is
+            # nothing to verify against, not because nothing is wrong.
+            echo "SKIP: $LIB defines wl_log_emit but this listing carries no location for it; cannot verify provenance" >&2
+            echo "  symbol(s) found: $(tr '\n' ' ' <<<"$emitter_syms")" >&2
+            return "$SKIP_EXIT"
+        fi
+        # No emitter symbol at all. Whether that is evidence depends on
+        # whether the LOCAL symbol table survived, because wl_log_emit is a
+        # local ('t') symbol in this library.
+        local locals_present
+        # /^[tdbrns]$/, not any lowercase: nm prints ELF IFUNC as 'i' and
+        # unique-global as 'u' REGARDLESS of binding, so a GLOBAL ifunc survives
+        # strip -x and would read as a surviving local -- re-arming the false
+        # failure this branch exists to remove. Measured on a two-line ifunc
+        # library: after strip -x the only lowercase symbol left is 'i'. This
+        # project already builds with -mavx2/-msse4.2, so a CPU-dispatch ifunc
+        # is a plausible addition rather than a hypothetical.
+        locals_present=$(awk '$2 ~ /^[tdbrns]$/ { n++ } END { print n + 0 }' <<<"$nm_out")
+        if [ "$locals_present" -eq 0 ]; then
+            # (2c) No local symbols anywhere: the local symbol table was
+            # discarded, so a missing LOCAL wl_log_emit is not evidence of
+            # anything. This is reachable legitimately -- `strip -x` followed by
+            # `objcopy --add-gnu-debuglink` yields exactly this, because GNU nm
+            # takes the symbol list from the stripped file while resolving line
+            # numbers through the separate debug file. Measured: 96 symbols, 96
+            # locations, no locals, no emitter. Calling that tampering would be
+            # a false failure in the one gate that must not cry wolf.
+            # Accepted detection boundary, stated so nobody "tightens" it back
+            # into the false failure: an attacker who strips locals from a
+            # tampered library gets a skip rather than a failure. That is
+            # unavoidable -- a local symbol's absence genuinely proves nothing
+            # here -- and it is no weaker than branch (1) or the nm-empty exit
+            # above. The gate declines to answer instead of answering wrongly.
+            echo "SKIP: $LIB carries line-number information but no local symbols (locals stripped, e.g. strip -x with a separate debug file); wl_log_emit is local, so its absence is not evidence" >&2
+            return "$SKIP_EXIT"
+        fi
+        # (2b) Locations present, local symbols present, and still no emitter.
+        # The local table survived and the emitter is not in it, so something
+        # removed it specifically: a rename, a relink against a different
+        # translation unit, or a substitution. All three are what this gate
+        # exists to catch and all three need a human -- the same condition the
+        # unrecognized-provenance branch below answers with 1.
+        #
+        # This verdict does not rest on line-number quality. "No symbol matches
+        # the pattern, and locals are present" is a statement about the SYMBOL
+        # TABLE, which every nm vintage reports alike; the line table only
+        # establishes that the build could have answered, and misreading it
+        # under-detects DWARF, which downgrades this to a skip -- the safe
+        # direction.
+        echo "FAIL: $LIB carries line-number information but defines no wl_log_emit; the emitter has been renamed, relinked or removed" >&2
+        # At 2am the next question is "then what IS in there", so answer it.
+        # One awk, no pipeline. `grep | sort -u | head -8` fails two independent
+        # ways, both measured on this host: grep exits 1 when nothing matches
+        # (the common case here -- most libraries have no stray wl_log symbol),
+        # and sort is SIGPIPE-killed at 141 once head stops reading a large
+        # listing. pipefail surfaces either, and set -e then aborts before this
+        # message is printed -- silently costing the diagnostic this branch
+        # exists to give. Two mechanisms and a status that varies by tool is
+        # why the fix is removing the pipeline, not tolerating a code.
+        local nearby
+        nearby=$(awk '
+            { for (i = 1; i <= NF; i++)
+                  if ($i ~ /wl_log/ && !seen[$i]++ && n < 8) { out = out " " $i; n++ } }
+            END { print out }' <<<"$nm_out")
+        echo "  wl_log-like symbols present:${nearby:- (none)}" >&2
+        return 1
     fi
     case "$prov" in
         *log_testhook.c*)

--- a/scripts/ci/test-check-no-testhook.sh
+++ b/scripts/ci/test-check-no-testhook.sh
@@ -47,6 +47,18 @@ expect_status() {
         failures=$((failures + 1))
     fi
 }
+# The negative form. Without it, asserting only that a message IS present
+# cannot rule out a second, contradictory message alongside it.
+refute_says() {
+    local name=$1 needle=$2
+    if grep -qF -e "$needle" "$tmp/out" "$tmp/err"; then
+        printf 'test-check-no-testhook: FAIL %s (unexpected %q in output)\n' "$name" "$needle" >&2
+        failures=$((failures + 1))
+    else
+        printf 'test-check-no-testhook: ok %s\n' "$name"
+    fi
+}
+
 expect_says() {
     local name=$1 needle=$2
     if grep -qF -e "$needle" "$tmp/out" "$tmp/err"; then
@@ -148,9 +160,22 @@ printf '0000000000001119 T wl_log_emit\t/build dir/wirelog/util/log_emit.c:42\n'
 expect_status 'a path containing spaces still resolves' 0 run "$clean_syms" "$spaced" --check=provenance
 
 # A longer symbol that merely starts with the name must not be mistaken for it.
+# This is shape 2b under #1305 -- the listing carries a location, and no symbol
+# matching the emitter pattern is defined -- so the verdict is 1, not the 77 it
+# was before. Assert the MESSAGE as well: after the flip the exit code alone no
+# longer distinguishes "the pattern correctly rejected _v2" from "the pattern
+# wrongly matched _v2 and found testhook provenance", which is what this case
+# exists to rule out.
 prefix="$tmp/prefix.txt"
-printf '0000000000001119 T wl_log_emit_v2\t/x/log_testhook.c:1\n' > "$prefix"
-expect_status 'a prefix symbol is not mistaken for wl_log_emit' 77 run "$clean_syms" "$prefix" --check=provenance
+# A local symbol is present so this is shape 2b (the local table survived and
+# the emitter is not in it), not 2c (locals stripped, absence proves nothing).
+# Real libraries have locals; without one this fixture would take the 2c skip
+# and stop testing what it names.
+printf '0000000000001119 T wl_log_emit_v2\t/x/log_testhook.c:1\n0000000000002220 t a_local\t/x/o.c:2\n' > "$prefix"
+expect_status 'a prefix symbol is not mistaken for wl_log_emit' 1 run "$clean_syms" "$prefix" --check=provenance
+expect_says 'and is reported as a missing emitter, not as testhook provenance' \
+    'defines no wl_log_emit'
+refute_says 'and does not claim provenance in log_testhook.c' 'originates from log_testhook.c'
 
 # --- independence (criterion 5) ---------------------------------------------
 # A provenance skip must not hide the leak check's real result, and a leak must
@@ -211,10 +236,116 @@ expect_status 'a GCC clone suffix resolves' 0 run "$clean_syms" "$clone" --check
 
 # ...but a different symbol that merely shares the prefix must not. The dot is
 # what separates a clone from an unrelated function.
+# Shape 2b as above, so 1 rather than 77, with the message carrying the proof.
 notclone="$tmp/notclone.txt"
-printf '0000000000001119 t wl_log_emit_v2\t/x/wirelog/util/log_testhook.c:1\n' > "$notclone"
-expect_status 'a prefix symbol is still not mistaken for a clone' 77 \
+printf '0000000000001119 t wl_log_emit_v2\t/x/wirelog/util/log_testhook.c:1\n0000000000002220 t a_local\t/x/o.c:2\n' > "$notclone"
+expect_status 'a prefix symbol is still not mistaken for a clone' 1 \
     run "$clean_syms" "$notclone" --check=provenance
+expect_says 'and reports a missing emitter' 'defines no wl_log_emit'
+refute_says 'and the clone rule did not match _v2 either' 'originates from log_testhook.c'
+
+# --- #1305: the three no-provenance shapes are distinguished --------------
+#
+# Before #1305 all three printed the stripped-build message, so a library with
+# 1,261 lines of line-number information and wl_log_emit renamed away was
+# byte-identical to a genuinely stripped build.
+#
+# (1) no locations anywhere -- the build cannot answer. SKIP 77.
+nodwarf="$tmp/nodwarf.txt"
+printf '0000000000001119 t wl_log_emit\n0000000000002220 T other_symbol\n' > "$nodwarf"
+expect_status 'no locations anywhere is the stripped-build skip' 77 \
+    run "$clean_syms" "$nodwarf" --check=provenance
+expect_says 'and names a stripped or non-debug build' 'stripped or non-debug build'
+
+# (2a) locations present, and the emitter IS defined but carries none. The
+# library is intact; the debug info is incomplete for one symbol. SKIP 77, but
+# it must not blame a strip that did not happen.
+partial="$tmp/partial.txt"
+printf '0000000000001119 t wl_log_emit\n0000000000002220 T other_symbol\t/x/other.c:9\n' > "$partial"
+expect_status 'emitter present without a location is a distinct skip' 77 \
+    run "$clean_syms" "$partial" --check=provenance
+expect_says 'and names the missing location, not a strip' 'carries no location for it'
+refute_says 'and does not blame a stripped build' 'stripped or non-debug build'
+
+# (2b) locations present, LOCAL SYMBOLS PRESENT, and still no symbol matching
+# the emitter pattern. The local table survived and the emitter is not in it, so
+# it was renamed, relinked or removed. FAIL 1. The locals precondition is what
+# separates this from (2c) below -- without it, a legitimately `strip -x`ed
+# library with a separate debug file would be failed as tampered.
+gone="$tmp/gone.txt"
+printf '0000000000002220 T other_symbol\t/x/other.c:9\n0000000000003330 t a_local\t/x/o.c:2\n' > "$gone"
+expect_status 'DWARF present with no emitter at all is a failure' 1 \
+    run "$clean_syms" "$gone" --check=provenance
+expect_says 'and says the emitter was renamed, relinked or removed' 'defines no wl_log_emit'
+refute_says 'and does not report it as a stripped build' 'stripped or non-debug build'
+
+# (2c) Locations present, but NO local symbols at all. wl_log_emit is local, so
+# its absence is not evidence. Reachable legitimately: `strip -x` plus
+# `objcopy --add-gnu-debuglink` produces exactly this under GNU nm -- measured
+# on a real library at 96 symbols, 96 locations, zero locals, no emitter. This
+# case is why (2b) is not simply "DWARF present and no emitter".
+nolocals="$tmp/nolocals.txt"
+printf '0000000000002220 T other_symbol\t/x/other.c:9\n0000000000003330 T third\t/x/third.c:4\n' > "$nolocals"
+expect_status 'no local symbols is a skip, not a missing emitter' 77 \
+    run "$clean_syms" "$nolocals" --check=provenance
+expect_says 'and says why the absence is not evidence' 'not evidence'
+refute_says 'and does not accuse a rename' 'renamed, relinked or removed'
+
+# A GLOBAL ifunc must not be counted as a surviving local. GNU nm prints ELF
+# IFUNC as 'i' and unique-global as 'u' regardless of binding, and a global
+# ifunc survives `strip -x` -- measured on a real two-line ifunc library, where
+# 'i' is the ONLY lowercase symbol left after stripping. Counting it as a local
+# would re-arm the false failure (2c) exists to remove, on a project that
+# already builds with -mavx2/-msse4.2 and could plausibly add CPU dispatch.
+ifunc="$tmp/ifunc.txt"
+printf '0000000000002220 T other_symbol\t/x/other.c:9\n0000000000003330 i dispatched\t/x/i.c:2\n' > "$ifunc"
+expect_status 'a global ifunc does not count as a surviving local' 77 \
+    run "$clean_syms" "$ifunc" --check=provenance
+expect_says 'and is reported as locals stripped' 'no local symbols'
+
+# emitter_symbols must recognise the same shapes provenance_of does, or a
+# legitimate build flips from skip to failure. /tmp/b-err in this repo defines
+# ONLY wl_log_emit.constprop.0 and no plain wl_log_emit, so the clone
+# alternation is load-bearing, not decorative.
+clone_noloc="$tmp/clone_noloc.txt"
+printf '0000000000001119 t wl_log_emit.constprop.0\n0000000000002220 T other\t/x/other.c:9\n' > "$clone_noloc"
+expect_status 'an unlocated clone is 2a, not a missing emitter' 77 \
+    run "$clean_syms" "$clone_noloc" --check=provenance
+refute_says 'and the clone is not reported as removed' 'renamed, relinked or removed'
+
+macho_noloc="$tmp/macho_noloc.txt"
+printf '0000000000001119 t _wl_log_emit\n0000000000002220 T other\t/x/other.c:9\n' > "$macho_noloc"
+expect_status 'an unlocated Mach-O _wl_log_emit is 2a' 77 \
+    run "$clean_syms" "$macho_noloc" --check=provenance
+refute_says 'and the Mach-O form is not reported as removed' 'renamed, relinked or removed'
+
+# The 2b diagnostic must survive a large listing. Without this the `nearby`
+# computation could regress to a pipeline -- which fails on exactly this input
+# and prints nothing -- and no case would notice.
+bigb="$tmp/bigb.txt"
+{
+    printf '0000000000002220 T other_symbol\t/x/other.c:9\n'
+    i=0
+    while [ "$i" -lt 9000 ]; do
+        printf '00000000000%05d t wl_log_filler_%d\t/x/f.c:%d\n' "$i" "$i" "$i"
+        i=$((i + 1))
+    done
+} > "$bigb"
+# The point is sort's OUTPUT exceeding the 64 KB pipe buffer, not the fixture's
+# size, so guard it: shortening the filler names would make this pass vacuously
+# while no longer exercising the regression it exists to catch.
+bigb_sorted_bytes=$(awk '{ for (i = 1; i <= NF; i++) if ($i ~ /wl_log/) n += length($i) + 1 } END { print n + 0 }' "$bigb")
+if [ "$bigb_sorted_bytes" -lt 100000 ]; then
+    printf 'test-check-no-testhook: FAIL 2b fixture too small (%s bytes of matches; need >100000 to clear the pipe buffer)\n' \
+        "$bigb_sorted_bytes" >&2
+    failures=$((failures + 1))
+else
+    printf 'test-check-no-testhook: ok the 2b fixture is large enough to exercise the pipe buffer\n'
+fi
+expect_status 'a large listing with no emitter still fails' 1 \
+    run "$clean_syms" "$bigb" --check=provenance
+expect_says 'and still lists the wl_log-like symbols it did find' \
+    'wl_log-like symbols present'
 
 # A tab-separated trailing field that is not a file:line must not be taken as a
 # location; without the :<line> guard this would be reported as provenance.


### PR DESCRIPTION
Closes #1305. Stacked on #1304 (`fix/1302-testhook-provenance`) — review that first.

## The defect

`check_provenance` printed one message for three conditions, so a library with 1,261 lines of
line-number information and `wl_log_emit` renamed away produced **byte-identical output and
status** to a genuinely stripped build.

| shape | before | after |
|---|---|---|
| no `file:line` anywhere | SKIP 77 | SKIP 77 (unchanged) |
| locations present, emitter defined but unlocated | SKIP 77, wrong reason | SKIP 77, own message |
| locations present, **no local symbols at all** | SKIP 77, wrong reason | SKIP 77, own message |
| locations present, locals present, **no emitter** | SKIP 77 | **FAIL 1** |
| emitter located | verdict | verdict |

## How the verdict was decided

Criterion 2 demanded a reasoned choice between 77 and 1, so it was put to an Architect, then
attacked by a Critic. **The Critic falsified the Architect's ruling, and that is the most
important thing in this PR.**

The Architect's argument was that `strip` removes the symbol table and the line table
together, so "DWARF present, emitter absent" cannot be a stripped build. It tested nine
configurations — LTO, ThinLTO, ASan, gold, `--gc-sections`, per-TU debug skew, unity, static
archives, split debuglink — and found no counterexample.

The Critic found the combination it hadn't tried:

```
strip -x  +  objcopy --add-gnu-debuglink
  →  96 symbols, 96 locations, 0 locals, 0 emitter
```

GNU `nm` takes the symbol list from the *stripped* file while resolving line numbers through
the *separate* debug file. Without the extra guard this PR would have failed that library as
tampered. **A documented-as-impossible false failure in a tampering gate is worse than no
gate** — it is what maintainers learn to bypass.

The discriminator is exact, because `wl_log_emit` is a **local** symbol: where no locals
survive, its absence proves nothing.

```
strip -x + debuglink (legitimate):  locations 96,   locals 0     → SKIP 77
renamed emitter (real tampering):   locations 1261, locals 1394  → FAIL 1
```

Locals are counted as `[tdbrns]`, not any lowercase type: GNU `nm` prints ELF IFUNC as `i` and
unique-global as `u` **regardless of binding**, and a *global* ifunc survives `strip -x` —
measured on a real ifunc library, where `i` is the only lowercase symbol left after stripping.
One such symbol would silently re-arm the false failure. This project already builds with
`-mavx2`/`-msse4.2`, so CPU dispatch is plausible rather than hypothetical.

## Tests

Fixtures for every shape, plus the ones review showed were missing. 13 mutations, 13 caught —
including `[tdbrns] → [a-z]`, `[tdbrns] → [tdbrnsi]`, the clone-suffix and Mach-O `^_?` cases
in `emitter_symbols`, deleting the diagnostic, and re-piping it.

Two existing assertions move 77 → 1, the intended verdict for their fixtures. Both now assert
on the *message*, since after the flip the exit code alone no longer separates "the pattern
rejected `wl_log_emit_v2`" from "the pattern matched it and found testhook provenance". Review
also caught that both flipped fixtures had **no local symbols**, so they were silently taking
the new skip instead of testing what they name — fixed.

Four real libraries: verdict `0`, stripped `77`, tampered `1`, locals-stripped `77`. Local
suite: **305 Ok / 0 Fail**.

## Things I got wrong, recorded because they shaped the result

- **I introduced a SIGPIPE bug in the fix** — `grep | sort -u | head -8` in the new diagnostic,
  in a script whose own comments discuss that trap. It printed nothing. Replaced with one awk.
  The reviewer and I then measured *different* exit codes for it and both were right: grep
  exits 1 when nothing matches, sort dies at 141 on a large listing. The comment names both,
  which is why the fix is removing the pipeline rather than tolerating a code.
- **I left the falsified strip claim in the test file** after removing it from the gate — eight
  lines above the fixture that says the opposite. `git show HEAD:` confirms this change
  introduced it.
- **The ifunc hardening was initially unprotected**: relaxing it back to `[a-z]` passed the
  whole suite. There is a fixture now.
- **The large-listing fixture was 14% over the pipe buffer** with no guard, so shrinking the
  filler names would have made it pass vacuously. Guarded on matched-symbol bytes, and the
  guard failed my first attempt.

## Residual, stated rather than hidden

- An attacker who strips locals from a tampered library gets a skip, not a failure. Unavoidable
  — a local's absence genuinely proves nothing — and no weaker than the existing branches. It
  is now a deliberate detection boundary, written down so nobody "tightens" it back into the
  false failure.
- **macOS: could not establish.** Four CI legs run this gate on `macos-latest` with an
  llvm-based `nm`; neither reviewer nor I has a host. Nothing in the comments claims otherwise.
