### PR TITLE
ci: restore MSVC selection in perf-nightly

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -108,9 +108,13 @@ jobs:
       - name: Configure release + trace ceiling (Windows)
         if: runner.os == 'Windows'
         shell: cmd
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cc }}
+        # Force MSVC even when the image also exposes MinGW. Meson discovers
+        # Visual Studio and restores its environment in compile/test steps.
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          meson setup build-perf --buildtype=release -Dwirelog_log_max_level=trace -Dtests=true -DmbedTLS=disabled
+          meson setup build-perf --vsenv --buildtype=release -Dwirelog_log_max_level=trace -Dtests=true -DmbedTLS=disabled
 
       - name: Build (Linux)
         if: runner.os == 'Linux'
@@ -120,7 +124,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           meson compile -C build-perf
 
       # Linux: taskset pins the meson test harness to CPU 0. The test
@@ -142,7 +145,6 @@ jobs:
         env:
           WIRELOG_PERF_GATE: '1'
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           meson test -C build-perf --suite perf --print-errorlogs --num-processes 1
 
       - name: Collect flowlog portfolio (Linux)

--- a/scripts/ci/test-perf-nightly-windows.py
+++ b/scripts/ci/test-perf-nightly-windows.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Pin the nightly Windows toolchain wiring; native CI verifies MSVC execution.
+
+This deliberately checks the workflow's existing block-scalar layout, not
+general YAML. No YAML package is needed on the platforms running the ABI suite.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github/workflows/perf-nightly.yml"
+CONFIGURE = "Configure release + trace ceiling (Windows)"
+BUILD = "Build (Windows)"
+TEST = "Run perf suite (Windows)"
+
+
+def step(text: str, name: str) -> str:
+    # Comments must not stand in for active options or environment settings.
+    text = "\n".join(line for line in text.splitlines()
+                     if line.strip() and not line.lstrip().startswith("#"))
+    matches = re.findall(
+        rf"^      - name: {re.escape(name)}\n(.*?)(?=^      - |^  \S|\Z)",
+        text, re.MULTILINE | re.DOTALL)
+    assert len(matches) == 1, f"expected exactly one step: {name}"
+    return matches[0] + "\n"
+
+
+def field(body: str, key: str) -> str:
+    match = re.search(rf"^        {key}:(?: \|)?\n((?:          [^\n]*\n)+)",
+                      body, re.MULTILINE)
+    assert match, f"missing {key} block"
+    return match[1]
+
+
+def validate(text: str) -> None:
+    assert re.search(r"- os: windows-latest\n\s+compiler: msvc\n\s+cc: cl\n", text), \
+        "Windows matrix must select cl"
+    bodies = {name: step(text, name) for name in (CONFIGURE, BUILD, TEST)}
+    for name, body in bodies.items():
+        assert "        if: runner.os == 'Windows'\n" in body, name
+        assert "        shell: cmd\n" in body, name
+        assert "vcvars" not in body, f"hardcoded activation in {name}"
+
+    configure = bodies[CONFIGURE]
+    command = field(configure, "run").strip().split()
+    assert command[:3] == ["meson", "setup", "build-perf"], "Windows setup command"
+    for option in ("--vsenv", "--buildtype=release", "-Dwirelog_log_max_level=trace",
+                   "-Dtests=true", "-DmbedTLS=disabled"):
+        assert option in command, f"Windows setup must include {option}"
+    env = field(configure, "env")
+    for variable in ("CC", "CXX"):
+        assert f"          {variable}: ${{{{ matrix.cc }}}}\n" in env, \
+            f"Windows configure must set {variable}"
+
+    # Separate processes must use the configured build tree via Meson, which
+    # restores the persisted --vsenv environment before invoking Ninja/tests.
+    assert field(bodies[BUILD], "run").strip() == "meson compile -C build-perf", \
+        "Windows build must use Meson"
+    assert field(bodies[TEST], "run").strip() == (
+        "meson test -C build-perf --suite perf --print-errorlogs --num-processes 1"
+    ), "Windows test must use Meson and retain the perf suite"
+    assert "          WIRELOG_PERF_GATE: '1'\n" in field(bodies[TEST], "env"), \
+        "Windows perf gate must remain enabled"
+
+
+class WindowsWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_actual_workflow(self):
+        validate(self.text)
+
+    def test_removing_activation_fails(self):
+        with self.assertRaisesRegex(AssertionError, "must include --vsenv"):
+            validate(self.text.replace(" --vsenv", ""))
+
+    def test_comment_cannot_supply_activation(self):
+        mutated = self.text.replace(" --vsenv", "")
+        mutated = mutated.replace("        run: |", "        # --vsenv\n        run: |")
+        with self.assertRaisesRegex(AssertionError, "must include --vsenv"):
+            validate(mutated)
+
+    def test_removing_compiler_selection_fails(self):
+        for variable in ("CC", "CXX"):
+            with self.subTest(variable=variable):
+                line = f"          {variable}: ${{{{ matrix.cc }}}}\n"
+                with self.assertRaisesRegex(AssertionError, f"must set {variable}"):
+                    validate(self.text.replace(line, ""))
+
+    def test_compiler_selection_in_wrong_step_fails(self):
+        line = "          CC: ${{ matrix.cc }}\n"
+        mutated = self.text.replace(line, "")
+        mutated = mutated.replace(f"      - name: {BUILD}\n",
+                                  f"      - name: {BUILD}\n        env:\n{line}")
+        with self.assertRaisesRegex(AssertionError, "must set CC"):
+            validate(mutated)
+
+    def test_comment_cannot_supply_compiler_selection(self):
+        with self.assertRaisesRegex(AssertionError, "must set CC"):
+            validate(self.text.replace("          CC:", "          # CC:"))
+
+    def test_activation_in_wrong_step_fails(self):
+        mutated = self.text.replace(" --vsenv", "")
+        mutated = mutated.replace("meson compile -C build-perf",
+                                  "meson compile -C build-perf --vsenv")
+        with self.assertRaisesRegex(AssertionError, "must include --vsenv"):
+            validate(mutated)
+
+    def test_gcc_matrix_fails(self):
+        with self.assertRaisesRegex(AssertionError, "matrix must select cl"):
+            validate(self.text.replace("            cc: cl", "            cc: gcc"))
+
+    def test_bypassing_meson_build_fails(self):
+        with self.assertRaisesRegex(AssertionError, "build must use Meson"):
+            validate(self.text.replace("meson compile -C build-perf", "ninja -C build-perf"))
+
+    def test_disabling_perf_gate_fails(self):
+        with self.assertRaisesRegex(AssertionError, "gate must remain enabled"):
+            validate(self.text.replace("WIRELOG_PERF_GATE: '1'", "WIRELOG_PERF_GATE: '0'"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -655,6 +655,13 @@ endif
 # Windows runners too.  Pass the build directory that actually contains
 # the generated header (see wirelog/meson.build's configure_file()).
 py3 = find_program('python3', 'python', required: true)
+
+# The nightly MSVC job must not silently select MinGW when hosted images
+# change Visual Studio versions. Native Windows CI verifies execution.
+test('perf_nightly_windows_contract', py3,
+     args: [meson.project_source_root() / 'scripts/ci/test-perf-nightly-windows.py'],
+     suite: 'abi')
+
 test('version_sync', py3,
      args: [meson.project_source_root() / 'scripts/ci/check-version-sync.py',
             meson.project_build_root() / 'wirelog'],


### PR DESCRIPTION
## Summary

Restore the nightly Windows MSVC toolchain without hardcoding a Visual Studio release or changing performance policy.

Recent scheduled runs failed for two separate reasons:

- Windows job [100958606186](https://github.com/semantic-reasoning/wirelog/actions/runs/33852619330/job/100958606186) cannot find the hardcoded Visual Studio 2022 `vcvars64.bat`. Meson then selects Strawberry GCC (`cc`) instead of MSVC, and compilation fails on `setenv`/`unsetenv` in `tests/test_program.c`. The September 2 and 3 runs have the same failure.
- The authoritative stable job has no registered matching runner. The September 3 [job](https://github.com/semantic-reasoning/wirelog/actions/runs/33732777223/job/100576316573) annotation explicitly reports exceeding 24 hours while awaiting a runner. The repository runner API currently returns zero runners. This is an infrastructure blocker under #1149, not a code build timeout.

## Change

- Configure Windows with Meson's `--vsenv` and explicit `CC`/`CXX` selection from the MSVC matrix entry. Meson discovers the installed Visual Studio version and restores its environment for separate compile/test invocations.
- Remove the three hardcoded VS2022 activation calls.
- Add a dependency-free, ABI-registered workflow regression with negative fixtures for activation, compiler selection, wrong-step/comment placement, and perf settings.

The [`--vsenv` spelling is supported since Meson 0.60](https://mesonbuild.com/Builtin-options.html#details-for-vsenv), below this project's existing 0.62 minimum. No minimum-version change is needed.

## Validation

- TDD RED: the new contract fails on the original hardcoded activation.
- GREEN: `python scripts/ci/test-perf-nightly-windows.py -v` — 10 tests pass.
- `meson test -C builddir perf_nightly_windows_contract --no-rebuild --print-errorlogs` — pass.
- `meson test -C builddir --no-rebuild --suite abi --print-errorlogs --num-processes 6` — 57 pass, 1 explicit SKIP (`release_template`: this is not a release tag), 0 failures.
- `bash scripts/ci/test-check-perf-gate-execution.sh` — all positive/negative fixtures pass.
- `actionlint -shellcheck= -pyflakes= .github/workflows/perf-nightly.yml` — changed workflow passes. Optional shellcheck/pyflakes integrations were unavailable and disabled. An additional whole-repository lint reports the pre-existing `matrix.os_runs_on` expression in `ci-main.yml:39`; the identical error reproduces from the untouched base version. That separate workflow is not changed here.
- `git diff --check` — pass.

Python validation used an isolated `uv` virtual environment. Native verification is running against commit `4e196a56a811c5b9f04da710de8935ddf8ec6c58` in [Perf Nightly run 33946334833](https://github.com/semantic-reasoning/wirelog/actions/runs/33946334833). Windows configuration passed; full compilation is in progress and perf-suite execution is pending. Only the supplementary portfolio tier was set to `smoke`; the build, perf suite and required stable gates are unchanged. This does not establish full Windows or default-portfolio success yet.

## Remaining operational blockers

This PR does **not** close #1149 or claim full `perf-nightly` restoration. A suitable isolated `[self-hosted, linux, x64, wirelog-perf]` runner must be provisioned and supply real timing evidence. Required gates, thresholds, labels, and fail/skip semantics are unchanged. DOOP MUST-enable #1351 remains blocked by #1149 and authentic calibration/manifest work in #1161; no benchmark calibration is fabricated here.
