### PR TITLE
Add typed memory admission primitives

### DIFF
--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -228,7 +228,7 @@ These exist so struct fields can be declared portably; the audit in
 
 Every `atomic_*` call site in `wirelog/` production sources. Counted
 mechanically by `scripts/ci/check-threading-doc.sh`; row count must
-match the script's count (currently **77**).
+match the script's count (currently **79**).
 
 Format: `file:function[#N]` | field | operation | order | justification.
 
@@ -337,7 +337,7 @@ and the wasted work is bounded.
 |---|---|---|---|---|
 | `session.c:col_worker_session_create` | per-worker view of `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Worker session reads coordinator's budget snapshot; advisory, no edge required |
 
-### 5.8 `wirelog/columnar/memory_governor.c` — reservation state (25 rows)
+### 5.8 `wirelog/columnar/memory_governor.c` — reservation state (27 rows)
 
 The governor uses one atomic counter for the shared reservation limit and
 token state transitions. The CAS admission loop is overflow-safe and a token
@@ -353,13 +353,14 @@ representation so transfer cannot race a release with a data race.
 | `memory_governor.c:wl_columnar_memory_governor_ref_retain` | `references` | `atomic_fetch_add_explicit` | `relaxed` | Retain the shared governor for a worker |
 | `memory_governor.c:wl_columnar_memory_governor_ref_release` | `references` | `atomic_fetch_sub_explicit` | `release` | Release one coordinator or worker ownership reference |
 | `memory_governor.c:wl_columnar_memory_governor_ref_release#2` | `references` | `atomic_load_explicit` | `acquire` | Synchronize final reference destruction |
-| `memory_governor.c:wl_columnar_memory_reserve` | `reservation->state` | `atomic_store_explicit` | `release` | Claim failure cleanup for an unadmitted token |
-| `memory_governor.c:wl_columnar_memory_reserve#2` | `reserved_bytes` | `atomic_load_explicit` | `relaxed` | Read current shared admission total for the CAS loop |
-| `memory_governor.c:wl_columnar_memory_reserve#3` | `usable_bytes` | `atomic_load_explicit` | `relaxed` | Read the immutable ordinary-admission limit |
-| `memory_governor.c:wl_columnar_memory_reserve#4` | `reservation->state` | `atomic_store_explicit` | `release` | Abandon a token that exceeded the usable limit |
-| `memory_governor.c:wl_columnar_memory_reserve#5` | `reservation->state` | `atomic_store_explicit` | `release` | Abandon a token that exceeded the usable limit |
-| `memory_governor.c:wl_columnar_memory_reserve#6` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Atomically admit without exceeding the shared limit |
-| `memory_governor.c:wl_columnar_memory_reserve#7` | `reservation->state` | `atomic_store_explicit` | `release` | Publish the fully initialized reserved token |
+| `memory_governor.c:reserve_internal` | `reservation->owner_bits` | `atomic_store_explicit` | `relaxed` | Initialize the caller identity before admission |
+| `memory_governor.c:reserve_internal#2` | `reserved_bytes` | `atomic_load_explicit` | `relaxed` | Read current shared admission total for the CAS loop |
+| `memory_governor.c:reserve_internal#3` | `usable_bytes` | `atomic_load_explicit` | `relaxed` | Read the immutable ordinary-admission limit |
+| `memory_governor.c:reserve_internal#4` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `acquire`/`relaxed` | Linearize the overflow verdict without wrapping the shared counter |
+| `memory_governor.c:reserve_internal#5` | `reservation->state` | `atomic_store_explicit` | `release` | Abandon a token after an overflow verdict |
+| `memory_governor.c:reserve_internal#6` | `reservation->state` | `atomic_store_explicit` | `release` | Abandon a token that exceeded the usable limit |
+| `memory_governor.c:reserve_internal#7` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Atomically admit without exceeding the shared limit |
+| `memory_governor.c:reserve_internal#8` | `reservation->state` | `atomic_store_explicit` | `release` | Publish the fully initialized reserved token |
 | `memory_governor.c:transition_reservation` | `reservation->state` | `atomic_compare_exchange_weak_explicit` | `release`/`acquire` | Retry spurious weak-CAS failures while enforcing a legal state transition |
 | `memory_governor.c:claim_reservation_state` | `reservation->state` | `atomic_compare_exchange_weak_explicit` | `release`/`acquire` | Claim a token or transfer state without relying on an MSVC-only strong-CAS shim |
 | `memory_governor.c:wl_columnar_memory_commit` | `reservation->owner_bits` | `atomic_store_explicit` | `release` | Publish committed ownership before the commit state |
@@ -370,6 +371,7 @@ representation so transfer cannot race a release with a data race.
 | `memory_governor.c:finish_reservation` | `reservation->state` | `atomic_load_explicit` | `acquire` | Wait for an in-flight commit or transfer to publish a stable state |
 | `memory_governor.c:finish_reservation#2` | `reserved_bytes` | `atomic_load_explicit` | `relaxed` | Read current total before returning token capacity |
 | `memory_governor.c:finish_reservation#3` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `release`/`relaxed` | Return exactly this token's bytes without underflow |
+| `memory_governor.c:wl_columnar_memory_reserve_growth` | `reservation->state` | `atomic_load_explicit` | `acquire` | Validate the source token before creating a distinct growth reservation |
 | `memory_governor.c:wl_columnar_memory_reserved` | `reserved_bytes` | `atomic_load_explicit` | `acquire` | Read a coherent observable reservation total |
 
 ### 5.9 `wirelog/intern.c` — shared symbol table (3 rows)
@@ -390,7 +392,7 @@ named in the justification.
 
 ### 5.9 Total
 
-21 + 4 + 2 + 19 + 1 + 1 + 1 + 3 + 25 = **77 atomic call sites**.
+21 + 4 + 2 + 19 + 1 + 1 + 1 + 3 + 27 = **79 atomic call sites**.
 
 The `#N` suffix counts all atomic sites in a symbol, regardless of operation;
 the first site remains unsuffixed. `scripts/ci/check-threading-doc.sh` uses

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -19,7 +19,7 @@ fi
 rows="$tmp_dir/rows"
 sed -nE 's/^\| `([^`]+:[A-Za-z_][A-Za-z0-9_]*(#[0-9]+)?)` \| [^|]* \| `([^`]*)` \|.*/\1\t\3/p' "$doc" >"$rows"
 row_count=$(wc -l <"$rows")
-expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-77}"
+expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-79}"
 [ "$row_count" -eq "$expected_rows" ] || {
     echo "check-threading-doc: FAIL: expected $expected_rows audit rows, found $row_count" >&2
     exit 1

--- a/tests/test_memory_governor.c
+++ b/tests/test_memory_governor.c
@@ -254,6 +254,87 @@ test_concurrent_admission(void)
     return 0;
 }
 
+static int
+test_checked_admission(void)
+{
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_t governor;
+    wl_columnar_memory_governor_t other_governor;
+    wl_columnar_memory_reservation_t reservation;
+    wl_columnar_memory_reservation_t copied;
+    wl_columnar_memory_reservation_t old_reservation;
+    wl_columnar_memory_reservation_t growth_reservation;
+    uint64_t value;
+
+    TEST("typed admission, growth overlap, arithmetic, and token identity");
+    make_resolution(&resolution, 1000, 900);
+    wl_columnar_memory_reservation_init(&reservation);
+    if (wl_columnar_memory_governor_init(&governor, &resolution) != 0
+        || wl_columnar_memory_size_add(UINT64_MAX, 1, &value)
+        || wl_columnar_memory_size_mul(UINT64_MAX, 2, &value)
+        || !wl_columnar_memory_size_add(40, 2, &value) || value != 42
+        || !wl_columnar_memory_size_mul(6, 7, &value) || value != 42
+        || wl_columnar_memory_reserve_checked(&governor, 901, &reservation)
+        != WL_COLUMNAR_MEMORY_ADMISSION_DENIED
+        || wl_columnar_memory_reserve_growth(&governor, 20, 10, &reservation)
+        != WL_COLUMNAR_MEMORY_ADMISSION_INVALID
+        || wl_columnar_memory_reserve_growth(&governor, 20, 20, &reservation)
+        != WL_COLUMNAR_MEMORY_ADMISSION_OK
+        || wl_columnar_memory_reserved(&governor) != 20
+        || !wl_columnar_memory_release(&reservation)
+        || !wl_columnar_memory_reserve(&governor, 400, &reservation)
+        || wl_columnar_memory_reserve_growth(&governor, 400, 400,
+        &reservation) != WL_COLUMNAR_MEMORY_ADMISSION_INVALID
+        || wl_columnar_memory_reserved(&governor) != 400) {
+        FAIL("checked admission or overflow arithmetic is wrong");
+        return 1;
+    }
+    copied = reservation;
+    if (wl_columnar_memory_release(&copied)
+        || !wl_columnar_memory_release(&reservation)
+        || wl_columnar_memory_reserved(&governor) != 0) {
+        FAIL("copied reservation token was able to release capacity");
+        return 1;
+    }
+    wl_columnar_memory_reservation_init(&old_reservation);
+    wl_columnar_memory_reservation_init(&growth_reservation);
+    if (!wl_columnar_memory_reserve(&governor, 100, &old_reservation)
+        || wl_columnar_memory_reserve_growth(&governor, 100, 200,
+        &growth_reservation) != WL_COLUMNAR_MEMORY_ADMISSION_OK
+        || wl_columnar_memory_reserved(&governor) != 300
+        || !wl_columnar_memory_release(&growth_reservation)
+        || !wl_columnar_memory_release(&old_reservation)) {
+        FAIL("growth did not reserve a distinct overlapping footprint");
+        return 1;
+    }
+    make_resolution(&resolution, 1000, 900);
+    if (wl_columnar_memory_governor_init(&other_governor, &resolution) != 0
+        || !wl_columnar_memory_reserve(&governor, 400, &reservation)
+        || wl_columnar_memory_reserve_growth(&other_governor, 400, 400,
+        &reservation) != WL_COLUMNAR_MEMORY_ADMISSION_INVALID
+        || !wl_columnar_memory_release(&reservation)) {
+        FAIL("growth accepted a token owned by another governor");
+        return 1;
+    }
+    memset(&resolution, 0, sizeof(resolution));
+    resolution.mode = WL_COLUMNAR_MEMORY_MODE_ADVISORY;
+    resolution.usable_bytes = UINT64_MAX;
+    resolution.status = WL_COLUMNAR_MEMORY_OK;
+    if (wl_columnar_memory_governor_init(&governor, &resolution) != 0) {
+        FAIL("advisory governor initialization failed");
+        return 1;
+    }
+    wl_columnar_memory_reservation_init(&reservation);
+    if (wl_columnar_memory_reserve_growth(&governor, 0, 1, &reservation)
+        != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY
+        || !wl_columnar_memory_release(&reservation)) {
+        FAIL("advisory admission status was not preserved");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
 int
 main(void)
 {
@@ -264,6 +345,7 @@ main(void)
     test_headroom_boundaries();
     test_reservation_lifecycle();
     test_concurrent_admission();
+    test_checked_admission();
     printf("\nPassed %d/%d; Failed %d\n",
         tests_run - tests_failed, tests_run, tests_failed);
     return tests_failed == 0 ? 0 : 1;

--- a/wirelog/columnar/memory_governor.c
+++ b/wirelog/columnar/memory_governor.c
@@ -323,6 +323,7 @@ wl_columnar_memory_reservation_init(
     if (!reservation)
         return;
     memset(reservation, 0, sizeof(*reservation));
+    reservation->identity = reservation;
     atomic_store_explicit(&reservation->state,
         WL_COLUMNAR_MEMORY_RESERVATION_EMPTY, memory_order_relaxed);
 }
@@ -474,22 +475,46 @@ static bool
 claim_reservation_state(wl_columnar_memory_reservation_t *reservation,
     uint64_t from, uint64_t to);
 
+static bool
+reservation_identity_valid(const wl_columnar_memory_reservation_t *reservation)
+{
+    return reservation && reservation->identity == reservation;
+}
+
 bool
-wl_columnar_memory_reserve(wl_columnar_memory_governor_t *governor,
+wl_columnar_memory_size_add(uint64_t left, uint64_t right, uint64_t *out)
+{
+    if (!out || left > UINT64_MAX - right)
+        return false;
+    *out = left + right;
+    return true;
+}
+
+bool
+wl_columnar_memory_size_mul(uint64_t left, uint64_t right, uint64_t *out)
+{
+    if (!out || (left != 0 && right > UINT64_MAX / left))
+        return false;
+    *out = left * right;
+    return true;
+}
+
+static wl_columnar_memory_admission_status_t
+reserve_internal(wl_columnar_memory_governor_t *governor,
     uint64_t bytes, wl_columnar_memory_reservation_t *reservation)
 {
     uint64_t old;
     uint64_t expected;
 
-    if (!governor || !reservation || bytes == 0)
-        return false;
+    if (!governor || !reservation_identity_valid(reservation) || bytes == 0)
+        return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
     expected = WL_COLUMNAR_MEMORY_RESERVATION_EMPTY;
     if (!claim_reservation_state(reservation, expected,
         WL_COLUMNAR_MEMORY_RESERVATION_CLAIMED)) {
         expected = WL_COLUMNAR_MEMORY_RESERVATION_RELEASED;
         if (!claim_reservation_state(reservation, expected,
             WL_COLUMNAR_MEMORY_RESERVATION_CLAIMED))
-            return false;
+            return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
     }
     reservation->governor = governor;
     reservation->bytes = bytes;
@@ -500,15 +525,26 @@ wl_columnar_memory_reserve(wl_columnar_memory_governor_t *governor,
                 memory_order_relaxed);
         uint64_t next;
         if (bytes > UINT64_MAX - old) {
-            atomic_store_explicit(&reservation->state,
-                WL_COLUMNAR_MEMORY_RESERVATION_RELEASED, memory_order_release);
-            return false;
+            uint64_t observed = old;
+            /* Linearize the overflow verdict with a no-op CAS.  If another
+             * thread changes the total after the load, retry against its new
+             * value instead of reporting an obsolete arithmetic state. */
+            if (atomic_compare_exchange_weak_explicit(
+                    &governor->reserved_bytes, &observed, old,
+                    memory_order_acquire, memory_order_relaxed)) {
+                atomic_store_explicit(&reservation->state,
+                    WL_COLUMNAR_MEMORY_RESERVATION_RELEASED,
+                    memory_order_release);
+                return WL_COLUMNAR_MEMORY_ADMISSION_OVERFLOW;
+            }
+            old = observed;
+            continue;
         }
         next = old + bytes;
         if (next > limit) {
             atomic_store_explicit(&reservation->state,
                 WL_COLUMNAR_MEMORY_RESERVATION_RELEASED, memory_order_release);
-            return false;
+            return WL_COLUMNAR_MEMORY_ADMISSION_DENIED;
         }
         if (atomic_compare_exchange_weak_explicit(
                 &governor->reserved_bytes, &old, next,
@@ -517,7 +553,57 @@ wl_columnar_memory_reserve(wl_columnar_memory_governor_t *governor,
     }
     atomic_store_explicit(&reservation->state,
         WL_COLUMNAR_MEMORY_RESERVATION_RESERVED, memory_order_release);
-    return true;
+    return governor->mode == WL_COLUMNAR_MEMORY_MODE_ADVISORY
+        ? WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY
+        : WL_COLUMNAR_MEMORY_ADMISSION_OK;
+}
+
+bool
+wl_columnar_memory_reserve(wl_columnar_memory_governor_t *governor,
+    uint64_t bytes, wl_columnar_memory_reservation_t *reservation)
+{
+    wl_columnar_memory_admission_status_t status
+        = reserve_internal(governor, bytes, reservation);
+    return status == WL_COLUMNAR_MEMORY_ADMISSION_OK
+           || status == WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY;
+}
+
+wl_columnar_memory_admission_status_t
+wl_columnar_memory_reserve_checked(wl_columnar_memory_governor_t *governor,
+    uint64_t bytes, wl_columnar_memory_reservation_t *reservation)
+{
+    if (!governor || !reservation_identity_valid(reservation) || bytes == 0)
+        return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
+    return reserve_internal(governor, bytes, reservation);
+}
+
+wl_columnar_memory_admission_status_t
+wl_columnar_memory_reserve_growth(wl_columnar_memory_governor_t *governor,
+    uint64_t old_bytes, uint64_t new_bytes,
+    wl_columnar_memory_reservation_t *reservation)
+{
+    uint64_t state;
+
+    if (!governor || !reservation_identity_valid(reservation)
+        || new_bytes < old_bytes)
+        return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
+    state = atomic_load_explicit(&reservation->state, memory_order_acquire);
+    if (new_bytes == old_bytes) {
+        if (state == WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+            || state == WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED) {
+            return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
+        }
+        if (state != WL_COLUMNAR_MEMORY_RESERVATION_EMPTY
+            && state != WL_COLUMNAR_MEMORY_RESERVATION_RELEASED)
+            return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
+        return wl_columnar_memory_reserve_checked(governor, new_bytes,
+                   reservation);
+    }
+    if (state == WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+        || state == WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED)
+        return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
+    return wl_columnar_memory_reserve_checked(governor, new_bytes,
+               reservation);
 }
 
 static bool
@@ -526,7 +612,7 @@ transition_reservation(wl_columnar_memory_reservation_t *reservation,
 {
     uint64_t observed = from;
 
-    if (!reservation)
+    if (!reservation_identity_valid(reservation))
         return false;
     for (;;) {
         if (atomic_compare_exchange_weak_explicit(&reservation->state,
@@ -544,7 +630,7 @@ claim_reservation_state(wl_columnar_memory_reservation_t *reservation,
 {
     uint64_t observed = from;
 
-    if (!reservation)
+    if (!reservation_identity_valid(reservation))
         return false;
     for (;;) {
         if (atomic_compare_exchange_weak_explicit(&reservation->state,
@@ -560,7 +646,7 @@ bool
 wl_columnar_memory_commit(wl_columnar_memory_reservation_t *reservation,
     const void *owner)
 {
-    if (!reservation
+    if (!reservation_identity_valid(reservation)
         || !transition_reservation(reservation,
         WL_COLUMNAR_MEMORY_RESERVATION_RESERVED,
         WL_COLUMNAR_MEMORY_RESERVATION_COMMITTING))
@@ -577,7 +663,7 @@ wl_columnar_memory_transfer(wl_columnar_memory_reservation_t *reservation,
     const void *owner)
 {
     uint64_t state;
-    if (!reservation)
+    if (!reservation_identity_valid(reservation))
         return false;
     state = atomic_load_explicit(&reservation->state, memory_order_acquire);
     if (state != WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
@@ -601,7 +687,7 @@ finish_reservation(wl_columnar_memory_reservation_t *reservation,
     uint64_t bytes;
     uint64_t old;
 
-    if (!reservation)
+    if (!reservation_identity_valid(reservation))
         return false;
     governor = reservation->governor;
     bytes = reservation->bytes;
@@ -646,7 +732,7 @@ wl_columnar_memory_rollback(
 bool
 wl_columnar_memory_release(wl_columnar_memory_reservation_t *reservation)
 {
-    if (!reservation)
+    if (!reservation_identity_valid(reservation))
         return false;
     if (finish_reservation(reservation, false))
         return true;

--- a/wirelog/columnar/memory_governor.h
+++ b/wirelog/columnar/memory_governor.h
@@ -104,11 +104,23 @@ typedef enum {
     WL_COLUMNAR_MEMORY_RESERVATION_TRANSFERRING = 6,
 } wl_columnar_memory_reservation_state_t;
 
+typedef enum {
+    WL_COLUMNAR_MEMORY_ADMISSION_OK = 0,
+    WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY = 1,
+    WL_COLUMNAR_MEMORY_ADMISSION_INVALID = 2,
+    WL_COLUMNAR_MEMORY_ADMISSION_OVERFLOW = 3,
+    WL_COLUMNAR_MEMORY_ADMISSION_DENIED = 4,
+} wl_columnar_memory_admission_status_t;
+
 typedef struct {
     wl_columnar_memory_governor_t *governor;
     uint64_t bytes;
     wl_atomic_u64 owner_bits;
     wl_atomic_u64 state;
+    /* Tokens are caller-owned and intentionally non-copyable.  A copied
+     * token retains the original address and is rejected by every operation,
+     * preventing a copied state from releasing the same reservation twice. */
+    const void *identity;
 } wl_columnar_memory_reservation_t;
 
 /* Initialize a caller-owned token before its first reserve or reuse. */
@@ -160,6 +172,25 @@ wl_columnar_memory_governor_init(wl_columnar_memory_governor_t *governor,
 bool
 wl_columnar_memory_reserve(wl_columnar_memory_governor_t *governor,
     uint64_t bytes, wl_columnar_memory_reservation_t *reservation);
+
+/* Checked admission result used by allocation sites. */
+wl_columnar_memory_admission_status_t
+wl_columnar_memory_reserve_checked(wl_columnar_memory_governor_t *governor,
+    uint64_t bytes, wl_columnar_memory_reservation_t *reservation);
+
+/* Reserve the new footprint while the old footprint is still live.
+ * The output token must be distinct from the token that accounts old_bytes;
+ * callers release the old token only after publishing the replacement. */
+wl_columnar_memory_admission_status_t
+wl_columnar_memory_reserve_growth(wl_columnar_memory_governor_t *governor,
+    uint64_t old_bytes, uint64_t new_bytes,
+    wl_columnar_memory_reservation_t *reservation);
+
+bool
+wl_columnar_memory_size_add(uint64_t left, uint64_t right, uint64_t *out);
+
+bool
+wl_columnar_memory_size_mul(uint64_t left, uint64_t right, uint64_t *out);
 
 bool
 wl_columnar_memory_commit(wl_columnar_memory_reservation_t *reservation,


### PR DESCRIPTION
## Summary

Implements the first atomic unit of #1369: typed, overflow-safe memory admission primitives that later allocation-site integrations can use.

- Adds explicit `OK`, `ADVISORY`, `INVALID`, `OVERFLOW`, and `DENIED` admission statuses.
- Adds checked size arithmetic and a growth API that requires a distinct output reservation before the old token is released.
- Rejects copied or cross-governor reservation tokens by identity validation.
- Preserves the legacy boolean reserve API as a compatibility wrapper.
- Updates the threading audit to the exact 79 atomic sites.

This PR intentionally does not claim completion of #1369. Allocation-site integration and reclaim work remain in #1417 and #1418, along with the other follow-up units.

## Validation

- `meson test -C builddir-1369 memory_governor --print-errorlogs`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 UBSAN_OPTIONS=halt_on_error=1 meson test -C builddir-1369-asan memory_governor --print-errorlogs`
- `meson test -C builddir-1369 --suite unit --print-errorlogs`
- `meson test -C builddir-1369 --suite abi --print-errorlogs` (61 passed, 1 skipped)
- `bash scripts/ci/check-threading-doc.sh` (79/79)
- `git diff --check origin/main...HEAD`

Refs #1369
Refs #1417
Refs #1418
