### PR TITLE
Define canonical result-content evidence for K-Fusion retirement

### DIFF
--- a/scripts/perf/audit-tdd-execution.py
+++ b/scripts/perf/audit-tdd-execution.py
@@ -25,6 +25,8 @@ DECISION_FLAGS = ("recursive", "snapshot", "exchange", "safe", "global_read_cand
 DECISION_COUNTS = ("idb_atoms", "segments", "segment_seed", "segment_global_read",
                    "segment_unsafe", "segment_max_idb", "segment_max_joins")
 FALLBACKS = ("none", "non_recursive", "snapshot_ineligible", "no_exchange", "unsafe_plan", "adaptive_workers")
+RESULT_CONTENT_HEADER = b"wirelog-result-content-v1\n"
+RESULT_VALUE_TYPES = ("int32", "int64", "uint32", "uint64", "bool", "float64", "string", "compound")
 
 
 def require(condition, message):
@@ -36,6 +38,84 @@ def number(value):
     result = float(value)
     require(math.isfinite(result) and result >= 0, f"invalid nonnegative number: {value}")
     return result
+
+
+def canonical_value(value_type, value):
+    """Validate a logical value without exposing process-local identifiers."""
+    require(value_type in RESULT_VALUE_TYPES, f"unknown result value type: {value_type}")
+    if value_type in ("int32", "int64", "uint32", "uint64"):
+        require(isinstance(value, int) and not isinstance(value, bool),
+                f"{value_type} requires an integer")
+        limits = {"int32": (-2**31, 2**31 - 1), "int64": (-2**63, 2**63 - 1),
+                  "uint32": (0, 2**32 - 1), "uint64": (0, 2**64 - 1)}
+        require(limits[value_type][0] <= value <= limits[value_type][1],
+                f"{value_type} out of range")
+    elif value_type == "bool":
+        require(isinstance(value, bool), "bool requires a boolean")
+    elif value_type == "float64":
+        require(isinstance(value, (int, float)) and not isinstance(value, bool),
+                "float64 requires a number")
+        require(math.isfinite(float(value)), "float64 must be finite")
+    elif value_type == "string":
+        require(isinstance(value, str), "string requires text")
+    else:
+        require(isinstance(value, dict) and isinstance(value.get("functor"), str)
+                and value["functor"], "compound requires a functor")
+        args = value.get("args")
+        require(isinstance(args, list), "compound requires an argument list")
+        for arg in args:
+            require(isinstance(arg, dict) and set(arg) == {"type", "value"},
+                    "compound arguments must be typed values")
+            canonical_value(arg["type"], arg["value"])
+    return value
+
+
+def canonical_tuple_line(relation, columns, values):
+    """Encode one relation-qualified, type-aware result tuple deterministically."""
+    require(isinstance(relation, str) and relation, "missing result relation")
+    require(isinstance(columns, list) and isinstance(values, list)
+            and len(columns) == len(values), "result schema/value mismatch")
+    names, normalized = set(), []
+    for column, value in zip(columns, values):
+        require(isinstance(column, dict) and set(column) == {"name", "type"},
+                "result columns must contain name and type")
+        name, value_type = column["name"], column["type"]
+        require(isinstance(name, str) and name and name not in names, "invalid result column name")
+        names.add(name)
+        normalized.append({"name": name, "type": value_type,
+                           "value": canonical_value(value_type, value)})
+    return (json.dumps({"columns": normalized, "relation": relation},
+                       ensure_ascii=True, allow_nan=False,
+                       separators=(",", ":"), sort_keys=True) + "\n").encode()
+
+
+def parse_result_content_stream(source):
+    """Validate a canonical stream and return its canonical tuple lines."""
+    raw = source.read_bytes() if isinstance(source, Path) else source
+    require(isinstance(raw, bytes) and raw.startswith(RESULT_CONTENT_HEADER),
+            "missing result-content header")
+    body = raw[len(RESULT_CONTENT_HEADER):]
+    require(body and body.endswith(b"\n"), "truncated result-content stream")
+    lines = body.splitlines(keepends=True)
+    require(all(line.endswith(b"\n") for line in lines), "unterminated result-content tuple")
+    canonical = []
+    for line in lines:
+        try:
+            item = json.loads(line)
+            columns = item["columns"]
+            values = [column["value"] for column in columns]
+            canonical.append(canonical_tuple_line(item["relation"],
+                                                   [{"name": c["name"], "type": c["type"]}
+                                                    for c in columns], values))
+        except (json.JSONDecodeError, KeyError, TypeError) as error:
+            raise ValueError(f"invalid result-content tuple: {error}") from error
+    require(canonical == sorted(canonical), "result-content tuples are not canonically sorted")
+    return canonical
+
+
+def compare_result_content_streams(left, right):
+    """Compare canonical streams exactly, including duplicate tuple multiplicity."""
+    return parse_result_content_stream(left) == parse_result_content_stream(right)
 
 
 def fields(line, skip=2):

--- a/tests/test_tdd_execution_audit.py
+++ b/tests/test_tdd_execution_audit.py
@@ -45,6 +45,55 @@ def evidence(framed=True, **changes):
 
 
 class AuditTests(unittest.TestCase):
+    def test_result_content_encoding_is_type_and_relation_qualified(self):
+        negative_zero = audit.canonical_tuple_line(
+            "facts", [{"name": "value", "type": "float64"}], [-0.0])
+        positive_zero = audit.canonical_tuple_line(
+            "facts", [{"name": "value", "type": "float64"}], [0.0])
+        self.assertIn(b'"relation":"facts"', negative_zero)
+        self.assertNotEqual(negative_zero, positive_zero)
+        self.assertNotEqual(
+            audit.canonical_tuple_line("facts", [{"name": "value", "type": "int64"}], [1]),
+            audit.canonical_tuple_line("facts", [{"name": "value", "type": "string"}], ["1"]))
+
+    def test_result_content_reordering_and_multiplicity(self):
+        rows = [
+            audit.canonical_tuple_line("r", [{"name": "x", "type": "int64"}], [1]),
+            audit.canonical_tuple_line("r", [{"name": "x", "type": "int64"}], [1]),
+            audit.canonical_tuple_line("s", [{"name": "x", "type": "int64"}], [2]),
+        ]
+        left = audit.RESULT_CONTENT_HEADER + b"".join(sorted(rows))
+        right = audit.RESULT_CONTENT_HEADER + b"".join(sorted(reversed(rows)))
+        # A producer may emit rows in any order, but persisted evidence is
+        # canonical before comparison; repeated rows remain repeated.
+        self.assertTrue(audit.compare_result_content_streams(left, left))
+        self.assertTrue(audit.compare_result_content_streams(left, right))
+        missing_duplicate = audit.RESULT_CONTENT_HEADER + b"".join(sorted(rows[:1] + rows[2:]))
+        self.assertFalse(audit.compare_result_content_streams(left, missing_duplicate))
+
+    def test_result_content_rejects_changed_values_and_malformed_streams(self):
+        def stream(relation="r", value=1):
+            return audit.RESULT_CONTENT_HEADER + audit.canonical_tuple_line(
+                relation, [{"name": "x", "type": "int64"}], [value])
+
+        self.assertFalse(audit.compare_result_content_streams(stream(), stream(value=2)))
+        self.assertFalse(audit.compare_result_content_streams(stream(), stream(relation="s")))
+        for bad in (b"", audit.RESULT_CONTENT_HEADER, stream()[:-1],
+                    stream().replace(b'"type":"int64"', b'"type":"unknown"')):
+            with self.subTest(bad=bad), self.assertRaises(ValueError):
+                audit.parse_result_content_stream(bad)
+
+    def test_result_content_value_domains_and_compounds(self):
+        with self.assertRaises(ValueError):
+            audit.canonical_value("uint32", -1)
+        with self.assertRaises(ValueError):
+            audit.canonical_value("float64", float("inf"))
+        compound = {"functor": "pair", "args": [
+            {"type": "string", "value": "left"},
+            {"type": "int32", "value": 2}]}
+        line = audit.canonical_tuple_line("r", [{"name": "p", "type": "compound"}], [compound])
+        self.assertIn(b'"functor":"pair"', line)
+
     def test_complete_pair_prefix_is_not_complete_inventory(self):
         root = Path(__file__).resolve().parents[1]
         inventory = json.loads((root / "docs/tdd-execution-audit/inventory.json").read_text())


### PR DESCRIPTION
## Summary
- define relation-qualified, type-aware canonical result-content records
- preserve duplicate tuples and distinguish typed values including `-0.0`
- validate canonical ordering and exact content equality with synthetic negative tests
- keep the historical schema-1 TDD inventory and runtime behavior unchanged

Closes #1397 partially; this is the first atomic evidence-contract unit. Benchmark capture, bounded external sorting for large streams, explicit binary/configuration identity checks, and strict six-workload retirement validation remain follow-up units under #1397.

## Validation
- `source .venv/bin/activate && python tests/test_tdd_execution_audit.py` — 20 tests, 1 runtime-specific test skipped
- `git diff --check`
- `meson test -C builddir --no-rebuild tdd_execution_audit` — environment failure in pre-existing runtime-frame probe: binaries do not support `--audit-frames`; direct Python suite passes
