### PR TITLE
docs: define memory budget contract

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,0 +1,173 @@
+# Memory budget contract
+
+This document defines the memory contract for a managed wirelog session. It
+is normative for the resolver, governor, allocation sites, and TDD workers;
+it does not turn the current accounting ledger into an allocator or an
+admission controller.
+
+## Scope and terminology
+
+The contract covers memory reservations owned by one session: its coordinator,
+workers, relation buffers, arenas, arrangements, caches, timestamps, exchange
+buffers, and spill state. It does not promise a process-wide or host-wide OOM
+guarantee. The following quantities remain distinct:
+
+| Quantity | Meaning | Contract role |
+| --- | --- | --- |
+| Managed reservation | Bytes admitted to the session governor | Enforced budget |
+| Ledger attribution | Best-effort current/peak counters by subsystem | Observability only |
+| RSS/working set | Process residency, including allocator retention | Safety signal, not a reservation |
+| cgroup/job/address-space limit | An external limit imposed by the host | Input to automatic resolution |
+| Physical RAM | Installed or visible machine memory | Never a bounded guarantee by itself |
+
+`wl_mem_ledger_t` currently implements attribution and reporting. Its
+`budget == 0` compatibility value means “unlimited ledger accounting”; it
+does not mean that a user supplied zero budget is accepted.
+
+## Selecting a budget
+
+There is one environment namespace: `WIRELOG_MEMORY_BUDGET`. The eventual
+versioned session-options API has precedence over the environment, and the
+environment has precedence over automatic resolution:
+
+```text
+versioned API option > WIRELOG_MEMORY_BUDGET > automatic resolution
+```
+
+Values are decimal bytes (not MiB or a human-readable suffix). The following
+table is part of the interface contract:
+
+| Input | Result |
+| --- | --- |
+| API option absent and environment unset | Automatic resolution |
+| Explicit positive value at least 256 MiB | Enforcing managed budget |
+| Explicit zero | Invalid configuration; never silently becomes unlimited |
+| Empty, signed, negative, non-decimal, or overflowed value | Invalid configuration |
+| Positive value below 256 MiB | Invalid configuration |
+| Explicit value on a supported platform | Enforcing managed budget |
+| Automatic resolution with no supported limit source | Advisory/unbounded mode, with an explicit diagnostic; no bounded guarantee |
+
+The minimum is a progress floor, not a promise that every workload fits. All
+parsing and arithmetic must reject overflow before converting to `uint64_t`.
+The internal zero value remains available only to represent an unlimited
+ledger in tests and compatibility paths.
+
+For the existing accounting hint, a threshold of `0` means pressure is true
+for any valid nonzero subsystem cap, `100` means pressure starts at the cap,
+and a value above `100` is invalid and returns false. This is not an admission
+decision and does not reject an allocation.
+
+Automatic resolution examines effective limits, not just the first file it can
+read:
+
+1. cgroup v2 `memory.max` and `memory.high`, including relevant ancestors;
+2. cgroup v1 memory limits, including ancestors and unlimited sentinels;
+3. `RLIMIT_AS` where supported, treating it as virtual address-space, not RSS;
+4. supported Windows Job Object process-memory limits;
+5. no physical-RAM-only fallback for an enforcing guarantee.
+
+An unlimited cgroup value, an absent optional source, and an unsupported
+platform are different observations. The resolver records which source was
+selected and whether the result is enforcing or advisory. Tests use injected
+provider fixtures for these cases; they must not depend on the host's actual
+cgroup or RAM configuration.
+
+## Reservation lifecycle
+
+Every managed allocation follows this transaction:
+
+```text
+reserve(bytes) -> commit/transfer(owner) -> release(bytes)
+       |                 |
+       +-- rollback/cancel on failure
+```
+
+- `reserve` is an atomic admission operation against the shared session
+  budget. It happens before the allocation can become visible to another
+  operation.
+- `commit` attaches the reservation to its owner. A transfer between the
+  coordinator and a worker changes attribution, not the shared limit.
+- `release` is idempotent for a committed reservation and returns capacity.
+- Failed allocations roll back their reservation. Cancellation releases
+  reservations and must not publish a partial result.
+- A realloc that needs both old and new storage reserves the new size while
+  the old size is still counted; only after a successful move may it release
+  the old reservation.
+- Overflow in a size, sum, or headroom calculation is a distinct
+  representation-overflow failure, never a wrapped small reservation.
+- A reserved cleanup/drain headroom remains available for rollback, error
+  reporting, and worker teardown. It is not handed out as ordinary work
+  capacity.
+
+Coordinator and worker operations use one shared governor. A worker share is
+only a fairness hint used for scheduling; `W` workers do not receive `W`
+independent hard budgets. RSS sampling, allocator retention, and sampling
+lag may trigger a safety brake, but they do not rewrite committed ownership.
+
+## Failure and retry contract
+
+These outcomes remain distinguishable internally and at the public boundary:
+
+| Outcome | Meaning | Retry/reset rule |
+| --- | --- | --- |
+| Budget denial | Reservation would consume available managed capacity | Reclaim, reduce work, spill, or report a bounded-memory failure |
+| Allocator failure | `malloc`/system allocation returned failure | Release reservation; report memory failure |
+| Representation overflow | Size arithmetic cannot be represented | Release reservation; report invalid/overflow failure |
+| I/O/spill failure | External backing store failed | Release or retain only durable committed state; report I/O failure |
+| Cancellation | Host or operation cancellation | Roll back unpublished work and reservations |
+| Unsupported configuration | Requested enforcement source/platform is unavailable | Explicit request fails; automatic mode may remain advisory as above |
+
+On a successful retry after reclaim or a smaller request, the operation's
+error state is reset and no partial rows are published. Retry loops are
+bounded; the governor must not spin indefinitely while RSS or capacity is
+unchanged. Public `create`, `insert`, `step`, and `snapshot` paths, including
+typed and easy facades, must map these outcomes consistently when enforcement
+is implemented.
+
+## Ownership and sequencing
+
+This issue defines the contract and boundary fixtures. Implementation is
+owned as follows:
+
+| Work | Owner | This contract supplies |
+| --- | --- | --- |
+| Budget source resolution, shared governor, advisory/enforcing state | #1368 | Precedence, providers, minimum, headroom, source provenance |
+| Allocation-site admission and public propagation | #1369 | Reservation lifecycle, error taxonomy, retry/reset boundaries |
+| Arrangement/cache lifetime and reclaim primitives | #1384 | Release/transfer behavior and cleanup reserve |
+| Join admission, ingestion, TDD backpressure | #1382, #1402, #1383 | Workload-specific reservation sizes and rollback tests |
+| Bounded DOOP and downstream gates | #1385–#1387 | Evidence that the contract works under constrained memory |
+
+The existing ledger tests prove accounting invariants only: they do not prove
+admission, allocator ownership, RSS control, or OOM prevention. In
+particular, `wl_mem_ledger_alloc()` remains a post-allocation accounting call
+and must not be used as a substitute for `reserve()`.
+
+```mermaid
+flowchart TD
+  A[#1380 baseline/report] --> B[#1381 this contract]
+  B --> C[#1368 resolver/governor]
+  B --> D[#1384 lifetime/reclaim]
+  C --> E[#1369 allocation admission]
+  D --> E
+  E --> F[#1382 join admission]
+  E --> G[#1402 bounded ingestion]
+  F --> H[#1383 TDD backpressure]
+  H --> I[#1385 bounded DOOP]
+  I --> J[#1386 six-workload gate]
+```
+
+## Acceptance evidence
+
+The contract unit is complete only when documentation and executable ledger
+fixtures agree on:
+
+- exact percentage arithmetic at `UINT64_MAX` scale;
+- zero/unlimited internal ledger behavior and clamped remaining capacity;
+- threshold `0`, `100`, and invalid values above `100`;
+- saturating accounting rather than counter wraparound;
+- deterministic subsystem percentages summing to 100;
+- the boundary between accounting evidence and future admission evidence.
+
+Resolver-provider, reservation-lifecycle, public-error, and allocation-site
+tests belong to #1368/#1369 and must be added there with their unimplemented
+symbols; this document does not claim those behaviors already exist.

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -239,8 +239,8 @@ Format: `file:function[#N]` | field | operation | order | justification.
 | `mem_ledger.c:update_peak` | `*peak_atom` (subsys or global) | `atomic_load_explicit` | `relaxed` | Read-current for monotone peak-update CAS loop; no happens-before edge required |
 | `mem_ledger.c:update_peak#2` | `*peak_atom` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Monotone high-water bump; if another thread won, retry; observed values are non-decreasing |
 | `mem_ledger.c:wl_mem_ledger_init` | `ledger->total_budget` | `atomic_store_explicit` | `relaxed` | Set-once at init; readers see the value eventually via per-counter relaxed loads |
-| `mem_ledger.c:wl_mem_ledger_alloc` | `ledger->subsys_bytes[subsys]` | `atomic_fetch_add_explicit` | `relaxed` | Per-subsystem counter; ordering of distinct subsystems is independent |
-| `mem_ledger.c:wl_mem_ledger_alloc#2` | `ledger->current_bytes` | `atomic_fetch_add_explicit` | `relaxed` | Aggregate accounting counter; per-allocator skew is tolerated |
+| `mem_ledger.c:saturating_add` | `*counter` (subsys or global) | `atomic_load_explicit` | `relaxed` | Read-current before overflow-safe saturating increment |
+| `mem_ledger.c:saturating_add#2` | `*counter` (subsys or global) | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Atomic saturating increment; retry with the observed value and never wrap |
 | `mem_ledger.c:wl_mem_ledger_free` | `ledger->subsys_bytes[subsys]` | `atomic_load_explicit` | `relaxed` | Read-current for clamp-to-zero free path |
 | `mem_ledger.c:wl_mem_ledger_free#2` | `ledger->subsys_bytes[subsys]` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Clamp-to-zero CAS loop; loss-of-race retries |
 | `mem_ledger.c:wl_mem_ledger_free#3` | `ledger->current_bytes` | `atomic_load_explicit` | `relaxed` | Read-current for clamp-to-zero free path |

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1277,6 +1277,16 @@ test_intern_exe = executable(
 
 test('intern', test_intern_exe)
 
+# Issue #1381: execute the memory-ledger arithmetic contract.  This remains
+# accounting-only; reservation/admission is owned by the #1368/#1369 units.
+test_mem_ledger_exe = executable(
+  'test_mem_ledger',
+  files('test_mem_ledger.c', '../wirelog/columnar/mem_ledger.c') + thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
+)
+test('mem_ledger_contract', test_mem_ledger_exe, suite: 'unit')
+
 # ============================================================================
 # Plan Generator + Session Facts Tests (Phase 2C columnar backend)
 # ============================================================================

--- a/tests/test_mem_ledger.c
+++ b/tests/test_mem_ledger.c
@@ -7,7 +7,7 @@
  *
  * Tests:
  *   1. alloc/free tracking accuracy
- *   2. budget enforcement (over_budget)
+ *   2. post-allocation budget observation (over_budget)
  *   3. peak_bytes high-water mark
  *   4. concurrent thread consistency
  *   5. human-readable report output (smoke test)
@@ -114,13 +114,13 @@ test_alloc_free_accuracy(void)
 }
 
 /* ======================================================================== */
-/* Test 2: budget enforcement (over_budget)                                 */
+/* Test 2: post-allocation budget observation (over_budget)                   */
 /* ======================================================================== */
 
 static int
 test_budget_enforcement(void)
 {
-    TEST("budget enforcement (over_budget)");
+    TEST("post-allocation budget observation (over_budget)");
 
     wl_mem_ledger_t ledger;
     wl_mem_ledger_init(&ledger, 1000); /* 1000 byte budget */
@@ -460,6 +460,77 @@ test_bytes_remaining(void)
 }
 
 /* ======================================================================== */
+/* Test 9: UINT64_MAX and invalid threshold boundaries                       */
+/* ======================================================================== */
+
+static int
+test_overflow_boundaries(void)
+{
+    TEST("overflow-safe boundaries");
+
+    wl_mem_ledger_t ledger;
+    wl_mem_ledger_init(&ledger, UINT64_MAX);
+    wl_mem_ledger_alloc(&ledger, WL_MEM_SUBSYS_RELATION, UINT64_MAX);
+    wl_mem_ledger_alloc(&ledger, WL_MEM_SUBSYS_RELATION, 1);
+
+    uint64_t current = (uint64_t)atomic_load_explicit(
+        &ledger.current_bytes, memory_order_relaxed);
+    uint64_t relation = (uint64_t)atomic_load_explicit(
+        &ledger.subsys_bytes[WL_MEM_SUBSYS_RELATION], memory_order_relaxed);
+    if (current != UINT64_MAX || relation != UINT64_MAX) {
+        FAIL("large accounting increment wrapped instead of saturating");
+        return 1;
+    }
+    if (wl_mem_ledger_bytes_remaining(&ledger) != 0
+        || wl_mem_ledger_over_budget(&ledger)) {
+        FAIL("UINT64_MAX budget boundary was not handled deterministically");
+        return 1;
+    }
+
+    wl_mem_ledger_t threshold;
+    wl_mem_ledger_init(&threshold, 1000);
+    wl_mem_ledger_alloc(&threshold, WL_MEM_SUBSYS_CACHE, 100);
+    if (!wl_mem_ledger_should_backpressure(
+            &threshold, WL_MEM_SUBSYS_CACHE, 0)
+        || !wl_mem_ledger_should_backpressure(
+            &threshold, WL_MEM_SUBSYS_CACHE, 100)
+        || wl_mem_ledger_should_backpressure(
+            &threshold, WL_MEM_SUBSYS_CACHE, 101)) {
+        FAIL("threshold 100/>100 boundary is incorrect");
+        return 1;
+    }
+
+    /* The RELATION cap is floor(UINT64_MAX * 50 / 100), not a wrapped value. */
+    wl_mem_ledger_t max_cap;
+    wl_mem_ledger_init(&max_cap, UINT64_MAX);
+    uint64_t relation_cap = (UINT64_MAX / 100) * 50
+        + ((UINT64_MAX % 100) * 50) / 100;
+    wl_mem_ledger_alloc(&max_cap, WL_MEM_SUBSYS_RELATION, relation_cap);
+    if (wl_mem_ledger_subsys_over_budget(
+            &max_cap, WL_MEM_SUBSYS_RELATION)) {
+        FAIL("exact UINT64_MAX subsystem cap was over budget");
+        return 1;
+    }
+    wl_mem_ledger_alloc(&max_cap, WL_MEM_SUBSYS_RELATION, 1);
+    if (!wl_mem_ledger_subsys_over_budget(
+            &max_cap, WL_MEM_SUBSYS_RELATION)) {
+        FAIL("UINT64_MAX subsystem cap did not advance at cap + 1");
+        return 1;
+    }
+
+    uint32_t percentage_sum = 0;
+    for (int i = 0; i < WL_MEM_SUBSYS_COUNT; i++)
+        percentage_sum += wl_mem_subsys_pct[i];
+    if (percentage_sum != 100) {
+        FAIL("subsystem percentages do not sum to 100");
+        return 1;
+    }
+
+    PASS();
+    return 0;
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -479,6 +550,7 @@ main(void)
     test_subsys_over_budget();
     test_backpressure_threshold();
     test_bytes_remaining();
+    test_overflow_boundaries();
 
     printf("\n");
     printf("Passed: %d/%d\n", tests_passed, tests_run);

--- a/wirelog/columnar/mem_ledger.c
+++ b/wirelog/columnar/mem_ledger.c
@@ -63,6 +63,36 @@ fmt_bytes(uint64_t bytes, char *buf, size_t len)
     return buf;
 }
 
+/* Return floor(value * percentage / 100) without overflowing value *
+ * percentage.  The percentage tables and public threshold inputs are
+ * uint32_t, so the quotient/remainder form keeps the multiplication bounded
+ * even for UINT64_MAX-scale budgets. */
+static uint64_t
+percent_of(uint64_t value, uint32_t percentage)
+{
+    uint64_t quotient = value / 100;
+    uint64_t remainder = value % 100;
+    return quotient * (uint64_t)percentage
+           + (remainder * (uint64_t)percentage) / 100;
+}
+
+/* The accounting API has no failure return.  Saturating increments preserve
+ * the invariant that a counter never wraps into a deceptively small value;
+ * admission and allocation failure remain responsibilities of the governor
+ * and allocator layers described in docs/MEMORY.md. */
+static uint64_t
+saturating_add(wl_atomic_u64 *counter, uint64_t bytes)
+{
+    uint64_t old = atomic_load_explicit(counter, memory_order_relaxed);
+    for (;;) {
+        uint64_t next = (UINT64_MAX - old < bytes) ? UINT64_MAX : old + bytes;
+        if (atomic_compare_exchange_weak_explicit(counter, &old, next,
+            memory_order_relaxed,
+            memory_order_relaxed))
+            return next;
+    }
+}
+
 /*
  * update_peak: atomically update @peak_atom to max(*peak_atom, new_val).
  * Uses compare-exchange loop.
@@ -104,16 +134,11 @@ wl_mem_ledger_alloc(wl_mem_ledger_t *ledger, int subsys, uint64_t bytes)
         return;
 
     /* Update subsystem counter */
-    uint64_t subsys_new
-        = atomic_fetch_add_explicit(&ledger->subsys_bytes[subsys], bytes,
-            memory_order_relaxed)
-        + bytes;
+    uint64_t subsys_new = saturating_add(&ledger->subsys_bytes[subsys], bytes);
     update_peak(&ledger->subsys_peak[subsys], subsys_new);
 
     /* Update total counter */
-    uint64_t total_new = atomic_fetch_add_explicit(&ledger->current_bytes,
-            bytes, memory_order_relaxed)
-        + bytes;
+    uint64_t total_new = saturating_add(&ledger->current_bytes, bytes);
     update_peak(&ledger->peak_bytes, total_new);
 }
 
@@ -177,7 +202,7 @@ wl_mem_ledger_subsys_over_budget(const wl_mem_ledger_t *ledger, int subsys)
         = atomic_load_explicit(&ledger->total_budget, memory_order_relaxed);
     if (budget == 0)
         return false;
-    uint64_t cap = (budget * wl_mem_subsys_pct[subsys]) / 100;
+    uint64_t cap = percent_of(budget, wl_mem_subsys_pct[subsys]);
     uint64_t current = atomic_load_explicit(&ledger->subsys_bytes[subsys],
             memory_order_relaxed);
     return current > cap;
@@ -193,13 +218,15 @@ wl_mem_ledger_should_backpressure(const wl_mem_ledger_t *ledger, int subsys,
         = atomic_load_explicit(&ledger->total_budget, memory_order_relaxed);
     if (budget == 0)
         return false;
-    uint64_t cap = (budget * wl_mem_subsys_pct[subsys]) / 100;
+    uint64_t cap = percent_of(budget, wl_mem_subsys_pct[subsys]);
     if (cap == 0)
+        return false;
+    if (threshold_pct > 100)
         return false;
     uint64_t current = atomic_load_explicit(&ledger->subsys_bytes[subsys],
             memory_order_relaxed);
     /* current >= cap * threshold_pct / 100 */
-    return current >= (cap * threshold_pct) / 100;
+    return current >= percent_of(cap, threshold_pct);
 }
 
 uint64_t
@@ -245,7 +272,8 @@ wl_mem_ledger_report(const wl_mem_ledger_t *ledger)
                 memory_order_relaxed);
         uint64_t sp = atomic_load_explicit(&ledger->subsys_peak[i],
                 memory_order_relaxed);
-        uint64_t cap = (budget > 0) ? (budget * wl_mem_subsys_pct[i]) / 100 : 0;
+        uint64_t cap = (budget > 0) ? percent_of(budget,
+                wl_mem_subsys_pct[i]) : 0;
         fprintf(stderr,
             "  %-12s current=%-10s peak=%-10s cap=%s current_bytes=%llu "
             "peak_bytes=%llu cap_bytes=%llu\n",

--- a/wirelog/columnar/mem_ledger.h
+++ b/wirelog/columnar/mem_ledger.h
@@ -8,7 +8,9 @@
  * INTERNAL HEADER - not installed, not part of public API.
  *
  * Thread-safe memory accounting ledger with per-subsystem tracking,
- * budget enforcement, and human-readable reporting.
+ * budget accounting, pressure hints, and human-readable reporting.  Admission
+ * enforcement is owned by the memory governor, not this post-allocation
+ * ledger.
  *
  * Issue #224: Memory Observability and Graceful Degradation for DOOP OOM
  */
@@ -75,11 +77,26 @@ wl_atomic_fetch_sub_internal(volatile __int64 *ptr, __int64 dec)
         wl_atomic_fetch_add_internal((volatile __int64 *)(ptr), (__int64)(inc))
 #define atomic_fetch_sub_explicit(ptr, dec, order) \
         wl_atomic_fetch_sub_internal((volatile __int64 *)(ptr), (__int64)(dec))
+
+static inline bool
+wl_atomic_compare_exchange_weak_internal(volatile __int64 *ptr,
+    uint64_t *expected, uint64_t desired)
+{
+    __int64 expected_value = (__int64)*expected;
+    __int64 observed = _InterlockedCompareExchange64(
+        ptr, (__int64)desired, expected_value);
+    if (observed != expected_value) {
+        *expected = (uint64_t)observed;
+        return false;
+    }
+    return true;
+}
+
 #define atomic_compare_exchange_weak_explicit(ptr, expected, desired,        \
             succ_order, fail_order)        \
-        (_InterlockedCompareExchange64((volatile __int64 *)(ptr),                \
-        (__int64)(desired), (__int64)*(expected)) \
-        == (__int64)*(expected))
+        wl_atomic_compare_exchange_weak_internal(                              \
+            (volatile __int64 *)(ptr), (uint64_t *)(expected), \
+            (uint64_t)(desired))
 
 /* Memory orders (ignored on MSVC - intrinsics always use acquire/release semantics) */
 #define memory_order_relaxed 0
@@ -160,7 +177,9 @@ wl_mem_ledger_init(wl_mem_ledger_t *ledger, uint64_t budget_bytes);
  * wl_mem_ledger_alloc:
  * @ledger:    Ledger to update.
  * @subsys:    WL_MEM_SUBSYS_* identifier.
- * @bytes:     Number of bytes allocated.
+ * @bytes:     Number of bytes allocated.  Accounting saturates at
+ *             UINT64_MAX; this function does not reserve memory or reject an
+ *             allocation.
  *
  * Records an allocation.  Updates current_bytes, peak_bytes,
  * subsys_bytes[subsys], and subsys_peak[subsys] atomically.
@@ -212,6 +231,8 @@ wl_mem_ledger_subsys_over_budget(const wl_mem_ledger_t *ledger, int subsys);
  * @threshold: Fraction (0-100) of subsystem cap at which to signal pressure.
  *
  * Returns true when the subsystem has consumed >= threshold% of its cap.
+ * Values above 100 are invalid and return false.  This accounting hint is
+ * not an admission decision.
  * Callers use this to trigger cache eviction, worker scaling, etc.
  * Returns false when budget is 0 (unlimited).
  * Thread-safe.


### PR DESCRIPTION
## Summary

- define the normative managed-session memory contract in `docs/MEMORY.md`
- make ledger percentage arithmetic and accounting increments overflow-safe
- register and extend the executable memory-ledger contract test
- keep admission/governor and public error implementation scoped to #1368/#1369

## Validation

- `meson compile -C build-1381 test_mem_ledger`
- `meson test -C build-1381 mem_ledger_contract --print-errorlogs`
- `meson test -C build-1381 --suite unit --print-errorlogs` (3/3)
- uncrustify checks for changed C/H files
- `git diff --check`

Addresses #1381. The issue depends on #1380; this PR does not claim the
baseline/report work or implement the resolver/governor.
