### PR TITLE
Admit compound arena metadata through shared governor

### DIFF
--- a/bench/meson.build
+++ b/bench/meson.build
@@ -87,6 +87,7 @@ bench_arena_src = files(
   subdir_wirelog / 'arena/arena.c',
   subdir_wirelog / 'arena/arena_admission.c',
   subdir_wirelog / 'arena/compound_arena.c',
+  subdir_wirelog / 'arena/compound_arena_admission.c',
 )
 
 bench_workqueue_src = files(

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -207,9 +207,9 @@ reporting share so the aggregate threshold does not multiply by the worker
 count. The removed `tdd_budget_per_party` value is no longer a second governor
 admission domain.
 Explicit invalid budgets fail session creation with the existing public
-execution error mapping and leave output handles null. Compound-arena
-admission remains a separate follow-up unit in #1417; parser/plan/result
-allocations remain tracked by #1418. The parent #1369
+execution error mapping and leave output handles null. Compound-arena fixed
+object, generation-table, and lazy-growth admission are now covered by #1417;
+parser/plan/result allocations remain tracked by #1418. The parent #1369
 contract is therefore only partially implemented until those units land.
 # wirelog Memory Instrumentation
 
@@ -264,7 +264,7 @@ every stratum that ran under TDD.
 | Subsystem | Style | What is counted | Where |
 |---|---|---|---|
 | `RELATION` | event | Column buffers of operator output relations whose `col_rel_t.mem_ledger` is attached; today that is every join output (`col_join_attach_ledger`). Capacity-based (`capacity × owned columns × 8`). | `relation.c` growth, compaction and free paths |
-| `ARENA` | event | Fixed capacity of the session's delta pool (slot slab + data arena) and eval arena. Both fixed backing footprints are admitted by the shared governor before allocation and released at destruction; the ledger remains attribution-only. `delta_pool_reset()`/`wl_arena_reset()` do not change it: the buffers are retained. K-fusion branch sessions charge their per-branch pool/arena to the parent. | `session.c`, `kfusion.c`, `arena.c`, `delta_pool.c` |
+| `ARENA` | event | Fixed capacity of the session's delta pool (slot slab + data arena) and eval arena, plus the compound arena object, generation table, payload buffers, and entry metadata. Each retained capacity is admitted before allocation with old/new peak overlap and released at destruction; the ledger remains attribution-only. `delta_pool_reset()`/`wl_arena_reset()` and compound epoch GC do not return retained capacity. K-fusion branch sessions charge their per-branch pool/arena to the parent. | `session.c`, `kfusion.c`, `arena.c`, `delta_pool.c`, `compound_arena.c` |
 | `CACHE` | event | Materialization-cache entries. On insert the cached result is re-parented: its RELATION (and TIMESTAMP) charge is credited and the same bytes are charged to CACHE, so a cached join is counted once. Credited on eviction, truncation and clear. | `cache.c` |
 | `ARRANGEMENT` | event | Hash arrangements (`ht_head` + `ht_next`), delta and filtered arrangements, sorted copies for LFTJ (`nrows × ncols × 8`, a full duplicate of the relation) and differential arrangements (struct + keys + buckets + chain). Worker clones are charged to the worker ledger. | `arrangement.c`, `diff_arrangement.c` |
 | `TIMESTAMP` | event | `timestamps[]` arrays (24 bytes per row of capacity) of ledger-attached relations. Reconciled together with RELATION. | `relation.c` |
@@ -393,8 +393,8 @@ and host Job Object limits; when no finite source exists, the resolver is
 advisory/unbounded. Explicit `0`, malformed values, overflow, and values below
 256 MiB are invalid. This resolver does not use physical RAM as an enforcing
 fallback. The legacy ledger worker-share hint remains separate from governor
-admission; fixed eval-arena and delta-pool backing storage are now admitted,
-while compound, join, and other allocation classes remain follow-up work.
+admission; fixed eval-arena, delta-pool, and compound-arena backing storage
+are now admitted. Joins and other allocation classes remain follow-up work.
 
 The only consumer is the join operator: when RELATION reaches 80% of its
 share (`wl_mem_ledger_should_backpressure(RELATION, 80)`), a worker session

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -542,10 +542,20 @@ sub-pass and reclaims the previous epoch's storage.
 
 ### 8.1 Coordinator-only invariant
 
-Worker sessions **borrow** the coordinator's compound arena.
-Workers are forbidden to advance the arena's epoch counter or to
-free its memory; only the coordinator may do so. The live invariant
+Worker sessions **borrow** the coordinator's compound arena and its
+fixed-and-growth admission reservations. Workers are forbidden to advance the
+arena's epoch counter or to free its memory; only the coordinator may do so.
+The coordinator destroys the arena before releasing its shared
+memory-governor reference, so the reservation callback always observes a
+live governor. The arena's callback context must not be copied or released
+by a worker. The live invariant
 that enforces this is the `sess->coordinator == NULL` predicate:
+
+Compound payload and entry-array growth must occur in the coordinator's
+single-mutator window, before workers borrow the arena or after all workers
+have been destroyed. A worker-held lookup pointer must not span a coordinator
+growth replacement. Enforcement and deterministic fault-injection coverage
+for this window are tracked separately in #1423.
 
 - `wirelog/columnar/kfusion.c:561-569` (K-fusion path):
   ```c

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1341,6 +1341,20 @@ test_memory_admission_delta_exe = executable(
 )
 test('memory_admission_delta', test_memory_admission_delta_exe, suite: 'unit')
 
+test_memory_admission_compound_exe = executable(
+  'test_memory_admission_compound',
+  files('test_memory_admission_compound.c',
+        '../wirelog/arena/compound_arena.c',
+        '../wirelog/arena/compound_arena_admission.c',
+        '../wirelog/columnar/memory_governor.c',
+        '../wirelog/util/log.c',
+        '../wirelog/util/log_emit.c') + thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
+)
+test('memory_admission_compound', test_memory_admission_compound_exe,
+     suite: 'unit')
+
 # ============================================================================
 # Plan Generator + Session Facts Tests (Phase 2C columnar backend)
 # ============================================================================
@@ -1405,6 +1419,7 @@ arena_src = files(
   '../wirelog/arena/arena.c',
   '../wirelog/arena/arena_admission.c',
   '../wirelog/arena/compound_arena.c',
+  '../wirelog/arena/compound_arena_admission.c',
   '../wirelog/columnar/memory_governor.c',
 )
 

--- a/tests/test_memory_admission_compound.c
+++ b/tests/test_memory_admission_compound.c
@@ -1,0 +1,288 @@
+/* test_memory_admission_compound.c - compound storage admission */
+
+#include "../wirelog/arena/compound_arena.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int failures;
+
+#define CHECK(condition, message) do { \
+            if (!(condition)) { \
+                fprintf(stderr, "FAIL: %s\n", message); \
+                failures++; \
+            } \
+} while (0)
+
+static void
+noop_context_release(void *context)
+{
+    (void)context;
+}
+
+static int
+allow_growth_prepare(void *context, uint64_t old_bytes, uint64_t new_bytes,
+    wl_columnar_memory_reservation_t *reservation)
+{
+    (void)context;
+    (void)old_bytes;
+    (void)new_bytes;
+    (void)reservation;
+    return 0;
+}
+
+static int
+fail_growth_publish(void *context,
+    wl_columnar_memory_reservation_t *old_reservation,
+    wl_columnar_memory_reservation_t *new_reservation, const void *owner)
+{
+    (void)context;
+    (void)old_reservation;
+    (void)new_reservation;
+    (void)owner;
+    return -1;
+}
+
+static int
+fail_second_growth_publish(void *context,
+    wl_columnar_memory_reservation_t *old_reservation,
+    wl_columnar_memory_reservation_t *new_reservation, const void *owner)
+{
+    int *publish_count = context;
+
+    (void)old_reservation;
+    (void)new_reservation;
+    (void)owner;
+    return (*publish_count)++ == 0 ? 0 : -1;
+}
+
+static void
+noop_growth_abort(void *context,
+    wl_columnar_memory_reservation_t *reservation)
+{
+    (void)context;
+    (void)reservation;
+}
+
+static int
+noop_growth_release(void *context,
+    wl_columnar_memory_reservation_t *reservation)
+{
+    (void)context;
+    (void)reservation;
+    return 0;
+}
+
+static void
+make_resolution(wl_columnar_memory_resolution_t *resolution,
+    uint64_t usable_bytes)
+{
+    memset(resolution, 0, sizeof(*resolution));
+    resolution->budget_bytes = usable_bytes;
+    resolution->usable_bytes = usable_bytes;
+    resolution->mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING;
+    resolution->source = WL_COLUMNAR_MEMORY_SOURCE_ENV;
+    resolution->status = WL_COLUMNAR_MEMORY_OK;
+}
+
+static uint64_t
+fixed_bytes(uint32_t max_epochs)
+{
+    return (uint64_t)sizeof(wl_compound_arena_t)
+           + (uint64_t)max_epochs * sizeof(wl_compound_gen_t);
+}
+
+static uint64_t
+entry_bytes(uint32_t entry_cap)
+{
+    return (uint64_t)entry_cap * (sizeof(uint32_t) + sizeof(int64_t));
+}
+
+static void
+test_managed_lifecycle(void)
+{
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_t governor;
+    wl_compound_arena_t *arena;
+    const uint64_t fixed = fixed_bytes(2);
+    const uint64_t first = fixed + 64 + entry_bytes(16);
+
+    make_resolution(&resolution, first);
+    CHECK(wl_columnar_memory_governor_init(&governor, &resolution)
+        == WL_COLUMNAR_MEMORY_OK, "governor initialization");
+    arena = wl_compound_arena_create_managed(1, 64, 2, &governor);
+    CHECK(arena != NULL, "managed compound arena creation");
+    CHECK(wl_columnar_memory_reserved(&governor) == fixed,
+        "fixed arena and generation table admitted");
+    CHECK(wl_compound_arena_alloc(arena, 16) != WL_COMPOUND_HANDLE_NULL,
+        "lazy payload allocation remains available");
+    CHECK(wl_columnar_memory_reserved(&governor) == first,
+        "first payload and entry metadata growth admitted");
+    wl_compound_arena_free(arena);
+    CHECK(wl_columnar_memory_reserved(&governor) == 0,
+        "destroy releases fixed metadata admission");
+}
+
+static void
+test_growth_peak_and_rollback(void)
+{
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_t governor;
+    wl_compound_arena_t *arena;
+    const uint64_t fixed = fixed_bytes(2);
+    const uint64_t first = fixed + 64 + entry_bytes(16);
+    const uint64_t peak = fixed + 64 + 128 + entry_bytes(16);
+    uint64_t handle;
+    uint32_t size = 0;
+
+    make_resolution(&resolution, first);
+    CHECK(wl_columnar_memory_governor_init(&governor, &resolution)
+        == WL_COLUMNAR_MEMORY_OK, "growth denial governor initialization");
+    arena = wl_compound_arena_create_managed(7, 64, 2, &governor);
+    CHECK(arena != NULL, "growth test arena creation");
+    handle = wl_compound_arena_alloc(arena, 16);
+    CHECK(handle != WL_COMPOUND_HANDLE_NULL, "initial growth-test handle");
+    CHECK(wl_compound_arena_alloc(arena, 64) == WL_COMPOUND_HANDLE_NULL,
+        "payload growth is denied at old-footprint budget");
+    CHECK(wl_columnar_memory_reserved(&governor) == first,
+        "denied payload growth leaves reservation unchanged");
+    CHECK(wl_compound_arena_lookup(arena, handle, &size) != NULL
+        && size == 16, "denied growth preserves the old handle");
+    wl_compound_arena_free(arena);
+
+    make_resolution(&resolution, peak);
+    CHECK(wl_columnar_memory_governor_init(&governor, &resolution)
+        == WL_COLUMNAR_MEMORY_OK, "growth success governor initialization");
+    arena = wl_compound_arena_create_managed(7, 64, 2, &governor);
+    CHECK(arena != NULL, "growth success arena creation");
+    handle = wl_compound_arena_alloc(arena, 16);
+    CHECK(handle != WL_COMPOUND_HANDLE_NULL, "growth success initial handle");
+    CHECK(wl_compound_arena_alloc(arena, 64) != WL_COMPOUND_HANDLE_NULL,
+        "payload growth admitted with peak overlap");
+    CHECK(wl_columnar_memory_reserved(&governor)
+        == fixed + 128 + entry_bytes(16),
+        "payload growth releases the old capacity after publish");
+    CHECK(wl_compound_arena_lookup(arena, handle, &size) != NULL
+        && size == 16, "payload growth preserves old handle contents");
+    wl_compound_arena_free(arena);
+    CHECK(wl_columnar_memory_reserved(&governor) == 0,
+        "payload growth destroy releases all reservations");
+}
+
+static void
+test_entry_growth(void)
+{
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_t governor;
+    wl_compound_arena_t *arena;
+    const uint64_t fixed = fixed_bytes(1);
+    const uint64_t peak = fixed + 4096 + entry_bytes(16)
+        + entry_bytes(32);
+    uint64_t first_handle = 0;
+
+    make_resolution(&resolution, peak);
+    CHECK(wl_columnar_memory_governor_init(&governor, &resolution)
+        == WL_COLUMNAR_MEMORY_OK, "entry growth governor initialization");
+    arena = wl_compound_arena_create_managed(9, 4096, 1, &governor);
+    CHECK(arena != NULL, "entry growth arena creation");
+    for (uint32_t i = 0; i < 17; i++) {
+        uint64_t handle = wl_compound_arena_alloc(arena, 8);
+        CHECK(handle != WL_COMPOUND_HANDLE_NULL,
+            "entry growth handle allocation");
+        if (i == 0)
+            first_handle = handle;
+    }
+    CHECK(wl_columnar_memory_reserved(&governor)
+        == fixed + 4096 + entry_bytes(32),
+        "paired entry arrays grow under peak admission");
+    CHECK(wl_compound_arena_multiplicity(arena, first_handle) == 1,
+        "entry growth preserves multiplicity");
+    wl_compound_arena_free(arena);
+    CHECK(wl_columnar_memory_reserved(&governor) == 0,
+        "entry growth destroy releases all reservations");
+}
+
+static void
+test_publish_failure_rollback(void)
+{
+    wl_compound_arena_t *arena = wl_compound_arena_create_with_admission(
+        11, 64, 1, NULL, noop_context_release, allow_growth_prepare,
+        fail_growth_publish, noop_growth_abort, noop_growth_release);
+
+    CHECK(arena != NULL, "publish-failure arena creation");
+    CHECK(wl_compound_arena_alloc(arena, 8) == WL_COMPOUND_HANDLE_NULL,
+        "publish failure denies the staged allocation");
+    CHECK(arena->gens[0].base == NULL && arena->gens[0].capacity == 0
+        && arena->gens[0].entry_offsets == NULL
+        && arena->gens[0].multiplicity == NULL
+        && arena->gens[0].entry_count == 0,
+        "publish failure preserves the old generation state");
+    wl_compound_arena_free(arena);
+
+    int publish_count = 0;
+    arena = wl_compound_arena_create_with_admission(
+        11, 64, 1, &publish_count, noop_context_release,
+        allow_growth_prepare, fail_second_growth_publish,
+        noop_growth_abort, noop_growth_release);
+    CHECK(arena != NULL, "second-publish-failure arena creation");
+    CHECK(wl_compound_arena_alloc(arena, 8) == WL_COMPOUND_HANDLE_NULL,
+        "second publish failure denies the staged allocation");
+    CHECK(arena->gens[0].base == NULL && arena->gens[0].capacity == 0
+        && arena->gens[0].entry_offsets == NULL
+        && arena->gens[0].multiplicity == NULL
+        && arena->gens[0].entry_count == 0,
+        "second publish failure preserves the old generation state");
+    wl_compound_arena_free(arena);
+}
+
+static void
+test_denial_and_legacy_contract(void)
+{
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_t governor;
+    wl_compound_arena_t *arena;
+    const uint64_t expected = fixed_bytes(2);
+
+    make_resolution(&resolution, expected - 1);
+    CHECK(wl_columnar_memory_governor_init(&governor, &resolution)
+        == WL_COLUMNAR_MEMORY_OK, "denial governor initialization");
+    arena = wl_compound_arena_create_managed(1, 64, 2, &governor);
+    CHECK(arena == NULL, "denied compound metadata returns NULL");
+    CHECK(wl_columnar_memory_reserved(&governor) == 0,
+        "denial leaves no reservation behind");
+
+    arena = wl_compound_arena_create_managed(1, 64, 0, &governor);
+    CHECK(arena == NULL, "default epoch table is also denied honestly");
+    CHECK(wl_columnar_memory_reserved(&governor) == 0,
+        "default denial leaves no reservation behind");
+
+    arena = wl_compound_arena_create_managed(1, 64, 2, NULL);
+    CHECK(arena != NULL, "NULL governor preserves unmanaged mode");
+    CHECK(arena->admission_context == NULL
+        && arena->admission_release == NULL,
+        "NULL governor creates an unmanaged arena");
+    wl_compound_arena_free(arena);
+
+    arena = wl_compound_arena_create(1, 64, 2);
+    CHECK(arena != NULL, "legacy compound arena creation");
+    CHECK(arena->admission_context == NULL
+        && arena->admission_release == NULL,
+        "legacy arena remains unmanaged");
+    CHECK(wl_columnar_memory_reserved(&governor) == 0,
+        "legacy arena does not charge a governor");
+    wl_compound_arena_free(arena);
+}
+
+int
+main(void)
+{
+    test_managed_lifecycle();
+    test_growth_peak_and_rollback();
+    test_entry_growth();
+    test_publish_failure_rollback();
+    test_denial_and_legacy_contract();
+    if (failures != 0)
+        return 1;
+    puts("memory admission compound arena: PASS");
+    return 0;
+}

--- a/wirelog/arena/compound_arena.c
+++ b/wirelog/arena/compound_arena.c
@@ -26,9 +26,6 @@
 #define WL_COMPOUND_ALIGN_UP(n) \
         (((n) + (WL_COMPOUND_ALIGN - 1)) & ~(uint32_t)(WL_COMPOUND_ALIGN - 1))
 
-/* Default max_epochs when the caller passes 0. */
-#define WL_COMPOUND_DEFAULT_MAX_EPOCHS (WL_COMPOUND_EPOCH_MAX + 1u)
-
 /* Initial entry-index capacity per generation.  Small (16) because we
  * lazy-grow; most epochs with a handful of compounds pay only this much. */
 #define WL_COMPOUND_DEFAULT_ENTRY_CAP 16u
@@ -38,49 +35,200 @@
 /* ======================================================================== */
 
 static int
-gen_reserve_entries(wl_compound_gen_t *gen)
+compound_admission_prepare(wl_compound_arena_t *arena, uint64_t old_bytes,
+    uint64_t new_bytes, wl_columnar_memory_reservation_t *reservation)
 {
-    if (gen->entry_count < gen->entry_cap)
+    if (!arena->admission_prepare)
         return 0;
-    uint32_t new_cap = gen->entry_cap > 0
-        ? gen->entry_cap * 2u
-        : WL_COMPOUND_DEFAULT_ENTRY_CAP;
-    if (new_cap <= gen->entry_cap) /* overflow guard */
-        return -1;
-    uint32_t *no = (uint32_t *)realloc(gen->entry_offsets,
-            (size_t)new_cap * sizeof(uint32_t));
-    if (!no)
-        return -1;
-    gen->entry_offsets = no;
-    int64_t *nm = (int64_t *)realloc(gen->multiplicity,
-            (size_t)new_cap * sizeof(int64_t));
-    if (!nm)
-        return -1; /* entry_offsets was upgraded; left as-is (safe; only cap */
-                   /* mismatch is a temporary state reverted on next retry). */
-    gen->multiplicity = nm;
-    gen->entry_cap = new_cap;
+    return arena->admission_prepare(arena->admission_context, old_bytes,
+               new_bytes, reservation);
+}
+
+static void
+compound_admission_abort(wl_compound_arena_t *arena,
+    wl_columnar_memory_reservation_t *reservation)
+{
+    if (arena->admission_abort)
+        arena->admission_abort(arena->admission_context, reservation);
+}
+
+static int
+compound_admission_publish(wl_compound_arena_t *arena,
+    wl_columnar_memory_reservation_t *old_reservation,
+    wl_columnar_memory_reservation_t *new_reservation, const void *owner)
+{
+    if (!arena->admission_publish)
+        return 0;
+    return arena->admission_publish(arena->admission_context, old_reservation,
+               new_reservation, owner);
+}
+
+static int
+compound_admission_release(wl_compound_arena_t *arena,
+    wl_columnar_memory_reservation_t *reservation)
+{
+    if (arena->admission_release_reservation)
+        return arena->admission_release_reservation(arena->admission_context,
+                   reservation);
     return 0;
 }
 
 static int
-gen_reserve_bytes(wl_compound_gen_t *gen, uint32_t need, uint32_t default_cap)
+compound_grow_capacity(uint32_t current, uint32_t used, uint32_t need,
+    uint32_t default_cap, uint32_t *out)
 {
-    uint32_t avail = gen->capacity - gen->used;
-    if (need <= avail)
-        return 0;
-    uint32_t new_cap = gen->capacity > 0 ? gen->capacity : default_cap;
-    while (new_cap - gen->used < need) {
-        uint32_t doubled = new_cap * 2u;
-        if (doubled <= new_cap) /* overflow */
-            return -1;
-        new_cap = doubled;
-    }
-    uint8_t *nb = (uint8_t *)realloc(gen->base, new_cap);
-    if (!nb)
+    uint32_t capacity = current > 0 ? current : default_cap;
+
+    if (capacity < used)
         return -1;
-    gen->base = nb;
-    gen->capacity = new_cap;
+    while ((uint64_t)capacity - used < need) {
+        if (capacity > UINT32_MAX / 2u)
+            return -1;
+        capacity *= 2u;
+    }
+    *out = capacity;
     return 0;
+}
+
+/* Stage payload and both entry arrays together.  The old buffers and
+ * reservations remain live until every new allocation is ready, so a denial
+ * or allocator failure leaves the generation unchanged. */
+static int
+gen_reserve(wl_compound_arena_t *arena, wl_compound_gen_t *gen,
+    uint32_t need, uint32_t default_cap)
+{
+    uint32_t new_payload_cap = gen->capacity;
+    uint32_t new_entry_cap = gen->entry_cap;
+    bool grow_payload = need > gen->capacity - gen->used;
+    bool grow_entries = gen->entry_count >= gen->entry_cap;
+    uint8_t *new_base = NULL;
+    uint32_t *new_offsets = NULL;
+    int64_t *new_multiplicity = NULL;
+    wl_columnar_memory_reservation_t *payload_reservation = NULL;
+    wl_columnar_memory_reservation_t *entries_reservation = NULL;
+    bool payload_published = false;
+    bool entries_published = false;
+
+    if (!grow_payload && !grow_entries)
+        return 0;
+    if (grow_payload
+        && compound_grow_capacity(gen->capacity, gen->used, need,
+        default_cap, &new_payload_cap) != 0)
+        return -1;
+    if (grow_entries) {
+        new_entry_cap = gen->entry_cap > 0
+            ? gen->entry_cap * 2u : WL_COMPOUND_DEFAULT_ENTRY_CAP;
+        if (new_entry_cap <= gen->entry_cap
+            || (uint64_t)new_entry_cap * sizeof(uint32_t) > SIZE_MAX
+            || (uint64_t)new_entry_cap * sizeof(int64_t) > SIZE_MAX)
+            return -1;
+    }
+    if (grow_payload && arena->admission_prepare) {
+        payload_reservation = malloc(sizeof(*payload_reservation));
+        if (!payload_reservation)
+            return -1;
+        if (compound_admission_prepare(arena, gen->capacity,
+            new_payload_cap, payload_reservation) != 0) {
+            free(payload_reservation);
+            return -1;
+        }
+    }
+    if (grow_entries && arena->admission_prepare) {
+        entries_reservation = malloc(sizeof(*entries_reservation));
+        if (!entries_reservation)
+            goto fail;
+    }
+    if (grow_entries
+        && compound_admission_prepare(arena,
+        (uint64_t)gen->entry_cap * (sizeof(uint32_t) + sizeof(int64_t)),
+        (uint64_t)new_entry_cap
+        * (sizeof(uint32_t) + sizeof(int64_t)),
+        entries_reservation) != 0) {
+        if (payload_reservation)
+            compound_admission_abort(arena, payload_reservation);
+        free(payload_reservation);
+        free(entries_reservation);
+        return -1;
+    }
+    if (grow_payload) {
+        new_base = (uint8_t *)malloc(new_payload_cap);
+        if (!new_base)
+            goto fail;
+        if (gen->used > 0)
+            memcpy(new_base, gen->base, gen->used);
+    }
+    if (grow_entries) {
+        new_offsets = (uint32_t *)malloc(
+            (size_t)new_entry_cap * sizeof(uint32_t));
+        new_multiplicity = (int64_t *)malloc(
+            (size_t)new_entry_cap * sizeof(int64_t));
+        if (!new_offsets || !new_multiplicity)
+            goto fail;
+        if (gen->entry_count > 0) {
+            memcpy(new_offsets, gen->entry_offsets,
+                (size_t)gen->entry_count * sizeof(uint32_t));
+            memcpy(new_multiplicity, gen->multiplicity,
+                (size_t)gen->entry_count * sizeof(int64_t));
+        }
+    }
+    /* A reservation returned by prepare is valid until this publish.  The
+     * governor commit cannot fail for such a token; keep both publishes
+     * adjacent so the ownership swap below is one logical transaction. */
+    if (grow_payload) {
+        if (compound_admission_publish(arena, gen->payload_admission,
+            payload_reservation, gen) != 0)
+            goto fail;
+        payload_published = true;
+    }
+    if (grow_entries) {
+        if (compound_admission_publish(arena, gen->entries_admission,
+            entries_reservation, gen) != 0)
+            goto fail;
+        entries_published = true;
+    }
+    if (grow_payload && gen->payload_admission
+        && compound_admission_release(arena, gen->payload_admission) != 0)
+        goto fail;
+    if (grow_entries && gen->entries_admission
+        && compound_admission_release(arena, gen->entries_admission) != 0)
+        goto fail;
+    if (grow_payload) {
+        free(gen->base);
+        gen->base = new_base;
+        gen->capacity = new_payload_cap;
+        free(gen->payload_admission);
+        gen->payload_admission = payload_reservation;
+    }
+    if (grow_entries) {
+        free(gen->entry_offsets);
+        free(gen->multiplicity);
+        gen->entry_offsets = new_offsets;
+        gen->multiplicity = new_multiplicity;
+        gen->entry_cap = new_entry_cap;
+        free(gen->entries_admission);
+        gen->entries_admission = entries_reservation;
+    }
+    return 0;
+
+fail:
+    free(new_base);
+    free(new_offsets);
+    free(new_multiplicity);
+    if (payload_reservation) {
+        if (payload_published)
+            (void)compound_admission_release(arena, payload_reservation);
+        else
+            compound_admission_abort(arena, payload_reservation);
+        free(payload_reservation);
+    }
+    if (entries_reservation) {
+        if (entries_published)
+            (void)compound_admission_release(arena, entries_reservation);
+        else
+            compound_admission_abort(arena, entries_reservation);
+        free(entries_reservation);
+    }
+    return -1;
 }
 
 static void
@@ -92,13 +240,31 @@ gen_free(wl_compound_gen_t *gen)
     memset(gen, 0, sizeof(*gen));
 }
 
+static void
+gen_release_admission(wl_compound_arena_t *arena, wl_compound_gen_t *gen)
+{
+    if (gen->payload_admission) {
+        (void)compound_admission_release(arena, gen->payload_admission);
+        free(gen->payload_admission);
+    }
+    if (gen->entries_admission) {
+        (void)compound_admission_release(arena, gen->entries_admission);
+        free(gen->entries_admission);
+    }
+}
+
 /* ======================================================================== */
 /* Public API                                                               */
 /* ======================================================================== */
 
-wl_compound_arena_t *
-wl_compound_arena_create(uint32_t session_seed, uint32_t default_gen_cap,
-    uint32_t max_epochs)
+static wl_compound_arena_t *
+compound_arena_create_impl(uint32_t session_seed, uint32_t default_gen_cap,
+    uint32_t max_epochs, void *admission_context,
+    void (*admission_release)(void *context),
+    wl_compound_admission_prepare_fn admission_prepare_fn,
+    wl_compound_admission_publish_fn admission_publish_fn,
+    wl_compound_admission_abort_fn admission_abort_fn,
+    wl_compound_admission_release_fn admission_release_reservation_fn)
 {
     if (default_gen_cap == 0)
         return NULL;
@@ -125,7 +291,36 @@ wl_compound_arena_create(uint32_t session_seed, uint32_t default_gen_cap,
     arena->default_gen_cap = default_gen_cap;
     arena->frozen = false;
     arena->live_handles = 0;
+    arena->admission_context = admission_context;
+    arena->admission_release = admission_release;
+    arena->admission_prepare = admission_prepare_fn;
+    arena->admission_publish = admission_publish_fn;
+    arena->admission_abort = admission_abort_fn;
+    arena->admission_release_reservation
+        = admission_release_reservation_fn;
     return arena;
+}
+
+wl_compound_arena_t *
+wl_compound_arena_create(uint32_t session_seed, uint32_t default_gen_cap,
+    uint32_t max_epochs)
+{
+    return compound_arena_create_impl(session_seed, default_gen_cap,
+               max_epochs, NULL, NULL, NULL, NULL, NULL, NULL);
+}
+
+wl_compound_arena_t *
+wl_compound_arena_create_with_admission(uint32_t session_seed,
+    uint32_t default_gen_cap, uint32_t max_epochs, void *context,
+    void (*release)(void *context),
+    wl_compound_admission_prepare_fn prepare,
+    wl_compound_admission_publish_fn publish,
+    wl_compound_admission_abort_fn abort,
+    wl_compound_admission_release_fn release_reservation)
+{
+    return compound_arena_create_impl(session_seed, default_gen_cap,
+               max_epochs, context, release, prepare, publish, abort,
+               release_reservation);
 }
 
 void
@@ -135,9 +330,13 @@ wl_compound_arena_free(wl_compound_arena_t *arena)
         return;
     if (arena->gens) {
         for (uint32_t e = 0; e < arena->max_epochs; e++)
+            gen_release_admission(arena, &arena->gens[e]);
+        for (uint32_t e = 0; e < arena->max_epochs; e++)
             gen_free(&arena->gens[e]);
         free(arena->gens);
     }
+    if (arena->admission_release)
+        arena->admission_release(arena->admission_context);
     free(arena);
 }
 
@@ -149,16 +348,22 @@ wl_compound_arena_alloc(wl_compound_arena_t *arena, uint32_t size)
     if (arena->current_epoch >= arena->max_epochs)
         return WL_COMPOUND_HANDLE_NULL;
 
-    uint32_t aligned = WL_COMPOUND_ALIGN_UP(size);
-    if (aligned < size) /* overflow */
+    if (size > UINT32_MAX - (WL_COMPOUND_ALIGN - 1u))
         return WL_COMPOUND_HANDLE_NULL;
+    uint32_t aligned = WL_COMPOUND_ALIGN_UP(size);
 
     wl_compound_gen_t *gen = &arena->gens[arena->current_epoch];
+    uint32_t reserve_need = aligned;
+    bool avoid_null_handle = arena->session_seed == 0
+        && arena->current_epoch == 0 && gen->used == 0;
+    if (avoid_null_handle) {
+        if (aligned > UINT32_MAX - WL_COMPOUND_ALIGN)
+            return WL_COMPOUND_HANDLE_NULL;
+        reserve_need = aligned + WL_COMPOUND_ALIGN;
+    }
 
-    /* Grow payload buffer if needed. */
-    if (gen_reserve_bytes(gen, aligned, arena->default_gen_cap) != 0)
-        return WL_COMPOUND_HANDLE_NULL;
-    if (gen_reserve_entries(gen) != 0)
+    /* Stage payload and metadata growth together. */
+    if (gen_reserve(arena, gen, reserve_need, arena->default_gen_cap) != 0)
         return WL_COMPOUND_HANDLE_NULL;
 
     uint32_t offset = gen->used;
@@ -166,10 +371,7 @@ wl_compound_arena_alloc(wl_compound_arena_t *arena, uint32_t size)
      * generation 0 so the very first allocation yields a non-zero handle.
      * (A zero session_seed + zero epoch + zero offset would collide with
      * WL_COMPOUND_HANDLE_NULL.) */
-    if (arena->session_seed == 0 && arena->current_epoch == 0 && offset == 0) {
-        if (gen_reserve_bytes(gen, aligned + WL_COMPOUND_ALIGN,
-            arena->default_gen_cap) != 0)
-            return WL_COMPOUND_HANDLE_NULL;
+    if (avoid_null_handle) {
         offset = WL_COMPOUND_ALIGN;
         gen->used = WL_COMPOUND_ALIGN;
     }

--- a/wirelog/arena/compound_arena.h
+++ b/wirelog/arena/compound_arena.h
@@ -64,6 +64,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "columnar/memory_governor.h"
+
 /* ======================================================================== */
 /* Handle encoding                                                          */
 /* ======================================================================== */
@@ -74,6 +76,9 @@
 /** Maximum epoch value (12 bits). Arena refuses new allocations when the
  *  current epoch exceeds this cap. */
 #define WL_COMPOUND_EPOCH_MAX ((uint32_t)0xFFF)
+
+/** Default generation table length when create() receives max_epochs == 0. */
+#define WL_COMPOUND_DEFAULT_MAX_EPOCHS (WL_COMPOUND_EPOCH_MAX + 1u)
 
 /** Maximum per-generation offset (32 bits). */
 #define WL_COMPOUND_OFFSET_MAX ((uint32_t)0xFFFFFFFFu)
@@ -131,7 +136,20 @@ typedef struct {
     int64_t *multiplicity;   /* Z-set multiplicity counter per handle (signed) */
     uint32_t entry_count;    /* number of handles allocated in this generation */
     uint32_t entry_cap;      /* capacity of entry_offsets[] / multiplicity[] */
+    wl_columnar_memory_reservation_t *payload_admission;
+    wl_columnar_memory_reservation_t *entries_admission;
 } wl_compound_gen_t;
+
+typedef int (*wl_compound_admission_prepare_fn)(void *context,
+    uint64_t old_bytes, uint64_t new_bytes,
+    wl_columnar_memory_reservation_t *reservation);
+typedef int (*wl_compound_admission_publish_fn)(void *context,
+    wl_columnar_memory_reservation_t *old_reservation,
+    wl_columnar_memory_reservation_t *new_reservation, const void *owner);
+typedef void (*wl_compound_admission_abort_fn)(void *context,
+    wl_columnar_memory_reservation_t *reservation);
+typedef int (*wl_compound_admission_release_fn)(void *context,
+    wl_columnar_memory_reservation_t *reservation);
 
 /**
  * wl_compound_arena_t:
@@ -145,8 +163,8 @@ typedef struct {
  * @current_epoch: Generation currently accepting new allocations.
  * @gens:         Array of generations, length == max_epochs.
  * @max_epochs:   Allocated length of gens[]; bounded by WL_COMPOUND_EPOCH_MAX + 1.
- * @default_gen_cap: Initial capacity per generation (bytes).  Generations
- *                   lazy-grow via realloc on overflow.
+ * @default_gen_cap: Initial capacity per generation (bytes). Generations
+ *                   grow transactionally on overflow when managed.
  * @frozen:       True while K-Fusion is executing; arena_alloc returns 0.
  * @live_handles: Total live handles (multiplicity > 0) across all epochs,
  *                maintained by arena_alloc/inc/dec/gc for test introspection.
@@ -159,6 +177,13 @@ typedef struct {
     uint32_t default_gen_cap;
     bool frozen;
     uint64_t live_handles;
+    /* Optional owner for fixed arena/generation-table admission. */
+    void *admission_context;
+    void (*admission_release)(void *context);
+    wl_compound_admission_prepare_fn admission_prepare;
+    wl_compound_admission_publish_fn admission_publish;
+    wl_compound_admission_abort_fn admission_abort;
+    wl_compound_admission_release_fn admission_release_reservation;
 } wl_compound_arena_t;
 
 /* ======================================================================== */
@@ -181,6 +206,22 @@ typedef struct {
 wl_compound_arena_t *
 wl_compound_arena_create(uint32_t session_seed, uint32_t default_gen_cap,
     uint32_t max_epochs);
+
+/** Create an arena with admission for fixed metadata and retained growth. */
+wl_compound_arena_t *
+wl_compound_arena_create_managed(uint32_t session_seed,
+    uint32_t default_gen_cap, uint32_t max_epochs,
+    wl_columnar_memory_governor_t *governor);
+
+/* Internal callback form used by the governor glue translation unit. */
+wl_compound_arena_t *
+wl_compound_arena_create_with_admission(uint32_t session_seed,
+    uint32_t default_gen_cap, uint32_t max_epochs, void *context,
+    void (*release)(void *context),
+    wl_compound_admission_prepare_fn prepare,
+    wl_compound_admission_publish_fn publish,
+    wl_compound_admission_abort_fn abort,
+    wl_compound_admission_release_fn release_reservation);
 
 /**
  * wl_compound_arena_free:

--- a/wirelog/arena/compound_arena_admission.c
+++ b/wirelog/arena/compound_arena_admission.c
@@ -1,0 +1,136 @@
+/* compound_arena_admission.c - shared-governor glue for fixed metadata */
+
+#include "compound_arena.h"
+
+#include "columnar/memory_governor.h"
+
+#include <stdlib.h>
+
+typedef struct {
+    wl_columnar_memory_governor_t *governor;
+    wl_columnar_memory_reservation_t reservation;
+} wl_compound_arena_admission_t;
+
+static void
+release_compound_arena_admission(void *context)
+{
+    wl_compound_arena_admission_t *admission = context;
+
+    if (!admission)
+        return;
+    (void)wl_columnar_memory_release(&admission->reservation);
+    free(admission);
+}
+
+static int
+prepare_compound_growth(void *context, uint64_t old_bytes,
+    uint64_t new_bytes, wl_columnar_memory_reservation_t *reservation)
+{
+    wl_compound_arena_admission_t *admission = context;
+    wl_columnar_memory_admission_status_t status;
+
+    wl_columnar_memory_reservation_init(reservation);
+    if (old_bytes == 0)
+        status = wl_columnar_memory_reserve_checked(admission->governor,
+                new_bytes, reservation);
+    else
+        status = wl_columnar_memory_reserve_growth(admission->governor,
+                old_bytes, new_bytes, reservation);
+    return status == WL_COLUMNAR_MEMORY_ADMISSION_OK
+           || status == WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY ? 0 : -1;
+}
+
+static int
+publish_compound_growth(void *context,
+    wl_columnar_memory_reservation_t *old_reservation,
+    wl_columnar_memory_reservation_t *new_reservation, const void *owner)
+{
+    (void)context;
+    (void)old_reservation;
+    if (!wl_columnar_memory_commit(new_reservation, owner))
+        return -1;
+    return 0;
+}
+
+static void
+abort_compound_growth(void *context,
+    wl_columnar_memory_reservation_t *reservation)
+{
+    (void)context;
+    (void)wl_columnar_memory_rollback(reservation);
+}
+
+static int
+release_compound_growth(void *context,
+    wl_columnar_memory_reservation_t *reservation)
+{
+    (void)context;
+    /* A committed token is owned exclusively by this generation. A false
+     * result means it was already terminal, so no bytes remain to release;
+     * treating that state as idempotent keeps destruction leak-free. */
+    (void)wl_columnar_memory_release(reservation);
+    return 0;
+}
+
+static uint32_t
+normalize_max_epochs(uint32_t max_epochs)
+{
+    if (max_epochs == 0)
+        return WL_COMPOUND_DEFAULT_MAX_EPOCHS;
+    if (max_epochs > WL_COMPOUND_DEFAULT_MAX_EPOCHS)
+        return WL_COMPOUND_DEFAULT_MAX_EPOCHS;
+    return max_epochs;
+}
+
+wl_compound_arena_t *
+wl_compound_arena_create_managed(uint32_t session_seed,
+    uint32_t default_gen_cap, uint32_t max_epochs,
+    wl_columnar_memory_governor_t *governor)
+{
+    wl_compound_arena_admission_t *admission;
+    wl_columnar_memory_admission_status_t status;
+    wl_compound_arena_t *arena;
+    uint64_t gens_bytes;
+    uint64_t fixed_bytes;
+
+    if (!governor)
+        return wl_compound_arena_create(session_seed, default_gen_cap,
+                   max_epochs);
+    if (default_gen_cap == 0)
+        return NULL;
+    max_epochs = normalize_max_epochs(max_epochs);
+    if (!wl_columnar_memory_size_mul(max_epochs,
+        sizeof(wl_compound_gen_t), &gens_bytes)
+        || !wl_columnar_memory_size_add(sizeof(wl_compound_arena_t),
+        gens_bytes, &fixed_bytes))
+        return NULL;
+
+    admission = (wl_compound_arena_admission_t *)malloc(sizeof(*admission));
+    if (!admission)
+        return NULL;
+    admission->governor = governor;
+    wl_columnar_memory_reservation_init(&admission->reservation);
+    status = wl_columnar_memory_reserve_checked(governor, fixed_bytes,
+            &admission->reservation);
+    if (status != WL_COLUMNAR_MEMORY_ADMISSION_OK
+        && status != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY) {
+        free(admission);
+        return NULL;
+    }
+
+    arena = wl_compound_arena_create_with_admission(session_seed,
+            default_gen_cap, max_epochs, admission,
+            release_compound_arena_admission, prepare_compound_growth,
+            publish_compound_growth, abort_compound_growth,
+            release_compound_growth);
+    if (!arena) {
+        (void)wl_columnar_memory_rollback(&admission->reservation);
+        free(admission);
+        return NULL;
+    }
+    if (!wl_columnar_memory_commit(&admission->reservation, arena)) {
+        wl_compound_arena_free(arena);
+        return NULL;
+    }
+    return arena;
+}

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1335,8 +1335,9 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
      * tests/test_compound_arena.c; max_epochs=0 selects the library
      * default (WL_COMPOUND_EPOCH_MAX + 1). */
     uint32_t compound_max_epochs = session_compound_max_epochs_from_env();
-    sess->compound_arena = wl_compound_arena_create(0x53455353u, 4096u,
-            compound_max_epochs);
+    sess->compound_arena = wl_compound_arena_create_managed(0x53455353u,
+            4096u, compound_max_epochs,
+            wl_columnar_memory_governor_ref_get(sess->memory_governor));
     if (!sess->compound_arena)
         goto oom;
     WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO,

--- a/wirelog/meson.build
+++ b/wirelog/meson.build
@@ -32,7 +32,8 @@ wirelog_optimizer_src = files('passes/fusion.c', 'passes/jpp.c', 'passes/sip.c',
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 
 wirelog_arena_src = files('arena/arena.c', 'arena/arena_admission.c',
-                          'arena/compound_arena.c', )
+                          'arena/compound_arena.c',
+                          'arena/compound_arena_admission.c', )
 
 #== == == == == == == == == == == == == == == == == == == == == == == == == == == == == == == ==
 #Thread Backend Module(Issue #88 - Cross-Platform Threading)


### PR DESCRIPTION
## Summary

- admit fixed compound-arena metadata and every retained generation growth through the shared governor
- reserve old/new peak overlap before payload or paired entry-array growth
- stage replacement buffers so denial/allocation failure leaves pointers, capacities, handles, and reservations unchanged
- preserve unmanaged and standalone `compound_arena.c` linkage
- keep coordinator ownership and worker borrowing unchanged
- add lifecycle, growth-denial, peak-overlap, paired-entry-growth, legacy, ASAN/UBSAN, and regression coverage

Rebased onto `main` after #1420 and #1421 merged: the three primitive/arena/delta-pool commits this branch used to carry are already on `main` and were dropped, leaving the compound-arena unit plus one CI fix. Compound capacity is retained through epoch GC and released only at arena destruction. Joins, exchange channels, and other allocation classes remain separate follow-up work.

Also adds `arena_admission.c`, `delta_pool_admission.c` and `compound_arena_admission.c` to `scripts/ci/clang-tidy-allowlist.txt`: the ratchet requires the allowlist and backlog to partition the library sources exactly, the first two were already missing on `main`, and all three are clang-tidy clean.

Closes no issue; #1417 remains open until its remaining acceptance work is complete.
