### PR TITLE
fix(parser): honor arithmetic operator precedence (#1353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- Correct arithmetic operator precedence in rule heads, comparisons, and
+  function/aggregate arguments (#1353). `*`, `/`, and `%` now bind more
+  tightly than `+` and `-`, with left associativity within each level.
+  For example, `8 + 3 * 2` now yields `14`, correcting the previous silent
+  wrong result of `22`. Example 14 and its golden output reflect the fix.
+
 ### Performance
 
 ### Security

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -530,6 +530,27 @@ aggregates.
 
 `+`, `-`, `*`, `/`, `%` (modulo)
 
+`*`, `/`, and `%` have higher precedence than `+` and `-`. Operators within
+each level associate left-to-right. For example, `8 + 3 * 2` yields `14`,
+`20 - 5 - 3` yields `12`, and `24 / 3 * 2` yields `16`.
+These rules apply to rule-head expressions, both sides of comparisons,
+and arithmetic expressions passed to aggregate and built-in functions.
+
+The arithmetic grammar is:
+
+```text
+arithmetic_expr = product (("+" | "-") product)*
+product         = factor (("*" | "/" | "%") factor)*
+```
+
+Factors include variables, supported literals, and supported built-in calls.
+General arithmetic grouping parentheses and unary negation of variables or
+expressions are not supported. A minus sign on a numeric literal is supported
+subject to the literal syntax rules above. Call parentheses, such as those in
+`min(A + B * C)` and `band(A + B * C, 15)`, remain supported; they are not
+general grouping parentheses. Use an intermediate relation when a different
+arithmetic grouping is needed.
+
 ### Bitwise Operators
 
 `band(x, y)`, `bor(x, y)`, `bxor(x, y)`, `bnot(x)`, `bshl(x, y)`, `bshr(x, y)`

--- a/examples/14-arithmetic-operations/README.md
+++ b/examples/14-arithmetic-operations/README.md
@@ -20,11 +20,13 @@ result(Label, A + B, A - B, A * B, A / B, A % B, A + B * C)
     :- sample(Label, A, B, C), B != 0.
 ```
 
-Arithmetic expressions are parsed left-associatively: `A + B * C` means
-`(A + B) * C` in this language, not conventional multiplication-first
-precedence. The `precedence` input row makes that behavior visible (`22`, not
-`14`). Use explicit intermediate relations when conventional grouping is
-needed.
+Multiplication, division, and remainder bind more tightly than addition and
+subtraction. `A + B * C` therefore adds `A` to the product of `B` and `C`.
+The `precedence` input row uses `8 + 3 * 2` and produces `14`, not `22`.
+Operators at the same precedence level associate left-to-right: `A - B - C`
+subtracts `B` and then `C`. General arithmetic grouping parentheses are not
+currently supported; use an intermediate relation to request a different
+grouping, such as adding `A` and `B` before multiplying by `C`.
 
 Each aggregate is in its own rule because a rule head accepts at most one
 aggregate. `min` and `max` operate on the integer column, `average` requires a
@@ -64,9 +66,9 @@ Example 14: Arithmetic Operations
 average_value(2.500000)
 maximum(17)
 minimum(-17)
-result("negative", -12, -22, -85, -3, -2, -24)
-result("positive", 22, 12, 85, 3, 2, 44)
-result("precedence", 11, 5, 24, 2, 2, 22)
+result("negative", -12, -22, -85, -3, -2, -7)
+result("positive", 22, 12, 85, 3, 2, 27)
+result("precedence", 11, 5, 24, 2, 2, 14)
 sample_count(3)
 zero_observed(+0.0)
 

--- a/examples/14-arithmetic-operations/expected.txt
+++ b/examples/14-arithmetic-operations/expected.txt
@@ -4,9 +4,9 @@ Example 14: Arithmetic Operations
 average_value(2.500000)
 maximum(17)
 minimum(-17)
-result("negative", -12, -22, -85, -3, -2, -24)
-result("positive", 22, 12, 85, 3, 2, 44)
-result("precedence", 11, 5, 24, 2, 2, 22)
+result("negative", -12, -22, -85, -3, -2, -7)
+result("positive", 22, 12, 85, 3, 2, 27)
+result("precedence", 11, 5, 24, 2, 2, 14)
 sample_count(3)
 zero_observed(+0.0)
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -108,6 +108,19 @@ test_program_exe = executable(
 )
 
 if host_machine.system() == 'linux'
+  test_parser_arithmetic_oom_exe = executable(
+    'test_parser_arithmetic_oom',
+    files('test_parser_arithmetic_oom.c'),
+    parser_src,
+    include_directories: [wirelog_inc, wirelog_src_inc],
+    link_args: [
+      '-Wl,--wrap=wl_parser_ast_node_create',
+      '-Wl,--wrap=wl_parser_ast_node_add_child',
+    ],
+    override_options: ['b_lto=false'],
+  )
+  test('parser_arithmetic_oom', test_parser_arithmetic_oom_exe, suite: 'unit')
+
   test_column_names_oom_exe = executable(
     'test_column_names_oom',
     files('test_column_names_oom.c'),

--- a/tests/test_expr_compile.c
+++ b/tests/test_expr_compile.c
@@ -462,6 +462,92 @@ test_filter_multiple_arithmetic(void)
 /* Main                                                                     */
 /* ======================================================================== */
 
+static void
+test_arithmetic_precedence_results(void)
+{
+    static const struct {
+        const char *expression;
+        int64_t expected;
+    } cases[] = {
+        { "x + y * z", 14 }, { "x - y * z", 2 },
+        { "x + y / z", 9 }, { "x - y / z", 7 },
+        { "x + y % z", 9 }, { "x - y % z", 7 },
+        { "x * y + z", 26 }, { "x / y - z", 0 },
+        { "x % y + z", 4 }, { "x - y - z", 3 },
+        { "24 / y / z", 4 }, { "24 / y * z", 16 },
+        { "x % y * z", 4 }, { "x * y % z", 0 },
+        { "20 - y * 4 + 18 / y % 4", 10 },
+        { "x + -3 * z", 2 }, { "-8 + y * z", -2 },
+        { "band(x + y * z, 15)", 14 },
+        { "min(x + y * z)", 14 },
+        { "sum(x + y * z)", 14 },
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        TEST(cases[i].expression);
+        char source[256];
+        snprintf(source, sizeof(source),
+            ".decl a(x: int64, y: int64, z: int64)\n"
+            "a(8, 3, 2).\n.decl r(value: int64)\n"
+            "r(%s) :- a(x, y, z).\n", cases[i].expression);
+        struct result_ctx out;
+        int n = run_program(source, "r", &out);
+        if (n != 1 || out.ncols[0] != 1
+            || out.rows[0][0] != cases[i].expected) {
+            FAIL("wrong arithmetic result");
+            continue;
+        }
+        PASS();
+    }
+}
+
+static void
+test_arithmetic_precedence_filters(void)
+{
+    static const char *conditions[] = {
+        "x + y * z = 14", "14 = x + y * z",
+        "x + y * z < 20", "20 > x + y * z",
+        "8 + y * z = 14", "band(x, 15) + y * z = 14",
+        "strlen(\"12345678\") + y * z = 14",
+    };
+    for (size_t i = 0; i < sizeof(conditions) / sizeof(conditions[0]); i++) {
+        TEST(conditions[i]);
+        char source[320];
+        snprintf(source, sizeof(source),
+            ".decl a(id: int64, x: int64, y: int64, z: int64)\n"
+            "a(1, 8, 3, 2). a(2, 8, 3, 4).\n"
+            ".decl r(id: int64)\nr(id) :- a(id, x, y, z), %s.\n",
+            conditions[i]);
+        struct result_ctx out;
+        int n = run_program(source, "r", &out);
+        if (n != 1 || out.ncols[0] != 1 || out.rows[0][0] != 1) {
+            FAIL("expected only row id 1, not id 2");
+            continue;
+        }
+        PASS();
+    }
+}
+
+static void
+test_float_arithmetic_precedence(void)
+{
+    TEST("float MAP and FILTER use multiplicative precedence");
+    const char *source =
+        ".decl a(x: float, y: float, z: float)\n"
+        "a(8.0, 3.0, 2.0). a(8.0, 3.0, 4.0).\n"
+        ".decl r(value: float)\n"
+        "r(x + y * z) :- a(x, y, z), x + y * z = 14.0.\n";
+    struct result_ctx out;
+    int n = run_program(source, "r", &out);
+    double value = 0.0;
+    if (n == 1)
+        memcpy(&value, &out.rows[0][0], sizeof(value));
+    if (n != 1 || out.ncols[0] != 1 || value != 14.0) {
+        FAIL("expected the single float result 14.0");
+        return;
+    }
+    PASS();
+}
+
 int
 main(void)
 {
@@ -480,6 +566,11 @@ main(void)
     printf("\n--- FILTER: complex arithmetic (CRDT patterns) ---\n");
     test_filter_crdt_double_arithmetic();
     test_filter_multiple_arithmetic();
+
+    printf("\n--- Arithmetic precedence (Issue #1353) ---\n");
+    test_arithmetic_precedence_results();
+    test_arithmetic_precedence_filters();
+    test_float_arithmetic_precedence();
 
     printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
     if (tests_failed > 0)

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -2171,20 +2171,181 @@ test_parse_error_invalid_type(void)
 static void
 test_parse_chained_arithmetic(void)
 {
-    TEST("chained arithmetic: a + b * c");
-    /* FlowLog arithmetic is left-associative flat: factor (op factor)* */
+    TEST("chained addition: (x + y) + z");
     PARSE("r(x + y + z) :- a(x, y, z).");
     ASSERT_PARSED();
     const wl_parser_ast_node_t *rule = child(program, 0);
     const wl_parser_ast_node_t *head = child(rule, 0);
     const wl_parser_ast_node_t *expr = child(head, 0);
     /* Should be binary tree: (x + y) + z */
-    if (expr->type != WL_PARSER_AST_NODE_BINARY_EXPR) {
+    if (expr->type != WL_PARSER_AST_NODE_BINARY_EXPR
+        || expr->arith_op != WIRELOG_ARITH_ADD || expr->child_count != 2
+        || child(expr, 0)->type != WL_PARSER_AST_NODE_BINARY_EXPR
+        || child(expr, 0)->arith_op != WIRELOG_ARITH_ADD
+        || child(expr, 0)->child_count != 2
+        || strcmp(child(child(expr, 0), 0)->name, "x") != 0
+        || strcmp(child(child(expr, 0), 1)->name, "y") != 0
+        || strcmp(child(expr, 1)->name, "z") != 0) {
         CLEANUP();
         FAIL("expected BINARY_EXPR");
         return;
     }
     CLEANUP();
+    PASS();
+}
+
+static bool
+is_binary(const wl_parser_ast_node_t *node, wirelog_arith_op_t op)
+{
+    return node && node->type == WL_PARSER_AST_NODE_BINARY_EXPR
+           && node->arith_op == op && node->child_count == 2;
+}
+
+static bool
+is_variable(const wl_parser_ast_node_t *node, const char *name)
+{
+    return node && node->type == WL_PARSER_AST_NODE_VARIABLE
+           && node->child_count == 0 && node->name
+           && strcmp(node->name, name) == 0;
+}
+
+static void
+test_parse_arithmetic_precedence(void)
+{
+    static const struct {
+        const char *expression;
+        wirelog_arith_op_t root;
+        wirelog_arith_op_t nested;
+        bool nested_right;
+    } cases[] = {
+        { "x + y * z", WIRELOG_ARITH_ADD, WIRELOG_ARITH_MUL, true },
+        { "x - y * z", WIRELOG_ARITH_SUB, WIRELOG_ARITH_MUL, true },
+        { "x + y / z", WIRELOG_ARITH_ADD, WIRELOG_ARITH_DIV, true },
+        { "x - y / z", WIRELOG_ARITH_SUB, WIRELOG_ARITH_DIV, true },
+        { "x + y % z", WIRELOG_ARITH_ADD, WIRELOG_ARITH_MOD, true },
+        { "x - y % z", WIRELOG_ARITH_SUB, WIRELOG_ARITH_MOD, true },
+        { "x * y + z", WIRELOG_ARITH_ADD, WIRELOG_ARITH_MUL, false },
+        { "x / y - z", WIRELOG_ARITH_SUB, WIRELOG_ARITH_DIV, false },
+        { "x % y + z", WIRELOG_ARITH_ADD, WIRELOG_ARITH_MOD, false },
+        { "x - y - z", WIRELOG_ARITH_SUB, WIRELOG_ARITH_SUB, false },
+        { "x + y - z", WIRELOG_ARITH_SUB, WIRELOG_ARITH_ADD, false },
+        { "x / y / z", WIRELOG_ARITH_DIV, WIRELOG_ARITH_DIV, false },
+        { "x / y * z", WIRELOG_ARITH_MUL, WIRELOG_ARITH_DIV, false },
+        { "x % y * z", WIRELOG_ARITH_MUL, WIRELOG_ARITH_MOD, false },
+        { "x * y % z", WIRELOG_ARITH_MOD, WIRELOG_ARITH_MUL, false },
+    };
+    static const char *contexts[] = {
+        "r(%s) :- a(x, y, z).",
+        "r(x) :- a(x, y, z), %s = 14.",
+        "r(x) :- a(x, y, z), 14 = %s.",
+        "r(sum(%s)) :- a(x, y, z).",
+        "r(band(%s, 1)) :- a(x, y, z).",
+        "r(substr(\"abc\", %s, 1)) :- a(x, y, z).",
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        for (size_t j = 0; j < sizeof(contexts) / sizeof(contexts[0]); j++) {
+            char source[256];
+            snprintf(source, sizeof(source), contexts[j], cases[i].expression);
+            TEST(source);
+            PARSE(source);
+            if (!program) {
+                FAIL(errbuf);
+                continue;
+            }
+            const wl_parser_ast_node_t *rule = child(program, 0);
+            const wl_parser_ast_node_t *expr = child(child(rule, 0), 0);
+            if (j == 1 || j == 2)
+                expr = child(child(rule, 2), (uint32_t)(j - 1));
+            else if (j >= 3)
+                expr = child(expr, j == 5 ? 1 : 0);
+            const wl_parser_ast_node_t *nested
+                = child(expr, cases[i].nested_right ? 1 : 0);
+            bool matches = is_binary(expr, cases[i].root)
+                && is_binary(nested, cases[i].nested)
+                && is_variable(cases[i].nested_right ? child(expr, 0)
+                                                    : child(nested, 0), "x")
+                && is_variable(child(nested, cases[i].nested_right ? 0 : 1),
+                    "y")
+                && is_variable(cases[i].nested_right ? child(nested, 1)
+                                                    : child(expr, 1), "z");
+            CLEANUP();
+            if (!matches) {
+                FAIL("wrong precedence, associativity, or ordered operands");
+                continue;
+            }
+            PASS();
+        }
+    }
+}
+
+static void
+test_parse_arithmetic_transitions(void)
+{
+    TEST("x + y * z - u / v % w: multiple precedence transitions");
+    PARSE("r(x + y * z - u / v % w) :- a(x, y, z, u, v, w).");
+    ASSERT_PARSED();
+    const wl_parser_ast_node_t *expr = child(child(child(program, 0), 0), 0);
+    const wl_parser_ast_node_t *add = child(expr, 0);
+    const wl_parser_ast_node_t *mul = child(add, 1);
+    const wl_parser_ast_node_t *mod = child(expr, 1);
+    const wl_parser_ast_node_t *div = child(mod, 0);
+    bool matches = is_binary(expr, WIRELOG_ARITH_SUB)
+        && is_binary(add, WIRELOG_ARITH_ADD)
+        && is_binary(mul, WIRELOG_ARITH_MUL)
+        && is_binary(mod, WIRELOG_ARITH_MOD)
+        && is_binary(div, WIRELOG_ARITH_DIV)
+        && is_variable(child(add, 0), "x")
+        && is_variable(child(mul, 0), "y")
+        && is_variable(child(mul, 1), "z")
+        && is_variable(child(div, 0), "u")
+        && is_variable(child(div, 1), "v")
+        && is_variable(child(mod, 1), "w");
+    CLEANUP();
+    if (!matches) {
+        FAIL("wrong mixed-precedence tree");
+        return;
+    }
+    PASS();
+}
+
+static void
+test_parse_arithmetic_invalid_and_lookahead(void)
+{
+    static const char *invalid[] = {
+        "r(x +) :- a(x).", "r(x + y *) :- a(x, y).",
+        "r(x + * y) :- a(x, y).", "r(x) :- a(x), x + = 1.",
+        "r(x) :- a(x), 1 = x + 2 /.",
+        "r((x + 1) * 2) :- a(x).", "r(-x) :- a(x).",
+        "r(x) :- a @ (x).", "r(x) :- a(x), x @ = 1.",
+    };
+    for (size_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+        TEST(invalid[i]);
+        PARSE(invalid[i]);
+        bool rejected = !program && errbuf[0] != '\0';
+        CLEANUP();
+        if (!rejected) {
+            FAIL("malformed or unsupported expression accepted");
+            continue;
+        }
+        PASS();
+    }
+    TEST("relation call lookahead preserves whitespace and comments");
+    PARSE("r(x) :- a // relation comment\n (x, y), x // expression\n + y > 0.");
+    ASSERT_PARSED();
+    const wl_parser_ast_node_t *rule = child(program, 0);
+    const wl_parser_ast_node_t *atom = child(rule, 1);
+    const wl_parser_ast_node_t *cmp = child(rule, 2);
+    bool matches = atom && atom->type == WL_PARSER_AST_NODE_ATOM
+        && atom->name && strcmp(atom->name, "a") == 0
+        && atom->child_count == 2 && is_variable(child(atom, 0), "x")
+        && is_variable(child(atom, 1), "y")
+        && cmp && cmp->type == WL_PARSER_AST_NODE_COMPARISON
+        && is_binary(child(cmp, 0), WIRELOG_ARITH_ADD);
+    CLEANUP();
+    if (!matches) {
+        FAIL("relation/expression lookahead changed the AST");
+        return;
+    }
     PASS();
 }
 
@@ -2264,6 +2425,9 @@ main(void)
     test_parse_arithmetic_comparison();
     test_parse_arithmetic_head();
     test_parse_chained_arithmetic();
+    test_parse_arithmetic_precedence();
+    test_parse_arithmetic_transitions();
+    test_parse_arithmetic_invalid_and_lookahead();
     test_parse_all_arithmetic_ops();
 
     printf("\n--- Aggregation ---\n");

--- a/tests/test_parser_arithmetic_oom.c
+++ b/tests/test_parser_arithmetic_oom.c
@@ -1,0 +1,99 @@
+/* Arithmetic AST ownership regression for issue #1353. */
+
+#include "../wirelog/parser/parser.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+
+wl_parser_ast_node_t *__real_wl_parser_ast_node_create(
+    wl_parser_ast_node_type_t type, uint32_t line, uint32_t col);
+int __real_wl_parser_ast_node_add_child(wl_parser_ast_node_t *parent,
+    wl_parser_ast_node_t *child);
+
+static bool fail_creation;
+static long fail_at = -1;
+static long calls;
+static bool injected;
+
+wl_parser_ast_node_t *
+__wrap_wl_parser_ast_node_create(wl_parser_ast_node_type_t type,
+    uint32_t line, uint32_t col)
+{
+    if (fail_creation && type == WL_PARSER_AST_NODE_BINARY_EXPR
+        && calls++ == fail_at) {
+        injected = true;
+        return NULL;
+    }
+    return __real_wl_parser_ast_node_create(type, line, col);
+}
+
+int
+__wrap_wl_parser_ast_node_add_child(wl_parser_ast_node_t *parent,
+    wl_parser_ast_node_t *child)
+{
+    if (!fail_creation && parent
+        && parent->type == WL_PARSER_AST_NODE_BINARY_EXPR
+        && calls++ == fail_at) {
+        injected = true;
+        return -1;
+    }
+    return __real_wl_parser_ast_node_add_child(parent, child);
+}
+
+static int
+sweep_arithmetic(const char *source, bool creation)
+{
+    fail_creation = creation;
+    fail_at = -1;
+    calls = 0;
+    injected = false;
+    char error[512] = {0};
+    wl_parser_ast_node_t *ast
+        = wl_parser_parse_string(source, error, sizeof(error));
+    long count = calls;
+    bool valid = ast && error[0] == '\0' && !injected && count > 0;
+    wl_parser_ast_node_free(ast);
+    if (!valid) {
+        fprintf(stderr, "uninjected arithmetic parse failed: %s\n", error);
+        return 1;
+    }
+
+    /* Include one final uninjected run to prove the sweep terminates normally. */
+    for (long attempt = 0; attempt <= count; attempt++) {
+        calls = 0;
+        fail_at = attempt;
+        injected = false;
+        error[0] = '\0';
+        ast = wl_parser_parse_string(source, error, sizeof(error));
+        fail_at = -1;
+        valid = attempt < count
+            ? injected && !ast && error[0] != '\0'
+            : !injected && ast && error[0] == '\0' && calls == count;
+        wl_parser_ast_node_free(ast);
+        if (!valid) {
+            fprintf(stderr, "arithmetic %s failure %ld/%ld was mishandled\n",
+                creation ? "creation" : "attachment", attempt, count);
+            return 1;
+        }
+    }
+    printf("arithmetic %s: %ld injected failures rejected and control passed\n",
+        creation ? "creation" : "attachment", count);
+    return 0;
+}
+
+int
+main(void)
+{
+    static const char *sources[] = {
+        "r(x + y * z - u / v % w) :- a(x, y, z, u, v, w).",
+        "r(x) :- a(x, y, z), x + y * z = x - y / z.",
+        "r(sum(x + y * z)) :- a(x, y, z).",
+        "r(x) :- a(x, y, z), 8 + y * z = x + y % z.",
+    };
+    for (size_t i = 0; i < sizeof(sources) / sizeof(sources[0]); i++) {
+        if (sweep_arithmetic(sources[i], true) != 0
+            || sweep_arithmetic(sources[i], false) != 0)
+            return 1;
+    }
+    return 0;
+}

--- a/wirelog/parser/parser.c
+++ b/wirelog/parser/parser.c
@@ -10,7 +10,7 @@
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
  *
- * Grammar (FlowLog-compatible):
+ * Grammar (core forms):
  *
  *   program     = (declaration | input_dir | output_dir | printsize_dir | rule | fact)*
  *   declaration = ".decl" IDENT "(" attributes? ")"
@@ -27,7 +27,8 @@
  *   negative    = "!" atom
  *   atom_args   = atom_arg ("," atom_arg)*
  *   atom_arg    = IDENT | signed_number | STRING | "_"
- *   arith_expr  = factor (arith_op factor)*
+ *   arith_expr  = product (("+" | "-") product)*
+ *   product     = factor (("*" | "/" | "%") factor)*
  *   factor      = IDENT | signed_number | STRING
  *   signed_int  = INTEGER | "-" INTEGER  (no whitespace between '-' and INTEGER)
  *   signed_number = signed_int | FLOAT | "-" FLOAT
@@ -902,10 +903,9 @@ token_to_arith_op(wl_parser_lexer_token_type_t type)
 }
 
 static bool
-is_arith_op(wl_parser_lexer_token_type_t type)
+is_multiplicative_op(wl_parser_lexer_token_type_t type)
 {
-    return type == WL_PARSER_LEXER_TOK_PLUS || type == WL_PARSER_LEXER_TOK_MINUS
-           || type == WL_PARSER_LEXER_TOK_STAR
+    return type == WL_PARSER_LEXER_TOK_STAR
            || type == WL_PARSER_LEXER_TOK_SLASH
            || type == WL_PARSER_LEXER_TOK_PERCENT;
 }
@@ -930,34 +930,61 @@ is_bitwise_token(wl_parser_lexer_token_type_t type)
            || type == WL_PARSER_LEXER_TOK_CRC32_CAST;
 }
 
+/* Each level folds left. The additive level consumes whole products, while
+ * the multiplicative level consumes factors; recursion adds only one level. */
 static wl_parser_ast_node_t *
-parse_arithmetic_expr(wl_parser_t *parser)
+parse_arithmetic_level(wl_parser_t *parser, bool multiplicative)
 {
-    wl_parser_ast_node_t *left = parse_factor(parser);
-    if (!left || parser->had_error)
-        return left;
+    wl_parser_ast_node_t *left = multiplicative
+        ? parse_factor(parser) : parse_arithmetic_level(parser, true);
+    if (!left || parser->had_error) {
+        wl_parser_ast_node_free(left);
+        return NULL;
+    }
 
-    while (is_arith_op(parser->current.type)) {
+    while (multiplicative ? is_multiplicative_op(parser->current.type)
+                          : parser_check(parser, WL_PARSER_LEXER_TOK_PLUS)
+        || parser_check(parser, WL_PARSER_LEXER_TOK_MINUS)) {
         uint32_t line = parser->current.line;
         uint32_t col = parser->current.col;
         wirelog_arith_op_t op = token_to_arith_op(parser->current.type);
         parser_advance(parser);
 
-        wl_parser_ast_node_t *right = parse_factor(parser);
-        if (!right) {
+        wl_parser_ast_node_t *right = multiplicative
+            ? parse_factor(parser) : parse_arithmetic_level(parser, true);
+        if (!right || parser->had_error) {
             wl_parser_ast_node_free(left);
+            wl_parser_ast_node_free(right);
             return NULL;
         }
 
         wl_parser_ast_node_t *bin = wl_parser_ast_node_create(
             WL_PARSER_AST_NODE_BINARY_EXPR, line, col);
+        if (!bin) {
+            parser_error(parser,
+                "out of memory while creating arithmetic expression");
+            wl_parser_ast_node_free(left);
+            wl_parser_ast_node_free(right);
+            return NULL;
+        }
         bin->arith_op = op;
-        PARSER_ADD_CHILD_OR_RETURN(bin, left);
+        if (!parser_add_child(parser, bin, left)) {
+            /* parser_add_child freed left; right is not owned by bin yet. */
+            wl_parser_ast_node_free(right);
+            wl_parser_ast_node_free(bin);
+            return NULL;
+        }
         PARSER_ADD_CHILD_OR_RETURN(bin, right);
         left = bin;
     }
 
     return left;
+}
+
+static wl_parser_ast_node_t *
+parse_arithmetic_expr(wl_parser_t *parser)
+{
+    return parse_arithmetic_level(parser, false);
 }
 
 static wirelog_agg_fn_t
@@ -1445,38 +1472,19 @@ parse_predicate(wl_parser_t *parser)
     }
 
     /* Atom or comparison (both start with IDENT) */
-    if (parser_match(parser, WL_PARSER_LEXER_TOK_IDENT)) {
+    if (parser_check(parser, WL_PARSER_LEXER_TOK_IDENT)) {
         /* Check if followed by '(' => atom */
-        if (parser_check(parser, WL_PARSER_LEXER_TOK_LPAREN)) {
+        wl_parser_lexer_token_t next =
+            wl_parser_lexer_peek_token(&parser->lexer);
+        if (next.type == WL_PARSER_LEXER_TOK_LPAREN) {
+            parser_advance(parser); /* parse_atom expects the consumed name. */
             return parse_atom(parser);
         }
 
-        /* Otherwise it's a comparison: arith_expr compare_op arith_expr
-        * We already consumed the identifier, so build the left side. */
-        wl_parser_ast_node_t *left_var = wl_parser_ast_node_create(
-            WL_PARSER_AST_NODE_VARIABLE, parser->previous.line,
-            parser->previous.col);
-        left_var->name = token_to_name(&parser->previous);
-
-        /* Build left arithmetic expression */
-        wl_parser_ast_node_t *left = left_var;
-        while (is_arith_op(parser->current.type)) {
-            uint32_t op_line = parser->current.line;
-            uint32_t op_col = parser->current.col;
-            wirelog_arith_op_t op = token_to_arith_op(parser->current.type);
-            parser_advance(parser);
-            wl_parser_ast_node_t *right_factor = parse_factor(parser);
-            if (!right_factor) {
-                wl_parser_ast_node_free(left);
-                return NULL;
-            }
-            wl_parser_ast_node_t *bin = wl_parser_ast_node_create(
-                WL_PARSER_AST_NODE_BINARY_EXPR, op_line, op_col);
-            bin->arith_op = op;
-            PARSER_ADD_CHILD_OR_RETURN(bin, left);
-            PARSER_ADD_CHILD_OR_RETURN(bin, right_factor);
-            left = bin;
-        }
+        /* Leave the identifier for the shared expression parser. */
+        wl_parser_ast_node_t *left = parse_arithmetic_expr(parser);
+        if (!left)
+            return NULL;
 
         if (!is_compare_op(parser->current.type)) {
             parser_error(parser, "expected comparison operator");


### PR DESCRIPTION
## Summary

Fixes #1353 (P0).

- Parse multiplication, division and remainder before addition/subtraction, preserving left associativity within each level.
- Remove the duplicate flat expression loop from identifier-led comparisons so both comparison operands use the same precedence rules.
- Reject arithmetic AST construction/attachment failures with correct operand cleanup.
- Correct Example 14 (`-7`, `27`, `14` in the final result column), the syntax reference and changelog. General grouping parentheses remain unsupported; this PR does not add new grammar or a legacy wrong-result mode.

## TDD and regression coverage

Before the parser fix, the new tests produced 37 failing AST checks, 20 failing evaluation checks, and an Example 14 golden mismatch. The targeted OOM test additionally reproduced a UBSan NULL dereference in arithmetic-node construction.

After the fix:

- 183 parser checks and 35 expression-evaluation checks pass, including ordered ASTs, both comparison operands, aggregate/built-in arguments, integer/float results and exact row inclusion/exclusion.
- 45 targeted arithmetic node-creation/attachment failures are rejected, with successful uninjected controls and sanitizer cleanup coverage.
- Focused Meson tests: **4/4 pass**.
- ASan/UBSan with leak detection: **14/14 pass**, covering the focused tests, arithmetic overflow, IR/program/plan generation, allocation-failure sweeps and built-in parsers.
- Full CRDT correctness: **pass, 40.55s**. CSPA and small CRDT correctness also pass in the broader suite.

## Broader validation

```sh
meson compile -C builddir -j 12
meson test -C builddir --no-rebuild --print-errorlogs --num-processes 6
```

The full run recorded **323 passed, 13 explicit opt-in/release skips, and one local-environment SBOM failure**. The SBOM scan found the local `.venv`'s Meson/Ninja tool packages. Running the unchanged checker on an export of the identical candidate with the pinned subproject sources and without the local tool environment passed: **84 packages match the committed snapshot**. No snapshot baseline, CI gate or repository exclusion changed.

Formatting, `git diff --check`, the full clang-tidy ratchet, and ABI checks pass. Release `.text` is **241,289 bytes**: **93 bytes** above an identical local build of unmodified main, and **3,969 bytes below** the committed baseline (5,120-byte growth budget). No size exception or baseline update.

## Review discipline

The requested Wirelog implementation harness selected planning, critique, focused/broad validation, independent raw-diff review, final design/risk approval and atomic commit gates. Architect, Critic and Reviewer are separate agents; the coordinator implemented the candidate. The unrelated hosted-perf work and original dirty worktree are excluded.

## Native CI result

All **29 PR checks pass** on commit `23f6774eb437793879de1a1208590c328a43693a`, including all **18 CI PR jobs**: Windows/MSVC, Linux/GCC and Clang, ARM, macOS, all four ASan/UBSan jobs, TSan, the native-thread TSan build/policy smoke, mbedTLS, formatting, CLA, SBOM, and binary size. Android, iOS and CodeQL checks also pass.

The hosted Linux size gate reports **247,647 bytes**, **+2,389** versus its committed baseline, below the **+5,120-byte** budget. The local compiler numbers above are a separate like-for-like comparison, not the hosted artifact's size. No baseline update or exception was used.

[Successful CI PR run](https://github.com/semantic-reasoning/wirelog/actions/runs/33952607810). No build was cancelled or retried. Merge has not been performed.
