### PR TITLE
ci: give the release tag its own SBOM gate

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -235,10 +235,12 @@ jobs:
             "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
             | tar -xz -C /usr/local/bin syft
 
-      # WIRELOG_SBOM_REQUIRED=1: syft is installed by the step above, and this
-      # is the ONLY place it is. Everywhere else check-sbom-snapshot.sh skips
-      # because syft is absent, which is correct there and useless here -- a
-      # gate that skips on every run asserts nothing.
+      # WIRELOG_SBOM_REQUIRED=1: syft is installed by the step above. The only
+      # other place it is installed is release-tag.yml's Tag / SBOM job, which
+      # sets the same variable for the same reason (#1337). Everywhere else
+      # check-sbom-snapshot.sh skips because syft is absent, which is correct
+      # there and useless here -- a gate that skips on every run asserts
+      # nothing.
       # scripts/ci/test-required-gates.sh asserts this line still exists (#1303).
       - name: SBOM snapshot gate
         env:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -331,10 +331,56 @@ jobs:
       ref: ${{ inputs.tag_ref || github.ref_name }}
       expected_sha: ${{ inputs.expected_sha || github.sha }}
 
+  sbom:
+    name: Tag / SBOM
+    needs: [validate-input]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ env.TAG_REF }}
+          fetch-depth: 0
+      - name: Verify tagged commit
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build jq
+          # Must match ci-pr.yml's pin: sbom/snapshot.txt is sensitive to the
+          # syft cataloger set, so two versions would disagree about the
+          # baseline. test-required-gates.sh asserts they are equal.
+          SYFT_VERSION="1.50.0"
+          curl -sSfL \
+            "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin syft
+      # WIRELOG_SBOM_REQUIRED=1 for the same reason the ABI job sets its own:
+      # syft is installed directly above, so a skip here means something is
+      # wrong rather than unavailable, and a gate that skips asserts nothing.
+      #
+      # What was actually broken, stated precisely because #1337 got it wrong:
+      # the sbom tests DID run on every tag -- `Tag / default` invokes
+      # `meson test` with no --suite filter -- but syft is not installed there,
+      # so check-sbom-snapshot.sh took its skip route, exited 77, and the job
+      # stayed green. The gate was invoked and asserted nothing. So the
+      # published artifact's dependency claim rested on whichever PR last ran
+      # the gate for real, not on the tag.
+      #
+      # A smaller fix existed: install syft and set the variable on the
+      # existing `default` job. A dedicated job is preferred anyway -- it
+      # mirrors Tag / ABI, gives the release a named check that can be read
+      # off the run list, and keeps a 29 MB fetch off the full-build job.
+      # scripts/ci/test-required-gates.sh asserts this line still exists.
+      - name: Build and test SBOM suite
+        env:
+          WIRELOG_SBOM_REQUIRED: '1'
+        run: |
+          meson setup build-sbom -Dtests=true --buildtype=debug
+          meson test -C build-sbom --suite sbom --print-errorlogs
+
   release-verification:
     name: Tag / release verification gate
     if: ${{ always() }}
-    needs: [default, abi, perf, fuzz, mbedtls, sanitizers, upgrade, downstream]
+    needs: [default, abi, sbom, perf, fuzz, mbedtls, sanitizers, upgrade, downstream]
     runs-on: ubuntu-latest
     steps:
       - name: Require every tagged verification job
@@ -343,7 +389,11 @@ jobs:
         run: |
           echo "verification results: $RESULTS"
           IFS=',' read -ra statuses <<< "$RESULTS"
-          test "${#statuses[@]}" -eq 8
+          # Count must track `needs:` above. It is asserted rather than derived
+          # because `join(needs.*.result)` silently yields fewer entries if a
+          # job is removed, and every remaining one could still be success --
+          # the gate would pass having checked less than it names.
+          test "${#statuses[@]}" -eq 9
           for result in "${statuses[@]}"; do
             test "$result" = success
           done

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -213,7 +213,7 @@ When cutting a release tag:
    force-move a published tag to replay verification; the workflow checks out
    the supplied tag and verifies that it resolves to the supplied SHA.
    The [release-tag verification workflow](../.github/workflows/release-tag.yml)
-   runs the default and ABI suites, the dedicated `wirelog-perf` runner
+   runs the default, ABI and SBOM suites, the dedicated `wirelog-perf` runner
    with `WIRELOG_PERF_REQUIRE=1`, mbedTLS-enabled crypto validation, and
    a 60-second-per-target fuzz seed campaign on the tagged commit. It
    calls the reusable Tier-1 sanitizer workflow, which verifies the
@@ -229,7 +229,12 @@ When cutting a release tag:
    `scripts/release/generate-sbom.sh` and
    `scripts/release/regenerate-abi-manifest.sh`, and drift against the
    committed baselines is CI-gated — `meson test --suite sbom` for the SBOM
-   snapshot, `--suite abi`'s `abi_manifest` for the ABI manifest. Attaching
+   snapshot, `--suite abi`'s `abi_manifest` for the ABI manifest. Both gates
+   run on the tag with their `WIRELOG_*_REQUIRED` variable set, so a missing
+   prerequisite fails the release rather than skipping (#1303, #1337). That
+   distinction matters: before the dedicated `Tag / SBOM` job, the SBOM tests
+   did run on every tag as part of the unfiltered default suite, but syft was
+   not installed there, so the gate skipped and the job stayed green. Attaching
    either to the GitHub Release is not automated, and no implementation issue
    owns it — it remains an open exit condition on the GA epic #687.
 5. **Review and publish the GitHub Release.** The tag workflow creates it as

--- a/scripts/ci/test-required-gates.sh
+++ b/scripts/ci/test-required-gates.sh
@@ -130,21 +130,110 @@ assert 'ci-pr.yml SBOM step sets WIRELOG_SBOM_REQUIRED' \
 assert 'release-tag.yml Tag/SBOM sets WIRELOG_SBOM_REQUIRED' \
     sets_in_step release-tag.yml 'Build and test SBOM suite' WIRELOG_SBOM_REQUIRED
 
-# release-verification asserts a hardcoded job count against its own `needs:`
-# list. The two must agree: `join(needs.*.result)` silently yields fewer entries
-# when a job is dropped, and every remaining one could still be success -- so
-# the gate would pass having checked less than it names. That is the same
-# defect class the escalation above exists to close, one level up, and adding
-# the Tag/SBOM job to `needs:` without touching the count would have caused it.
+# release-verification must WAIT ON every verification job, not merely agree
+# with itself about how many there are. Comparing counts caught drift between
+# the `needs:` list and the hardcoded `-eq N`, but not the defect one level up:
+# a job never added to `needs:` at all. Reproduced -- a tenth job left out
+# entirely kept the whole suite green, and the release gate then passes without
+# ever consulting that job's result. Set equality kills that.
+#
+# It does NOT kill a trailing comma, despite an earlier version of this comment
+# claiming so: YAML reads `[a, b,]` as two elements, and both parsers below drop
+# the empty before comparing, so the two sets are identical. The trailing comma
+# is caught by the COUNT check instead, whose filter counts only non-empty
+# elements. Do not collapse the two assertions on the strength of the wrong
+# claim.
+#
+# awk, not a YAML parser -- see the note above `sets_in_step`: installing one
+# would skip this whole wiring half in CI, which is this file's own defect class.
+#
+# The job pattern is anchored at both ends. A substring match is not safe here:
+# an early draft of this very check enumerated jobs with `grep -v 'on:'` and
+# silently dropped `release-verification`, because its name ends in "on:". The
+# optional quotes accept both `"job":` and the single-quoted form (written
+# \047 because the awk program is itself single-quoted), which YAML admits on
+# the same footing; an unquoted-only
+# pattern would silently omit from the expected set -- the same silent-drop
+# shape one spelling over.
+#
+# The `on:` block is excluded by the in_jobs gate, not by appearing before
+# `jobs:`: any column-0 line clears it, so the exclusion is order-independent.
+release_tag_jobs() {
+    awk '
+        /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+        in_jobs && /^[^[:space:]]/ { in_jobs = 0 }
+        in_jobs && /^  ["\047]?[A-Za-z0-9_-]+["\047]?:[[:space:]]*$/ {
+            name = $0
+            sub(/^  /, "", name); sub(/:[[:space:]]*$/, "", name)
+            gsub(/["\047]/, "", name)
+            print name
+        }
+    ' "$root/.github/workflows/release-tag.yml"
+}
+
+# The three jobs that are legitimately absent from `needs:`, each for its own
+# reason -- listed by name so a future verification job cannot be exempted by a
+# pattern that happens to match it.
+#   validate-input       runs BEFORE the others; they all need it.
+#   release-verification is the gate itself.
+#   release-artifacts    runs AFTER the gate, gated on its result.
+needs_covers_every_verification_job() {
+    local expected actual
+    expected=$(release_tag_jobs \
+        | grep -vxE 'validate-input|release-verification|release-artifacts' \
+        | sort)
+    actual=$(awk '
+        /^  ["\047]?[A-Za-z0-9_-]+["\047]?:[[:space:]]*$/ { inside = 0 }
+        /^  release-verification:/ { inside = 1; next }
+        inside && /^    needs: \[/ {
+            line = $0
+            sub(/.*\[/, "", line); sub(/\].*/, "", line)
+            n = split(line, parts, /,/)
+            for (i = 1; i <= n; i++) {
+                gsub(/[[:space:]]/, "", parts[i])
+                if (parts[i] != "") print parts[i]
+            }
+            exit
+        }' "$root/.github/workflows/release-tag.yml" | sort)
+    if [ -z "$expected" ] || [ -z "$actual" ]; then
+        echo "  neither side may be empty: expected='$expected' actual='$actual'" >&2
+        return 1
+    fi
+    if [ "$expected" != "$actual" ]; then
+        local missing extra
+        missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual"))
+        extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual"))
+        if [ -n "$missing" ]; then
+            echo "  jobs not gated by release-verification:" >&2
+            printf '%s\n' "$missing" | sed 's/^/    /' >&2
+            echo "  add them to its needs:, or to the exempt list in this file" \
+                 "if they are genuinely not verification jobs" >&2
+        fi
+        if [ -n "$extra" ]; then
+            echo "  in needs but not a job:" >&2
+            printf '%s\n' "$extra" | sed 's/^/    /' >&2
+        fi
+        return 1
+    fi
+}
+assert 'release-verification needs every verification job' \
+    needs_covers_every_verification_job
+
+# The hardcoded count must still track the list it counts.
 verification_count_matches_needs() {
-    local wf="$root/.github/workflows/release-tag.yml" needs_n asserted_n
+    local needs_n asserted_n wf="$root/.github/workflows/release-tag.yml"
     needs_n=$(awk '
         /^  release-verification:/ { inside = 1 }
         inside && /^    needs: \[/ {
             line = $0
             sub(/.*\[/, "", line); sub(/\].*/, "", line)
             n = split(line, parts, /,/)
-            print n
+            c = 0
+            for (i = 1; i <= n; i++) {
+                gsub(/[[:space:]]/, "", parts[i])
+                if (parts[i] != "") c++
+            }
+            print c
             exit
         }' "$wf")
     asserted_n=$(awk '

--- a/scripts/ci/test-required-gates.sh
+++ b/scripts/ci/test-required-gates.sh
@@ -127,6 +127,55 @@ assert 'release-tag.yml Tag/ABI sets WIRELOG_ABI_REQUIRED' \
     sets_in_step release-tag.yml 'Build and test ABI suite' WIRELOG_ABI_REQUIRED
 assert 'ci-pr.yml SBOM step sets WIRELOG_SBOM_REQUIRED' \
     sets_in_step ci-pr.yml 'SBOM snapshot gate' WIRELOG_SBOM_REQUIRED
+assert 'release-tag.yml Tag/SBOM sets WIRELOG_SBOM_REQUIRED' \
+    sets_in_step release-tag.yml 'Build and test SBOM suite' WIRELOG_SBOM_REQUIRED
+
+# release-verification asserts a hardcoded job count against its own `needs:`
+# list. The two must agree: `join(needs.*.result)` silently yields fewer entries
+# when a job is dropped, and every remaining one could still be success -- so
+# the gate would pass having checked less than it names. That is the same
+# defect class the escalation above exists to close, one level up, and adding
+# the Tag/SBOM job to `needs:` without touching the count would have caused it.
+verification_count_matches_needs() {
+    local wf="$root/.github/workflows/release-tag.yml" needs_n asserted_n
+    needs_n=$(awk '
+        /^  release-verification:/ { inside = 1 }
+        inside && /^    needs: \[/ {
+            line = $0
+            sub(/.*\[/, "", line); sub(/\].*/, "", line)
+            n = split(line, parts, /,/)
+            print n
+            exit
+        }' "$wf")
+    asserted_n=$(awk '
+        /^  release-verification:/ { inside = 1 }
+        inside && /\$\{#statuses\[@\]}" -eq / {
+            match($0, /-eq [0-9]+/)
+            print substr($0, RSTART + 4, RLENGTH - 4)
+            exit
+        }' "$wf")
+    [ -n "$needs_n" ] && [ -n "$asserted_n" ] && [ "$needs_n" = "$asserted_n" ]
+}
+assert 'release-verification job count matches its needs list' \
+    verification_count_matches_needs
+
+# sbom/snapshot.txt is sensitive to syft's cataloger set, so the PR gate and the
+# GA gate must scan with the same version or they disagree about the committed
+# baseline. Bumping one alone fails closed -- the tag goes red -- but that is
+# the drift this file exists to catch, and it is one assertion.
+syft_pins_agree() {
+    local a b
+    a=$(awk -F'"' '/SYFT_VERSION=/ { print $2; exit }' \
+        "$root/.github/workflows/ci-pr.yml")
+    b=$(awk -F'"' '/SYFT_VERSION=/ { print $2; exit }' \
+        "$root/.github/workflows/release-tag.yml")
+    # Each file must yield a pin AND they must match. Comparing a deduplicated
+    # set instead was satisfied by one file having no pin at all -- the
+    # remaining pin still made the set unique. Absence has to be checked
+    # separately from disagreement.
+    [ -n "$a" ] && [ -n "$b" ] && [ "$a" = "$b" ]
+}
+assert 'ci-pr.yml and release-tag.yml pin the same syft version' syft_pins_agree
 
 if ((failures)); then
     printf 'test-required-gates: %d case(s) failed\n' "$failures" >&2


### PR DESCRIPTION
Closes #1337. Stacked on #1336 (`fix/1303-required-gates`) — review that first.

## What was actually broken

**Not what the issue said.** I filed #1337 claiming `check-sbom-snapshot.sh` "never executes on
a release tag, in any form", and that #1303's escalation "does not reach this hole, and cannot".
Both are false, and review caught it:

```
$ sed -n '65,69p' .github/workflows/release-tag.yml
      - name: Build and test default suite
        run: |
          ...
          meson test -C build-default --print-errorlogs   # no --suite filter
```

The sbom tests **did** run on every tag. syft simply isn't installed in that job, so the gate
took its skip route, exited 77, and the job stayed green. The gate was invoked and asserted
nothing — a materially different defect from never running, and one #1303's escalation reaches
exactly. Installing syft and setting `WIRELOG_SBOM_REQUIRED=1` on the existing `default` job
would have been a smaller fix. The issue body is corrected.

The consequence for the artifact is unchanged: the published dependency claim rested on
whichever PR last ran the gate for real, not on the tag.

## Why a dedicated job anyway

Legibility, not reachability: it mirrors `Tag / ABI`, gives the release a named check readable
off the run list, and keeps a 29 MB syft fetch off the full-build job. It needs `meson setup`
only — the three sbom tests have no compiled dependencies, and setup alone resolves the wraps
the baseline describes (verified on a genuinely clean `git ls-files` tree, not an incremental
one).

## The trap that would have broken every release

`release-verification` hardcodes `test "${#statuses[@]}" -eq 8` against its own `needs:` list.
Adding a ninth job without touching that count makes the gate **pass while checking one fewer
job** — `join(needs.*.result)` just yields fewer entries and every remaining one can still be
success. Updated in the same edit, with an assertion so the two can't drift:

```
sbom dropped from needs, count stale        → FAIL (named)
count reverted to 8 without touching needs  → FAIL (named)
```

## Syft version pinning

The version is now pinned in two workflows, and `sbom/snapshot.txt` is sensitive to syft's
cataloger set — bumping one alone leaves the PR gate and the GA gate disagreeing about the
baseline. Asserted.

**That assertion caught a defect in itself on first run.** My first version compared a
deduplicated set: divergent pins failed correctly, but *deleting* a pin from one file passed,
because the remaining pin still made the set unique. Absence had to be checked separately from
disagreement. Five mutations now die by name: divergent, deleted from either file, deleted from
both, and unquoted.

## Also corrected

- `ci-pr.yml`'s "syft ... this is the **ONLY** place it is" — now two places.
- `docs/RELEASE_PROCESS.md` enumerated the tag suites without SBOM, and stated SBOM drift is
  "CI-gated" — the exact sentence #1337 proves was misleading. Both fixed, including a note on
  what the skip actually did.

Local: **315 Ok / 0 Fail**. Verified on real GNU bash 3.2.57.

## Not closed by this

The GA gate does not verify the **nanoarrow pin**. `sbom/snapshot.txt` records
`# nanoarrow-resolved-sha:` as a comment, but the comparison is one-package-per-line syft
output, so that line is structurally unverifiable by it — and `nanoarrow@0.9.0.9000` is a
development version string constant across every commit in that window. To be clear about
scope: the dependency **is** pinned to consumers, since `subprojects/nanoarrow.wrap` ships in
the signed tarball with the revision in it. What's missing is a cross-check that the wrap and
the snapshot agree. Filed separately.
