### PR TITLE
Make TDD memory reports machine-readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ external-consumer audit.
 
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) -- system design, optimizer pipeline, execution model
 - [docs/THREADING.md](docs/THREADING.md) -- threading backends, atomics audit, K-fusion / TDD concurrency contracts
+- [docs/TDD_MEMORY_BASELINE.md](docs/TDD_MEMORY_BASELINE.md) -- TDD memory-report semantics, coverage, and baseline evidence limits
 - [docs/CRASH_RESTART.md](docs/CRASH_RESTART.md) -- crash/restart durability responsibilities for embedded hosts
 - [docs/EMBEDDED.md](docs/EMBEDDED.md) -- embedded integration posture, build options, and host responsibilities
 - [docs/INTERNALS.md](docs/INTERNALS.md) -- maintainer map of internal subsystems and public/private boundaries

--- a/docs/TDD_MEMORY_BASELINE.md
+++ b/docs/TDD_MEMORY_BASELINE.md
@@ -1,0 +1,57 @@
+# TDD memory baseline and coverage
+
+This document records what the opt-in `WL_MEM_REPORT=1` diagnostic proves. It
+does not turn a ledger report into a process-RSS or bounded-memory guarantee.
+
+## Reproduction
+
+The report is emitted at session teardown for the coordinator and each worker
+when `WL_MEM_REPORT` is present (the value is not interpreted). Using
+`WL_MEM_REPORT=1` is the conventional invocation.
+The exact fields ending in `_bytes` are IEC byte counts and are intended for
+machine-readable collection. Human-readable fields are retained for operators.
+
+```sh
+WL_MEM_REPORT=1 builddir/tests/test_safe_worker_scaling
+```
+
+For a workload measurement, preserve the complete stderr, the command, the
+build tree and binary hashes, compiler/options, input manifest, worker count,
+and effective process/container memory ceiling beside the report. A report
+without those identities is an observation, not a reproducible qualification.
+
+## Current evidence
+
+The historical DOOP report attached to issue #1380 records 13,828,835 tuples
+and 153 iterations. Its observed process RSS was approximately 52.1 GiB at W1
+and 54.1 GiB at W2; the coordinator ledger reported approximately 32.0 GiB
+and 15.2 GiB respectively. The original artifact does not recover a complete
+candidate tree/binary identity, raw-log location, or all host-limit metadata;
+those fields remain **unavailable**, not reconstructed here. It does not prove
+unfused W8 completion or bounded DOOP.
+
+## Coverage inventory
+
+| Domain | Current status | Interpretation |
+| --- | --- | --- |
+| Relation, arena, cache, arrangement, timestamp ledger counters | measured when the owning path calls the ledger | Exact current/peak bytes are reported per ledger; missing call sites are not zero. |
+| Coordinator ledger | measured | Session-owned logical accounting, not process RSS. |
+| Worker ledgers | measured at worker teardown | Per-worker lifetime ledger; do not sum peaks as a process peak. |
+| Parser/read buffers, CSV token growth, interning | partial/uninstrumented | Must be assigned to the ingestion/governor owners before bounded DOOP is claimed. |
+| Channels, external allocations, allocator fragmentation | uninstrumented | OS RSS may exceed ledger totals. |
+| Process RSS and cgroup/container ceiling | unavailable in this report | Must be collected as separate host evidence. |
+| Spill/disk usage and cleanup | unavailable | No bounded spill qualification is implied. |
+
+The five ledger domains are accounting categories, not proof that every
+allocation site is covered. `current_bytes` can return to zero while `peak_bytes`
+retains the high-water mark; a worker's teardown report is therefore not a
+simultaneous process-wide peak.
+
+## Acceptance boundary
+
+The baseline is suitable for #1381 to consume as a truthful partial inventory.
+It is not sufficient to close #1380 until the provenance gaps are either
+recovered from immutable artifacts or explicitly attached to the enforcing
+owner, and until report-on/report-off correctness and measurement overhead are
+recorded. Full low-memory DOOP qualification belongs to #1385; integrated
+six-workload enforcement belongs to #1386.

--- a/docs/memory/issue-1380-evidence.tsv
+++ b/docs/memory/issue-1380-evidence.tsv
@@ -1,0 +1,15 @@
+field	value	status	source
+issue	1380	observed	https://github.com/semantic-reasoning/wirelog/issues/1380
+historical_comment	5558626636	observed	https://github.com/semantic-reasoning/wirelog/issues/1380#issuecomment-5558626636
+workload	doop	observed	historical issue evidence
+tuples	13828835	observed	historical issue evidence
+iterations	153	observed	historical issue evidence
+workers	W1;W2	observed	historical issue evidence
+process_rss	approximately 52.1 GiB; approximately 54.1 GiB	observed, approximate	historical issue evidence
+coordinator_ledger	approximately 32.0 GiB; approximately 15.2 GiB	observed, approximate	historical issue evidence
+tree_identity	unavailable	unavailable	historical artifact did not preserve it
+binary_identity	unavailable	unavailable	historical artifact did not preserve it
+compiler_options	unavailable	unavailable	historical artifact did not preserve it
+raw_log_path	unavailable	unavailable	historical artifact did not preserve it
+host_container_limits	unavailable	unavailable	historical artifact did not preserve it
+qualification	unfused W8 and bounded completion not established	partial	issue #1380 acceptance boundary

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4990,6 +4990,13 @@ test_tdd_decision_stats_seq_exe = executable(
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
 test('tdd_decision_stats_nofusion', test_tdd_decision_stats_seq_exe, timeout: 300)
+test('mem_report_contract', bench_flowlog_json_py3,
+     args: [files('test_mem_report_contract.py')[0],
+            test_tdd_decision_stats_exe.full_path(),
+            test_tdd_decision_stats_seq_exe.full_path()],
+     depends: [test_tdd_decision_stats_exe, test_tdd_decision_stats_seq_exe],
+     suite: 'bench',
+     timeout: 660)
 test('tdd_execution_audit', bench_flowlog_json_py3,
      args: [files('test_tdd_execution_audit.py')[0],
             '--runtime-bin', test_tdd_decision_stats_exe.full_path(),

--- a/tests/test_mem_report_contract.py
+++ b/tests/test_mem_report_contract.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Check that WL_MEM_REPORT is diagnostic-only and byte fields are stable."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def run(binary, enabled):
+    env = os.environ.copy()
+    env.pop("WL_MEM_REPORT", None)
+    if enabled:
+        env["WL_MEM_REPORT"] = "1"
+    return subprocess.run([binary], capture_output=True, text=True,
+                          env=env, timeout=300, check=False)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: test_mem_report_contract.py BINARY...", file=sys.stderr)
+        return 2
+    for name in sys.argv[1:]:
+        binary = str(Path(name))
+        off = run(binary, False)
+        on = run(binary, True)
+        if off.returncode != on.returncode or off.stdout != on.stdout:
+            raise AssertionError(f"WL_MEM_REPORT changed result output: {binary}")
+        if "[wirelog mem]" in off.stderr:
+            raise AssertionError(f"report leaked into off-mode stderr: {binary}")
+        if "[wirelog mem]" not in on.stderr:
+            raise AssertionError(f"report missing in on-mode stderr: {binary}")
+        for field in ("budget_bytes=", "current_bytes=", "peak_bytes="):
+            if field not in on.stderr:
+                raise AssertionError(f"missing {field}: {binary}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_safe_worker_scaling.c
+++ b/tests/test_safe_worker_scaling.c
@@ -201,6 +201,7 @@ test_integer_overflow_guard(void)
 
     wl_plan_t *plan = build_plan(SIMPLE_PROG);
     if (!plan) {
+        unsetenv("WL_MEM_REPORT");
         FAIL("could not build plan");
         return 1;
     }
@@ -300,6 +301,8 @@ test_env_override_with_warning(void)
     char tmppath[] = "/tmp/wl_test_stderr_XXXXXX";
     int tmpfd = mkstemp(tmppath);
     int saved_stderr = -1;
+    char report[4096] = {0};
+    ssize_t report_len = 0;
     if (tmpfd >= 0) {
         saved_stderr = dup(STDERR_FILENO);
         dup2(tmpfd, STDERR_FILENO);
@@ -331,9 +334,9 @@ test_env_override_with_warning(void)
 #endif
 
     unsetenv("WIRELOG_MAX_WORKERS");
-    unsetenv("WL_MEM_REPORT");
 
     if (!plan) {
+        unsetenv("WL_MEM_REPORT");
         FAIL("could not build plan");
         return 1;
     }
@@ -342,12 +345,50 @@ test_env_override_with_warning(void)
         char msg[64];
         snprintf(msg, sizeof(msg),
             "session_create failed with rc=%d (WIRELOG_MAX_WORKERS=4096)", rc);
+        if (sess)
+            wl_session_destroy(sess);
+        unsetenv("WL_MEM_REPORT");
         FAIL(msg);
         return 1;
     }
 
+    /* Capture teardown separately: WL_MEM_REPORT is emitted when the session
+     * is destroyed, after the constructor warning has already been checked. */
+#if !defined(_MSC_VER)
+    char report_path[] = "/tmp/wl_test_mem_report_XXXXXX";
+    int report_fd = mkstemp(report_path);
+    int report_saved_stderr = -1;
+    if (report_fd >= 0) {
+        report_saved_stderr = dup(STDERR_FILENO);
+        if (report_saved_stderr >= 0)
+            dup2(report_fd, STDERR_FILENO);
+        else {
+            close(report_fd);
+            unlink(report_path);
+            report_fd = -1;
+        }
+    }
+#endif
+
     uint32_t actual = ((wl_col_session_t *)sess)->num_workers;
     wl_session_destroy(sess);
+#if !defined(_MSC_VER)
+    if (report_fd >= 0) {
+        fflush(stderr);
+        dup2(report_saved_stderr, STDERR_FILENO);
+        close(report_saved_stderr);
+        off_t report_size = lseek(report_fd, 0, SEEK_END);
+        if (report_size > 0 && report_size < (off_t)sizeof(report)) {
+            lseek(report_fd, 0, SEEK_SET);
+            report_len = read(report_fd, report, (size_t)report_size);
+            if (report_len > 0)
+                report[report_len] = '\0';
+        }
+        close(report_fd);
+        unlink(report_path);
+    }
+#endif
+    unsetenv("WL_MEM_REPORT");
 
     if (actual != 4096) {
         char msg[128];
@@ -362,6 +403,14 @@ test_env_override_with_warning(void)
             "WIRELOG_MAX_WORKERS=4096 accepted but no stderr warning was emitted");
         return 1;
     }
+
+#if !defined(_MSC_VER)
+    if (!strstr(report, "budget_bytes=") || !strstr(report, "current_bytes=")
+        || !strstr(report, "peak_bytes=")) {
+        FAIL("WL_MEM_REPORT lacks stable byte-valued total fields");
+        return 1;
+    }
+#endif
 
     PASS();
     return 0;

--- a/wirelog/columnar/mem_ledger.c
+++ b/wirelog/columnar/mem_ledger.c
@@ -52,7 +52,7 @@ fmt_bytes(uint64_t bytes, char *buf, size_t len)
 {
     if (bytes >= (uint64_t)1024 * 1024 * 1024) {
         snprintf(buf, len, "%.1fGB",
-                 (double)bytes / ((double)1024 * 1024 * 1024));
+            (double)bytes / ((double)1024 * 1024 * 1024));
     } else if (bytes >= (uint64_t)1024 * 1024) {
         snprintf(buf, len, "%.1fMB", (double)bytes / ((double)1024 * 1024));
     } else if (bytes >= 1024) {
@@ -73,8 +73,8 @@ update_peak(wl_atomic_u64 *peak_atom, uint64_t new_val)
     uint64_t old = atomic_load_explicit(peak_atom, memory_order_relaxed);
     while (old < new_val) {
         if (atomic_compare_exchange_weak_explicit(peak_atom, &old, new_val,
-                                                  memory_order_relaxed,
-                                                  memory_order_relaxed)) {
+            memory_order_relaxed,
+            memory_order_relaxed)) {
             break;
         }
         /* old updated by CAS on failure; retry */
@@ -92,7 +92,7 @@ wl_mem_ledger_init(wl_mem_ledger_t *ledger, uint64_t budget_bytes)
         return;
     memset(ledger, 0, sizeof(*ledger));
     atomic_store_explicit(&ledger->total_budget, budget_bytes,
-                          memory_order_relaxed);
+        memory_order_relaxed);
 }
 
 void
@@ -106,14 +106,14 @@ wl_mem_ledger_alloc(wl_mem_ledger_t *ledger, int subsys, uint64_t bytes)
     /* Update subsystem counter */
     uint64_t subsys_new
         = atomic_fetch_add_explicit(&ledger->subsys_bytes[subsys], bytes,
-                                    memory_order_relaxed)
-          + bytes;
+            memory_order_relaxed)
+        + bytes;
     update_peak(&ledger->subsys_peak[subsys], subsys_new);
 
     /* Update total counter */
     uint64_t total_new = atomic_fetch_add_explicit(&ledger->current_bytes,
-                                                   bytes, memory_order_relaxed)
-                         + bytes;
+            bytes, memory_order_relaxed)
+        + bytes;
     update_peak(&ledger->peak_bytes, total_new);
 }
 
@@ -126,30 +126,31 @@ wl_mem_ledger_free(wl_mem_ledger_t *ledger, int subsys, uint64_t bytes)
         return;
 
     /* Clamp-subtract subsystem with CAS loop: avoids TOCTOU race between
-     * load and subtract under concurrent K-fusion worker teardown.
-     * Without CAS, two concurrent frees could both read the same old_s,
-     * both decide sub_s = bytes, and both subtract, causing underflow. */
+    * load and subtract under concurrent K-fusion worker teardown.
+    * Without CAS, two concurrent frees could both read the same old_s,
+    * both decide sub_s = bytes, and both subtract, causing underflow. */
     {
         uint64_t old_s = atomic_load_explicit(&ledger->subsys_bytes[subsys],
-                                              memory_order_relaxed);
+                memory_order_relaxed);
         uint64_t new_s;
         do {
             new_s = (bytes > old_s) ? 0 : old_s - bytes;
         } while (!atomic_compare_exchange_weak_explicit(
-            &ledger->subsys_bytes[subsys], &old_s, new_s, memory_order_relaxed,
-            memory_order_relaxed));
+                &ledger->subsys_bytes[subsys], &old_s, new_s,
+                memory_order_relaxed,
+                memory_order_relaxed));
     }
 
     /* Clamp-subtract total with CAS loop (same race fix) */
     {
         uint64_t old_t = atomic_load_explicit(&ledger->current_bytes,
-                                              memory_order_relaxed);
+                memory_order_relaxed);
         uint64_t new_t;
         do {
             new_t = (bytes > old_t) ? 0 : old_t - bytes;
         } while (!atomic_compare_exchange_weak_explicit(
-            &ledger->current_bytes, &old_t, new_t, memory_order_relaxed,
-            memory_order_relaxed));
+                &ledger->current_bytes, &old_t, new_t, memory_order_relaxed,
+                memory_order_relaxed));
     }
 }
 
@@ -178,13 +179,13 @@ wl_mem_ledger_subsys_over_budget(const wl_mem_ledger_t *ledger, int subsys)
         return false;
     uint64_t cap = (budget * wl_mem_subsys_pct[subsys]) / 100;
     uint64_t current = atomic_load_explicit(&ledger->subsys_bytes[subsys],
-                                            memory_order_relaxed);
+            memory_order_relaxed);
     return current > cap;
 }
 
 bool
 wl_mem_ledger_should_backpressure(const wl_mem_ledger_t *ledger, int subsys,
-                                  uint32_t threshold_pct)
+    uint32_t threshold_pct)
 {
     if (!ledger || subsys < 0 || subsys >= WL_MEM_SUBSYS_COUNT)
         return false;
@@ -196,7 +197,7 @@ wl_mem_ledger_should_backpressure(const wl_mem_ledger_t *ledger, int subsys,
     if (cap == 0)
         return false;
     uint64_t current = atomic_load_explicit(&ledger->subsys_bytes[subsys],
-                                            memory_order_relaxed);
+            memory_order_relaxed);
     /* current >= cap * threshold_pct / 100 */
     return current >= (cap * threshold_pct) / 100;
 }
@@ -231,21 +232,28 @@ wl_mem_ledger_report(const wl_mem_ledger_t *ledger)
         = atomic_load_explicit(&ledger->peak_bytes, memory_order_relaxed);
 
     char b1[32], b2[32], b3[32], b4[32];
-    fprintf(stderr, "[wirelog mem] budget=%s current=%s peak=%s\n",
-            budget == 0 ? "unlimited" : fmt_bytes(budget, b1, sizeof(b1)),
-            fmt_bytes(current, b2, sizeof(b2)),
-            fmt_bytes(peak, b3, sizeof(b3)));
+    fprintf(stderr,
+        "[wirelog mem] budget=%s current=%s peak=%s budget_bytes=%llu "
+        "current_bytes=%llu peak_bytes=%llu\n",
+        budget == 0 ? "unlimited" : fmt_bytes(budget, b1, sizeof(b1)),
+        fmt_bytes(current, b2, sizeof(b2)),
+        fmt_bytes(peak, b3, sizeof(b3)), (unsigned long long)budget,
+        (unsigned long long)current, (unsigned long long)peak);
 
     for (int i = 0; i < WL_MEM_SUBSYS_COUNT; i++) {
         uint64_t sc = atomic_load_explicit(&ledger->subsys_bytes[i],
-                                           memory_order_relaxed);
+                memory_order_relaxed);
         uint64_t sp = atomic_load_explicit(&ledger->subsys_peak[i],
-                                           memory_order_relaxed);
+                memory_order_relaxed);
         uint64_t cap = (budget > 0) ? (budget * wl_mem_subsys_pct[i]) / 100 : 0;
-        fprintf(stderr, "  %-12s current=%-10s peak=%-10s cap=%s\n",
-                wl_mem_subsys_names[i], fmt_bytes(sc, b1, sizeof(b1)),
-                fmt_bytes(sp, b2, sizeof(b2)),
-                cap > 0 ? fmt_bytes(cap, b3, sizeof(b3))
-                        : fmt_bytes(0, b4, sizeof(b4)));
+        fprintf(stderr,
+            "  %-12s current=%-10s peak=%-10s cap=%s current_bytes=%llu "
+            "peak_bytes=%llu cap_bytes=%llu\n",
+            wl_mem_subsys_names[i], fmt_bytes(sc, b1, sizeof(b1)),
+            fmt_bytes(sp, b2, sizeof(b2)),
+            cap > 0 ? fmt_bytes(cap, b3, sizeof(b3))
+                        : fmt_bytes(0, b4, sizeof(b4)),
+            (unsigned long long)sc, (unsigned long long)sp,
+            (unsigned long long)cap);
     }
 }

--- a/wirelog/columnar/mem_ledger.h
+++ b/wirelog/columnar/mem_ledger.h
@@ -238,13 +238,15 @@ wl_mem_ledger_bytes_remaining(const wl_mem_ledger_t *ledger);
  * Prints a human-readable per-subsystem memory breakdown to stderr.
  * Format (one line per subsystem plus totals):
  *
- *   [wirelog mem] budget=48.0GB current=12.3GB peak=15.6GB
- *     RELATION     current=8.2GB  peak=10.1GB  cap=24.0GB
+ *   [wirelog mem] budget=48.0GB current=12.3GB peak=15.6GB budget_bytes=...
+ *     RELATION     current=8.2GB  peak=10.1GB  cap=24.0GB current_bytes=...
  *     ARENA        current=1.1GB  peak=2.0GB   cap=9.6GB
  *     CACHE        current=0.3GB  peak=0.5GB   cap=4.8GB
  *     ARRANGEMENT  current=0.4GB  peak=0.6GB   cap=4.8GB
  *     TIMESTAMP    current=0.1GB  peak=0.2GB   cap=4.8GB
  *
+ * The exact *_bytes fields use IEC byte counts and are stable for parsers;
+ * the human-readable fields are retained for operator diagnostics.
  * Thread-safe (reads atomics with relaxed ordering; for reporting only).
  */
 void

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1307,11 +1307,10 @@ col_session_destroy(wl_session_t *session)
     wl_col_session_t *sess = COL_SESSION(session);
     wl_columnar_delta_events_clear(sess);
 
-    /* Issue #1380: emit the memory baseline before teardown when explicitly
-     * requested.  The ledger is session-owned, so this is the last point at
-     * which current and peak values for relations, arenas, caches,
-     * arrangements, and timestamps are all available.  Keep the report
-     * opt-in so normal runs and their stderr remain unchanged. */
+    /* Issue #1380: emit the session-owned ledger snapshot before teardown
+     * when explicitly requested.  This reports only allocations charged to
+     * the five ledger domains; it is not a complete RSS/allocation census.
+     * Keep the report opt-in so normal runs and their stderr remain unchanged. */
     if (getenv("WL_MEM_REPORT")) {
         fprintf(stderr, "[wirelog mem] scope=coordinator workers=%u\n",
             sess->num_workers);
@@ -1643,9 +1642,9 @@ col_worker_session_destroy(wl_col_session_t *worker)
     wl_columnar_delta_events_clear(worker);
 
     /* Issue #1380: worker ledgers are independent copies with their own
-     * allocations and peaks.  Report them before freeing worker-owned
-     * relations, pools, and arenas so bounded-memory runs can compare worker
-     * peaks instead of seeing only the coordinator baseline. */
+     * charged allocations and lifetime peaks.  Report them before freeing
+     * worker-owned state; these values are not a simultaneous process RSS
+     * peak and must not be summed as one. */
     if (getenv("WL_MEM_REPORT")) {
         fprintf(stderr, "[wirelog mem] scope=worker id=%u workers=%u\n",
             worker->worker_id, worker->num_workers);


### PR DESCRIPTION
## Summary
- add stable decimal byte fields to opt-in coordinator/worker memory reports
- document ledger coverage, provenance gaps, and the limits of historical DOOP W1/W2 evidence
- add a report on/off contract test proving result stdout and exit status are unchanged
- preserve existing human-readable diagnostics and clarify that ledger peaks are not process RSS

This is an atomic follow-up unit for #1380. Full allocation coverage, low-memory DOOP qualification, and integrated six-workload enforcement remain owned by #1368/#1385/#1386.

## Validation
- `meson test -C builddir --no-rebuild mem_report_contract tdd_decision_stats tdd_decision_stats_nofusion safe_worker_scaling k_fusion_memory k_fusion_memory_nofusion deep_copy_ledger_canary` — 7 passed
- `uncrustify -c uncrustify.cfg --check` on changed C/H files — passed
- `git diff --check` — passed
