### PR TITLE
Admit fixed arena slabs through the shared governor

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -84,6 +84,7 @@ bench_io_src = files(
 
 bench_arena_src = files(
   subdir_wirelog / 'arena/arena.c',
+  subdir_wirelog / 'arena/arena_admission.c',
   subdir_wirelog / 'arena/compound_arena.c',
 )
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -187,21 +187,29 @@ An enforcing resolution reserves 5% cleanup headroom, capped at 256 MiB and
 never above half the budget. Ordinary reservations can consume only the
 remaining usable limit. Reservation tokens move through reserved, committed,
 and released states; rollback is valid only from reserved, and release
-returns capacity exactly once. This foundation is not yet wired into session
-creation or allocation sites: session lifetime/public error integration is
-#1413 and allocation-site enforcement is #1369.
+returns capacity exactly once. This foundation is wired into session creation
+and fixed eval-arena backing storage; session lifetime/public error integration
+is #1413. Other allocation-site enforcement remains split between #1369,
+#1417, and #1418.
 
 The #1413 integration adds a reference-counted coordinator-owned governor to
 columnar sessions before relation, pool, arena, cache, or worker setup. Worker
 sessions retain the same governor reference and release it during every
-normal or partial teardown path. Their ledgers remain attribution-only; while
-the legacy join backpressure path still reads ledger thresholds, each worker
-gets an equal reporting share so the aggregate threshold does not multiply by
-the worker count. The removed `tdd_budget_per_party` value is no longer a
-second governor admission domain.
+normal or partial teardown path. The fixed eval arenas now use
+`wl_arena_create_managed()`: their complete backing capacity is admitted before
+`malloc`, retained across reset, and released exactly once at destruction.
+Coordinator, ordinary worker, and K-fusion branch eval arenas all use the same
+shared governor; legacy standalone `wl_arena_create()` callers remain
+unmanaged. Their ledgers remain attribution-only; while the legacy join
+backpressure path still reads ledger thresholds, each worker gets an equal
+reporting share so the aggregate threshold does not multiply by the worker
+count. The removed `tdd_budget_per_party` value is no longer a second governor
+admission domain.
 Explicit invalid budgets fail session creation with the existing public
-execution error mapping and leave output handles null. Allocation-site
-admission remains the separate responsibility of #1369.
+execution error mapping and leave output handles null. Delta-pool and
+compound-arena admission remain the separate follow-up units in #1417;
+parser/plan/result allocations remain tracked by #1418. The parent #1369
+contract is therefore only partially implemented until those units land.
 # wirelog Memory Instrumentation
 
 This document describes what the columnar engine measures about its own
@@ -255,7 +263,7 @@ every stratum that ran under TDD.
 | Subsystem | Style | What is counted | Where |
 |---|---|---|---|
 | `RELATION` | event | Column buffers of operator output relations whose `col_rel_t.mem_ledger` is attached; today that is every join output (`col_join_attach_ledger`). Capacity-based (`capacity × owned columns × 8`). | `relation.c` growth, compaction and free paths |
-| `ARENA` | event | Fixed capacity of the session's delta pool (slot slab + data arena) and eval arena. Charged at creation, credited at destruction. `delta_pool_reset()`/`wl_arena_reset()` do not change it: the buffers are retained. K-fusion branch sessions charge their per-branch pool/arena to the parent. | `session.c`, `kfusion.c` |
+| `ARENA` | event | Fixed capacity of the session's delta pool (slot slab + data arena) and eval arena. The eval arena's fixed backing capacity is admitted by the shared governor before allocation and released at destruction; the ledger remains attribution-only. `delta_pool_reset()`/`wl_arena_reset()` do not change it: the buffers are retained. K-fusion branch sessions charge their per-branch pool/arena to the parent. | `session.c`, `kfusion.c`, `arena.c` |
 | `CACHE` | event | Materialization-cache entries. On insert the cached result is re-parented: its RELATION (and TIMESTAMP) charge is credited and the same bytes are charged to CACHE, so a cached join is counted once. Credited on eviction, truncation and clear. | `cache.c` |
 | `ARRANGEMENT` | event | Hash arrangements (`ht_head` + `ht_next`), delta and filtered arrangements, sorted copies for LFTJ (`nrows × ncols × 8`, a full duplicate of the relation) and differential arrangements (struct + keys + buckets + chain). Worker clones are charged to the worker ledger. | `arrangement.c`, `diff_arrangement.c` |
 | `TIMESTAMP` | event | `timestamps[]` arrays (24 bytes per row of capacity) of ledger-attached relations. Reconciled together with RELATION. | `relation.c` |
@@ -383,8 +391,10 @@ unset value resolves the effective minimum of supported cgroup, address-space,
 and host Job Object limits; when no finite source exists, the resolver is
 advisory/unbounded. Explicit `0`, malformed values, overflow, and values below
 256 MiB are invalid. This resolver does not use physical RAM as an enforcing
-fallback. The current ledger's legacy worker-share hint remains separate until
-the governor is wired into session lifetime and allocation sites.
+fallback. The legacy ledger worker-share hint remains separate from governor
+admission; fixed eval-arena backing storage is now admitted, while the
+delta-pool, compound, join, and other allocation classes remain follow-up
+work.
 
 The only consumer is the join operator: when RELATION reaches 80% of its
 share (`wl_mem_ledger_should_backpressure(RELATION, 80)`), a worker session

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -228,7 +228,7 @@ These exist so struct fields can be declared portably; the audit in
 
 Every `atomic_*` call site in `wirelog/` production sources. Counted
 mechanically by `scripts/ci/check-threading-doc.sh`; row count must
-match the script's count (currently **77**).
+match the script's count (currently **79**).
 
 Format: `file:function[#N]` | field | operation | order | justification.
 
@@ -337,7 +337,7 @@ and the wasted work is bounded.
 |---|---|---|---|---|
 | `session.c:col_worker_session_create` | per-worker view of `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Worker session reads coordinator's budget snapshot; advisory, no edge required |
 
-### 5.8 `wirelog/columnar/memory_governor.c` — reservation state (25 rows)
+### 5.8 `wirelog/columnar/memory_governor.c` — reservation state (27 rows)
 
 The governor uses one atomic counter for the shared reservation limit and
 token state transitions. The CAS admission loop is overflow-safe and a token
@@ -353,13 +353,14 @@ representation so transfer cannot race a release with a data race.
 | `memory_governor.c:wl_columnar_memory_governor_ref_retain` | `references` | `atomic_fetch_add_explicit` | `relaxed` | Retain the shared governor for a worker |
 | `memory_governor.c:wl_columnar_memory_governor_ref_release` | `references` | `atomic_fetch_sub_explicit` | `release` | Release one coordinator or worker ownership reference |
 | `memory_governor.c:wl_columnar_memory_governor_ref_release#2` | `references` | `atomic_load_explicit` | `acquire` | Synchronize final reference destruction |
-| `memory_governor.c:wl_columnar_memory_reserve` | `reservation->state` | `atomic_store_explicit` | `release` | Claim failure cleanup for an unadmitted token |
-| `memory_governor.c:wl_columnar_memory_reserve#2` | `reserved_bytes` | `atomic_load_explicit` | `relaxed` | Read current shared admission total for the CAS loop |
-| `memory_governor.c:wl_columnar_memory_reserve#3` | `usable_bytes` | `atomic_load_explicit` | `relaxed` | Read the immutable ordinary-admission limit |
-| `memory_governor.c:wl_columnar_memory_reserve#4` | `reservation->state` | `atomic_store_explicit` | `release` | Abandon a token that exceeded the usable limit |
-| `memory_governor.c:wl_columnar_memory_reserve#5` | `reservation->state` | `atomic_store_explicit` | `release` | Abandon a token that exceeded the usable limit |
-| `memory_governor.c:wl_columnar_memory_reserve#6` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Atomically admit without exceeding the shared limit |
-| `memory_governor.c:wl_columnar_memory_reserve#7` | `reservation->state` | `atomic_store_explicit` | `release` | Publish the fully initialized reserved token |
+| `memory_governor.c:reserve_internal` | `reservation->owner_bits` | `atomic_store_explicit` | `relaxed` | Initialize the caller identity before admission |
+| `memory_governor.c:reserve_internal#2` | `reserved_bytes` | `atomic_load_explicit` | `relaxed` | Read current shared admission total for the CAS loop |
+| `memory_governor.c:reserve_internal#3` | `usable_bytes` | `atomic_load_explicit` | `relaxed` | Read the immutable ordinary-admission limit |
+| `memory_governor.c:reserve_internal#4` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `acquire`/`relaxed` | Linearize the overflow verdict without wrapping the shared counter |
+| `memory_governor.c:reserve_internal#5` | `reservation->state` | `atomic_store_explicit` | `release` | Abandon a token after an overflow verdict |
+| `memory_governor.c:reserve_internal#6` | `reservation->state` | `atomic_store_explicit` | `release` | Abandon a token that exceeded the usable limit |
+| `memory_governor.c:reserve_internal#7` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Atomically admit without exceeding the shared limit |
+| `memory_governor.c:reserve_internal#8` | `reservation->state` | `atomic_store_explicit` | `release` | Publish the fully initialized reserved token |
 | `memory_governor.c:transition_reservation` | `reservation->state` | `atomic_compare_exchange_weak_explicit` | `release`/`acquire` | Retry spurious weak-CAS failures while enforcing a legal state transition |
 | `memory_governor.c:claim_reservation_state` | `reservation->state` | `atomic_compare_exchange_weak_explicit` | `release`/`acquire` | Claim a token or transfer state without relying on an MSVC-only strong-CAS shim |
 | `memory_governor.c:wl_columnar_memory_commit` | `reservation->owner_bits` | `atomic_store_explicit` | `release` | Publish committed ownership before the commit state |
@@ -370,6 +371,7 @@ representation so transfer cannot race a release with a data race.
 | `memory_governor.c:finish_reservation` | `reservation->state` | `atomic_load_explicit` | `acquire` | Wait for an in-flight commit or transfer to publish a stable state |
 | `memory_governor.c:finish_reservation#2` | `reserved_bytes` | `atomic_load_explicit` | `relaxed` | Read current total before returning token capacity |
 | `memory_governor.c:finish_reservation#3` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `release`/`relaxed` | Return exactly this token's bytes without underflow |
+| `memory_governor.c:wl_columnar_memory_reserve_growth` | `reservation->state` | `atomic_load_explicit` | `acquire` | Validate the source token before creating a distinct growth reservation |
 | `memory_governor.c:wl_columnar_memory_reserved` | `reserved_bytes` | `atomic_load_explicit` | `acquire` | Read a coherent observable reservation total |
 
 ### 5.9 `wirelog/intern.c` — shared symbol table (3 rows)
@@ -390,7 +392,7 @@ named in the justification.
 
 ### 5.9 Total
 
-21 + 4 + 2 + 19 + 1 + 1 + 1 + 3 + 25 = **77 atomic call sites**.
+21 + 4 + 2 + 19 + 1 + 1 + 1 + 3 + 27 = **79 atomic call sites**.
 
 The `#N` suffix counts all atomic sites in a symbol, regardless of operation;
 the first site remains unsuffixed. `scripts/ci/check-threading-doc.sh` uses

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -19,7 +19,7 @@ fi
 rows="$tmp_dir/rows"
 sed -nE 's/^\| `([^`]+:[A-Za-z_][A-Za-z0-9_]*(#[0-9]+)?)` \| [^|]* \| `([^`]*)` \|.*/\1\t\3/p' "$doc" >"$rows"
 row_count=$(wc -l <"$rows")
-expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-77}"
+expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-79}"
 [ "$row_count" -eq "$expected_rows" ] || {
     echo "check-threading-doc: FAIL: expected $expected_rows audit rows, found $row_count" >&2
     exit 1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1317,6 +1317,19 @@ test_memory_governor_exe = executable(
 )
 test('memory_governor', test_memory_governor_exe, suite: 'unit')
 
+test_memory_admission_arena_exe = executable(
+  'test_memory_admission_arena',
+  files('test_memory_admission_arena.c',
+        '../wirelog/arena/arena.c',
+        '../wirelog/arena/arena_admission.c',
+        '../wirelog/columnar/memory_governor.c',
+        '../wirelog/util/log.c',
+        '../wirelog/util/log_emit.c') + thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
+)
+test('memory_admission_arena', test_memory_admission_arena_exe, suite: 'unit')
+
 # ============================================================================
 # Plan Generator + Session Facts Tests (Phase 2C columnar backend)
 # ============================================================================
@@ -1378,7 +1391,9 @@ backend_src = files(
 
 arena_src = files(
   '../wirelog/arena/arena.c',
+  '../wirelog/arena/arena_admission.c',
   '../wirelog/arena/compound_arena.c',
+  '../wirelog/columnar/memory_governor.c',
 )
 
 workqueue_src = files(

--- a/tests/test_memory_admission_arena.c
+++ b/tests/test_memory_admission_arena.c
@@ -1,0 +1,97 @@
+/*
+ * test_memory_admission_arena.c - fixed arena admission contract
+ *
+ * The arena owns one reservation for its fixed backing slab.  Reset retains
+ * the slab and therefore retains admission; destroy is the only terminal
+ * release path.
+ */
+
+#include "../wirelog/arena/arena.h"
+#include "../wirelog/columnar/memory_governor.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int failures;
+
+#define CHECK(condition, message) do { \
+            if (!(condition)) { \
+                fprintf(stderr, "FAIL: %s\n", message); \
+                failures++; \
+            } \
+} while (0)
+
+static void
+make_resolution(wl_columnar_memory_resolution_t *resolution,
+    uint64_t usable_bytes)
+{
+    memset(resolution, 0, sizeof(*resolution));
+    resolution->budget_bytes = usable_bytes;
+    resolution->usable_bytes = usable_bytes;
+    resolution->mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING;
+    resolution->source = WL_COLUMNAR_MEMORY_SOURCE_ENV;
+    resolution->status = WL_COLUMNAR_MEMORY_OK;
+}
+
+static void
+test_managed_lifecycle(void)
+{
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_t governor;
+    wl_arena_t *arena;
+
+    make_resolution(&resolution, 1024);
+    CHECK(wl_columnar_memory_governor_init(&governor, &resolution)
+        == WL_COLUMNAR_MEMORY_OK, "governor initialization");
+
+    arena = wl_arena_create_managed(512, &governor);
+    CHECK(arena != NULL, "managed arena creation");
+    CHECK(wl_columnar_memory_reserved(&governor) == 512,
+        "fixed backing capacity admitted");
+    CHECK(wl_arena_alloc(arena, 64) != NULL, "managed arena allocation");
+
+    wl_arena_reset(arena);
+    CHECK(wl_columnar_memory_reserved(&governor) == 512,
+        "reset retains backing admission");
+    CHECK(wl_arena_alloc(arena, 512) != NULL,
+        "reset makes the admitted slab reusable");
+    wl_arena_free(arena);
+    CHECK(wl_columnar_memory_reserved(&governor) == 0,
+        "destroy releases backing admission");
+}
+
+static void
+test_denial_and_legacy_contract(void)
+{
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_t governor;
+    wl_arena_t *arena;
+
+    make_resolution(&resolution, 512);
+    CHECK(wl_columnar_memory_governor_init(&governor, &resolution)
+        == WL_COLUMNAR_MEMORY_OK, "denial governor initialization");
+    arena = wl_arena_create_managed(513, &governor);
+    CHECK(arena == NULL, "denied backing capacity returns NULL");
+    CHECK(wl_columnar_memory_reserved(&governor) == 0,
+        "denial leaves no reservation behind");
+
+    arena = wl_arena_create(64);
+    CHECK(arena != NULL, "legacy unmanaged arena creation");
+    CHECK(arena->admission_context == NULL
+        && arena->admission_release == NULL,
+        "legacy arena remains unmanaged");
+    CHECK(wl_columnar_memory_reserved(&governor) == 0,
+        "legacy arena does not charge a governor");
+    wl_arena_free(arena);
+}
+
+int
+main(void)
+{
+    test_managed_lifecycle();
+    test_denial_and_legacy_contract();
+    if (failures != 0)
+        return 1;
+    puts("memory admission arena: PASS");
+    return 0;
+}

--- a/tests/test_memory_governor.c
+++ b/tests/test_memory_governor.c
@@ -254,6 +254,87 @@ test_concurrent_admission(void)
     return 0;
 }
 
+static int
+test_checked_admission(void)
+{
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_t governor;
+    wl_columnar_memory_governor_t other_governor;
+    wl_columnar_memory_reservation_t reservation;
+    wl_columnar_memory_reservation_t copied;
+    wl_columnar_memory_reservation_t old_reservation;
+    wl_columnar_memory_reservation_t growth_reservation;
+    uint64_t value;
+
+    TEST("typed admission, growth overlap, arithmetic, and token identity");
+    make_resolution(&resolution, 1000, 900);
+    wl_columnar_memory_reservation_init(&reservation);
+    if (wl_columnar_memory_governor_init(&governor, &resolution) != 0
+        || wl_columnar_memory_size_add(UINT64_MAX, 1, &value)
+        || wl_columnar_memory_size_mul(UINT64_MAX, 2, &value)
+        || !wl_columnar_memory_size_add(40, 2, &value) || value != 42
+        || !wl_columnar_memory_size_mul(6, 7, &value) || value != 42
+        || wl_columnar_memory_reserve_checked(&governor, 901, &reservation)
+        != WL_COLUMNAR_MEMORY_ADMISSION_DENIED
+        || wl_columnar_memory_reserve_growth(&governor, 20, 10, &reservation)
+        != WL_COLUMNAR_MEMORY_ADMISSION_INVALID
+        || wl_columnar_memory_reserve_growth(&governor, 20, 20, &reservation)
+        != WL_COLUMNAR_MEMORY_ADMISSION_OK
+        || wl_columnar_memory_reserved(&governor) != 20
+        || !wl_columnar_memory_release(&reservation)
+        || !wl_columnar_memory_reserve(&governor, 400, &reservation)
+        || wl_columnar_memory_reserve_growth(&governor, 400, 400,
+        &reservation) != WL_COLUMNAR_MEMORY_ADMISSION_INVALID
+        || wl_columnar_memory_reserved(&governor) != 400) {
+        FAIL("checked admission or overflow arithmetic is wrong");
+        return 1;
+    }
+    copied = reservation;
+    if (wl_columnar_memory_release(&copied)
+        || !wl_columnar_memory_release(&reservation)
+        || wl_columnar_memory_reserved(&governor) != 0) {
+        FAIL("copied reservation token was able to release capacity");
+        return 1;
+    }
+    wl_columnar_memory_reservation_init(&old_reservation);
+    wl_columnar_memory_reservation_init(&growth_reservation);
+    if (!wl_columnar_memory_reserve(&governor, 100, &old_reservation)
+        || wl_columnar_memory_reserve_growth(&governor, 100, 200,
+        &growth_reservation) != WL_COLUMNAR_MEMORY_ADMISSION_OK
+        || wl_columnar_memory_reserved(&governor) != 300
+        || !wl_columnar_memory_release(&growth_reservation)
+        || !wl_columnar_memory_release(&old_reservation)) {
+        FAIL("growth did not reserve a distinct overlapping footprint");
+        return 1;
+    }
+    make_resolution(&resolution, 1000, 900);
+    if (wl_columnar_memory_governor_init(&other_governor, &resolution) != 0
+        || !wl_columnar_memory_reserve(&governor, 400, &reservation)
+        || wl_columnar_memory_reserve_growth(&other_governor, 400, 400,
+        &reservation) != WL_COLUMNAR_MEMORY_ADMISSION_INVALID
+        || !wl_columnar_memory_release(&reservation)) {
+        FAIL("growth accepted a token owned by another governor");
+        return 1;
+    }
+    memset(&resolution, 0, sizeof(resolution));
+    resolution.mode = WL_COLUMNAR_MEMORY_MODE_ADVISORY;
+    resolution.usable_bytes = UINT64_MAX;
+    resolution.status = WL_COLUMNAR_MEMORY_OK;
+    if (wl_columnar_memory_governor_init(&governor, &resolution) != 0) {
+        FAIL("advisory governor initialization failed");
+        return 1;
+    }
+    wl_columnar_memory_reservation_init(&reservation);
+    if (wl_columnar_memory_reserve_growth(&governor, 0, 1, &reservation)
+        != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY
+        || !wl_columnar_memory_release(&reservation)) {
+        FAIL("advisory admission status was not preserved");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
 int
 main(void)
 {
@@ -264,6 +345,7 @@ main(void)
     test_headroom_boundaries();
     test_reservation_lifecycle();
     test_concurrent_admission();
+    test_checked_admission();
     printf("\nPassed %d/%d; Failed %d\n",
         tests_run - tests_failed, tests_run, tests_failed);
     return tests_failed == 0 ? 0 : 1;

--- a/wirelog/arena/arena.c
+++ b/wirelog/arena/arena.c
@@ -20,8 +20,9 @@
 #define WL_ARENA_ALIGN_UP(n) \
         (((n) + (WL_ARENA_ALIGN - 1)) & ~(size_t)(WL_ARENA_ALIGN - 1))
 
-wl_arena_t *
-wl_arena_create(size_t capacity)
+static wl_arena_t *
+wl_arena_create_impl(size_t capacity, void *admission_context,
+    void (*admission_release)(void *context))
 {
     if (capacity == 0)
         return NULL;
@@ -30,6 +31,7 @@ wl_arena_create(size_t capacity)
     if (!arena)
         return NULL;
 
+    memset(arena, 0, sizeof(*arena));
     arena->base = malloc(capacity);
     if (!arena->base) {
         free(arena);
@@ -38,7 +40,22 @@ wl_arena_create(size_t capacity)
 
     arena->capacity = capacity;
     arena->used = 0;
+    arena->admission_context = admission_context;
+    arena->admission_release = admission_release;
     return arena;
+}
+
+wl_arena_t *
+wl_arena_create(size_t capacity)
+{
+    return wl_arena_create_impl(capacity, NULL, NULL);
+}
+
+wl_arena_t *
+wl_arena_create_with_admission(size_t capacity, void *context,
+    void (*admission_release)(void *context))
+{
+    return wl_arena_create_impl(capacity, context, admission_release);
 }
 
 void *
@@ -80,6 +97,8 @@ wl_arena_free(wl_arena_t *arena)
             "free() with %zu bytes still allocated",
             arena->used);
     }
+    if (arena->admission_release)
+        arena->admission_release(arena->admission_context);
     free(arena->base);
     free(arena);
 }

--- a/wirelog/arena/arena.h
+++ b/wirelog/arena/arena.h
@@ -59,6 +59,8 @@
 #ifndef WL_ARENA_H
 #define WL_ARENA_H
 
+#include "columnar/memory_governor.h"
+
 #include <stddef.h>
 
 /* ======================================================================== */
@@ -76,11 +78,17 @@
  * @capacity: Total size of the backing buffer in bytes.
  * @used:     Bytes allocated so far (always <= capacity).
  */
-typedef struct {
+typedef struct wl_arena wl_arena_t;
+
+struct wl_arena {
     void *base;
     size_t capacity;
     size_t used;
-} wl_arena_t;
+    /* Optional ownership hook. Keeping admission behind this callback means
+     * legacy users that link arena.c alone do not acquire governor symbols. */
+    void *admission_context;
+    void (*admission_release)(void *context);
+};
 
 /**
  * wl_arena_create:
@@ -95,6 +103,25 @@ typedef struct {
  */
 wl_arena_t *
 wl_arena_create(size_t capacity);
+
+/**
+ * wl_arena_create_managed:
+ * @capacity: Size of the backing buffer in bytes.  Must be > 0.
+ * @governor: Shared session governor that admits the complete backing slab.
+ *
+ * Create an arena whose fixed backing capacity is admitted before allocation
+ * and released only when wl_arena_free() destroys the arena.  Reset preserves
+ * the admission because it retains the backing slab.  On allocation failure
+ * or denial, no bytes remain reserved in @governor.
+ */
+wl_arena_t *
+wl_arena_create_managed(size_t capacity,
+    wl_columnar_memory_governor_t *governor);
+
+/* Internal constructor used by the managed-admission glue. */
+wl_arena_t *
+wl_arena_create_with_admission(size_t capacity, void *context,
+    void (*admission_release)(void *context));
 
 /**
  * wl_arena_alloc:

--- a/wirelog/arena/arena_admission.c
+++ b/wirelog/arena/arena_admission.c
@@ -1,0 +1,58 @@
+/* arena/arena_admission.c - shared-governor glue for fixed arena slabs */
+
+#include "arena.h"
+#include "columnar/memory_governor.h"
+
+#include <stdlib.h>
+
+typedef struct {
+    wl_columnar_memory_reservation_t reservation;
+} wl_arena_admission_t;
+
+static void
+release_arena_admission(void *context)
+{
+    wl_arena_admission_t *admission = context;
+
+    if (!admission)
+        return;
+    (void)wl_columnar_memory_release(&admission->reservation);
+    free(admission);
+}
+
+wl_arena_t *
+wl_arena_create_managed(size_t capacity,
+    wl_columnar_memory_governor_t *governor)
+{
+    wl_arena_admission_t *admission;
+    wl_columnar_memory_admission_status_t status;
+    wl_arena_t *arena;
+
+    if (!governor || capacity == 0)
+        return wl_arena_create(capacity);
+
+    admission = (wl_arena_admission_t *)malloc(sizeof(*admission));
+    if (!admission)
+        return NULL;
+    wl_columnar_memory_reservation_init(&admission->reservation);
+    status = wl_columnar_memory_reserve_checked(governor, capacity,
+            &admission->reservation);
+    if (status != WL_COLUMNAR_MEMORY_ADMISSION_OK
+        && status != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY) {
+        free(admission);
+        return NULL;
+    }
+
+    arena = wl_arena_create_with_admission(capacity, admission,
+            release_arena_admission);
+    if (!arena) {
+        (void)wl_columnar_memory_rollback(&admission->reservation);
+        free(admission);
+        return NULL;
+    }
+    if (!wl_columnar_memory_commit(&admission->reservation, arena)) {
+        wl_arena_free(arena);
+        return NULL;
+    }
+    return arena;
+}

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -762,7 +762,8 @@ col_op_k_fusion_dispatch(const wl_plan_op_t *op, eval_stack_t *stack,
             size_t worker_cap = parent_cap / live_count;
             if (worker_cap < 8 * 1024 * 1024)
                 worker_cap = 8 * 1024 * 1024; /* 8MB minimum */
-            worker_sess[d].eval_arena = wl_arena_create(worker_cap);
+            worker_sess[d].eval_arena = wl_arena_create_managed(worker_cap,
+                    wl_columnar_memory_governor_ref_get(sess->memory_governor));
             /* NULL arena is handled gracefully: operators check before use */
             /* Issue #1380: branch sessions are struct copies whose embedded
              * ledger is discarded at teardown, so charge the parent. */

--- a/wirelog/columnar/memory_governor.c
+++ b/wirelog/columnar/memory_governor.c
@@ -323,6 +323,7 @@ wl_columnar_memory_reservation_init(
     if (!reservation)
         return;
     memset(reservation, 0, sizeof(*reservation));
+    reservation->identity = reservation;
     atomic_store_explicit(&reservation->state,
         WL_COLUMNAR_MEMORY_RESERVATION_EMPTY, memory_order_relaxed);
 }
@@ -474,22 +475,46 @@ static bool
 claim_reservation_state(wl_columnar_memory_reservation_t *reservation,
     uint64_t from, uint64_t to);
 
+static bool
+reservation_identity_valid(const wl_columnar_memory_reservation_t *reservation)
+{
+    return reservation && reservation->identity == reservation;
+}
+
 bool
-wl_columnar_memory_reserve(wl_columnar_memory_governor_t *governor,
+wl_columnar_memory_size_add(uint64_t left, uint64_t right, uint64_t *out)
+{
+    if (!out || left > UINT64_MAX - right)
+        return false;
+    *out = left + right;
+    return true;
+}
+
+bool
+wl_columnar_memory_size_mul(uint64_t left, uint64_t right, uint64_t *out)
+{
+    if (!out || (left != 0 && right > UINT64_MAX / left))
+        return false;
+    *out = left * right;
+    return true;
+}
+
+static wl_columnar_memory_admission_status_t
+reserve_internal(wl_columnar_memory_governor_t *governor,
     uint64_t bytes, wl_columnar_memory_reservation_t *reservation)
 {
     uint64_t old;
     uint64_t expected;
 
-    if (!governor || !reservation || bytes == 0)
-        return false;
+    if (!governor || !reservation_identity_valid(reservation) || bytes == 0)
+        return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
     expected = WL_COLUMNAR_MEMORY_RESERVATION_EMPTY;
     if (!claim_reservation_state(reservation, expected,
         WL_COLUMNAR_MEMORY_RESERVATION_CLAIMED)) {
         expected = WL_COLUMNAR_MEMORY_RESERVATION_RELEASED;
         if (!claim_reservation_state(reservation, expected,
             WL_COLUMNAR_MEMORY_RESERVATION_CLAIMED))
-            return false;
+            return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
     }
     reservation->governor = governor;
     reservation->bytes = bytes;
@@ -500,15 +525,26 @@ wl_columnar_memory_reserve(wl_columnar_memory_governor_t *governor,
                 memory_order_relaxed);
         uint64_t next;
         if (bytes > UINT64_MAX - old) {
-            atomic_store_explicit(&reservation->state,
-                WL_COLUMNAR_MEMORY_RESERVATION_RELEASED, memory_order_release);
-            return false;
+            uint64_t observed = old;
+            /* Linearize the overflow verdict with a no-op CAS.  If another
+             * thread changes the total after the load, retry against its new
+             * value instead of reporting an obsolete arithmetic state. */
+            if (atomic_compare_exchange_weak_explicit(
+                    &governor->reserved_bytes, &observed, old,
+                    memory_order_acquire, memory_order_relaxed)) {
+                atomic_store_explicit(&reservation->state,
+                    WL_COLUMNAR_MEMORY_RESERVATION_RELEASED,
+                    memory_order_release);
+                return WL_COLUMNAR_MEMORY_ADMISSION_OVERFLOW;
+            }
+            old = observed;
+            continue;
         }
         next = old + bytes;
         if (next > limit) {
             atomic_store_explicit(&reservation->state,
                 WL_COLUMNAR_MEMORY_RESERVATION_RELEASED, memory_order_release);
-            return false;
+            return WL_COLUMNAR_MEMORY_ADMISSION_DENIED;
         }
         if (atomic_compare_exchange_weak_explicit(
                 &governor->reserved_bytes, &old, next,
@@ -517,7 +553,57 @@ wl_columnar_memory_reserve(wl_columnar_memory_governor_t *governor,
     }
     atomic_store_explicit(&reservation->state,
         WL_COLUMNAR_MEMORY_RESERVATION_RESERVED, memory_order_release);
-    return true;
+    return governor->mode == WL_COLUMNAR_MEMORY_MODE_ADVISORY
+        ? WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY
+        : WL_COLUMNAR_MEMORY_ADMISSION_OK;
+}
+
+bool
+wl_columnar_memory_reserve(wl_columnar_memory_governor_t *governor,
+    uint64_t bytes, wl_columnar_memory_reservation_t *reservation)
+{
+    wl_columnar_memory_admission_status_t status
+        = reserve_internal(governor, bytes, reservation);
+    return status == WL_COLUMNAR_MEMORY_ADMISSION_OK
+           || status == WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY;
+}
+
+wl_columnar_memory_admission_status_t
+wl_columnar_memory_reserve_checked(wl_columnar_memory_governor_t *governor,
+    uint64_t bytes, wl_columnar_memory_reservation_t *reservation)
+{
+    if (!governor || !reservation_identity_valid(reservation) || bytes == 0)
+        return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
+    return reserve_internal(governor, bytes, reservation);
+}
+
+wl_columnar_memory_admission_status_t
+wl_columnar_memory_reserve_growth(wl_columnar_memory_governor_t *governor,
+    uint64_t old_bytes, uint64_t new_bytes,
+    wl_columnar_memory_reservation_t *reservation)
+{
+    uint64_t state;
+
+    if (!governor || !reservation_identity_valid(reservation)
+        || new_bytes < old_bytes)
+        return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
+    state = atomic_load_explicit(&reservation->state, memory_order_acquire);
+    if (new_bytes == old_bytes) {
+        if (state == WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+            || state == WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED) {
+            return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
+        }
+        if (state != WL_COLUMNAR_MEMORY_RESERVATION_EMPTY
+            && state != WL_COLUMNAR_MEMORY_RESERVATION_RELEASED)
+            return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
+        return wl_columnar_memory_reserve_checked(governor, new_bytes,
+                   reservation);
+    }
+    if (state == WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+        || state == WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED)
+        return WL_COLUMNAR_MEMORY_ADMISSION_INVALID;
+    return wl_columnar_memory_reserve_checked(governor, new_bytes,
+               reservation);
 }
 
 static bool
@@ -526,7 +612,7 @@ transition_reservation(wl_columnar_memory_reservation_t *reservation,
 {
     uint64_t observed = from;
 
-    if (!reservation)
+    if (!reservation_identity_valid(reservation))
         return false;
     for (;;) {
         if (atomic_compare_exchange_weak_explicit(&reservation->state,
@@ -544,7 +630,7 @@ claim_reservation_state(wl_columnar_memory_reservation_t *reservation,
 {
     uint64_t observed = from;
 
-    if (!reservation)
+    if (!reservation_identity_valid(reservation))
         return false;
     for (;;) {
         if (atomic_compare_exchange_weak_explicit(&reservation->state,
@@ -560,7 +646,7 @@ bool
 wl_columnar_memory_commit(wl_columnar_memory_reservation_t *reservation,
     const void *owner)
 {
-    if (!reservation
+    if (!reservation_identity_valid(reservation)
         || !transition_reservation(reservation,
         WL_COLUMNAR_MEMORY_RESERVATION_RESERVED,
         WL_COLUMNAR_MEMORY_RESERVATION_COMMITTING))
@@ -577,7 +663,7 @@ wl_columnar_memory_transfer(wl_columnar_memory_reservation_t *reservation,
     const void *owner)
 {
     uint64_t state;
-    if (!reservation)
+    if (!reservation_identity_valid(reservation))
         return false;
     state = atomic_load_explicit(&reservation->state, memory_order_acquire);
     if (state != WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
@@ -601,7 +687,7 @@ finish_reservation(wl_columnar_memory_reservation_t *reservation,
     uint64_t bytes;
     uint64_t old;
 
-    if (!reservation)
+    if (!reservation_identity_valid(reservation))
         return false;
     governor = reservation->governor;
     bytes = reservation->bytes;
@@ -646,7 +732,7 @@ wl_columnar_memory_rollback(
 bool
 wl_columnar_memory_release(wl_columnar_memory_reservation_t *reservation)
 {
-    if (!reservation)
+    if (!reservation_identity_valid(reservation))
         return false;
     if (finish_reservation(reservation, false))
         return true;

--- a/wirelog/columnar/memory_governor.h
+++ b/wirelog/columnar/memory_governor.h
@@ -104,11 +104,23 @@ typedef enum {
     WL_COLUMNAR_MEMORY_RESERVATION_TRANSFERRING = 6,
 } wl_columnar_memory_reservation_state_t;
 
+typedef enum {
+    WL_COLUMNAR_MEMORY_ADMISSION_OK = 0,
+    WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY = 1,
+    WL_COLUMNAR_MEMORY_ADMISSION_INVALID = 2,
+    WL_COLUMNAR_MEMORY_ADMISSION_OVERFLOW = 3,
+    WL_COLUMNAR_MEMORY_ADMISSION_DENIED = 4,
+} wl_columnar_memory_admission_status_t;
+
 typedef struct {
     wl_columnar_memory_governor_t *governor;
     uint64_t bytes;
     wl_atomic_u64 owner_bits;
     wl_atomic_u64 state;
+    /* Tokens are caller-owned and intentionally non-copyable.  A copied
+     * token retains the original address and is rejected by every operation,
+     * preventing a copied state from releasing the same reservation twice. */
+    const void *identity;
 } wl_columnar_memory_reservation_t;
 
 /* Initialize a caller-owned token before its first reserve or reuse. */
@@ -160,6 +172,25 @@ wl_columnar_memory_governor_init(wl_columnar_memory_governor_t *governor,
 bool
 wl_columnar_memory_reserve(wl_columnar_memory_governor_t *governor,
     uint64_t bytes, wl_columnar_memory_reservation_t *reservation);
+
+/* Checked admission result used by allocation sites. */
+wl_columnar_memory_admission_status_t
+wl_columnar_memory_reserve_checked(wl_columnar_memory_governor_t *governor,
+    uint64_t bytes, wl_columnar_memory_reservation_t *reservation);
+
+/* Reserve the new footprint while the old footprint is still live.
+ * The output token must be distinct from the token that accounts old_bytes;
+ * callers release the old token only after publishing the replacement. */
+wl_columnar_memory_admission_status_t
+wl_columnar_memory_reserve_growth(wl_columnar_memory_governor_t *governor,
+    uint64_t old_bytes, uint64_t new_bytes,
+    wl_columnar_memory_reservation_t *reservation);
+
+bool
+wl_columnar_memory_size_add(uint64_t left, uint64_t right, uint64_t *out);
+
+bool
+wl_columnar_memory_size_mul(uint64_t left, uint64_t right, uint64_t *out);
 
 bool
 wl_columnar_memory_commit(wl_columnar_memory_reservation_t *reservation,

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1246,7 +1246,8 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
      * (COL_REL_INIT_CAP * ncols * sizeof(int64_t) per operator).
      * Reset at each iteration boundary alongside delta_pool_reset.
      * NULL arena is handled gracefully: operators fall back to malloc. */
-    sess->eval_arena = wl_arena_create(64UL * 1024 * 1024);
+    sess->eval_arena = wl_arena_create_managed(64UL * 1024 * 1024,
+            wl_columnar_memory_governor_ref_get(sess->memory_governor));
     /* Non-fatal if NULL: col_rel_pool_new_auto falls back to malloc */
 
     /* The ledger remains attribution-only. The shared governor owns admission
@@ -1472,6 +1473,7 @@ oom:
     free((void *)sess->rels);
     wl_workqueue_destroy(sess->wq);       /* NULL-safe */
     delta_pool_destroy(sess->delta_pool); /* NULL-safe */
+    wl_arena_free(sess->eval_arena);      /* NULL-safe; releases admission */
     wl_compound_arena_free(sess->compound_arena); /* NULL-safe (Issue #559) */
     wl_columnar_memory_governor_ref_release(sess->memory_governor);
     free(sess);
@@ -1784,7 +1786,9 @@ col_worker_session_create(wl_col_session_t *coordinator,
             : 8UL * 1024 * 1024;
         if (arena_cap < 8UL * 1024 * 1024)
             arena_cap = 8UL * 1024 * 1024;
-        out_worker->eval_arena = wl_arena_create(arena_cap);
+        out_worker->eval_arena = wl_arena_create_managed(arena_cap,
+                wl_columnar_memory_governor_ref_get(
+                    out_worker->memory_governor));
         /* Non-fatal if NULL: operators fall back to malloc */
     }
 

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -31,7 +31,8 @@ wirelog_optimizer_src = files('passes/fusion.c', 'passes/jpp.c', 'passes/sip.c',
 #Arena Allocator Module
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
-wirelog_arena_src = files('arena/arena.c', 'arena/compound_arena.c', )
+wirelog_arena_src = files('arena/arena.c', 'arena/arena_admission.c',
+                          'arena/compound_arena.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Thread Backend Module(Issue #88 - Cross-Platform Threading)


### PR DESCRIPTION
## Summary

Implements the first atomic unit of #1417, stacked on PR #1419:

- Adds a governor-aware fixed-capacity arena constructor.
- Reserves the complete eval-arena backing slab before `malloc`.
- Rolls back admission on denial or backing allocation failure.
- Retains admission across `wl_arena_reset()` and releases it exactly once at destruction.
- Wires coordinator, ordinary workers, and K-Fusion branch arenas to the existing shared governor.
- Preserves legacy standalone `arena.c` linkage by isolating governor calls in `arena_admission.c`.
- Closes the session-create OOM cleanup leak for the eval arena.
- Documents the boundary: delta-pool and compound-arena admission remain later #1417 units.

This PR is intentionally stacked on #1419 (`issue-1369-memory-admission`) and does not close #1417 or #1369.

## Validation

- `meson compile -C builddir-1417`
- `meson test -C builddir-1417 memory_admission_arena gc_freeze_guard session --print-errorlogs`
- `meson test -C builddir-1417-asan memory_admission_arena --print-errorlogs` with ASAN/UBSAN enabled
- `git diff --check`
- legacy arena object checked with `nm`: no unresolved governor symbols

Refs #1417
Refs #1369
Depends on #1419
