### PR TITLE
ci: cross-check the SBOM snapshot's nanoarrow sha against the wrap

### DIFF
--- a/scripts/ci/check-sbom-wrap-pin.sh
+++ b/scripts/ci/check-sbom-wrap-pin.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Assert sbom/snapshot.txt's recorded nanoarrow commit matches the wrap pin.
+#
+# generate-sbom.sh appends the resolved subproject commit as a comment:
+#
+#   # nanoarrow-resolved-sha: 3f824063...
+#
+# and subprojects/nanoarrow.wrap declares the pin the build actually resolves:
+#
+#   revision = 3f824063...
+#
+# Nothing compared them. check-sbom-snapshot.sh cannot: it diffs the baseline
+# against `syft | jq | sort` output, which is one package per line and never
+# emits a `#` line, so the sha is metadata inside a file whose format has no
+# room for it. The `grep -v '^#'` there is a consequence, not the cause -- do
+# not "fix" this by removing that strip, it would compare a comment against
+# package lines and fail every run.
+#
+# Why it matters despite the entry being present: the compared line is
+# `nanoarrow@0.9.0.9000:Apache`. The `.9000` suffix is the
+# development-version convention meaning "after 0.9.0, unreleased", so that
+# string is constant across every commit in that window -- a wrap revision bump
+# produces a byte-identical snapshot line and the gate stays green while the
+# recorded sha and the actual pin have diverged. The windows are long enough to
+# matter: the previous one, 0.8.0.9000, spanned 58 nanoarrow commits over about
+# six months.
+#
+# Scope, so triage does not read this as a supply-chain hole: the wrap ships
+# inside the source tarball with its revision, and that tarball is checksummed,
+# attested and Sigstore-signed, so the dependency IS pinned for consumers. What
+# this closes is CI never noticing snapshot/wrap divergence. (#1339)
+#
+# Deliberately a separate script rather than a branch of check-sbom-snapshot.sh:
+# that one SKIPs when syft is absent, and this comparison needs only two
+# committed files. Folding it in would make it skip for a reason that does not
+# apply to it -- the defect class #1303 exists to remove.
+set -euo pipefail
+
+root=${1:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)}
+snapshot="$root/sbom/snapshot.txt"
+wrap="$root/subprojects/nanoarrow.wrap"
+
+for f in "$snapshot" "$wrap"; do
+    [ -f "$f" ] || {
+        echo "check-sbom-wrap-pin: FAIL: missing $f" >&2
+        exit 1
+    }
+done
+
+# Both extractions require exactly one match, and require it to be present. A missing
+# sha line is a failure, not a skip: generate-sbom.sh omits it when the
+# subproject is not checked out, so its absence means the committed snapshot was
+# regenerated from a tree that could not see the dependency it claims to
+# describe.
+# The wrap revision is read from the [wrap-git] SECTION, not from the first
+# `revision =` anywhere in the file. meson resolves the one under [wrap-git];
+# an unanchored match reports OK against a `revision` sitting in [provide],
+# while the build uses a different commit. Verified against meson's own parser
+# (ConfigParser, interpolation=None): that wrap parses cleanly and resolves to
+# the [wrap-git] value. A false green in the gate whose only job is catching
+# divergence is the one direction that must not be possible.
+#
+# [0-9a-fA-F], matching check-wrap-revisions.sh's accepted alphabet. A
+# lowercase-only class turned a legal uppercase revision into "no hex revision
+# found", which is an actively misleading diagnostic when one is plainly there.
+snapshot_shas=$(sed -n 's/^# nanoarrow-resolved-sha:[[:space:]]*\([0-9a-fA-F]\{7,\}\).*/\1/p' \
+    "$snapshot")
+wrap_shas=$(awk '
+    /^[[:space:]]*\[/ { in_git = ($0 ~ /^[[:space:]]*\[wrap-git\][[:space:]]*$/) ; next }
+    in_git && /^[[:space:]]*revision[[:space:]]*=/ {
+        line = $0
+        sub(/^[[:space:]]*revision[[:space:]]*=[[:space:]]*/, "", line)
+        sub(/[^0-9a-fA-F].*$/, "", line)
+        if (length(line) >= 7) print line
+    }' "$wrap")
+
+# Exactly one of each. A second, diverging sha line is not reachable through
+# generate-sbom.sh, which truncates then appends once -- but it is reachable
+# through a bad merge, and taking the first match would leave the gate green on
+# the stale one.
+count_of() { printf '%s\n' "$1" | grep -c . || true; }
+for pair in "snapshot:$snapshot_shas" "wrap:$wrap_shas"; do
+    label=${pair%%:*}
+    n=$(count_of "${pair#*:}")
+    if [ "$n" -gt 1 ]; then
+        echo "check-sbom-wrap-pin: FAIL: $n conflicting revisions in the $label" >&2
+        printf '%s\n' "${pair#*:}" | sed 's/^/    /' >&2
+        exit 1
+    fi
+done
+# Compared case-insensitively: the same commit written 3F82... and 3f82... is
+# the same commit, and git accepts either. Comparing raw would report a
+# disagreement between two spellings of one sha -- fail-closed, but a false
+# failure, and the diagnostic would show two shas that look identical to a
+# reader skimming them.
+lower() { printf '%s\n' "$1" | tr 'A-F' 'a-f'; }
+snapshot_sha=$(lower "$(printf '%s\n' "$snapshot_shas" | sed -n 1p)")
+wrap_sha=$(lower "$(printf '%s\n' "$wrap_shas" | sed -n 1p)")
+
+if [ -z "$snapshot_sha" ]; then
+    echo "check-sbom-wrap-pin: FAIL: no '# nanoarrow-resolved-sha:' in $snapshot" >&2
+    echo "  regenerate with scripts/release/generate-sbom.sh from a tree where" >&2
+    echo "  subprojects/nanoarrow is checked out" >&2
+    exit 1
+fi
+if [ -z "$wrap_sha" ]; then
+    echo "check-sbom-wrap-pin: FAIL: no hex 'revision =' under [wrap-git] in $wrap" >&2
+    exit 1
+fi
+
+if [ "$snapshot_sha" != "$wrap_sha" ]; then
+    echo "check-sbom-wrap-pin: FAIL: the SBOM snapshot and the wrap disagree" >&2
+    echo "  sbom/snapshot.txt records:      $snapshot_sha" >&2
+    echo "  subprojects/nanoarrow.wrap pins: $wrap_sha" >&2
+    echo "  The snapshot's nanoarrow@ line cannot show this: 0.9.0.9000 is a" >&2
+    echo "  development version constant across the window, so regenerate the" >&2
+    echo "  snapshot after a wrap bump even when its diff looks empty." >&2
+    exit 1
+fi
+
+echo "check-sbom-wrap-pin: OK; snapshot and wrap agree on $wrap_sha"

--- a/scripts/ci/check-sbom-wrap-pin.sh
+++ b/scripts/ci/check-sbom-wrap-pin.sh
@@ -66,7 +66,21 @@ done
 snapshot_shas=$(sed -n 's/^# nanoarrow-resolved-sha:[[:space:]]*\([0-9a-fA-F]\{7,\}\).*/\1/p' \
     "$snapshot")
 wrap_shas=$(awk '
-    /^[[:space:]]*\[/ { in_git = ($0 ~ /^[[:space:]]*\[wrap-git\][[:space:]]*$/) ; next }
+    # Derive the section name through the last `]`, as ConfigParser greedy
+    # SECTCRE does. This accepts `[wrap-git]  # the pin` but does not mistake
+    # `[wrap-git] [other]` for the `wrap-git` section. The two gates must agree
+    # on the parser section-name semantics (#1343).
+    function section_name(line, i, last) {
+        sub(/^[[:space:]]*/, "", line)
+        if (substr(line, 1, 1) != "[") return ""
+        last = 0
+        for (i = length(line); i > 0; i--) {
+            if (substr(line, i, 1) == "]") { last = i; break }
+        }
+        if (last < 3) return ""
+        return substr(line, 2, last - 2)
+    }
+    /^[[:space:]]*\[/ { in_git = (section_name($0) == "wrap-git") ; next }
     in_git && /^[[:space:]]*revision[[:space:]]*=/ {
         line = $0
         sub(/^[[:space:]]*revision[[:space:]]*=[[:space:]]*/, "", line)

--- a/scripts/ci/check-wrap-revisions.sh
+++ b/scripts/ci/check-wrap-revisions.sh
@@ -82,7 +82,19 @@ check_wrap() {
         [ -z "$line" ] && continue
         [[ "$line" == \#* ]] && continue
 
-        if [[ "$line" =~ ^\[(.+)\]$ ]]; then
+        # No `$` anchor: Python's configparser applies SECTCRE with .match, so
+        # text after `]` is ignored and `[wrap-git]  # the pin` resolves
+        # normally -- meson builds that wrap. Requiring `]` at end of line made
+        # this loop not recognise the header at all, so `section` stayed empty,
+        # the `wrap-git:revision` case never fired, and the gate reported
+        # "OK; release dependency wraps are reproducible" having checked
+        # nothing. Measured: a wrap with that header and `revision = notahex`
+        # passed. The literal `]` is still required, so this cannot over-match.
+        # Use a greedy capture, matching ConfigParser's greedy SECTCRE: the
+        # section name extends through the last `]` on the line. This keeps
+        # `[wrap-git]  # the pin` legal while refusing to misread
+        # `[wrap-git] [other]` as the `wrap-git` section. (#1343)
+        if [[ "$line" =~ ^\[(.*)\] ]]; then
             local new_section=${BASH_REMATCH[1]}
             finish_section
             section=$new_section

--- a/scripts/ci/test-gate-skip-exit-codes.sh
+++ b/scripts/ci/test-gate-skip-exit-codes.sh
@@ -77,7 +77,14 @@ check() {
 # that is already clean. Listing the clean ones is the point: the backstop then
 # guards them against acquiring the defect, which a list of only the broken ones
 # could not do.
+# check-sbom-wrap-pin.sh (#1339) is listed here although it has no skip route
+# today. Exempting it was the first instinct and it inverts this file's own
+# rule: EXEMPT is for gates where exit 77 would be WRONG, not for gates that
+# merely do not skip. Listing an already-clean gate is exactly the point --
+# the backstop then guards it against ACQUIRING the defect. Measured with a
+# `SKIP ...; exit 0` injected into it: EXEMPT passed, COVERED failed by name.
 COVERED="
+check-sbom-wrap-pin.sh
 check-abi-manifest.sh
 check-abi-symbols.sh
 check-abi-symbols-locale.sh

--- a/scripts/ci/test-wrap-section-syntax.sh
+++ b/scripts/ci/test-wrap-section-syntax.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# The two wrap-reading gates must agree on what a section header is (#1343).
+#
+# check-wrap-revisions.sh asserts the 40-hex shape; check-sbom-wrap-pin.sh
+# asserts the snapshot and the wrap name the same commit and deliberately leans
+# on the first for the shape. They disagreed:
+#
+#   [wrap-git]  # the pin
+#
+# is a legal header -- Python's configparser applies SECTCRE with .match, so
+# text after `]` is ignored and meson builds that wrap. check-wrap-revisions.sh
+# required `]` at end of line, never recognised the section, and reported
+# "OK; release dependency wraps are reproducible" having checked nothing.
+# check-sbom-wrap-pin.sh had the mirror-image bug and hard-failed with
+# "no hex revision under [wrap-git]" when one was plainly there.
+#
+# One was a silent pass and one was a false failure, from the same disagreement.
+# This file exists so they cannot drift apart again: it drives BOTH gates over
+# the same header spellings and requires them to agree about which are legal.
+set -euo pipefail
+
+root=${1:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)}
+failures=0
+cases=0
+check() {
+    cases=$((cases + 1))
+    if [ "$2" = 0 ]; then printf 'test-wrap-section-syntax: ok %s\n' "$1"
+    else printf 'test-wrap-section-syntax: FAIL %s\n' "$1" >&2; failures=$((failures + 1)); fi
+}
+assert() { local n=$1 s=0; shift; "$@" || s=1; check "$n" "$s"; }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-wrapsyntax.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+# A fixture tree holding only what the two gates read, so neither is influenced
+# by the real repository's contents.
+# check-wrap-revisions.sh takes no root argument -- it derives repo_root from
+# its own location -- so the gate has to be COPIED INTO the fixture tree or it
+# silently checks the real repository and every assertion here passes for the
+# wrong reason. That is exactly what the first version of this file did.
+fixture() {
+    local header=$1 revision=$2 dir="$tmp/f"
+    rm -rf "$dir"; mkdir -p "$dir/subprojects" "$dir/sbom" "$dir/scripts/ci"
+    cp "$root/scripts/ci/check-wrap-revisions.sh" "$dir/scripts/ci/"
+    # [provide] carries its OWN revision, different from the real one. A gate
+    # that stops anchoring to [wrap-git] -- or treats every section as
+    # wrap-git -- then reads this decoy, which is the over-match
+    # check-sbom-wrap-pin.sh's own comment says must not be possible. Without
+    # it, widening that awk to `in_git = 1` passed every assertion here.
+    printf '%s\n' "$header" \
+        'url = https://github.com/apache/arrow-nanoarrow.git' \
+        "revision = $revision" \
+        '' '[provide]' \
+        'revision = 00000000000000000000000000000000000000ff' \
+        'nanoarrow = nanoarrow_dep' > "$dir/subprojects/nanoarrow.wrap"
+    printf 'nanoarrow@0.9.0.9000:Apache\n# nanoarrow-resolved-sha: %s\n' \
+        "${3:-$revision}" > "$dir/sbom/snapshot.txt"
+    printf '%s' "$dir"
+}
+
+# No ${x@Q}: that is bash 4.4+, and the floor here is the macOS runner's 3.2.57,
+# where it dies with "bad substitution". An earlier draft used it and ran ZERO
+# assertions on 3.2.57 while still exiting 0. The exit status depends on where
+# the expansion sits -- at top level or in a function under `set -e` it exits 1
+# -- so do not read the clean exit as general; what is general is that the
+# construct does not work at the floor and the failure was silent enough to
+# reach review.
+# Out of scope, stated so nobody adds a row for it: the `[ wrap-git ]` family
+# -- inner spaces, `[wrap-gitx]`, `[WRAP-GIT]`, unclosed, `[]` -- still has the
+# two gates disagreeing, check-wrap-revisions passing vacuously because its
+# `case` compares the untrimmed ${BASH_REMATCH[1]}, and the pin gate hard-
+# failing. meson rejects all of them, so no buildable wrap reaches it. A row
+# here could only assert "at least one gate objects", which would pin the
+# vacuous pass as correct and would have to be rewritten the day someone
+# trims the captured name -- a real improvement a test should not obstruct.
+GOOD=3f824063f59848e05692ab520de8ab4d9ebb1880
+
+# Both gates must ACCEPT every legal header spelling. A gate that rejects one is
+# a false failure; a gate that fails to find one is a vacuous pass. Requiring
+# both to accept catches either.
+for header in '[wrap-git]' '[wrap-git]  # the pin' '[wrap-git] ; note' '[wrap-git]	' '  [wrap-git]'; do
+    d=$(fixture "$header" "$GOOD")
+    accepts_shape() { "$1/scripts/ci/check-wrap-revisions.sh" >/dev/null 2>&1; }
+    accepts_pin() { "$root/scripts/ci/check-sbom-wrap-pin.sh" "$1" >/dev/null 2>&1; }
+    assert "check-wrap-revisions accepts <$header>" accepts_shape "$d"
+    assert "check-sbom-wrap-pin accepts <$header>" accepts_pin "$d"
+done
+
+# And both must still REJECT a bad revision under every one of those headers --
+# otherwise "accepts" could be satisfied by not looking.
+for header in '[wrap-git]' '[wrap-git]  # the pin'; do
+    d=$(fixture "$header" 'notahex')
+    rejects_shape() { ! "$1/scripts/ci/check-wrap-revisions.sh" >/dev/null 2>&1; }
+    assert "check-wrap-revisions rejects a non-hex revision under <$header>" \
+        rejects_shape "$d"
+
+    # A DIVERGENT BUT HEX sha, deliberately not reusing the notahex fixture:
+    # there the snapshot line is also non-hex, so the pin gate fails on "no
+    # nanoarrow-resolved-sha" rather than on the disagreement -- passing for the
+    # wrong reason. Without this row the pin gate had accept-only coverage here
+    # and a stub `exit 0` satisfied every assertion.
+    d=$(fixture "$header" "$GOOD" 'ffffffffffffffffffffffffffffffffffffffff')
+    rejects_pin() { ! "$root/scripts/ci/check-sbom-wrap-pin.sh" "$1" >/dev/null 2>&1; }
+    assert "check-sbom-wrap-pin rejects a divergent sha under <$header>" \
+        rejects_pin "$d"
+done
+
+# A bracketed suffix belongs to the section name under ConfigParser's greedy
+# header expression. Neither gate may treat it as [wrap-git]. Put a legal
+# section after the decoy so the correct parser accepts the fixture, while a
+# first-`]` matcher would inspect the bad revision and fail.
+d=$(fixture '[wrap-git] [evil]' 'notahex')
+printf '%s\n' '[wrap-git]' \
+    'url = https://github.com/apache/arrow-nanoarrow.git' \
+    "revision = $GOOD" >> "$d/subprojects/nanoarrow.wrap"
+assert 'check-wrap-revisions ignores a bracketed section suffix' \
+    accepts_shape "$d"
+d=$(fixture '[wrap-git] [evil]' "$GOOD" "$GOOD")
+printf '%s\n' '[wrap-git]' \
+    'url = https://github.com/apache/arrow-nanoarrow.git' \
+    "revision = $GOOD" >> "$d/subprojects/nanoarrow.wrap"
+assert 'check-sbom-wrap-pin ignores a bracketed section suffix' \
+    accepts_pin "$d"
+
+# A floor, for the reason scripts/ci/test-gate-skip-exit-codes.sh states at its
+# own: "nothing failed" and "nothing ran" are otherwise the same result. A loop
+# that stops iterating -- a renamed fixture helper, an emptied header list --
+# would print "all cases passed" and exit 0 having asserted nothing, which is
+# this issue's defect one level up, inside this issue's own regression test.
+if [ "$cases" -lt 16 ]; then
+    printf 'test-wrap-section-syntax: FAIL only %d assertions ran; expected at least 16\n' \
+        "$cases" >&2
+    exit 1
+fi
+
+if ((failures)); then
+    printf 'test-wrap-section-syntax: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test-wrap-section-syntax: all %d cases passed\n' "$cases"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1053,6 +1053,20 @@ if sh.found()
        timeout: 120)
 endif
 
+# Issue #1339: the snapshot records which nanoarrow commit it described, and
+# the wrap declares which one the build resolves. Nothing compared them, and the
+# snapshot's own diff structurally cannot -- nanoarrow@0.9.0.9000 is a
+# development version constant across the window, so a wrap bump leaves the
+# package line byte-identical. Registered separately from sbom_snapshot because
+# it needs no syft: folding it in would make it skip whenever syft is absent,
+# for a reason that does not apply to comparing two committed files.
+if sh.found()
+  test('sbom_wrap_pin', sh,
+       args: [meson.project_source_root() / 'scripts/ci/check-sbom-wrap-pin.sh',
+              meson.project_source_root()],
+       suite: 'sbom')
+endif
+
 # Issue #1297: the perf gate's dataset manifest embedded the directory the
 # operator passed, so relative, absolute and trailing-slash spellings of one
 # directory produced three different hashes -- reported as if the dataset had

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -837,6 +837,18 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #1343: the two wrap-reading gates must agree on what a section header
+# is. They did not -- `[wrap-git]  # the pin` is legal (configparser matches
+# headers by prefix, so meson builds it), and check-wrap-revisions.sh reported
+# OK having never found the section while check-sbom-wrap-pin.sh hard-failed on
+# the same input. A silent pass and a false failure from one disagreement.
+if sh.found()
+  test('wrap_section_syntax', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-wrap-section-syntax.sh',
+              meson.project_source_root()],
+       suite: 'abi')
+endif
+
 # Issue #737: forbid new unanchored "Phase NX" labels in wirelog/ source.
 # Each Phase NX label must either carry an explicit issue cross-reference
 # on the same line ("#N", "Issue N", "US-N-NNN"), or be present in the


### PR DESCRIPTION
Closes #1339. Stacked on #1341 (`fix/1340-needs-set`) — review that first.

## The gap

`generate-sbom.sh` records the resolved nanoarrow commit in `sbom/snapshot.txt` as a comment;
`subprojects/nanoarrow.wrap` declares the revision meson resolves. **Nothing compared them.**

The snapshot's own diff structurally cannot: `check-sbom-snapshot.sh` compares the baseline
against `syft | jq | sort` output — one package per line, never a `#` line. So the `grep -v '^#'`
there is a *consequence*, not the cause; removing it would compare a comment against package
lines and fail every run.

And the only nanoarrow package line is `nanoarrow@0.9.0.9000:Apache`. `.9000` means "after
0.9.0, unreleased", so it's constant across the whole window — the previous one, `0.8.0.9000`,
spanned **58 commits over roughly six months**. A wrap bump leaves that line byte-identical.

Verified end-to-end: with the wrap bumped and the snapshot untouched, `sbom_snapshot` reports
`OK; 84 packages in snapshot match baseline` while `sbom_wrap_pin` fails naming both shas.

## Scope — not a supply-chain hole

The wrap ships inside the source tarball with its revision, and that tarball is checksummed,
attested and Sigstore-signed. The dependency **is** pinned for consumers. What this closes is
CI never noticing snapshot/wrap divergence.

## What review caught

**A false green I would have shipped.** My first extraction took the first `revision =` anywhere
in the file. The reviewer built a wrap with `revision` under `[provide]` and a different one
under `[wrap-git]`, proved it legal with meson's own `ConfigParser`, and showed my gate
reporting `OK; snapshot and wrap agree on 3f824063...` while meson would build `a1b2c3d4...`.
My header argues at length about why the snapshot diff can't see the sha, and I never checked
whether my replacement read the right section. Now anchored to `[wrap-git]`.

**The `EXEMPT` classification was backwards**, settled by demonstration: injecting
`SKIP …; exit 0` passes under `EXEMPT` and fails by name under `COVERED`, which costs nothing on
the clean script. `EXEMPT` is for gates where exit 77 would be *wrong*, not gates that merely
don't skip. Listing an already-clean gate is the point — the backstop then guards it against
*acquiring* the defect.

Also fixed: the hex alphabet now matches `check-wrap-revisions.sh`'s `[0-9a-fA-F]` — and aligning
it surfaced a second problem, that comparing case-sensitively reported "disagree" between two
spellings of the *same* commit; exactly one match is required on each side, so a second
conflicting sha from a bad merge can't hide behind the first; and a license string in the header
that I'd written without reading (`Apache-2.0` → `Apache`).

## Tests

`sbom_wrap_pin` in suite `sbom`, registered separately from `sbom_snapshot` because it needs no
syft — folding it in would make it skip whenever syft is absent, for a reason that doesn't apply
to comparing two committed files. Confirmed it runs and passes with syft entirely off `PATH`.

Mutations, each with a distinct diagnostic: wrap bumped without regenerating; sha line deleted;
`revision` emptied; `[provide]`-first wrap; second conflicting sha; injected skip branch. Also
fail-closed on `[wrap-git]` twice, a pre-section `revision`, CRLF, and tab indentation.

**316 Ok / 0 Fail**, bash 3.2.57 clean.

## Follow-up

`[wrap-git] # comment` is a legal wrap this gate rejects — and the reviewer found
`check-wrap-revisions.sh` passes **vacuously** on that same spelling, so the 40-hex backstop this
gate leans on isn't there for it. That's a pre-existing hole in the sibling gate, filed
separately.
