### PR TITLE
ci: require DOOP in stable perf nightly gate

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -307,7 +307,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build linux-tools-common linux-tools-generic
+          sudo apt-get install -y curl meson ninja-build unzip linux-tools-common linux-tools-generic
 
       - name: Verify stable timing host
         shell: bash
@@ -323,6 +323,11 @@ jobs:
             echo 'stable perf runner requires CPU 0 to be online' >&2
             exit 1
           fi
+          cpu_count=$(nproc --all)
+          (( cpu_count >= 8 )) || {
+            echo "DOOP W=8 gate requires at least 8 CPUs; found $cpu_count" >&2
+            exit 1
+          }
           sudo -n cpupower frequency-set -g performance
           actual=$(<"$governor")
           [[ "$actual" == performance ]] || {
@@ -361,6 +366,9 @@ jobs:
         env:
           CC: gcc
 
+      - name: Download pinned DOOP dataset
+        run: bench/data/doop/download.sh
+
       - name: Build stripped build
         run: meson compile -C build-perf-error
 
@@ -368,10 +376,29 @@ jobs:
         env:
           WIRELOG_PERF_GATE: '1'
           WIRELOG_PERF_REQUIRE: '1'
+          WL_DOOP_PERF_GATE_TARGET_MS: ${{ vars.WL_DOOP_PERF_GATE_TARGET_MS }}
         run: >
           taskset -c 0 meson test -C build-perf-error
           crdt_perf_gate cspa_w1_gate sub_ms_graph_perf_gate
           --print-errorlogs --num-processes 1
+
+      # DOOP is W=8 and must not inherit the single-CPU affinity used by the
+      # W=1 evaluator gates above.  Keep a separate Meson log, then append it
+      # to the authoritative error log so the common execution checker still
+      # verifies one complete evidence stream.
+      - name: Run DOOP W=8 timing gate
+        env:
+          WIRELOG_PERF_GATE: '1'
+          WIRELOG_PERF_REQUIRE: '1'
+          WL_DOOP_PERF_GATE_TARGET_MS: ${{ vars.WL_DOOP_PERF_GATE_TARGET_MS }}
+        run: |
+          set +e
+          taskset -c 0-7 meson test -C build-perf-error doop_w8_gate \
+            --logbase doop-testlog --print-errorlogs --num-processes 1
+          rc=$?
+          cat build-perf-error/meson-logs/doop-testlog.txt >> \
+            build-perf-error/meson-logs/testlog.txt
+          exit "$rc"
 
       - name: Verify timing gates executed
         run: >

--- a/scripts/ci/check-perf-gate-execution.sh
+++ b/scripts/ci/check-perf-gate-execution.sh
@@ -51,5 +51,6 @@ check_gate "$trace_log" log_perf_gate 'test_log_perf_gate OK'
 check_gate "$error_log" crdt_perf_gate 'test_crdt_perf_gate OK'
 check_gate "$error_log" cspa_w1_gate 'test_cspa_perf_gate OK'
 check_gate "$error_log" sub_ms_graph_perf_gate 'test_sub_ms_graph_perf_gate OK'
+check_gate "$error_log" doop_w8_gate 'doop_w8_gate OK'
 
-echo "perf gate execution check: all four timing gates executed successfully"
+echo "perf gate execution check: all five timing gates executed successfully"

--- a/scripts/ci/test-check-perf-gate-execution.sh
+++ b/scripts/ci/test-check-perf-gate-execution.sh
@@ -40,6 +40,7 @@ write_log "$tmp_dir/trace.log" 0 log_perf_gate 'test_log_perf_gate OK'
     write_log "$tmp_dir/error.log" 0 crdt_perf_gate 'test_crdt_perf_gate OK'
     append_log "$tmp_dir/error.log" 0 cspa_w1_gate 'test_cspa_perf_gate OK'
     append_log "$tmp_dir/error.log" 0 sub_ms_graph_perf_gate 'test_sub_ms_graph_perf_gate OK'
+    append_log "$tmp_dir/error.log" 0 doop_w8_gate 'doop_w8_gate OK: tuples=13828835 iterations=153 median_ms=100 target_ms=105'
 }
 
 "$script_dir/check-perf-gate-execution.sh" "$tmp_dir/trace.log" "$tmp_dir/error.log"
@@ -79,6 +80,23 @@ fi
 write_log "$tmp_dir/correctness-only.log" 0 crdt_correctness_full 'test_crdt_perf_gate OK'
 if "$script_dir/check-perf-gate-execution.sh" "$tmp_dir/trace.log" "$tmp_dir/correctness-only.log"; then
     echo "correctness-only fixture unexpectedly passed" >&2
+    exit 1
+fi
+
+write_log "$tmp_dir/missing-doop.log" 0 crdt_perf_gate 'test_crdt_perf_gate OK'
+append_log "$tmp_dir/missing-doop.log" 0 cspa_w1_gate 'test_cspa_perf_gate OK'
+append_log "$tmp_dir/missing-doop.log" 0 sub_ms_graph_perf_gate 'test_sub_ms_graph_perf_gate OK'
+if "$script_dir/check-perf-gate-execution.sh" "$tmp_dir/trace.log" "$tmp_dir/missing-doop.log"; then
+    echo "missing DOOP fixture unexpectedly passed" >&2
+    exit 1
+fi
+
+write_log "$tmp_dir/skipped-doop.log" 0 crdt_perf_gate 'test_crdt_perf_gate OK'
+append_log "$tmp_dir/skipped-doop.log" 0 cspa_w1_gate 'test_cspa_perf_gate OK'
+append_log "$tmp_dir/skipped-doop.log" 0 sub_ms_graph_perf_gate 'test_sub_ms_graph_perf_gate OK'
+append_log "$tmp_dir/skipped-doop.log" 77 doop_w8_gate 'doop_w8_gate: SKIP: no calibrated 5-repetition W=8 target'
+if "$script_dir/check-perf-gate-execution.sh" "$tmp_dir/trace.log" "$tmp_dir/skipped-doop.log"; then
+    echo "skipped DOOP fixture unexpectedly passed" >&2
     exit 1
 fi
 

--- a/scripts/ci/test-perf-nightly-doop.py
+++ b/scripts/ci/test-perf-nightly-doop.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Verify the authoritative perf-nightly DOOP wiring is still active."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github/workflows/perf-nightly.yml"
+
+
+def job(text: str, name: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(name)}:\n(.*?)(?=^  \S|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, f"missing job: {name}"
+    return match[1]
+
+
+def step(text: str, name: str) -> str:
+    matches = re.findall(
+        rf"^      - name: {re.escape(name)}\n(.*?)(?=^      - |^  \S|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert len(matches) == 1, f"expected exactly one step: {name}"
+    return matches[0]
+
+
+def field(body: str, key: str) -> str:
+    match = re.search(
+        rf"^        {re.escape(key)}:(?: [|>])?\n((?:          [^\n]*\n)+)",
+        body,
+        re.MULTILINE,
+    )
+    if match:
+        return match[1]
+    inline = re.search(rf"^        {re.escape(key)}: ([^\n]+)$", body,
+                       re.MULTILINE)
+    assert inline, f"missing {key} block"
+    return inline[1] + "\n"
+
+
+def validate(text: str) -> None:
+    stable = job(text, "perf-stable")
+    install = field(step(stable, "Install dependencies"), "run")
+    assert "curl" in install and "unzip" in install, \
+        "stable runner must install DOOP download tools"
+
+    host = field(step(stable, "Verify stable timing host"), "run")
+    assert "nproc --all" in host and "cpu_count >= 8" in host, \
+        "stable runner must verify W=8 CPU capacity"
+
+    download = field(step(stable, "Download pinned DOOP dataset"), "run")
+    assert download.strip() == "bench/data/doop/download.sh", \
+        "stable path must download the pinned DOOP dataset"
+
+    evaluator = step(stable, "Run evaluator timing gates")
+    evaluator_run = field(evaluator, "run")
+    assert "taskset -c 0 meson test -C build-perf-error" in evaluator_run, \
+        "W=1 evaluator affinity must remain on CPU 0"
+    assert "crdt_perf_gate cspa_w1_gate sub_ms_graph_perf_gate" in evaluator_run
+    assert "doop_w8_gate" not in evaluator_run, \
+        "W=1 evaluator invocation must not hide DOOP on CPU 0"
+
+    doop = step(stable, "Run DOOP W=8 timing gate")
+    doop_env = field(doop, "env")
+    for variable in (
+        "WIRELOG_PERF_GATE: '1'",
+        "WIRELOG_PERF_REQUIRE: '1'",
+        "WL_DOOP_PERF_GATE_TARGET_MS: ${{ vars.WL_DOOP_PERF_GATE_TARGET_MS }}",
+    ):
+        assert variable in doop_env, f"DOOP step must set {variable}"
+    doop_run = field(doop, "run")
+    assert "taskset -c 0-7 meson test -C build-perf-error doop_w8_gate" in doop_run, \
+        "DOOP must run with W=8 CPU affinity"
+    assert "--logbase doop-testlog" in doop_run
+    assert "doop-testlog.txt >>" in doop_run
+    assert 'exit "$rc"' in doop_run
+
+    verify = field(step(stable, "Verify timing gates executed"), "run")
+    assert "check-perf-gate-execution.sh" in verify
+
+
+class PerfNightlyDoopWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_actual_workflow(self):
+        validate(self.text)
+
+    def test_doop_removal_fails(self):
+        mutated = self.text.replace(
+            "taskset -c 0-7 meson test -C build-perf-error doop_w8_gate",
+            "taskset -c 0-7 meson test -C build-perf-error",
+        )
+        with self.assertRaisesRegex(AssertionError, "DOOP must"):
+            validate(mutated)
+
+    def test_single_cpu_affinity_fails(self):
+        mutated = self.text.replace("taskset -c 0-7 meson test -C build-perf-error doop_w8_gate",
+                                    "taskset -c 0 meson test -C build-perf-error doop_w8_gate")
+        with self.assertRaisesRegex(AssertionError, "DOOP must"):
+            validate(mutated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1928,6 +1928,19 @@ test('crdt_correctness_full', test_crdt_perf_gate_exe,
        'WIRELOG_CRDT_DATA_DIR=' + meson.project_source_root() / 'bench/data/crdt',
      ])
 
+# Issue #1351: keep the authoritative stable-path evidence checker under test.
+# This deterministic fixture ensures that removing DOOP from the workflow, or
+# allowing a SKIP record, cannot silently restore a green required gate.
+if host_machine.system() == 'linux' and sh.found()
+  test('check_perf_gate_execution', sh,
+       args: [meson.project_source_root() / 'scripts/ci/test-check-perf-gate-execution.sh'],
+       suite: 'abi')
+endif
+
+test('perf_nightly_doop_contract', py3,
+     args: [meson.project_source_root() / 'scripts/ci/test-perf-nightly-doop.py'],
+     suite: 'abi')
+
 # ============================================================================
 # CSPA W=1 perf-suite gate.
 #


### PR DESCRIPTION
## Summary
- run the pinned DOOP dataset on the authoritative stable perf-nightly path
- keep W=1 evaluator gates on CPU 0 and run DOOP W=8 on CPUs 0-7
- require DOOP evidence in the execution checker and add workflow regression fixtures

## Validation
- `scripts/ci/test-check-perf-gate-execution.sh`
- `python scripts/ci/test-perf-nightly-doop.py` (uv venv)
- Meson ABI tests: `check_perf_gate_execution`, `perf_nightly_doop_contract`
- `git diff --check`

Related to #1351. This PR implements the mandatory wiring; #1351 remains open until a real stable-run W=8/repeat=5 calibration and retained success artifact are available.