### PR TITLE
Integrate memory governor with sessions

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -168,9 +168,9 @@ fixtures agree on:
 - deterministic subsystem percentages summing to 100;
 - the boundary between accounting evidence and future admission evidence.
 
-Resolver-provider, reservation-lifecycle, public-error, and allocation-site
-tests belong to #1368/#1369 and must be added there with their unimplemented
-symbols; this document does not claim those behaviors already exist.
+Resolver-provider, reservation-lifecycle, and session-lifecycle tests now cover
+the #1368/#1413 foundation. Allocation-site admission tests belong to #1369;
+the current ledger still does not claim to enforce individual allocations.
 
 ## Foundation implementation status
 
@@ -190,6 +190,18 @@ and released states; rollback is valid only from reserved, and release
 returns capacity exactly once. This foundation is not yet wired into session
 creation or allocation sites: session lifetime/public error integration is
 #1413 and allocation-site enforcement is #1369.
+
+The #1413 integration adds a reference-counted coordinator-owned governor to
+columnar sessions before relation, pool, arena, cache, or worker setup. Worker
+sessions retain the same governor reference and release it during every
+normal or partial teardown path. Their ledgers remain attribution-only; while
+the legacy join backpressure path still reads ledger thresholds, each worker
+gets an equal reporting share so the aggregate threshold does not multiply by
+the worker count. The removed `tdd_budget_per_party` value is no longer a
+second governor admission domain.
+Explicit invalid budgets fail session creation with the existing public
+execution error mapping and leave output handles null. Allocation-site
+admission remains the separate responsibility of #1369.
 # wirelog Memory Instrumentation
 
 This document describes what the columnar engine measures about its own

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -228,7 +228,7 @@ These exist so struct fields can be declared portably; the audit in
 
 Every `atomic_*` call site in `wirelog/` production sources. Counted
 mechanically by `scripts/ci/check-threading-doc.sh`; row count must
-match the script's count (currently **73**).
+match the script's count (currently **77**).
 
 Format: `file:function[#N]` | field | operation | order | justification.
 
@@ -337,7 +337,7 @@ and the wasted work is bounded.
 |---|---|---|---|---|
 | `session.c:col_worker_session_create` | per-worker view of `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Worker session reads coordinator's budget snapshot; advisory, no edge required |
 
-### 5.8 `wirelog/columnar/memory_governor.c` — reservation state (21 rows)
+### 5.8 `wirelog/columnar/memory_governor.c` — reservation state (25 rows)
 
 The governor uses one atomic counter for the shared reservation limit and
 token state transitions. The CAS admission loop is overflow-safe and a token
@@ -349,6 +349,10 @@ representation so transfer cannot race a release with a data race.
 | `memory_governor.c:wl_columnar_memory_governor_init` | `usable_bytes` | `atomic_store_explicit` | `relaxed` | Set-once before the governor is published |
 | `memory_governor.c:wl_columnar_memory_governor_init#2` | `reserved_bytes` | `atomic_store_explicit` | `relaxed` | Set-once before reservations are possible |
 | `memory_governor.c:wl_columnar_memory_reservation_init` | `reservation->state` | `atomic_store_explicit` | `relaxed` | Publish the empty state before a caller can reserve or reuse the token |
+| `memory_governor.c:wl_columnar_memory_governor_ref_create` | `references` | `atomic_store_explicit` | `relaxed` | Publish the coordinator's initial ownership reference |
+| `memory_governor.c:wl_columnar_memory_governor_ref_retain` | `references` | `atomic_fetch_add_explicit` | `relaxed` | Retain the shared governor for a worker |
+| `memory_governor.c:wl_columnar_memory_governor_ref_release` | `references` | `atomic_fetch_sub_explicit` | `release` | Release one coordinator or worker ownership reference |
+| `memory_governor.c:wl_columnar_memory_governor_ref_release#2` | `references` | `atomic_load_explicit` | `acquire` | Synchronize final reference destruction |
 | `memory_governor.c:wl_columnar_memory_reserve` | `reservation->state` | `atomic_store_explicit` | `release` | Claim failure cleanup for an unadmitted token |
 | `memory_governor.c:wl_columnar_memory_reserve#2` | `reserved_bytes` | `atomic_load_explicit` | `relaxed` | Read current shared admission total for the CAS loop |
 | `memory_governor.c:wl_columnar_memory_reserve#3` | `usable_bytes` | `atomic_load_explicit` | `relaxed` | Read the immutable ordinary-admission limit |
@@ -386,7 +390,7 @@ named in the justification.
 
 ### 5.9 Total
 
-21 + 4 + 2 + 19 + 1 + 1 + 1 + 3 + 21 = **73 atomic call sites**.
+21 + 4 + 2 + 19 + 1 + 1 + 1 + 3 + 25 = **77 atomic call sites**.
 
 The `#N` suffix counts all atomic sites in a symbol, regardless of operation;
 the first site remains unsuffixed. `scripts/ci/check-threading-doc.sh` uses

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -19,7 +19,7 @@ fi
 rows="$tmp_dir/rows"
 sed -nE 's/^\| `([^`]+:[A-Za-z_][A-Za-z0-9_]*(#[0-9]+)?)` \| [^|]* \| `([^`]*)` \|.*/\1\t\3/p' "$doc" >"$rows"
 row_count=$(wc -l <"$rows")
-expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-73}"
+expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-77}"
 [ "$row_count" -eq "$expected_rows" ] || {
     echo "check-threading-doc: FAIL: expected $expected_rows audit rows, found $row_count" >&2
     exit 1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1351,6 +1351,7 @@ backend_src = files(
   '../wirelog/columnar/delta_pool.c',
   '../wirelog/columnar/lftj.c',
   '../wirelog/columnar/mem_ledger.c',
+  '../wirelog/columnar/memory_governor.c',
   '../wirelog/columnar/diff_trace.c',
   '../wirelog/columnar/diff_arrangement.c',
   '../wirelog/columnar/diff_vtable.c',

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -2364,6 +2364,28 @@ test_issue_665_partial_conjunction_multi_worker(void)
     return run_issue_665_partial_conjunction(4, "issue 665 multi-worker");
 }
 
+static int
+test_invalid_memory_budget(void)
+{
+    wirelog_program_t *program = NULL;
+    wirelog_session_t *session = (wirelog_session_t *)(uintptr_t)1;
+    wirelog_error_t error;
+
+    setenv("WIRELOG_MEMORY_BUDGET", "0", 1);
+    program = parse_or_die(PROG_SRC, "invalid-memory-budget");
+    error = wirelog_session_create(program, WIRELOG_BACKEND_DEFAULT, 2,
+            &session);
+    unsetenv("WIRELOG_MEMORY_BUDGET");
+    if (error != WIRELOG_ERR_EXEC || session != NULL) {
+        if (session)
+            wirelog_session_destroy(session);
+        wirelog_program_free(program);
+        return 1;
+    }
+    wirelog_program_free(program);
+    return 0;
+}
+
 int
 main(void)
 {
@@ -2407,6 +2429,7 @@ main(void)
     failures += test_delta_cb_multi_round_recursive_insert();
     failures += test_issue_665_partial_conjunction_default_workers();
     failures += test_issue_665_partial_conjunction_multi_worker();
+    failures += test_invalid_memory_budget();
     failures += test_typed_float_ingress();
     if (failures == 0)
         printf("test_wirelog_advanced: OK\n");

--- a/tests/test_wirelog_easy.c
+++ b/tests/test_wirelog_easy.c
@@ -2502,11 +2502,42 @@ test_snapshot_rebuilds_idb_after_query_mode_input_changes(void)
 /* Main                                                                     */
 /* ======================================================================== */
 
+static void
+test_invalid_memory_budget(void)
+{
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
+    wirelog_easy_session_t *session = NULL;
+    wirelog_error_t error;
+
+    opts.eager_build = true;
+    setenv("WIRELOG_MEMORY_BUDGET", "0", 1);
+    error = wirelog_easy_open_opts(RELATION_NAME_LIFETIME_SRC, &opts,
+            &session);
+    unsetenv("WIRELOG_MEMORY_BUDGET");
+    if (error != WIRELOG_ERR_EXEC || session != NULL)
+        FAIL("invalid memory budget must fail eager easy-session creation");
+    else
+        PASS();
+
+    session = NULL;
+    setenv("WIRELOG_MEMORY_BUDGET", "0", 1);
+    error = wirelog_easy_open(RELATION_NAME_LIFETIME_SRC, &session);
+    if (error != WIRELOG_OK || !session
+        || wirelog_easy_step(session) != WIRELOG_ERR_EXEC)
+        FAIL("invalid memory budget must fail lazy easy-session build");
+    else
+        PASS();
+    unsetenv("WIRELOG_MEMORY_BUDGET");
+    wirelog_easy_close(session);
+}
+
 int
 main(void)
 {
     printf("wirelog_easy Tests (Issue #441)\n");
     printf("==========================\n\n");
+
+    test_invalid_memory_budget();
 
     test_open_close_null_safe();
     test_open_parse_error();

--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -231,6 +231,14 @@ test_create_destroy(void)
     }
     free(parts);
 
+    if (!coord->memory_governor
+        || worker.memory_governor != coord->memory_governor) {
+        col_worker_session_destroy(&worker);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("worker did not retain the coordinator governor");
+        return 1;
+    }
+
     col_worker_session_destroy(&worker);
     cleanup_coordinator(coord, plan, prog);
     PASS();
@@ -825,7 +833,6 @@ test_join_output_limit_scaling(void)
     coord_active->num_workers = 4;
     coord_active->tdd_active_workers = 2;
     coord_active->join_output_limit = 8000;
-    coord_active->tdd_budget_per_party = 1800;
     atomic_store_explicit(&coord_active->mem_ledger.total_budget, 9000,
         memory_order_relaxed);
 
@@ -845,7 +852,7 @@ test_join_output_limit_scaling(void)
             ok = 0;
         uint64_t worker_budget = atomic_load_explicit(
             &active_workers[w].mem_ledger.total_budget, memory_order_relaxed);
-        if (worker_budget != 3000)
+        if (worker_budget != 4500)
             ok = 0;
     }
     free(parts_active);

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -21,6 +21,7 @@
 #include "columnar/diff_trace.h"
 #include "columnar/delta_pool.h"
 #include "columnar/mem_ledger.h"
+#include "columnar/memory_governor.h"
 #include "columnar/kfusion_adaptive.h"
 #include "columnar/progress.h"
 #include "session.h"
@@ -1418,6 +1419,9 @@ typedef struct wl_col_session_t {
      * Initialized in col_session_create via wl_mem_ledger_init().
      * Accessible to all columnar code via &COL_SESSION(sess)->mem_ledger. */
     wl_mem_ledger_t mem_ledger;
+    /* Shared coordinator-owned governor. Workers retain this reference and
+     * never copy or destroy the embedded governor value. */
+    wl_columnar_memory_governor_ref_t *memory_governor;
     /* Issue #1380: memory instrumentation state that is not part of the
      * ledger proper.
      *   mem_channel_ring_bytes: bytes charged to CHANNEL for the MPSC ring
@@ -1493,15 +1497,6 @@ typedef struct wl_col_session_t {
     uint32_t tdd_active_workers;        /* current adaptive TDD width */
     uint32_t tdd_last_active_workers;   /* last selected TDD width */
     uint32_t tdd_max_active_workers;    /* max selected width this eval */
-    /* Per-party memory budget for TDD replicate-mode (Issue #416).
-     * = total_ram*75% / (num_workers+1): the share that keeps aggregate
-     * usage within 75% RAM when coordinator + W workers each hold a full
-     * IDB copy simultaneously.  Coordinator starts with the full budget
-     * and is reduced to this value lazily on the first worker-session init,
-     * so that single-threaded strata (use_tdd=false for all) are not
-     * penalised by an artificially low join-backpressure threshold.
-     * 0 = not applicable (W=1 or env-override path). */
-    uint64_t tdd_budget_per_party;
     /* MPSC delta queue for async delta transport (Issue #410).
      * Created/destroyed per recursive stratum evaluation in
      * col_eval_stratum_tdd_recursive(). NULL outside that scope.

--- a/wirelog/columnar/memory_governor.c
+++ b/wirelog/columnar/memory_governor.c
@@ -8,11 +8,11 @@
 #include "columnar/memory_governor.h"
 
 #include <string.h>
+#include <stdlib.h>
 
 #ifndef _WIN32
 #include <errno.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/resource.h>
 #include <unistd.h>
 #else
@@ -48,6 +48,11 @@ finite_source_limit(wl_columnar_memory_source_t source, uint64_t value)
     return source != WL_COLUMNAR_MEMORY_SOURCE_CGROUP_V1
            || value < (UINT64_C(1) << 62);
 }
+
+struct wl_columnar_memory_governor_ref {
+    wl_columnar_memory_governor_t governor;
+    wl_atomic_u64 references;
+};
 
 typedef enum {
     WL_MEMORY_PARSE_INVALID,
@@ -416,6 +421,53 @@ wl_columnar_memory_governor_init(wl_columnar_memory_governor_t *governor,
         memory_order_relaxed);
     atomic_store_explicit(&governor->reserved_bytes, 0, memory_order_relaxed);
     return WL_COLUMNAR_MEMORY_OK;
+}
+
+wl_columnar_memory_governor_ref_t *
+wl_columnar_memory_governor_ref_create(
+    const wl_columnar_memory_resolution_t *resolution)
+{
+    wl_columnar_memory_governor_ref_t *ref;
+
+    if (!resolution || resolution->status != WL_COLUMNAR_MEMORY_OK)
+        return NULL;
+    ref = (wl_columnar_memory_governor_ref_t *)calloc(1, sizeof(*ref));
+    if (!ref)
+        return NULL;
+    if (wl_columnar_memory_governor_init(&ref->governor, resolution)
+        != WL_COLUMNAR_MEMORY_OK) {
+        free(ref);
+        return NULL;
+    }
+    atomic_store_explicit(&ref->references, 1, memory_order_relaxed);
+    return ref;
+}
+
+void
+wl_columnar_memory_governor_ref_retain(
+    wl_columnar_memory_governor_ref_t *ref)
+{
+    if (ref)
+        atomic_fetch_add_explicit(&ref->references, 1, memory_order_relaxed);
+}
+
+void
+wl_columnar_memory_governor_ref_release(
+    wl_columnar_memory_governor_ref_t *ref)
+{
+    if (ref
+        && atomic_fetch_sub_explicit(&ref->references, 1,
+        memory_order_release) == 1) {
+        (void)atomic_load_explicit(&ref->references, memory_order_acquire);
+        free(ref);
+    }
+}
+
+wl_columnar_memory_governor_t *
+wl_columnar_memory_governor_ref_get(
+    wl_columnar_memory_governor_ref_t *ref)
+{
+    return ref ? &ref->governor : NULL;
 }
 
 static bool

--- a/wirelog/columnar/memory_governor.h
+++ b/wirelog/columnar/memory_governor.h
@@ -74,6 +74,26 @@ typedef struct {
     wl_columnar_memory_source_t source;
 } wl_columnar_memory_governor_t;
 
+typedef struct wl_columnar_memory_governor_ref
+    wl_columnar_memory_governor_ref_t;
+
+/* A coordinator-owned lifetime wrapper shared by coordinator and workers. */
+wl_columnar_memory_governor_ref_t *
+wl_columnar_memory_governor_ref_create(
+    const wl_columnar_memory_resolution_t *resolution);
+
+void
+wl_columnar_memory_governor_ref_retain(
+    wl_columnar_memory_governor_ref_t *ref);
+
+void
+wl_columnar_memory_governor_ref_release(
+    wl_columnar_memory_governor_ref_t *ref);
+
+wl_columnar_memory_governor_t *
+wl_columnar_memory_governor_ref_get(
+    wl_columnar_memory_governor_ref_t *ref);
+
 typedef enum {
     WL_COLUMNAR_MEMORY_RESERVATION_EMPTY = 0,
     WL_COLUMNAR_MEMORY_RESERVATION_RESERVED = 1,

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1021,13 +1021,27 @@ static int
 col_session_create(const wl_plan_t *plan, uint32_t num_workers,
     wl_session_t **out)
 {
+    wl_columnar_memory_resolution_t memory_resolution;
+    wl_columnar_memory_governor_ref_t *memory_governor;
+    const char *memory_budget = getenv("WIRELOG_MEMORY_BUDGET");
+
     if (!plan || !out)
         return EINVAL;
+    if (wl_columnar_memory_resolve(memory_budget, NULL, &memory_resolution)
+        != WL_COLUMNAR_MEMORY_OK)
+        return EINVAL;
+    memory_governor = wl_columnar_memory_governor_ref_create(
+        &memory_resolution);
+    if (!memory_governor)
+        return ENOMEM;
 
     wl_col_session_t *sess
         = (wl_col_session_t *)calloc(1, sizeof(wl_col_session_t));
-    if (!sess)
+    if (!sess) {
+        wl_columnar_memory_governor_ref_release(memory_governor);
         return ENOMEM;
+    }
+    sess->memory_governor = memory_governor;
 
     sess->frontier_ops = &col_frontier_epoch_ops;
 
@@ -1068,6 +1082,8 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
         if (chosen->init) {
             int rc = chosen->init(sess);
             if (rc != 0) {
+                wl_columnar_memory_governor_ref_release(
+                    sess->memory_governor);
                 free(sess);
                 return ENOMEM;
             }
@@ -1140,6 +1156,8 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
                     "(set WIRELOG_MAX_WORKERS to override, max %u)\n",
                     sess->num_workers, effective_cap,
                     WL_MAX_WORKERS_HARD_LIMIT);
+                wl_columnar_memory_governor_ref_release(
+                    sess->memory_governor);
                 free(sess);
                 return EINVAL;
             }
@@ -1205,6 +1223,7 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
     sess->pending_input_change = true;
     sess->rels = (col_rel_t **)calloc(sess->rel_cap, sizeof(col_rel_t *));
     if (!sess->rels) {
+        wl_columnar_memory_governor_ref_release(sess->memory_governor);
         free(sess);
         return ENOMEM;
     }
@@ -1230,40 +1249,11 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
     sess->eval_arena = wl_arena_create(64UL * 1024 * 1024);
     /* Non-fatal if NULL: col_rel_pool_new_auto falls back to malloc */
 
-    /* Issue #224: Initialize memory accounting ledger.
-     * Budget: 75% of physical RAM, or from WIRELOG_MEMORY_BUDGET env var.
-     * 0 = unlimited (when physical memory detection fails). */
-    {
-        uint64_t budget = 0;
-        const char *budget_env = getenv("WIRELOG_MEMORY_BUDGET");
-        if (budget_env && budget_env[0] != '\0') {
-            char *endp = NULL;
-            errno = 0;
-            uint64_t val = strtoull(budget_env, &endp, 10);
-            if (endp != budget_env && *endp == '\0' && errno != ERANGE)
-                budget = val;
-        }
-        if (budget == 0) {
-            uint64_t phys = col_detect_physical_memory();
-            if (phys > 0) {
-                uint64_t total = (phys / 4ULL) * 3ULL; /* 75% of RAM */
-                uint32_t nw = sess->num_workers;
-                if (nw > 1) {
-                    /* Issue #416 (lazy budget partitioning): coordinator
-                     * keeps the full budget so single-threaded strata
-                     * (use_tdd=false) are not penalised by an artificially
-                     * low backpressure threshold. Worker sessions receive a
-                     * per-party budget when they are actually used. */
-                    sess->tdd_budget_per_party
-                        = total / (uint64_t)(nw + 1);
-                    budget = total;
-                } else {
-                    budget = total;
-                }
-            }
-        }
-        wl_mem_ledger_init(&sess->mem_ledger, budget);
-    }
+    /* The ledger remains attribution-only. The shared governor owns admission
+     * policy; workers must not receive divided ledger budgets. */
+    wl_mem_ledger_init(&sess->mem_ledger,
+        memory_resolution.mode == WL_COLUMNAR_MEMORY_MODE_ENFORCING
+            ? memory_resolution.budget_bytes : 0);
 
     /* Issue #1380: memory instrumentation wiring.  The delta pool and eval
      * arena above were created before the ledger existed, so charge their
@@ -1483,6 +1473,7 @@ oom:
     wl_workqueue_destroy(sess->wq);       /* NULL-safe */
     delta_pool_destroy(sess->delta_pool); /* NULL-safe */
     wl_compound_arena_free(sess->compound_arena); /* NULL-safe (Issue #559) */
+    wl_columnar_memory_governor_ref_release(sess->memory_governor);
     free(sess);
     return ENOMEM;
 }
@@ -1640,6 +1631,7 @@ col_session_destroy(wl_session_t *session)
             ? (unsigned long long)sess->compound_arena->live_handles
             : 0ULL);
     wl_compound_arena_free(sess->compound_arena);
+    wl_columnar_memory_governor_ref_release(sess->memory_governor);
     free(sess);
 }
 
@@ -1667,6 +1659,8 @@ col_worker_session_create(wl_col_session_t *coordinator,
     /* Step 2: Set identity fields */
     out_worker->worker_id = worker_id;
     out_worker->coordinator = coordinator;
+    out_worker->memory_governor = coordinator->memory_governor;
+    wl_columnar_memory_governor_ref_retain(out_worker->memory_governor);
     out_worker->extension_expr_status = 0;
     out_worker->callback_session_key = coordinator->callback_session_key;
     out_worker->delta_events = NULL;
@@ -1736,29 +1730,17 @@ col_worker_session_create(wl_col_session_t *coordinator,
     out_worker->last_inserted_relation = NULL;
     out_worker->last_removed_relation = NULL;
 
-    /* Step 5: Initialize independent mem_ledger (avoid copying atomics).
-     * Workers receive a per-party budget, but the coordinator keeps its
-     * original budget. W is an upper bound on active workers, and shrinking the
-     * coordinator permanently causes later sequential strata to trip
-     * backpressure under a stale worker-sized budget. */
+    /* Step 5: Initialize an attribution-only worker ledger. The governor is
+     * shared; only the legacy ledger threshold uses an equal reporting share
+     * so its aggregate backpressure does not multiply by worker count. */
     uint32_t active_workers = coordinator->tdd_active_workers > 0
         ? coordinator->tdd_active_workers : coordinator->num_workers;
     if (active_workers == 0)
         active_workers = 1;
-    uint64_t worker_budget;
-    if (coordinator->tdd_budget_per_party > 0) {
-        uint64_t max_workers = coordinator->num_workers > 0
-            ? coordinator->num_workers : active_workers;
-        uint64_t active_party_budget = (coordinator->tdd_budget_per_party
-            * (max_workers + 1)) / (uint64_t)(active_workers + 1);
-        if (active_party_budget == 0)
-            active_party_budget = coordinator->tdd_budget_per_party;
-        worker_budget = active_party_budget;
-    } else {
-        worker_budget = atomic_load_explicit(
-            &coordinator->mem_ledger.total_budget, memory_order_relaxed)
-            / active_workers;
-    }
+    uint64_t worker_budget = atomic_load_explicit(
+        &coordinator->mem_ledger.total_budget, memory_order_relaxed);
+    if (worker_budget > 0 && active_workers > 1)
+        worker_budget /= active_workers;
     wl_mem_ledger_init(&out_worker->mem_ledger, worker_budget);
     /* Issue #1380: the bitwise copy carried the coordinator's cache ledger
      * link and aggregate counters; workers account against their own
@@ -1937,6 +1919,8 @@ col_worker_session_destroy(wl_col_session_t *worker)
             col_rel_destroy(worker->filt_cache[i].filtered);
     }
     free(worker->filt_cache);
+
+    wl_columnar_memory_governor_ref_release(worker->memory_governor);
 
     /* Zero the struct to prevent dangling pointer use */
     memset(worker, 0, sizeof(*worker));


### PR DESCRIPTION
## Summary

- create the shared memory governor before columnar session resources
- retain/release one coordinator-owned governor reference across worker sessions and partial teardown
- reject invalid explicit `WIRELOG_MEMORY_BUDGET` values before session resource growth and preserve existing public error mapping
- remove `tdd_budget_per_party`; retain only equal legacy ledger reporting shares to prevent worker backpressure multiplication
- add advanced/easy API and worker lifetime coverage, docs, and atomic audit entries

## Scope

This is the session integration unit for #1413 and is stacked on #1414/#1368. Allocation-site admission remains #1369; Windows Job Object handle plumbing remains #1415.

Refs #1413 #1368 #1414 #1369 #1415

## Validation

- focused worker, advanced, easy, and memory-governor tests
- ASAN/UBSAN focused tests
- unit suite: 4 passed
- ABI suite: 61 passed, 1 skipped
- threading audit: 77 rows
- production build and `git diff --check`
