### PR TITLE
fix(release): preserve terminal newline in archive names

### DIFF
--- a/scripts/ci/test-release-roundtrip.sh
+++ b/scripts/ci/test-release-roundtrip.sh
@@ -346,6 +346,20 @@ assert 'an archive whose name contains a space verifies' \
 assert 'a name containing a literal backslash-n verifies' \
     verifies_awkward_name 'a\nb.tar.gz' backslash_n
 
+# A terminal newline is the one basename shape command substitution cannot
+# preserve. Generate both manifests with the real coreutils so this exercises
+# the complete reader path rather than a hand-written name.
+terminal_newline_name() {
+    local name=$'trailing\n' dir="$escaping_dir/terminal-newline"
+    mkdir -p "$dir"
+    printf 'payload' >"$dir/$name"
+    ( cd "$dir" && sha256sum -- "$name" >"$name.sha256" &&
+      b3sum -- "$name" >"$name.blake3" )
+    "$vr" "$dir/$name" "$dir/$name.sha256" "$dir/$name.blake3" \
+        >/dev/null 2>&1
+}
+assert 'an archive whose name ends in a newline verifies' terminal_newline_name
+
 # --- #1316: make-tarball.sh's manifest-writing hardening ----------------------
 #
 # Three hardenings, each with its own fixture, because a fixture that passes

--- a/scripts/release/verify-release.sh
+++ b/scripts/release/verify-release.sh
@@ -133,7 +133,9 @@ command -v b3sum >/dev/null || { echo 'b3sum is required' >&2; exit 1; }
 # whose real target was tampered. Measured. In the only script third parties
 # run to detect tampering, that is the wrong direction to be wrong in.
 archive_dir=$(CDPATH= cd -P -- "$(dirname -- "$archive")" && pwd -P)
-archive_name=$(basename -- "$archive")
+# Parameter expansion preserves a terminal newline; command substitution around
+# basename would strip it before the manifest-name comparison.
+archive_name=${archive##*/}
 # Compare against the ESCAPED form of the expected name rather than unescaping
 # the manifest's. GNU coreutils escapes exactly three characters in a name --
 # backslash as `\\`, newline as `\n`, carriage return as `\r` -- and marks the


### PR DESCRIPTION
Fixes #1329.

- derive archive basenames with parameter expansion so terminal newlines are preserved
- add a real sha256sum/b3sum round-trip case for a filename ending in newline

Validation:
- bash -n scripts/release/verify-release.sh scripts/ci/test-release-roundtrip.sh
- scripts/ci/test-release-roundtrip.sh (all cases passed)
- git diff --cached --check