### PR TITLE
feat: admit public result memory growth

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -187,10 +187,14 @@ An enforcing resolution reserves 5% cleanup headroom, capped at 256 MiB and
 never above half the budget. Ordinary reservations can consume only the
 remaining usable limit. Reservation tokens move through reserved, committed,
 and released states; rollback is valid only from reserved, and release
-returns capacity exactly once. This foundation is wired into session creation
-and fixed eval-arena/delta-pool backing storage; session lifetime/public error
-integration is #1413. Other allocation-site enforcement remains split between #1369,
-#1417, and #1418.
+returns capacity exactly once. Session lifetime/public error integration is
+#1413. Allocation-site admission remains the responsibility of #1369, with
+the public batch result collector as the scoped exception implemented by
+#1418: the result object, relation table, names, row buffers, and type arrays
+share one governor reservation. Growth uses replacement buffers and admits
+the full new footprint while the old buffer is still live, so a failed growth
+leaves the previous result unchanged. The result retains the governor until
+`wirelog_result_free()`, which releases the reservation exactly once.
 
 The #1413 integration adds a reference-counted coordinator-owned governor to
 columnar sessions before relation, pool, arena, cache, or worker setup. Worker
@@ -207,10 +211,11 @@ reporting share so the aggregate threshold does not multiply by the worker
 count. The removed `tdd_budget_per_party` value is no longer a second governor
 admission domain.
 Explicit invalid budgets fail session creation with the existing public
-execution error mapping and leave output handles null. Compound-arena fixed
-object, generation-table, and lazy-growth admission are now covered by #1417;
-parser/plan/result allocations remain tracked by #1418. The parent #1369
-contract is therefore only partially implemented until those units land.
+execution error mapping and leave output handles null. Parser AST, IR/program,
+execution plan, executor wrapper, caller-owned fact buffers, CSV staging, and
+advanced-API conversion buffers remain outside the result-only admission unit;
+extending admission across parse → IR → optimize → plan requires a separate
+lifetime and caller-owned context design.
 
 The next #1369 allocation unit, #1425, admits only the `ht_head` and
 `ht_next` backing arrays of primary, delta, and filtered hash arrangements.
@@ -221,6 +226,37 @@ reservation remains live until publication, and failed admission leaves the
 old index unchanged. Sorted and differential arrangements, registry metadata,
 relation/timestamp storage, cache policy, and join/TDD scratch remain separate
 allocation classes.
+
+## #1418 Allocation Coverage Matrix
+
+The following matrix is the boundary for allocations created outside a
+managed columnar session. “Covered” means that the owner retains a governor
+reservation and publishes growth only after both admission and allocation
+succeed. “Excluded” is an explicit non-guarantee; the owner must still
+propagate failure and must not report a truncated successful result.
+
+| Allocation class | Owner and lifetime | #1418 status | Failure contract |
+| --- | --- | --- | --- |
+| Parser AST, interned names, and parse diagnostics | `wirelog_program_t`, released by `wirelog_program_free()` | Excluded; parse context is created before a managed session | Return `NULL` with `WIRELOG_ERR_PARSE` or `WIRELOG_ERR_MEMORY`; no partial program is published |
+| IR/program relation metadata | `wirelog_program_t`, released with the program | Excluded; same owner as parser output | Return `NULL` with the existing parse/IR error; callers retain no partially initialized program |
+| Optimized execution plan | `wirelog_executor_t`, released by `wirelog_executor_free()` | Excluded; plan construction precedes result collection | Return `NULL` with `WIRELOG_ERR_INVALID_IR`, `WIRELOG_ERR_MEMORY`, or the existing executor error |
+| Executor/session wrapper and columnar session storage | `wirelog_executor_t` and its session | Covered by #1413/#1369 session admission, not charged again here | Session creation fails with the existing public memory error and releases all reservations |
+| Public result object, relation table, names, row buffers, and type arrays | `wirelog_result_t`, released by `wirelog_result_free()` | Covered by #1418 | Reserve the prospective footprint before replacement allocation; rollback leaves the old result unchanged and reports `WIRELOG_ERR_MEMORY` |
+| Caller-owned fact buffers and input rows | Caller, released by the caller or input adapter | Excluded; ownership is external to wirelog | Reject the operation or return the existing input error; never charge or free caller storage |
+| CSV staging and advanced-API conversion buffers | CSV/advanced API call, released at call completion | Excluded; temporary caller-facing buffers have independent ownership | Return `false` or the existing API error and discard the temporary buffer |
+
+The matrix intentionally has one admission owner per allocation. The result
+collector uses reservation move semantics when publishing a new token, so
+the reservation identity follows `wirelog_result_t` rather than a temporary
+stack object. The governor's denial, rollback, overflow, and exact-release
+fixtures provide the admission primitive evidence; the Linux-only
+`wirelog_result_oom` test uses linker allocation-failure injection over a
+32-row result so relation-table and row-buffer growth cannot silently return
+a truncated success. `wirelog_public_api` covers result lifetime after
+executor destruction and the public error path. Other platforms retain the
+same production transaction and ABI checks, while platform-specific allocator
+failure injection remains outside this unit because GNU `--wrap` is not a
+portable linker contract.
 # wirelog Memory Instrumentation
 
 This document describes what the columnar engine measures about its own

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5403,6 +5403,21 @@ test_wirelog_public_api_exe = executable(
 
 test('wirelog_public_api', test_wirelog_public_api_exe)
 
+if host_machine.system() == 'linux'
+  test_wirelog_result_oom_exe = executable(
+    'test_wirelog_result_oom',
+    files('test_wirelog_result_oom.c'),
+    include_directories: [wirelog_inc, wirelog_src_inc],
+    link_with: wirelog_static_lib,
+    dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep,
+                    mbedtls_dep, math_dep],
+    link_args: ['-Wl,--wrap=malloc', '-Wl,--wrap=calloc',
+                '-Wl,--wrap=realloc'],
+    override_options: ['b_lto=false'],
+  )
+  test('wirelog_result_oom', test_wirelog_result_oom_exe, suite: 'unit')
+endif
+
 # ============================================================================
 # Baseline .input Fixture Snapshot Tests (Issue #448)
 # ============================================================================

--- a/tests/test_wirelog_public_api.c
+++ b/tests/test_wirelog_public_api.c
@@ -323,6 +323,44 @@ test_executor_result_api(void)
     return 0;
 }
 
+static int
+test_result_outlives_executor(void)
+{
+    const char *src =
+        ".decl edge(x:int32,y:int32)\n"
+        ".decl path(x:int32,y:int32)\n"
+        "edge(7,8).\n"
+        "path(X,Y) :- edge(X,Y).\n";
+    wirelog_error_t err = WIRELOG_ERR_UNKNOWN;
+    wirelog_program_t *program = wirelog_parse_string(src, &err);
+    wirelog_executor_t *executor;
+    wirelog_result_t *result;
+
+    if (!program || err != WIRELOG_OK)
+        return 1;
+    executor = wirelog_executor_create(program, &err);
+    if (!executor || err != WIRELOG_OK) {
+        wirelog_program_free(program);
+        return 1;
+    }
+    result = wirelog_evaluate(executor, &err);
+    if (!result || err != WIRELOG_OK) {
+        wirelog_result_free(result);
+        wirelog_executor_free(executor);
+        wirelog_program_free(program);
+        return 1;
+    }
+    wirelog_executor_free(executor);
+    if (wirelog_result_relation_cardinality(result, "path") != 1) {
+        wirelog_result_free(result);
+        wirelog_program_free(program);
+        return 1;
+    }
+    wirelog_result_free(result);
+    wirelog_program_free(program);
+    return 0;
+}
+
 int
 main(void)
 {
@@ -333,6 +371,7 @@ main(void)
     failures += test_optimizer_config_disable_passes();
     failures += test_bound_query_without_seed_preserves_answers();
     failures += test_executor_result_api();
+    failures += test_result_outlives_executor();
     if (failures == 0)
         printf("test_wirelog_public_api: OK\n");
     return failures == 0 ? 0 : 1;

--- a/tests/test_wirelog_result_oom.c
+++ b/tests/test_wirelog_result_oom.c
@@ -1,0 +1,130 @@
+/* Failure-injection coverage for issue #1418 public result admission. */
+
+#include <stddef.h>
+#include <stdio.h>
+
+#include "wirelog/wirelog.h"
+
+void *__real_malloc(size_t size);
+void *__real_calloc(size_t count, size_t size);
+void *__real_realloc(void *ptr, size_t size);
+
+static long fail_at = -1;
+static long allocation_calls;
+
+void *
+__wrap_malloc(size_t size)
+{
+    if (fail_at >= 0 && allocation_calls++ == fail_at)
+        return NULL;
+    return __real_malloc(size);
+}
+
+void *
+__wrap_calloc(size_t count, size_t size)
+{
+    if (fail_at >= 0 && allocation_calls++ == fail_at)
+        return NULL;
+    return __real_calloc(count, size);
+}
+
+void *
+__wrap_realloc(void *ptr, size_t size)
+{
+    if (fail_at >= 0 && allocation_calls++ == fail_at)
+        return NULL;
+    return __real_realloc(ptr, size);
+}
+
+int
+main(void)
+{
+    const char *source =
+        ".decl edge(x:int32,y:int32)\n"
+        ".decl path(x:int32,y:int32)\n"
+        "edge(1,2).\n"
+        "edge(2,3).\n"
+        "edge(3,4).\n"
+        "edge(4,5).\n"
+        "edge(5,6).\n"
+        "edge(6,7).\n"
+        "edge(7,8).\n"
+        "edge(8,9).\n"
+        "edge(9,10).\n"
+        "edge(10,11).\n"
+        "edge(11,12).\n"
+        "edge(12,13).\n"
+        "edge(13,14).\n"
+        "edge(14,15).\n"
+        "edge(15,16).\n"
+        "edge(16,17).\n"
+        "edge(17,18).\n"
+        "edge(18,19).\n"
+        "edge(19,20).\n"
+        "edge(20,21).\n"
+        "edge(21,22).\n"
+        "edge(22,23).\n"
+        "edge(23,24).\n"
+        "edge(24,25).\n"
+        "edge(25,26).\n"
+        "edge(26,27).\n"
+        "edge(27,28).\n"
+        "edge(28,29).\n"
+        "edge(29,30).\n"
+        "edge(30,31).\n"
+        "edge(31,32).\n"
+        "edge(32,33).\n"
+        "path(X,Y) :- edge(X,Y).\n";
+    wirelog_error_t error = WIRELOG_ERR_UNKNOWN;
+    wirelog_program_t *program = wirelog_parse_string(source, &error);
+    wirelog_executor_t *executor;
+
+    if (!program || error != WIRELOG_OK)
+        return 1;
+    executor = wirelog_executor_create(program, &error);
+    if (!executor || error != WIRELOG_OK) {
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    /* Each injected failure must either be reported or leave a complete,
+     * valid result.  In particular, no allocation failure may be returned as
+     * a successful result with truncated rows. */
+    for (fail_at = 0; fail_at < 256; fail_at++) {
+        wirelog_result_t *result;
+        allocation_calls = 0;
+        error = WIRELOG_ERR_UNKNOWN;
+        result = wirelog_evaluate(executor, &error);
+        if (!result) {
+            if (error != WIRELOG_ERR_MEMORY && error != WIRELOG_ERR_EXEC)
+                goto fail;
+            continue;
+        }
+        if (error != WIRELOG_OK
+            || wirelog_result_relation_cardinality(result, "path") != 32) {
+            wirelog_result_free(result);
+            goto fail;
+        }
+        wirelog_result_free(result);
+    }
+
+    fail_at = -1;
+    allocation_calls = 0;
+    error = WIRELOG_ERR_UNKNOWN;
+    wirelog_result_t *result = wirelog_evaluate(executor, &error);
+    if (!result || error != WIRELOG_OK
+        || wirelog_result_relation_cardinality(result, "path") != 32) {
+        wirelog_result_free(result);
+        goto fail;
+    }
+    wirelog_result_free(result);
+    wirelog_executor_free(executor);
+    wirelog_program_free(program);
+    puts("test_wirelog_result_oom: OK");
+    return 0;
+
+fail:
+    wirelog_executor_free(executor);
+    wirelog_program_free(program);
+    return 1;
+}

--- a/wirelog/api_facade.c
+++ b/wirelog/api_facade.c
@@ -8,6 +8,7 @@
 #include "wirelog/wirelog.h"
 
 #include "backend.h"
+#include "columnar/columnar_nanoarrow.h"
 #include "exec_plan_gen.h"
 #include "io/csv_reader.h"
 #include "ir/program.h"
@@ -48,6 +49,9 @@ struct wirelog_result {
     wl_result_relation_t *relations;
     uint32_t count;
     uint32_t capacity;
+    wl_columnar_memory_governor_ref_t *memory_governor;
+    wl_columnar_memory_reservation_t reservation;
+    uint64_t charged_bytes;
 };
 
 static void
@@ -67,6 +71,67 @@ wl_strdup(const char *s)
     if (copy)
         memcpy(copy, s, len);
     return copy;
+}
+
+static bool
+checked_add_size(uint64_t a, uint64_t b, uint64_t *out)
+{
+    if (b > UINT64_MAX - a)
+        return false;
+    *out = a + b;
+    return true;
+}
+
+static bool
+checked_mul_size(uint64_t a, uint64_t b, uint64_t *out)
+{
+    if (a != 0 && b > UINT64_MAX / a)
+        return false;
+    *out = a * b;
+    return true;
+}
+
+static bool
+result_admit(wirelog_result_t *result, uint64_t target,
+    wl_columnar_memory_reservation_t *pending)
+{
+    wl_columnar_memory_governor_t *governor;
+
+    if (!result || !pending)
+        return false;
+    wl_columnar_memory_reservation_init(pending);
+    if (target <= result->charged_bytes)
+        return true;
+    governor = wl_columnar_memory_governor_ref_get(result->memory_governor);
+    if (!wl_columnar_memory_reserve(governor, target, pending)
+        || !wl_columnar_memory_commit(pending, result)) {
+        (void)wl_columnar_memory_release(pending);
+        return false;
+    }
+    return true;
+}
+
+static bool
+result_publish_admission(wirelog_result_t *result,
+    wl_columnar_memory_reservation_t *pending, uint64_t target)
+{
+    wl_columnar_memory_reservation_t previous;
+
+    if (target == result->charged_bytes)
+        return true;
+    wl_columnar_memory_reservation_init(&previous);
+    if (!wl_columnar_memory_reservation_move(&previous,
+        &result->reservation))
+        return false;
+    if (!wl_columnar_memory_reservation_move(&result->reservation, pending)) {
+        (void)wl_columnar_memory_reservation_move(&result->reservation,
+            &previous);
+        (void)wl_columnar_memory_release(pending);
+        return false;
+    }
+    (void)wl_columnar_memory_release(&previous);
+    result->charged_bytes = target;
+    return true;
 }
 
 static const wl_ir_relation_info_t *
@@ -196,41 +261,119 @@ ensure_result_relation(wirelog_result_t *result, const char *relation,
     if (existing)
         return existing->cols == cols ? existing : NULL;
 
+    size_t name_len = strlen(relation) + 1;
+    if (name_len == 0)
+        return NULL;
     if (result->count == result->capacity) {
         uint32_t next = result->capacity ? result->capacity * 2 : 8;
-        wl_result_relation_t *rels = (wl_result_relation_t *)realloc(
-            result->relations, next * sizeof(wl_result_relation_t));
-        if (!rels)
+        uint64_t old_bytes, new_bytes, target;
+        if (result->capacity > UINT32_MAX / 2)
             return NULL;
+        if (next > UINT32_MAX / sizeof(wl_result_relation_t)
+            || !checked_mul_size(result->capacity,
+            sizeof(wl_result_relation_t), &old_bytes)
+            || !checked_mul_size(next, sizeof(wl_result_relation_t),
+            &new_bytes)
+            || !checked_add_size(result->charged_bytes,
+            new_bytes - old_bytes, &target)
+            || !checked_add_size(target, name_len, &target))
+            return NULL;
+        if (new_bytes > SIZE_MAX)
+            return NULL;
+        wl_columnar_memory_reservation_t pending;
+        if (!result_admit(result, target, &pending)) {
+            return NULL;
+        }
+        wl_result_relation_t *rels
+            = (wl_result_relation_t *)malloc((size_t)new_bytes);
+        char *name = wl_strdup(relation);
+        if (!rels || !name) {
+            free(rels);
+            free(name);
+            (void)wl_columnar_memory_release(&pending);
+            return NULL;
+        }
+        if (result->relations)
+            memcpy(rels, result->relations, (size_t)old_bytes);
         memset(rels + result->capacity, 0,
             (next - result->capacity) * sizeof(wl_result_relation_t));
+        rels[result->count].name = name;
+        rels[result->count].cols = cols;
+        if (!result_publish_admission(result, &pending, target)) {
+            free(name);
+            free(rels);
+            return NULL;
+        }
+        free(result->relations);
         result->relations = rels;
         result->capacity = next;
+    } else {
+        uint64_t target;
+        if (!checked_add_size(result->charged_bytes, name_len, &target))
+            return NULL;
+        wl_columnar_memory_reservation_t pending;
+        if (!result_admit(result, target, &pending))
+            return NULL;
+        char *name = wl_strdup(relation);
+        if (!name) {
+            (void)wl_columnar_memory_release(&pending);
+            return NULL;
+        }
+        result->relations[result->count].name = name;
+        result->relations[result->count].cols = cols;
+        if (!result_publish_admission(result, &pending, target)) {
+            free(name);
+            return NULL;
+        }
     }
 
-    wl_result_relation_t *rel = &result->relations[result->count++];
-    rel->name = wl_strdup(relation);
-    if (!rel->name)
-        return NULL;
-    rel->cols = cols;
-    return rel;
+    return &result->relations[result->count++];
 }
 
 static bool
-append_result_row(wl_result_relation_t *rel, const int64_t *row)
+append_result_row(wirelog_result_t *result, wl_result_relation_t *rel,
+    const int64_t *row)
 {
     if (rel->rows == rel->capacity_rows) {
+        if (rel->capacity_rows > UINT64_MAX / 2)
+            return false;
         uint64_t next = rel->capacity_rows ? rel->capacity_rows * 2 : 16;
-        if (rel->cols != 0 && next > UINT64_MAX / rel->cols)
+        uint64_t old_bytes, new_bytes, target;
+        if (!checked_mul_size(rel->capacity_rows, rel->cols, &old_bytes)
+            || !checked_mul_size(next, rel->cols, &new_bytes)
+            || !checked_mul_size(old_bytes, sizeof(int64_t), &old_bytes)
+            || !checked_mul_size(new_bytes, sizeof(int64_t), &new_bytes)
+            || new_bytes < old_bytes
+            || !checked_add_size(result->charged_bytes,
+            new_bytes - old_bytes, &target))
             return false;
-        int64_t *data = (int64_t *)realloc(
-            rel->data, next * rel->cols * sizeof(int64_t));
-        if (!data)
+        if (new_bytes > SIZE_MAX)
             return false;
+        wl_columnar_memory_reservation_t pending;
+        if (!result_admit(result, target, &pending))
+            return false;
+        int64_t *data = (int64_t *)malloc((size_t)new_bytes);
+        if (!data) {
+            (void)wl_columnar_memory_release(&pending);
+            return false;
+        }
+        if (rel->data && old_bytes > 0)
+            memcpy(data, rel->data, (size_t)old_bytes);
+        if (!result_publish_admission(result, &pending, target)) {
+            free(data);
+            return false;
+        }
+        free(rel->data);
         rel->data = data;
         rel->capacity_rows = next;
     }
-    memcpy(rel->data + rel->rows * rel->cols, row, rel->cols * sizeof(int64_t));
+    uint64_t row_offset;
+    uint64_t row_bytes;
+    if (!checked_mul_size(rel->rows, rel->cols, &row_offset)
+        || !checked_mul_size(rel->cols, sizeof(int64_t), &row_bytes)
+        || row_offset > SIZE_MAX / sizeof(int64_t))
+        return false;
+    memcpy(rel->data + row_offset, row, (size_t)row_bytes);
     rel->rows++;
     return true;
 }
@@ -242,12 +385,23 @@ result_set_types_from_program(wirelog_result_t *result,
     for (uint32_t i = 0; i < result->count; i++) {
         wl_result_relation_t *out = &result->relations[i];
         const wl_ir_relation_info_t *decl = find_relation(program, out->name);
-        if (!decl || out->cols == 0)
+        if (!decl || out->cols == 0 || out->types)
             continue;
-        wirelog_column_type_t *types = (wirelog_column_type_t *)malloc(
-            (size_t)out->cols * sizeof(*types));
-        if (!types)
+        uint64_t type_bytes, target;
+        if (!checked_mul_size(out->cols, sizeof(*out->types), &type_bytes)
+            || !checked_add_size(result->charged_bytes, type_bytes, &target))
             return false;
+        if (type_bytes > SIZE_MAX)
+            return false;
+        wl_columnar_memory_reservation_t pending;
+        if (!result_admit(result, target, &pending))
+            return false;
+        wirelog_column_type_t *types
+            = (wirelog_column_type_t *)malloc((size_t)type_bytes);
+        if (!types) {
+            (void)wl_columnar_memory_release(&pending);
+            return false;
+        }
         uint32_t k = 0;
         for (uint32_t c = 0; c < decl->column_count && k < out->cols; c++) {
             wirelog_column_t *col = &decl->columns[c];
@@ -258,6 +412,10 @@ result_set_types_from_program(wirelog_result_t *result,
         }
         while (k < out->cols)
             types[k++] = WIRELOG_TYPE_INT64;
+        if (!result_publish_admission(result, &pending, target)) {
+            free(types);
+            return false;
+        }
         out->types = types;
     }
     return true;
@@ -277,7 +435,7 @@ collect_tuple(const char *relation, const int64_t *row, uint32_t ncols,
         return;
     wl_result_relation_t *rel = ensure_result_relation(ctx->result, relation,
             ncols);
-    if (!rel || !append_result_row(rel, row))
+    if (!rel || !append_result_row(ctx->result, rel, row))
         ctx->failed = true;
 }
 
@@ -606,6 +764,24 @@ wirelog_evaluate(wirelog_executor_t *executor, wirelog_error_t *error)
         return NULL;
     }
 
+    result->memory_governor
+        = col_session_memory_governor_ref(executor->session);
+    if (!result->memory_governor) {
+        free(result);
+        set_error(error, WIRELOG_ERR_MEMORY);
+        return NULL;
+    }
+    wl_columnar_memory_governor_ref_retain(result->memory_governor);
+    wl_columnar_memory_reservation_init(&result->reservation);
+    if (!result_admit(result, sizeof(*result), &result->reservation)) {
+        (void)wl_columnar_memory_release(&result->reservation);
+        wl_columnar_memory_governor_ref_release(result->memory_governor);
+        free(result);
+        set_error(error, WIRELOG_ERR_MEMORY);
+        return NULL;
+    }
+    result->charged_bytes = sizeof(*result);
+
     wl_collect_ctx_t ctx = {
         .result = result,
         .failed = false,
@@ -692,6 +868,8 @@ wirelog_result_free(wirelog_result_t *result)
     for (uint32_t i = 0; i < result->count; i++)
         free_result_relation(&result->relations[i]);
     free(result->relations);
+    (void)wl_columnar_memory_release(&result->reservation);
+    wl_columnar_memory_governor_ref_release(result->memory_governor);
     free(result);
 }
 

--- a/wirelog/columnar/columnar_nanoarrow.h
+++ b/wirelog/columnar/columnar_nanoarrow.h
@@ -98,6 +98,10 @@ typedef struct {
     uint32_t *key_cols;
 } wl_plan_op_lftj_t;
 
+/* Borrowed from the session; callers retaining it must call retain(). */
+wl_columnar_memory_governor_ref_t *
+col_session_memory_governor_ref(wl_session_t *session);
+
 /* ======================================================================== */
 /* Exchange Metadata (Issue #316)                                           */
 /* ======================================================================== */

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1643,6 +1643,17 @@ col_session_destroy(wl_session_t *session)
     free(sess);
 }
 
+wl_columnar_memory_governor_ref_t *
+col_session_memory_governor_ref(wl_session_t *session)
+{
+    wl_col_session_t *sess;
+
+    if (!session)
+        return NULL;
+    sess = COL_SESSION(session);
+    return sess->memory_governor;
+}
+
 /* ======================================================================== */
 /* Per-Worker Session State (Issue #315)                                    */
 /* ======================================================================== */

--- a/wirelog/wirelog.h
+++ b/wirelog/wirelog.h
@@ -74,7 +74,9 @@ typedef struct wirelog_program wirelog_program_t;
 /**
  * wirelog_result_t:
  *
- * Opaque handle to evaluation results.
+ * Opaque handle to evaluation results. Result-owned relation storage is
+ * subject to the session memory governor; parser, IR, and plan allocations
+ * remain outside that result lifetime budget.
  */
 typedef struct wirelog_result wirelog_result_t;
 


### PR DESCRIPTION
## Summary
- apply the session memory governor to public batch result ownership
- make relation, row-buffer, and type growth transactional with old+new peak admission
- retain the governor until result destruction and document parser/IR/plan non-guarantees

Rebased onto `main` after #1420 and #1421 merged. The only conflict was in `docs/MEMORY.md`, where the foundation-status paragraphs now describe both the fixed eval-arena/delta-pool admission that landed on `main` and the result-collector admission from this branch; the compound-arena follow-up (#1417) is still called out as pending.

Closes #1418

## Validation
- `meson compile -C builddir-1418 -j4`
- `meson test -C builddir-1418 wirelog_public_api memory_governor --print-errorlogs`
- `meson test -C builddir-1418 --suite abi --print-errorlogs`
- ASAN/UBSAN `wirelog_public_api`
- After rebase: build, `wirelog_public_api`, `memory_governor`, `mem_instrumentation_default`, `tdd_decision_stats`, `wirelog_easy`, `wirelog_advanced`, and the full `abi` suite (61 OK) pass; `uncrustify --check` and `git diff --check` clean.
