### PR TITLE
test: make Bash construct ratchet self-test platform-independent

### DIFF
--- a/scripts/ci/test-check-bash-constructs.sh
+++ b/scripts/ci/test-check-bash-constructs.sh
@@ -266,9 +266,9 @@ printf '%s\n' '[{"cmd":["/bin/bash","'"$root"'/ci/seed.sh"]}]' >"$build/meson-in
 printf '%s\n' 'linux nope' 'darwin 30' >"$tmp/bash-tier1-minimum.txt"
 expect_status 1 python3 "$analyzer_copy" "$build" "$root"
 grep -Fq 'invalid floor record' "$tmp/out" "$tmp/err"
-printf '%s\n' 'darwin 30' >"$tmp/bash-tier1-minimum.txt"
+printf '%s\n' 'linux 999999' 'darwin 999999' >"$tmp/bash-tier1-minimum.txt"
 expect_status 1 python3 "$analyzer_copy" "$build" "$root"
-grep -Fq 'invalid' "$tmp/out" "$tmp/err"
+grep -Fq 'minimum is 999999' "$tmp/out" "$tmp/err"
 
 write_fixture ci/seed.sh 'source "$DYNAMIC_SCRIPT"'
 expect_status 77 python3 -c \


### PR DESCRIPTION
Fixes the macOS-only failure in bash_construct_ratchet_selftest.

The floor mutation previously left only `darwin 30`, which is a valid floor on macOS when the closure contains 33 files; Linux failed only accidentally because its floor key was absent. The mutation now records an intentionally unreachable high floor for both supported platforms and asserts the expected diagnostic.

Validation:
- Bash 3.2-compatible syntax check
- scripts/ci/test-check-bash-constructs.sh
- meson test -C builddir bash_construct_ratchet_selftest --print-errorlogs
- Linux and Darwin floor behavior verified