### PR TITLE
ci: make the two wrap-reading gates agree on what a section header is

### DIFF
--- a/scripts/ci/check-sbom-wrap-pin.sh
+++ b/scripts/ci/check-sbom-wrap-pin.sh
@@ -66,7 +66,13 @@ done
 snapshot_shas=$(sed -n 's/^# nanoarrow-resolved-sha:[[:space:]]*\([0-9a-fA-F]\{7,\}\).*/\1/p' \
     "$snapshot")
 wrap_shas=$(awk '
-    /^[[:space:]]*\[/ { in_git = ($0 ~ /^[[:space:]]*\[wrap-git\][[:space:]]*$/) ; next }
+    # No end anchor on the header: configparser matches section headers by
+    # PREFIX, so `[wrap-git]  # the pin` is a legal header meson resolves. An
+    # anchored pattern rejected it and hard-failed with "no hex revision under
+    # [wrap-git]" when one was plainly there. check-wrap-revisions.sh had the
+    # mirror-image bug for the same spelling and passed VACUOUSLY; the two gates
+    # must agree on what a section header is (#1343).
+    /^[[:space:]]*\[/ { in_git = ($0 ~ /^[[:space:]]*\[wrap-git\]/) ; next }
     in_git && /^[[:space:]]*revision[[:space:]]*=/ {
         line = $0
         sub(/^[[:space:]]*revision[[:space:]]*=[[:space:]]*/, "", line)

--- a/scripts/ci/check-wrap-revisions.sh
+++ b/scripts/ci/check-wrap-revisions.sh
@@ -82,7 +82,19 @@ check_wrap() {
         [ -z "$line" ] && continue
         [[ "$line" == \#* ]] && continue
 
-        if [[ "$line" =~ ^\[(.+)\]$ ]]; then
+        # No `$` anchor: Python's configparser applies SECTCRE with .match, so
+        # text after `]` is ignored and `[wrap-git]  # the pin` resolves
+        # normally -- meson builds that wrap. Requiring `]` at end of line made
+        # this loop not recognise the header at all, so `section` stayed empty,
+        # the `wrap-git:revision` case never fired, and the gate reported
+        # "OK; release dependency wraps are reproducible" having checked
+        # nothing. Measured: a wrap with that header and `revision = notahex`
+        # passed. The literal `]` is still required, so this cannot over-match.
+        # Deliberately `[^]]+` and not a literal port of configparser's
+        # SECTCRE, which is greedy: do not "correct" this to `.+`. The
+        # literal `]` is still required, which is the direction that
+        # matters. (#1343)
+        if [[ "$line" =~ ^\[([^]]+)\] ]]; then
             local new_section=${BASH_REMATCH[1]}
             finish_section
             section=$new_section

--- a/scripts/ci/test-wrap-section-syntax.sh
+++ b/scripts/ci/test-wrap-section-syntax.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# The two wrap-reading gates must agree on what a section header is (#1343).
+#
+# check-wrap-revisions.sh asserts the 40-hex shape; check-sbom-wrap-pin.sh
+# asserts the snapshot and the wrap name the same commit and deliberately leans
+# on the first for the shape. They disagreed:
+#
+#   [wrap-git]  # the pin
+#
+# is a legal header -- Python's configparser applies SECTCRE with .match, so
+# text after `]` is ignored and meson builds that wrap. check-wrap-revisions.sh
+# required `]` at end of line, never recognised the section, and reported
+# "OK; release dependency wraps are reproducible" having checked nothing.
+# check-sbom-wrap-pin.sh had the mirror-image bug and hard-failed with
+# "no hex revision under [wrap-git]" when one was plainly there.
+#
+# One was a silent pass and one was a false failure, from the same disagreement.
+# This file exists so they cannot drift apart again: it drives BOTH gates over
+# the same header spellings and requires them to agree about which are legal.
+set -euo pipefail
+
+root=${1:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)}
+failures=0
+cases=0
+check() {
+    cases=$((cases + 1))
+    if [ "$2" = 0 ]; then printf 'test-wrap-section-syntax: ok %s\n' "$1"
+    else printf 'test-wrap-section-syntax: FAIL %s\n' "$1" >&2; failures=$((failures + 1)); fi
+}
+assert() { local n=$1 s=0; shift; "$@" || s=1; check "$n" "$s"; }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-wrapsyntax.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+# A fixture tree holding only what the two gates read, so neither is influenced
+# by the real repository's contents.
+# check-wrap-revisions.sh takes no root argument -- it derives repo_root from
+# its own location -- so the gate has to be COPIED INTO the fixture tree or it
+# silently checks the real repository and every assertion here passes for the
+# wrong reason. That is exactly what the first version of this file did.
+fixture() {
+    local header=$1 revision=$2 dir="$tmp/f"
+    rm -rf "$dir"; mkdir -p "$dir/subprojects" "$dir/sbom" "$dir/scripts/ci"
+    cp "$root/scripts/ci/check-wrap-revisions.sh" "$dir/scripts/ci/"
+    # [provide] carries its OWN revision, different from the real one. A gate
+    # that stops anchoring to [wrap-git] -- or treats every section as
+    # wrap-git -- then reads this decoy, which is the over-match
+    # check-sbom-wrap-pin.sh's own comment says must not be possible. Without
+    # it, widening that awk to `in_git = 1` passed every assertion here.
+    printf '%s\n' "$header" \
+        'url = https://github.com/apache/arrow-nanoarrow.git' \
+        "revision = $revision" \
+        '' '[provide]' \
+        'revision = 00000000000000000000000000000000000000ff' \
+        'nanoarrow = nanoarrow_dep' > "$dir/subprojects/nanoarrow.wrap"
+    printf 'nanoarrow@0.9.0.9000:Apache\n# nanoarrow-resolved-sha: %s\n' \
+        "${3:-$revision}" > "$dir/sbom/snapshot.txt"
+    printf '%s' "$dir"
+}
+
+# No ${x@Q}: that is bash 4.4+, and the floor here is the macOS runner's 3.2.57,
+# where it dies with "bad substitution". An earlier draft used it and ran ZERO
+# assertions on 3.2.57 while still exiting 0. The exit status depends on where
+# the expansion sits -- at top level or in a function under `set -e` it exits 1
+# -- so do not read the clean exit as general; what is general is that the
+# construct does not work at the floor and the failure was silent enough to
+# reach review.
+# Out of scope, stated so nobody adds a row for it: the `[ wrap-git ]` family
+# -- inner spaces, `[wrap-gitx]`, `[WRAP-GIT]`, unclosed, `[]` -- still has the
+# two gates disagreeing, check-wrap-revisions passing vacuously because its
+# `case` compares the untrimmed ${BASH_REMATCH[1]}, and the pin gate hard-
+# failing. meson rejects all of them, so no buildable wrap reaches it. A row
+# here could only assert "at least one gate objects", which would pin the
+# vacuous pass as correct and would have to be rewritten the day someone
+# trims the captured name -- a real improvement a test should not obstruct.
+GOOD=3f824063f59848e05692ab520de8ab4d9ebb1880
+
+# Both gates must ACCEPT every legal header spelling. A gate that rejects one is
+# a false failure; a gate that fails to find one is a vacuous pass. Requiring
+# both to accept catches either.
+for header in '[wrap-git]' '[wrap-git]  # the pin' '[wrap-git] ; note' '[wrap-git]	' '  [wrap-git]'; do
+    d=$(fixture "$header" "$GOOD")
+    accepts_shape() { "$1/scripts/ci/check-wrap-revisions.sh" >/dev/null 2>&1; }
+    accepts_pin() { "$root/scripts/ci/check-sbom-wrap-pin.sh" "$1" >/dev/null 2>&1; }
+    assert "check-wrap-revisions accepts <$header>" accepts_shape "$d"
+    assert "check-sbom-wrap-pin accepts <$header>" accepts_pin "$d"
+done
+
+# And both must still REJECT a bad revision under every one of those headers --
+# otherwise "accepts" could be satisfied by not looking.
+for header in '[wrap-git]' '[wrap-git]  # the pin'; do
+    d=$(fixture "$header" 'notahex')
+    rejects_shape() { ! "$1/scripts/ci/check-wrap-revisions.sh" >/dev/null 2>&1; }
+    assert "check-wrap-revisions rejects a non-hex revision under <$header>" \
+        rejects_shape "$d"
+
+    # A DIVERGENT BUT HEX sha, deliberately not reusing the notahex fixture:
+    # there the snapshot line is also non-hex, so the pin gate fails on "no
+    # nanoarrow-resolved-sha" rather than on the disagreement -- passing for the
+    # wrong reason. Without this row the pin gate had accept-only coverage here
+    # and a stub `exit 0` satisfied every assertion.
+    d=$(fixture "$header" "$GOOD" 'ffffffffffffffffffffffffffffffffffffffff')
+    rejects_pin() { ! "$root/scripts/ci/check-sbom-wrap-pin.sh" "$1" >/dev/null 2>&1; }
+    assert "check-sbom-wrap-pin rejects a divergent sha under <$header>" \
+        rejects_pin "$d"
+done
+
+# A floor, for the reason scripts/ci/test-gate-skip-exit-codes.sh states at its
+# own: "nothing failed" and "nothing ran" are otherwise the same result. A loop
+# that stops iterating -- a renamed fixture helper, an emptied header list --
+# would print "all cases passed" and exit 0 having asserted nothing, which is
+# this issue's defect one level up, inside this issue's own regression test.
+if [ "$cases" -lt 14 ]; then
+    printf 'test-wrap-section-syntax: FAIL only %d assertions ran; expected at least 14\n' \
+        "$cases" >&2
+    exit 1
+fi
+
+if ((failures)); then
+    printf 'test-wrap-section-syntax: %d case(s) failed\n' "$failures" >&2
+    exit 1
+fi
+printf 'test-wrap-section-syntax: all %d cases passed\n' "$cases"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -813,6 +813,18 @@ if sh.found()
        suite: 'abi')
 endif
 
+# Issue #1343: the two wrap-reading gates must agree on what a section header
+# is. They did not -- `[wrap-git]  # the pin` is legal (configparser matches
+# headers by prefix, so meson builds it), and check-wrap-revisions.sh reported
+# OK having never found the section while check-sbom-wrap-pin.sh hard-failed on
+# the same input. A silent pass and a false failure from one disagreement.
+if sh.found()
+  test('wrap_section_syntax', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-wrap-section-syntax.sh',
+              meson.project_source_root()],
+       suite: 'abi')
+endif
+
 # Issue #737: forbid new unanchored "Phase NX" labels in wirelog/ source.
 # Each Phase NX label must either carry an explicit issue cross-reference
 # on the same line ("#N", "Issue N", "US-N-NNN"), or be present in the


### PR DESCRIPTION
Closes #1343. Stacked on #1342 (`fix/1339-nanoarrow-pin`) — review that first.

## The bug

`[wrap-git]  # the pin` is a legal section header — Python's `configparser` applies `SECTCRE`
with `.match`, so text after `]` is ignored and **meson builds that wrap**. Two gates disagreed
about it, in opposite directions:

| gate | behaviour | defect |
|---|---|---|
| `check-wrap-revisions.sh` | `^\[(.+)\]$` never matched, so the section was never entered | **silent pass** — reported "OK; release dependency wraps are reproducible" with `revision = notahex` |
| `check-sbom-wrap-pin.sh` | anchored the same way in awk | **false failure** — "no hex revision under [wrap-git]" when one was plainly there |

One disagreement, two opposite defects. Both now match by prefix; the literal `]` is still
required so neither can over-match.

## The test, and three defects found by mutating it

`scripts/ci/test-wrap-section-syntax.sh` drives **both** gates over the same header spellings and
requires them to agree, so they can't drift apart again.

Every one of these was found by mutation, not by reading:

- **It passed with `check-sbom-wrap-pin.sh` replaced by `exit 0`.** The reject loop exercised
  only the other gate, so the pin gate had accept-only coverage — while the file's docstring
  claimed it required both to agree. A test that survives its subject being deleted is not a
  test. Now asserts a divergent-but-hex sha in a *separate* fixture: reusing the `notahex` one
  would have failed on "no `nanoarrow-resolved-sha`" rather than on the disagreement, passing for
  the wrong reason.
- **It passed with the pin gate's awk widened to `in_git = 1`** — treating every section as
  `[wrap-git]`, the exact over-match that gate's own comment says must not be possible. The
  fixture's `[provide]` now carries a decoy revision, verified to be the single thing killing
  that mutant.
- **It had no assertion-count floor**, so zero iterations printed "all cases passed".
  `test-gate-skip-exit-codes.sh` carries the same guard and rationale three directories away.
  Shipping #1343's own regression test without it reproduces #1343 one level up.

Seven mutants now die by name, on bash 5.3 **and** real 3.2.57 — including two the reviewer
added that neuter each gate's *core assertion* rather than its header regex, so coverage is
two-sided per gate rather than symmetric on paper.

## Two claims of mine that were wrong

An earlier draft used `${x@Q}`, which is **bash 4.4+** and dies at the macOS floor of 3.2.57.
I described it as "runs zero assertions and exits 0"; the reviewer refused to confirm that and
was right — the exit status depends on where the expansion sits. The comment now records the
observation without generalising the mechanism.

I also wrote "matching configparser's prefix semantics", which is true for the shipped spellings
but not literally: `SECTCRE` is greedy, `[^]]+` is lazy. The comment now warns against
"correcting" it to `.+` rather than asserting an equivalence that doesn't hold.

## Out of scope, deliberately

The `[ wrap-git ]` family (inner spaces, `[WRAP-GIT]`, unclosed, `[]`) still has the gates
disagreeing, from an untrimmed `${BASH_REMATCH[1]}`. **meson rejects every spelling**, so no
buildable wrap reaches it. A test row could only assert "at least one gate objects", which would
pin the vacuous pass as correct and would need rewriting the day someone trims the captured name
— a real improvement a test shouldn't obstruct. Named in a comment with the underlying cause.

Local: **317 Ok / 0 Fail / 14 Skipped**.
