### PR TITLE
ci: let the ABI and SBOM gates be required where they must enforce

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -235,7 +235,14 @@ jobs:
             "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
             | tar -xz -C /usr/local/bin syft
 
+      # WIRELOG_SBOM_REQUIRED=1: syft is installed by the step above, and this
+      # is the ONLY place it is. Everywhere else check-sbom-snapshot.sh skips
+      # because syft is absent, which is correct there and useless here -- a
+      # gate that skips on every run asserts nothing.
+      # scripts/ci/test-required-gates.sh asserts this line still exists (#1303).
       - name: SBOM snapshot gate
+        env:
+          WIRELOG_SBOM_REQUIRED: '1'
         run: |
           meson test -C builddir --suite sbom --print-errorlogs || {
             echo "=== SBOM gate failed. Generating debug info..."

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -83,7 +83,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y meson ninja-build abigail-tools b3sum
+      # WIRELOG_ABI_REQUIRED=1: this is the GA ABI gate, and a gate that skips
+      # asserts nothing. abigail-tools is installed above, so abidiff is present
+      # here and a skip means something is wrong rather than unavailable.
+      # Advisory (unset) everywhere else, where abidiff genuinely is absent.
+      # scripts/ci/test-required-gates.sh asserts this line still exists (#1303).
       - name: Build and test ABI suite
+        env:
+          WIRELOG_ABI_REQUIRED: '1'
         run: |
           meson setup build-abi -Dtests=true --buildtype=debug
           meson compile -C build-abi

--- a/scripts/ci/check-abi-manifest.sh
+++ b/scripts/ci/check-abi-manifest.sh
@@ -51,6 +51,28 @@ set -euo pipefail
 # where 77 fails the job.  Do not invoke this from one.
 SKIP_EXIT=77
 
+# A skip is visible but not fatal: a gate that skips on every run asserts
+# nothing, it is merely yellow instead of green. WIRELOG_ABI_REQUIRED=1 turns
+# every MISSING-PREREQUISITE skip route into a failure, for the one job where
+# this gate must actually enforce. Platform- and policy-scope skips are
+# deliberately excluded and annotated at their sites: escalating those would
+# assert "this job must not run here", a different claim. Default unset, so
+# the gate stays advisory everywhere else. Same shape as WIRELOG_TIDY_REQUIRED
+# in check-clang-tidy-backlog-monotonic.sh. (#1303) Routed through one helper
+# rather than escalating each site: a later skip added straight to `exit
+# "$SKIP_EXIT"` would silently opt out of the escalation, which is the defect
+# class this issue exists to close.
+#
+skip() {
+    if [ "${WIRELOG_ABI_REQUIRED:-0}" = "1" ]; then
+        echo "check-abi-manifest: FAIL: $*" \
+             "(WIRELOG_ABI_REQUIRED=1 forbids skipping)" >&2
+        exit 1
+    fi
+    echo "check-abi-manifest: SKIP: $*"
+    exit "$SKIP_EXIT"
+}
+
 if [ $# -lt 1 ]; then
     echo "usage: $0 <build_root>" >&2
     exit 1
@@ -73,15 +95,13 @@ for candidate in \
 done
 
 if [ -z "$lib" ]; then
-    echo "check-abi-manifest: SKIP: libwirelog.so not found in $build_root" >&2
-    echo "  (expected on Windows / static-only / cross builds)" >&2
-    exit "$SKIP_EXIT"
+    skip "libwirelog.so not found in $build_root" \
+         "(expected on Windows / static-only / cross builds)"
 fi
 
 if ! command -v abidiff >/dev/null 2>&1; then
-    echo "check-abi-manifest: SKIP: abidiff not on PATH" >&2
-    echo "  install libabigail (Ubuntu: apt-get install -y abigail-tools)" >&2
-    exit "$SKIP_EXIT"
+    skip "abidiff not on PATH;" \
+         "install libabigail (Ubuntu: apt-get install -y abigail-tools)"
 fi
 
 # Not a skip: abi/libwirelog-1.0.abi.json is committed, so its absence means
@@ -110,6 +130,11 @@ if [ "$host_arch" != "x86_64" ]; then
     echo "  issue #824 scopes v1.0 Linux arm64 ABI coverage to" >&2
     echo "  abi/libwirelog-1.0.symbols; per-arch libabigail baselines" >&2
     echo "  require a separate post-v1.0 policy and regeneration flow." >&2
+    # Deliberately NOT routed through skip(): #824 scopes v1.0 arm64 coverage
+    # out on purpose, so this is a policy decision rather than a missing
+    # prerequisite. Escalating it under WIRELOG_ABI_REQUIRED would turn "check
+    # the ABI" into "do not run on arm64" and fail a legitimately out-of-scope
+    # architecture. The job that sets the variable is ubuntu-latest. (#1303)
     exit "$SKIP_EXIT"
 fi
 

--- a/scripts/ci/check-abi-symbols.sh
+++ b/scripts/ci/check-abi-symbols.sh
@@ -48,6 +48,28 @@ set -euo pipefail
 # where 77 fails the job.  Do not invoke this from one.
 SKIP_EXIT=77
 
+# A skip is visible but not fatal: a gate that skips on every run asserts
+# nothing, it is merely yellow instead of green. WIRELOG_ABI_REQUIRED=1 turns
+# every MISSING-PREREQUISITE skip route into a failure, for the one job where
+# this gate must actually enforce. Platform- and policy-scope skips are
+# deliberately excluded and annotated at their sites: escalating those would
+# assert "this job must not run here", a different claim. Default unset, so
+# the gate stays advisory everywhere else. Same shape as WIRELOG_TIDY_REQUIRED
+# in check-clang-tidy-backlog-monotonic.sh. (#1303) Routed through one helper
+# rather than escalating each site: a later skip added straight to `exit
+# "$SKIP_EXIT"` would silently opt out of the escalation, which is the defect
+# class this issue exists to close.
+#
+skip() {
+    if [ "${WIRELOG_ABI_REQUIRED:-0}" = "1" ]; then
+        echo "check-abi-symbols: FAIL: $*" \
+             "(WIRELOG_ABI_REQUIRED=1 forbids skipping)" >&2
+        exit 1
+    fi
+    echo "check-abi-symbols: SKIP: $*"
+    exit "$SKIP_EXIT"
+}
+
 if [ $# -lt 1 ]; then
     echo "usage: $0 <build_root>" >&2
     exit 1
@@ -60,6 +82,12 @@ allowlist="$repo_root/abi/libwirelog-1.0.symbols"
 
 case "$(uname -s)" in
   MSYS*|MINGW*|CYGWIN*)
+    # Deliberately NOT routed through skip(): this is a PLATFORM SCOPE
+    # decision, not a missing prerequisite. WIRELOG_ABI_REQUIRED exists to say
+    # "this job must actually check the ABI", and escalating here would instead
+    # say "this job must not run on Windows" -- a different claim, and a false
+    # failure if the required job ever moves. The job that sets it is
+    # ubuntu-latest, so this branch cannot fire there today either way. (#1303)
     echo "check-abi-symbols: SKIP: Windows POSIX layer ($(uname -s)) detected" >&2
     exit "$SKIP_EXIT"
     ;;
@@ -80,9 +108,8 @@ for candidate in \
 done
 
 if [ -z "$lib" ]; then
-    echo "check-abi-symbols: SKIP: libwirelog.so not found in $build_root" >&2
-    echo "  (expected on Windows / static-only / cross builds)" >&2
-    exit "$SKIP_EXIT"
+    skip "libwirelog.so not found in $build_root" \
+         "(expected on Windows / static-only / cross builds)"
 fi
 
 if [ ! -f "$allowlist" ]; then

--- a/scripts/ci/check-sbom-snapshot.sh
+++ b/scripts/ci/check-sbom-snapshot.sh
@@ -16,14 +16,35 @@ set -euo pipefail
 # where 77 fails the job.  Do not invoke this from one.
 SKIP_EXIT=77
 
+# A skip is visible but not fatal: a gate that skips on every run asserts
+# nothing, it is merely yellow instead of green. WIRELOG_SBOM_REQUIRED=1 turns
+# every MISSING-PREREQUISITE skip route into a failure, for the one job where
+# this gate must actually enforce. This gate has exactly one skip route --
+# syft absent -- and it is escalated; the ABI gates additionally carry
+# platform- and policy-scope skips that are deliberately excluded there.
+# Default unset, so the gate stays advisory everywhere else. Same shape as
+# WIRELOG_TIDY_REQUIRED in check-clang-tidy-backlog-monotonic.sh. (#1303)
+# Routed through one helper rather than escalating each site: a later skip
+# added straight to `exit "$SKIP_EXIT"` would silently opt out of the
+# escalation, which is the defect class this issue exists to close.
+#
+skip() {
+    if [ "${WIRELOG_SBOM_REQUIRED:-0}" = "1" ]; then
+        echo "check-sbom-snapshot: FAIL: $*" \
+             "(WIRELOG_SBOM_REQUIRED=1 forbids skipping)" >&2
+        exit 1
+    fi
+    echo "check-sbom-snapshot: SKIP: $*"
+    exit "$SKIP_EXIT"
+}
+
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 baseline="$repo_root/sbom/snapshot.txt"
 
 # SKIP if syft not available
 if ! command -v syft >/dev/null 2>&1; then
-    echo "check-sbom-snapshot: SKIP: syft not on PATH" >&2
-    exit "$SKIP_EXIT"
+    skip "syft not on PATH"
 fi
 
 # NOT a skip: the baseline is committed, so its absence means deletion.

--- a/scripts/ci/test-gate-skip-exit-codes.sh
+++ b/scripts/ci/test-gate-skip-exit-codes.sh
@@ -32,7 +32,16 @@ expect_status() {
     local name=$1 want=$2 got=0
     shift 2
     last_case=$name
-    "$@" >"$tmp/out" 2>"$tmp/err" || got=$?
+    # Unset the #1303 escalation variables. This file asserts that gates SKIP
+    # (77) where they cannot check, and release-tag.yml sets
+    # WIRELOG_ABI_REQUIRED=1 for a whole STEP that runs `meson test --suite abi`
+    # -- which is this test as well as the two gates the variable is aimed at.
+    # Without this, the Tag / ABI job goes red on every release tag: measured,
+    # both abi assertions below returned 1 instead of 77. The escalation's own
+    # behaviour is covered by test-required-gates.sh, which sets the variables
+    # deliberately rather than inheriting them.
+    ( unset WIRELOG_ABI_REQUIRED WIRELOG_SBOM_REQUIRED
+      "$@" ) >"$tmp/out" 2>"$tmp/err" || got=$?
     if [[ "$got" == "$want" ]]; then
         printf 'test-gate-skip-exit-codes: ok %s\n' "$name"
     else

--- a/scripts/ci/test-required-gates.sh
+++ b/scripts/ci/test-required-gates.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Self-test for the WIRELOG_*_REQUIRED escalation (#1303).
+#
+# Exit 77 makes a false pass visible but not fatal: a gate that skips on every
+# run is still asserting nothing, merely yellow instead of green. The escalation
+# turns skips into failures in the one job where each gate must enforce.
+#
+# Two halves, asserting different things:
+#
+#   1. Behaviour -- each gate SKIPs with the variable unset and FAILs with it
+#      set, on a tree where the prerequisite is genuinely absent. A fixture that
+#      supplied the prerequisite would pass either way and pin nothing.
+#   2. Wiring -- the workflows still set the variable. Without this the
+#      escalation can be deleted from a workflow and every behavioural assertion
+#      above keeps passing, which is precisely the silent-downgrade defect this
+#      issue exists to close.
+set -euo pipefail
+
+# check-abi-symbols.sh's Windows POSIX-layer skip is deliberately NOT escalated
+# (it is a platform-scope decision, not a missing prerequisite), so on a Windows
+# host `fails_when_required` would see 77 where it asserts 1. This test is
+# registered under a bare `if sh.found()`, which DOES resolve on windows-latest,
+# so the guard has to be here.
+case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux|Darwin) ;;
+    *) echo "test-required-gates: SKIP: needs a POSIX host (the Windows skip route is not escalated)"; exit 77 ;;
+esac
+
+root=${1:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)}
+failures=0
+
+check() {
+    local name=$1 status=$2
+    if [ "$status" = 0 ]; then
+        printf 'test-required-gates: ok %s\n' "$name"
+    else
+        printf 'test-required-gates: FAIL %s\n' "$name" >&2
+        failures=$((failures + 1))
+    fi
+}
+assert() { local n=$1 s=0; shift; "$@" || s=1; check "$n" "$s"; }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-required.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+empty="$tmp/empty-build"
+mkdir -p "$empty"
+
+# --- 1. behaviour -----------------------------------------------------------
+# $empty holds no libwirelog and no sbom baseline, so every gate below reaches a
+# genuine skip route rather than a manufactured one.
+skips_when_advisory() {
+    local gate=$1 st=0
+    shift
+    ( unset WIRELOG_ABI_REQUIRED WIRELOG_SBOM_REQUIRED
+      "$root/scripts/ci/$gate" "$@" ) >/dev/null 2>&1 || st=$?
+    [ "$st" = 77 ]
+}
+fails_when_required() {
+    local gate=$1 var=$2 st=0
+    shift 2
+    ( export "$var=1"; "$root/scripts/ci/$gate" "$@" ) >/dev/null 2>&1 || st=$?
+    [ "$st" = 1 ]
+}
+
+for gate in check-abi-manifest.sh check-abi-symbols.sh; do
+    assert "$gate skips when advisory" skips_when_advisory "$gate" "$empty"
+    assert "$gate fails when WIRELOG_ABI_REQUIRED=1" \
+        fails_when_required "$gate" WIRELOG_ABI_REQUIRED "$empty"
+done
+
+# The SBOM gate needs a PATH without syft to reach its skip route. Without this
+# pair, deleting its escalation entirely left the suite green -- half the change
+# was behaviourally untested.
+nosyft="$tmp/nosyft"
+mkdir -p "$nosyft"
+for tool in bash sh env python3 jq git sed awk grep sort head printf uname dirname basename mktemp rm cat; do
+    p=$(command -v "$tool" 2>/dev/null) && ln -sf "$p" "$nosyft/$tool"
+done
+without_syft() { ( PATH="$nosyft"; "$@" ); }
+sbom_skips_when_advisory() {
+    local st=0
+    without_syft env -u WIRELOG_SBOM_REQUIRED \
+        "$root/scripts/ci/check-sbom-snapshot.sh" "$empty" >/dev/null 2>&1 || st=$?
+    [ "$st" = 77 ]
+}
+sbom_fails_when_required() {
+    local st=0
+    without_syft env WIRELOG_SBOM_REQUIRED=1 \
+        "$root/scripts/ci/check-sbom-snapshot.sh" "$empty" >/dev/null 2>&1 || st=$?
+    [ "$st" = 1 ]
+}
+assert 'check-sbom-snapshot.sh skips when advisory' sbom_skips_when_advisory
+assert 'check-sbom-snapshot.sh fails when WIRELOG_SBOM_REQUIRED=1' sbom_fails_when_required
+
+# --- 2. wiring --------------------------------------------------------------
+# Assert on the job/step that must carry it, not merely on the file: the
+# variable appearing anywhere in a workflow would satisfy a bare grep while
+# sitting in the wrong job.
+# Assert on the STEP, not the file: the variable appearing anywhere in a
+# workflow would satisfy a bare grep while sitting on a different step.
+#
+# awk over the YAML rather than a parser: no workflow in this repo installs
+# PyYAML and nothing else under scripts/ imports it, so a `python3 -c 'import
+# yaml'` guard would skip this half in CI -- leaving criterion 5 enforced
+# nowhere, which is the failure this test exists to prevent.
+#
+# The range runs from the named step to the next list item at any indent, so
+# neither a neighbouring step nor a job-level `env:` satisfies it.
+#
+# It asserts step-level PLACEMENT, not merely presence, so three edits fail it
+# that a reader might expect to pass: renaming the step, quoting the step name,
+# and hoisting the env to job level. The rename is a true failure -- after it,
+# nothing guarantees the escalation still sits on the step that runs the gate --
+# and the other two are the cost of the placement assertion. Update this test
+# alongside any of the three.
+sets_in_step() {
+    local file=$1 step=$2 var=$3
+    awk -v want="- name: $step" -v var="$var" '
+        index($0, want)  { inside = 1; next }
+        inside && /^[[:space:]]*- / { exit }
+        inside && index($0, var ":") && /: *.?1.?$/ { found = 1; exit }
+        END { exit found ? 0 : 1 }
+    ' "$root/.github/workflows/$file"
+}
+
+assert 'release-tag.yml Tag/ABI sets WIRELOG_ABI_REQUIRED' \
+    sets_in_step release-tag.yml 'Build and test ABI suite' WIRELOG_ABI_REQUIRED
+assert 'ci-pr.yml SBOM step sets WIRELOG_SBOM_REQUIRED' \
+    sets_in_step ci-pr.yml 'SBOM snapshot gate' WIRELOG_SBOM_REQUIRED
+
+if ((failures)); then
+    printf 'test-required-gates: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test-required-gates: all cases passed\n'

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -871,6 +871,18 @@ if host_machine.system() == 'linux' and sh.found()
        suite: 'abi')
 endif
 
+# Issue #1303: the WIRELOG_*_REQUIRED escalation. Half of this asserts gate
+# behaviour, half asserts the workflows still set the variable -- without the
+# second half the escalation can be deleted from a workflow while every
+# behavioural assertion keeps passing, which is the silent downgrade the issue
+# exists to close.
+if sh.found()
+  test('required_gates', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-required-gates.sh',
+              meson.project_source_root()],
+       suite: 'abi')
+endif
+
 # Issue #1272: the release upgrade matrix must prove the consumer loaded the
 # libraries this release installs, not whatever the host had installed.  The
 # matrix itself only runs on a release tag, so this self-test is the only


### PR DESCRIPTION
Closes #1303. Based on `main`, independently mergeable.

Exit 77 makes a false pass *visible* but not *fatal*: a gate that skips on every run still
asserts nothing. `WIRELOG_ABI_REQUIRED` / `WIRELOG_SBOM_REQUIRED` turn missing-prerequisite
skips into failures in the one job where each gate must enforce, following the existing
`WIRELOG_TIDY_REQUIRED` pattern. Unset elsewhere.

## Deliberate deviation from criterion 2

The criterion says "every branch that would skip instead fails". Two branches are **not**
escalated, and are annotated at their sites: `check-abi-manifest.sh`'s non-x86_64 skip (#824
scopes it out on purpose) and `check-abi-symbols.sh`'s Windows POSIX-layer skip.

Those are policy and platform *scope* decisions, not missing prerequisites. Escalating them
would turn "this job must check the ABI" into "this job must not run on arm64/Windows" — a
different claim, and a false failure the moment the required job moves. I flagged this to
review rather than conforming quietly; the reviewer ruled the deviation correct and the
criterion not to be honoured literally.

## What review caught — the change would have broken the job it strengthens

**`WIRELOG_ABI_REQUIRED=1` on a step applies to the whole step**, and that step runs
`meson test --suite abi` — ~43 tests, including `gate_skip_exit_codes` from #1301, which
asserts 77 *by design*. Measured: its two ABI assertions returned 1 instead of 77. **The
Tag/ABI job would have gone red on every release tag.**

That is where this diverges from the `WIRELOG_TIDY_REQUIRED` precedent it cites: the tidy step
runs `--suite tidy`, one gate. I reasoned about which *gates* the variable affects and never
about which *tests* the step runs.

Fixed by unsetting both variables inside `test-gate-skip-exit-codes.sh`. #1301 asserting "these
gates skip" and #1303 asserting "these gates escalate" are both correct and need opposite
environments; the one asserting skip owns its own. Verified on the real scenario:
`WIRELOG_ABI_REQUIRED=1 meson test --suite abi` → **50 Ok / 0 Fail**.

Three more, each real:

- **The test would fail on Windows.** It is registered under a bare `sh.found()`, which
  resolves on `windows-latest`, where the deliberately un-escalated Windows branch returns 77
  against an assertion of 1. The deviation broke the test shipped with it. Now gated to
  Linux/Darwin, with the causal chain at the guard.
- **My PyYAML `exit 77` reproduced this issue's own defect inside its own test**: a bare exit
  after recorded failures meant a totally broken escalation reported *yellow*. And PyYAML is
  installed **nowhere** in CI — confirmed, and nothing else under `scripts/` imports it — so
  criterion 5's only enforcement would have skipped exactly where it matters. Replaced with awk
  over a step-scoped range.
- **The SBOM half was behaviourally untested.** Removing its escalation entirely left the suite
  green. It needs a syft-free PATH to reach its skip route; the reviewer confirmed the pair
  passes for the right reason on a host that has a real syft.

Also corrected: all three headers claimed the variable "turns **every** skip route into a
failure", contradicted by my own annotations 70 lines below.

## Tests

`scripts/ci/test-required-gates.sh`, suite `abi`. Eight cases. Mutations, each killed by its
own named case:

```
env: deleted from release-tag.yml     env: deleted from ci-pr.yml
value set to '0'                      ABI helper never escalates
SBOM helper never escalates
```

The `'0'` case matters — a bare grep for the variable name would miss it. The reviewer added
five more (`'11'`, `true`, env on a later step, env hoisted to job level, step renamed): the
range is genuinely step-scoped, so neither a neighbouring step nor a job-level `env:` satisfies
it.

Verified on real GNU bash 3.2.57. Local: **315 Ok / 0 Fail / 14 Skipped**.

## Not closed by this

`release-tag.yml` neither installs syft nor runs `--suite sbom`, so the GA path performs no
SBOM check at all — escalating a gate the release path never invokes is orthogonal to invoking
it. Filed separately.
