### PR TITLE
chore(release): prepare 0.61.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,28 @@ All notable changes to wirelog are documented in this file.
 
 ### Documentation
 
+## [0.61.1] - 2026-09-06
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- **Downstream release archive verification no longer fails with SIGPIPE**
+  (#1358): the tar commit check now avoids a `gzip` producer pipe being
+  terminated early by `git get-tar-commit-id` under `pipefail`.
+
+### Performance
+
+### Security
+
+### Documentation
+
 ## [0.61.0] - 2026-09-05
 
 ### Added

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wirelog',
   'c',
-  version: '0.61.0',
+  version: '0.61.1',
   license: 'LGPL-3.0-or-later',
   meson_version: '>=0.62.0',
   default_options: [


### PR DESCRIPTION
Prepare a patch release containing the downstream archive verification fix from #1358.

- bump the Meson project version to 0.61.1
- add the 0.61.1 changelog section

Validation:
- changelog format check
- version synchronization check
- debug build