### PR TITLE
fix(eval): preserve live alternatives in recursive SCCs (#1376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **Unfused recursive SCCs no longer terminate with incomplete results**
+  (#1376). The forced-delta pre-scan now leaves concatenated rule alternatives
+  to normal evaluation instead of treating one empty input as an empty union.
+  Regression tests cover both fusion configurations, multiple worker counts,
+  and the existing shared-SCC recursive-aggregate rejection contract.
+  The newly exercised empty-delta differential JOIN path also retains its
+  left input until output column types have been copied, preventing invalid
+  memory access and spurious allocation errors.
+
 ### Performance
 
 ### Security

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1700,6 +1700,23 @@ test_recursive_agg_kfusion_nofusion_exe = executable(
 test('recursive_agg_kfusion_nofusion', test_recursive_agg_kfusion_nofusion_exe,
      suite: 'semantics', timeout: 120)
 
+# Issue #1376: the same multi-relation SCC must reach its complete fixpoint
+# with and without K-Fusion. Compile the planner AND evaluator in each mode.
+foreach configuration : ['default', 'nofusion']
+  scc_args = configuration == 'nofusion' ? ['-DENABLE_K_FUSION=0'] : []
+  scc_test = executable(
+    'test_recursive_scc_' + configuration,
+    files('test_recursive_scc.c'),
+    parser_src, ir_src, optimizer_src, backend_src, io_src,
+    arena_src, thread_src, workqueue_src,
+    c_args: scc_args,
+    include_directories: [wirelog_inc, wirelog_src_inc],
+    dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+  )
+  test('recursive_scc_' + configuration, scc_test,
+       suite: 'semantics', timeout: 120)
+endforeach
+
 # Issue #978: average() was never implemented -- col_op_reduce() had no AVG
 # arm, so each group kept the first operand the scan happened to reach.  The
 # legacy int64 executor has no float lane to return a mean in, so it is

--- a/tests/test_recursive_agg_kfusion.c
+++ b/tests/test_recursive_agg_kfusion.c
@@ -923,6 +923,69 @@ test_same_stratum_consumer_rejected(void)
     PASS();
 }
 
+/* #1376: run all #1135 fixtures in BOTH build configurations. These pin
+ * today's shared-SCC rejection, not #1135's future aggregate readmission.
+ * REPRO_UNFUSED and REPRO_FUSED above are F3 and C1 respectively. */
+static void
+test_1135_fixtures_rejected(void)
+{
+    static const char edge[] =
+        ".decl Edge(x: int64, y: int64)\n"
+        "Edge(1,2). Edge(2,3). Edge(3,4).\n";
+    static const struct {
+        const char *name;
+        const char *rules;
+    } fixtures[] = {
+        { "F1: mutual min propagation",
+          ".decl A(x: int64, v: int64)\n.decl B(x: int64, v: int64)\n"
+          "A(x, min(x)) :- Edge(x, y).\n"
+          "A(y, min(y)) :- Edge(x, y).\n"
+          "B(x, min(v)) :- A(x, v).\n"
+          "A(x, min(v)) :- B(y, v), Edge(y, x).\n" },
+        { "F2: bipartite propagation",
+          ".decl L(x: int64, v: int64)\n.decl R(x: int64, v: int64)\n"
+          "Edge(4,5).\n"
+          "L(x, min(x)) :- Edge(x, y).\n"
+          "R(y, min(v)) :- L(x, v), Edge(x, y).\n"
+          "L(y, min(v)) :- R(x, v), Edge(y, x).\n" },
+        { "F4: mutual max propagation",
+          ".decl A(x: int64, v: int64)\n.decl B(x: int64, v: int64)\n"
+          "A(x, max(x)) :- Edge(x, y).\n"
+          "A(y, max(y)) :- Edge(x, y).\n"
+          "B(x, max(v)) :- A(x, v).\n"
+          "A(x, max(v)) :- B(y, v), Edge(y, x).\n" },
+        { "F5: key-determined aggregate",
+          ".decl M(x: int64, v: int64)\n.decl Root(x: int64)\n"
+          "Edge(4,5).\n"
+          "M(x, min(x)) :- Edge(x, _).\n"
+          "Root(x) :- M(x, v).\n"
+          "M(x, min(x)) :- Root(x).\n" },
+        { "C2: consumer without aggregate predicate",
+          ".decl Label(x: int64, l: int64)\n.decl Seen(x: int64)\n"
+          "Label(x, min(x)) :- Edge(x, y).\n"
+          "Label(y, min(y)) :- Edge(x, y).\n"
+          "Label(x, min(l)) :- Label(y, l), Edge(y, x).\n"
+          "Seen(x) :- Label(x, l).\n"
+          "Label(x, min(9)) :- Seen(x).\n" },
+        { "C3: aggregate consumer with predicate",
+          ".decl a(x: int64, v: int64)\n.decl b(x: int64, v: int64)\n"
+          "a(x, min(x)) :- Edge(x, y).\n"
+          "a(y, min(y)) :- Edge(x, y).\n"
+          "a(x, min(v)) :- a(y, v), Edge(y, x).\n"
+          "b(x, min(v)) :- a(x, v), v > 2.\n"
+          "a(x, min(9)) :- b(x, v).\n" },
+    };
+    for (size_t i = 0; i < sizeof(fixtures) / sizeof(fixtures[0]); i++) {
+        char src[1024];
+        TEST(fixtures[i].name);
+        int n = snprintf(src, sizeof(src), "%s%s", edge, fixtures[i].rules);
+        ASSERT(n > 0 && (size_t)n < sizeof(src), "fixture truncated");
+        ASSERT(plan_generation_rejected(src),
+            "expected valid parsing/optimization followed by plan rejection");
+        PASS();
+    }
+}
+
 /*
  * The control the rejection has to leave alone, and the workaround the
  * diagnostic names: drop the rule that feeds Big back into Label, and Big
@@ -1010,6 +1073,7 @@ main(void)
     test_operand_type_is_order_independent();
     test_operand_domain_conflict_is_vetoed();
     test_same_stratum_consumer_rejected();
+    test_1135_fixtures_rejected();
     test_stratified_consumer_control();
     test_single_relation_aggregate_control();
 

--- a/tests/test_recursive_scc.c
+++ b/tests/test_recursive_scc.c
@@ -1,0 +1,280 @@
+/*
+ * Recursive SCC completeness and forced-delta skip contracts (#1376).
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/wirelog.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int failures;
+
+#define CHECK(condition)                                                     \
+        do {                                                                     \
+            if (!(condition)) {                                                  \
+                fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, #condition);   \
+                failures++;                                                      \
+            }                                                                    \
+        } while (0)
+
+#define SCC_SEED                                               \
+        ".decl e(x: int64, y: int64)\n"                            \
+        ".decl q(x: int64, y: int64, z: int64)\n"                  \
+        ".decl p(x: int64, y: int64)\n"                            \
+        ".decl r(x: int64, y: int64, z: int64)\n"                  \
+        ".output p\n.output r\n"                                  \
+        "e(1,2). e(2,3). e(3,4). e(4,5). e(5,6). e(6,7).\n"    \
+        "e(7,8). e(8,9). e(9,10). e(10,11). e(11,12).\n"        \
+        "q(1,7,3). q(2,7,5).\n"
+
+static const char original[] = SCC_SEED
+    "p(x, y) :- e(x, y).\n"
+    "r(x, y, z) :- q(x, y, z).\n"
+    "p(x, z) :- p(x, y), p(y, z).\n"
+    "r(x, k, z) :- p(x, y), r(y, k, z).\n"
+    "p(x, z) :- r(x, k, y), e(y, z).\n";
+
+static const char reordered[] = SCC_SEED
+    "r(x, y, z) :- q(x, y, z).\n"
+    "r(x, k, z) :- p(x, y), r(y, k, z).\n"
+    "p(x, z) :- r(x, k, y), e(y, z).\n"
+    "p(x, z) :- p(x, y), p(y, z).\n"
+    "p(x, y) :- e(x, y).\n";
+
+struct results {
+    bool p[13][13];
+    bool r[3];
+    unsigned count;
+};
+
+static void
+collect(const char *relation, const int64_t *row, uint32_t ncols, void *data)
+{
+    struct results *result = data;
+    result->count++;
+    if (strcmp(relation, "p") == 0) {
+        bool valid = ncols == 2 && row[0] >= 1 && row[0] < row[1]
+            && row[1] <= 12;
+        CHECK(valid);
+        if (valid) {
+            CHECK(!result->p[row[0]][row[1]]);
+            result->p[row[0]][row[1]] = true;
+        }
+    } else if (strcmp(relation, "r") == 0) {
+        static const int64_t expected[3][3] = {
+            { 1, 7, 3 }, { 2, 7, 5 }, { 1, 7, 5 }
+        };
+        bool found = false;
+        for (unsigned i = 0; i < 3; i++) {
+            if (ncols == 3 && memcmp(row, expected[i],
+                sizeof(expected[i])) == 0) {
+                CHECK(!result->r[i]);
+                result->r[i] = true;
+                found = true;
+            }
+        }
+        CHECK(found);
+    } else {
+        CHECK(false);
+    }
+}
+
+static void
+check_scc(const char *src, uint32_t workers, bool pin_iterations)
+{
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    CHECK(prog != NULL);
+    if (!prog)
+        return;
+    wl_plan_t *plan = NULL;
+    wl_session_t *sess = NULL;
+    if (wl_fusion_apply(prog, NULL) != 0 || wl_jpp_apply(prog, NULL) != 0
+        || wl_sip_apply(prog, NULL) != 0) {
+        CHECK(false);
+        goto cleanup;
+    }
+    int rc = wl_plan_from_program(prog, &plan);
+    CHECK(rc == 0);
+    if (rc != 0)
+        goto cleanup;
+    rc = wl_session_create(wl_backend_columnar(), plan, workers, &sess);
+    CHECK(rc == 0);
+    if (rc != 0)
+        goto cleanup;
+    rc = wl_session_load_facts(sess, prog);
+    CHECK(rc == 0);
+    if (rc != 0)
+        goto cleanup;
+    struct results result = { 0 };
+    rc = wl_session_snapshot(sess, collect, &result);
+    CHECK(rc == 0);
+    CHECK(result.count == 69);
+    for (unsigned x = 1; x < 12; x++)
+        for (unsigned y = x + 1; y <= 12; y++)
+            CHECK(result.p[x][y]);
+    for (unsigned i = 0; i < 3; i++)
+        CHECK(result.r[i]);
+    uint32_t iterations = col_session_get_iteration_count(sess);
+    printf("workers=%u reordered=%u rows=%u iterations=%u\n", workers,
+        (unsigned)!pin_iterations, result.count, iterations);
+    if (pin_iterations) {
+        /* This fixture has exactly one recursive stratum and no later
+         * stratum to reset current_iteration. The terminal empty round is
+         * index 5 (six rounds). The accessor retains the last productive
+         * index, 4, because the terminal round breaks before updating it. */
+        CHECK(plan->stratum_count == 1);
+        CHECK(COL_SESSION(sess)->current_iteration + 1 == 6);
+        CHECK(iterations == 4);
+    }
+cleanup:
+    if (sess)
+        wl_session_destroy(sess);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+}
+
+static void
+check_skip_contract(void)
+{
+    /* Real session lookup with stack-owned relations; no evaluation needs rows. */
+    col_rel_t delta = { .name = "$d$p", .nrows = 1 };
+    col_rel_t retraction = { .name = "$r$p", .nrows = 0 };
+    col_rel_t *rels[] = { &delta, &retraction };
+    wl_col_session_t sess = { .rels = rels, .nrels = 2, .rel_cap = 2 };
+    wl_plan_op_t ops[] = {
+        { .op = WL_PLAN_OP_VARIABLE, .relation_name = "missing",
+          .delta_mode = WL_DELTA_FORCE_DELTA },
+        { .op = WL_PLAN_OP_VARIABLE, .relation_name = "p",
+          .delta_mode = WL_DELTA_FORCE_DELTA },
+        { .op = WL_PLAN_OP_CONCAT }
+    };
+    wl_plan_relation_t plan = { .ops = ops, .op_count = 3 };
+    /* The missing early alternative cannot suppress the later live one. */
+    CHECK(!has_empty_forced_delta(&plan, &sess, 1));
+    plan.op_count = 1;
+    CHECK(has_empty_forced_delta(&plan, &sess, 1));
+    CHECK(!has_empty_forced_delta(&plan, &sess, 0));
+    sess.delta_seeded = true;
+    CHECK(has_empty_forced_delta(&plan, &sess, 0));
+    plan.ops = &ops[1];
+    CHECK(!has_empty_forced_delta(&plan, &sess, 0));
+    delta.nrows = 0;
+    CHECK(has_empty_forced_delta(&plan, &sess, 0));
+    delta.nrows = 1;
+    sess.delta_seeded = false;
+    sess.retraction_seeded = true;
+    CHECK(has_empty_forced_delta(&plan, &sess, 0));
+    CHECK(!has_empty_forced_delta(&plan, &sess, 1));
+    retraction.nrows = 1;
+    CHECK(!has_empty_forced_delta(&plan, &sess, 0));
+    ops[1].right_relation = "missing";
+    ops[1].op = WL_PLAN_OP_JOIN;
+    CHECK(has_empty_forced_delta(&plan, &sess, 1));
+    ops[1].right_relation = "p";
+    CHECK(!has_empty_forced_delta(&plan, &sess, 1));
+    ops[1].op = WL_PLAN_OP_SEMIJOIN;
+    CHECK(!has_empty_forced_delta(&plan, &sess, 1));
+    delta.nrows = 0;
+    CHECK(has_empty_forced_delta(&plan, &sess, 1));
+    session_rel_free_hash(&sess);
+}
+
+static void
+check_empty_join(bool differential, bool present_delta, bool projected,
+    bool owned, bool pooled)
+{
+    delta_pool_t *pool = pooled
+        ? delta_pool_create(4, sizeof(col_rel_t), 4096) : NULL;
+    CHECK(!pooled || pool != NULL);
+    if (pooled && !pool)
+        return;
+    col_rel_t *left = pooled ? col_rel_pool_new_auto(pool, NULL, "left", 1)
+        : col_rel_new_auto("left", 1);
+    col_rel_t *right = col_rel_new_auto("right", 1);
+    col_rel_t *delta = col_rel_new_auto("$d$right", 1);
+    CHECK(left && right && delta);
+    if (!left || !right || !delta) {
+        col_rel_destroy(left);
+        col_rel_destroy(right);
+        col_rel_destroy(delta);
+        delta_pool_destroy(pool);
+        return;
+    }
+    const wirelog_column_type_t left_type[] = { WIRELOG_TYPE_FLOAT };
+    const wirelog_column_type_t right_type[] = { WIRELOG_TYPE_INT64 };
+    CHECK(col_rel_set_column_types(left, left_type, 1) == 0);
+    CHECK(col_rel_set_column_types(right, right_type, 1) == 0);
+    int64_t row[] = { 0 };
+    CHECK(col_rel_append_row(right, row) == 0);
+    col_rel_t *rels[] = { right, delta };
+    wl_col_session_t sess = {
+        .rels = rels, .nrels = present_delta ? 2 : 1,
+        .rel_cap = 2, .current_iteration = 1
+    };
+    uint32_t projection[] = { 1, 0 };
+    wl_plan_op_t op = {
+        .op = WL_PLAN_OP_JOIN, .right_relation = "right",
+        .delta_mode = WL_DELTA_FORCE_DELTA,
+        .project_indices = projected ? projection : NULL,
+        .project_count = projected ? 2 : 0
+    };
+    eval_stack_t stack;
+    eval_stack_init(&stack);
+    int rc = eval_stack_push(&stack, left, owned);
+    CHECK(rc == 0);
+    if (rc == 0) {
+        rc = differential ? wl_columnar_join_diff_op(&op, &stack, &sess)
+            : wl_columnar_join_op(&op, &stack, &sess);
+        CHECK(rc == 0);
+        CHECK(stack.top == (rc == 0 ? 1u : 0u));
+        if (rc == 0) {
+            eval_entry_t result = eval_stack_pop(&stack);
+            CHECK(result.owned && result.rel != NULL);
+            if (result.rel) {
+                CHECK(result.rel->nrows == 0 && result.rel->ncols == 2);
+                CHECK(result.rel->column_types != NULL);
+                if (result.rel->column_types && result.rel->ncols == 2) {
+                    CHECK(result.rel->column_types[projected ? 1 : 0]
+                        == WIRELOG_TYPE_FLOAT);
+                    CHECK(result.rel->column_types[projected ? 0 : 1]
+                        == WIRELOG_TYPE_INT64);
+                }
+                col_rel_destroy(result.rel);
+            }
+        }
+    } else {
+        col_rel_destroy(left);
+        left = NULL;
+    }
+    eval_stack_drain(&stack);
+    if (!owned && left) {
+        CHECK(left->ncols == 1 && left->column_types[0] == WIRELOG_TYPE_FLOAT);
+        col_rel_destroy(left);
+    }
+    session_rel_free_hash(&sess);
+    col_rel_destroy(right);
+    col_rel_destroy(delta);
+    delta_pool_destroy(pool);
+}
+
+int
+main(void)
+{
+    check_scc(original, 1, true);
+    check_scc(original, 8, true);
+    check_scc(reordered, 1, false);
+    check_scc(reordered, 8, false);
+    check_skip_contract();
+    for (unsigned bits = 0; bits < 32; bits++)
+        check_empty_join((bits & 1u) != 0, (bits & 2u) != 0,
+            (bits & 4u) != 0, (bits & 8u) != 0, (bits & 16u) != 0);
+    return failures != 0;
+}

--- a/wirelog/columnar/eval_plan.c
+++ b/wirelog/columnar/eval_plan.c
@@ -203,9 +203,9 @@ retraction_rel_name(const char *rel, char *buf, size_t sz)
  * On iteration 0, no deltas exist yet; FORCE_DELTA ops fall back to the
  * full relation (base-case seeding), so we always return false.
  *
- * On iteration > 0, if any FORCE_DELTA VARIABLE or JOIN op references a
- * delta that is empty/absent, the entire plan would produce 0 rows, so
- * we can safely skip evaluation.
+ * For a conjunctive plan, an empty/absent forced-delta input proves the
+ * output empty. CONCAT alternatives require normal evaluation instead:
+ * an empty input in one branch says nothing about the other branches.
  *
  * Returns true if the plan can be skipped (empty forced-delta found).
  *
@@ -248,6 +248,16 @@ has_empty_forced_delta(const wl_plan_relation_t *rp, wl_col_session_t *sess,
 {
     if (iteration == 0 && !sess->delta_seeded && !sess->retraction_seeded)
         return false; /* Base case: no deltas exist yet (non-incremental) */
+
+    /* CONCAT joins independent rule/delta alternatives, not conjunctive
+     * inputs. One empty input cannot prove that their union is empty (#1376).
+     * Scan the WHOLE plan first: an empty input may precede the CONCAT.
+     * Let normal evaluation handle these plans, including fused inner lists.
+     */
+    for (uint32_t oi = 0; oi < rp->op_count; oi++) {
+        if (rp->ops[oi].op == WL_PLAN_OP_CONCAT)
+            return false;
+    }
 
     for (uint32_t oi = 0; oi < rp->op_count; oi++) {
         const wl_plan_op_t *op = &rp->ops[oi];

--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -1925,15 +1925,21 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
         } else if (sess->current_iteration > 0 || sess->delta_seeded
             || sess->retraction_seeded) {
             uint32_t ocols = col_join_output_width(left_e.rel, right, op);
-            if (left_e.owned)
-                col_rel_destroy(left_e.rel);
             col_rel_t *empty = col_rel_new_auto("$join_diff_empty", ocols);
-            if (!empty)
-                return ENOMEM;
-            if (col_join_set_output_types(empty, left_e.rel, right, op) != 0) {
-                col_rel_destroy(empty);
+            if (!empty) {
+                if (left_e.owned)
+                    col_rel_destroy(left_e.rel);
                 return ENOMEM;
             }
+            /* The schema copy still reads the left input (#1376). */
+            if (col_join_set_output_types(empty, left_e.rel, right, op) != 0) {
+                col_rel_destroy(empty);
+                if (left_e.owned)
+                    col_rel_destroy(left_e.rel);
+                return ENOMEM;
+            }
+            if (left_e.owned)
+                col_rel_destroy(left_e.rel);
             int push_rc = eval_stack_push(stack, empty, true);
             if (push_rc != 0)
                 col_rel_destroy(empty);


### PR DESCRIPTION
## Summary

Restore complete recursive SCC evaluation with K-Fusion disabled, and repair the differential JOIN lifetime bug exposed by evaluating previously skipped alternatives.

Refs #1376; implements its runtime/default-test acceptance criteria. This PR deliberately does **not** close the issue: the separate nightly six-workload gate remains pending the DOOP runner/resource decision. Full DOOP is not validated here.

## Root causes

- `has_empty_forced_delta()` treated one empty forced-delta input anywhere in a concatenated relation plan as proof that the entire union was empty. Scan for CONCAT before making any such inference; retain skipping for conjunctive plans and preserve seed/retraction behavior.
- The newly reachable empty forced-delta path in differential JOIN destroyed its owned left input before copying its column types. Heap inputs cause use-after-free; pool inputs lose their width and produce spurious ENOMEM. Retain the input through the schema copy and clean up on every exit.

## Regression coverage

- Default and nofusion SCC executables compile both planner and evaluator in their intended mode. Exact 66 p rows + 3 r rows at W=1/W=8, including reordered rules.
- Six actual rounds are pinned using this single-stratum fixture's terminal iteration index. The existing accessor reports the last productive index (4), not total rounds; its semantics and benchmark pins are unchanged.
- Forced-delta absence/emptiness/live input, alternatives, initial seed, insertion seed, and retraction seed.
- 32 empty-JOIN combinations: normal/differential, absent/empty delta, projection, borrowed/owned input, heap/pool storage; exact empty-output schema assertions.
- Complete #1135 F1–F5/C1–C3 fixtures in both existing aggregate targets, preserving today's plan-time rejection and accepting stratified/single-relation controls. This does not implement aggregate readmission.

## TDD and validation

- RED: unfused SCC returned 44 instead of 69 rows. New direct JOIN fixture reproduced ASan heap-use-after-free before the lifetime fix.
- GREEN: `meson test -C build --no-rebuild --print-errorlogs --num-processes 8`: **326 passed, 0 failed, 13 conditional skips**. Includes LLVM 22 clang-tidy ratchet, incremental/frontier/retraction coverage and ABI contracts.
- ASan/UBSan: both SCC and both recursive aggregate targets **4/4 passed**; unfused DDISASM also passed under sanitizers.
- `uncrustify --check` on all changed C files; changelog format and `git diff --check`: pass.
- Default release configuration (`optimization=s`, LTO): `.text` **241,306 bytes**, baseline 245,258, delta **-3,952 bytes**; size gate passes without a baseline change. Debugoptimized size is not compared as a valid release gate result.
- Galen: both configurations, W=1/W=8: **5,568 tuples / 23**.
- DDISASM: both configurations: **704 / 0 at W=1; 704 / 19 at W=8**.
- Release unfused W=1: CSPA-fast **20,381 / 6**, Polonius **1,983 / 23**, CRDT **2,152,328 / 14,148**.

## Workflow and remaining scope

Used `dev-workflows:implementation-skill`: all 12 atomic skills selected for non-trivial shared/cross-module behavior; selector blocked list empty. Independent Architect (Gibbs), Critic (Singer), and Reviewer (Leibniz); no self-review or degraded judgment gates.

Candidate tree: `d3b1b362d9e704984b9b29f6e2065c79da303d07`.
Diff SHA-256: `32ba347da0f5e9e3bd9eb8e7e5eb5b6f7ec03f8d25247a0c0cb83fa651b80d02`.
Reviewer, Architect final-design, and Critic final-risk verdicts: **approved** for this exact tree. Commit `b47725a9a6141bd52642c5fe14d8ad804f1aea79` was created only after all three approvals; staged, approved, and committed trees match.

The runtime/test unit is independent of nightly workflow work. Critic blocked that second unit because full DOOP needs roughly 40 GB memory and no suitably sized hosted runner is established. A five-workload nightly gate with explicit DOOP deferral versus provisioned high-memory hosted execution needs the user's decision. No workflow changes or false six-workload coverage claim are included.
