### PR TITLE
chore(release): prepare 0.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ All notable changes to wirelog are documented in this file.
 
 ### Changed
 
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Performance
+
+### Security
+
+### Documentation
+
+## [0.61.0] - 2026-09-05
+
+### Added
+
+### Changed
+
 - **`WIRELOG_DOOP_DATASET_MANIFEST_SHA256` must be re-pinned.** The DOOP perf
   gate's dataset manifest no longer embeds the directory path it is given, so
   relative, absolute and trailing-slash spellings of one directory no longer

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,6 +7,16 @@ steps for each significant Wirelog release. Entries are ordered newest first.
 
 ---
 
+## 0.60 -> 0.61
+
+Version `0.61.0` corrects arithmetic operator precedence. Multiplication,
+division, and remainder now bind more tightly than addition and subtraction,
+with left associativity within each precedence level. Expressions such as
+`8 + 3 * 2` therefore evaluate to `14`, not `22`. Programs that relied on
+the previous incorrect grouping must be reviewed.
+
+---
+
 ## 0.54 -> 0.60
 
 Version `0.60.0` adds a public parser-metadata query for hosts that need to

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.60.0',
+  version: '0.61.0',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
Prepare the 0.61.0 release from the merged main history.

- bump the Meson project version to 0.61.0
- move the current Unreleased notes into the 0.61.0 changelog section
- add arithmetic-precedence migration guidance

Validation:
- python3 scripts/ci/check-changelog-format.py CHANGELOG.md
- python3 scripts/ci/check-version-sync.py build-release/wirelog
- meson compile -C build-release