### PR TITLE
feat: admit hash arrangement storage

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -211,6 +211,16 @@ execution error mapping and leave output handles null. Compound-arena
 admission remains a separate follow-up unit in #1417; parser/plan/result
 allocations remain tracked by #1418. The parent #1369
 contract is therefore only partially implemented until those units land.
+
+The next #1369 allocation unit, #1425, admits only the `ht_head` and
+`ht_next` backing arrays of primary, delta, and filtered hash arrangements.
+Each arrangement retains the shared session governor while its registry entry
+is alive. Full rebuilds and incremental capacity growth reserve the
+prospective footprint before allocating replacement arrays; the old
+reservation remains live until publication, and failed admission leaves the
+old index unchanged. Sorted and differential arrangements, registry metadata,
+relation/timestamp storage, cache policy, and join/TDD scratch remain separate
+allocation classes.
 # wirelog Memory Instrumentation
 
 This document describes what the columnar engine measures about its own

--- a/tests/test_arrangement.c
+++ b/tests/test_arrangement.c
@@ -21,7 +21,10 @@
  *   If the private struct layout changes, update the mirrors below.
  */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/columnar/internal.h"
 #include "../wirelog/exec_plan_gen.h"
 #include "../wirelog/passes/fusion.h"
 #include "../wirelog/passes/jpp.h"
@@ -36,6 +39,24 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+
+#define setenv wl_test_setenv_
+#define unsetenv wl_test_unsetenv_
+#endif
 
 /* ----------------------------------------------------------------
  * Test framework
@@ -199,6 +220,26 @@ free_session(wl_session_t *sess, wl_plan_t *plan, wirelog_program_t *prog)
     wirelog_program_free(prog);
 }
 
+static void
+set_memory_budget_for_test(void)
+{
+#ifdef _WIN32
+    (void)_putenv_s("WIRELOG_MEMORY_BUDGET", "268435456");
+#else
+    (void)setenv("WIRELOG_MEMORY_BUDGET", "268435456", 1);
+#endif
+}
+
+static void
+clear_memory_budget_for_test(void)
+{
+#ifdef _WIN32
+    (void)_putenv_s("WIRELOG_MEMORY_BUDGET", "");
+#else
+    (void)unsetenv("WIRELOG_MEMORY_BUDGET");
+#endif
+}
+
 /*
  * find_rel_mirror: locate a relation by name in the mirrored session.
  * Returns NULL if not found.
@@ -234,21 +275,90 @@ find_rel_mirror(wl_session_t *sess, const char *rel_name)
  *   uint32_t  generation   4  (offset 48)
  *   (4 bytes padding)
  *   struct wl_mem_ledger *ledger 8 (offset 56, Issue #1380)
- *                         = 64 bytes total
+ *                         = 120 bytes total
  * ================================================================ */
 static void
 test_arrangement_struct_size(void)
 {
     TEST("col_arrangement_t struct size (layout sentinel)");
-
-    /* 64 bytes: 4 pointers (32) + 5 uint32 (20) + 1 uint64 (8) + 4 pad. */
-    ASSERT(sizeof(col_arrangement_t) == 64,
-        "col_arrangement_t must be 64 bytes; update if struct changes");
+    /* 120 bytes: legacy fields plus governor reference, reservation, and
+     * reserved byte count. */
+    ASSERT(sizeof(col_arrangement_t) == 120,
+        "col_arrangement_t must be 120 bytes; update if struct changes");
     ASSERT(offsetof(col_arrangement_t, ht_head) == 16,
         "ht_head layout changed unexpectedly");
     ASSERT(offsetof(col_arrangement_t, generation) == 48,
         "generation layout changed unexpectedly");
 
+    PASS();
+}
+
+static void
+test_arrangement_admission_denial(void)
+{
+    const char *src =
+        ".decl edge(x:int32,y:int32)\n"
+        "edge(1,2).\n"
+        "edge(2,3).\n"
+        "edge(3,4).\n";
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *cs;
+    wl_columnar_memory_governor_t *governor;
+    wl_columnar_memory_reservation_t blocker;
+    test_col_rel_mirror_t *rel;
+    uint64_t usable;
+    uint64_t reserved;
+    uint32_t key_cols[] = { 0 };
+    col_arrangement_t *arr;
+
+    TEST("arrangement admission denies before allocation and recovers");
+    set_memory_budget_for_test();
+    if (make_session(src, &sess, &plan, &prog) != 0) {
+        clear_memory_budget_for_test();
+        FAIL("session setup failed");
+    }
+    cs = COL_SESSION(sess);
+    governor = wl_columnar_memory_governor_ref_get(cs->memory_governor);
+    usable = atomic_load_explicit(&governor->usable_bytes,
+            memory_order_relaxed);
+    reserved = wl_columnar_memory_reserved(governor);
+    if (usable <= reserved + 1) {
+        free_session(sess, plan, prog);
+        clear_memory_budget_for_test();
+        FAIL("session consumed the entire test budget");
+    }
+    wl_columnar_memory_reservation_init(&blocker);
+    ASSERT(wl_columnar_memory_reserve(governor, usable - reserved - 1,
+        &blocker), "failed to install admission blocker");
+    arr = col_session_get_arrangement(sess, "edge", key_cols, 1);
+    ASSERT(arr == NULL, "arrangement bypassed a denied reservation");
+    ASSERT(wl_columnar_memory_reserved(governor)
+        >= usable - 1,
+        "denied arrangement changed reservation accounting");
+    ASSERT(wl_columnar_memory_release(&blocker),
+        "failed to release admission blocker");
+    arr = col_session_get_arrangement(sess, "edge", key_cols, 1);
+    ASSERT(arr != NULL, "arrangement did not recover after release");
+    rel = find_rel_mirror(sess, "edge");
+    ASSERT(rel != NULL, "edge relation disappeared");
+    rel->nrows = 16;
+    reserved = wl_columnar_memory_reserved(governor);
+    wl_columnar_memory_reservation_init(&blocker);
+    ASSERT(wl_columnar_memory_reserve(governor, usable - reserved - 1,
+        &blocker), "failed to install rebuild blocker");
+    ASSERT(col_session_get_arrangement(sess, "edge", key_cols, 1) == NULL,
+        "bucket-only rebuild bypassed admission");
+    ASSERT(arr->indexed_rows == 3,
+        "denied bucket rebuild destroyed the previous index");
+    ASSERT(wl_columnar_memory_release(&blocker),
+        "failed to release rebuild blocker");
+    ASSERT(col_session_get_arrangement(sess, "edge", key_cols, 1) != NULL
+        && arr->indexed_rows == 16,
+        "bucket-only rebuild did not recover after release");
+    free_session(sess, plan, prog);
+    clear_memory_budget_for_test();
     PASS();
 }
 
@@ -650,6 +760,7 @@ main(void)
     test_arrangement_invalidate();
     test_arrangement_registry_cache();
     test_arrangement_generation_wrap();
+    test_arrangement_admission_denial();
 
     printf("\nResults: %d/%d passed", pass_count, test_count);
     if (fail_count > 0)

--- a/tests/test_memory_governor.c
+++ b/tests/test_memory_governor.c
@@ -261,14 +261,17 @@ test_checked_admission(void)
     wl_columnar_memory_governor_t governor;
     wl_columnar_memory_governor_t other_governor;
     wl_columnar_memory_reservation_t reservation;
+    wl_columnar_memory_reservation_t second;
     wl_columnar_memory_reservation_t copied;
     wl_columnar_memory_reservation_t old_reservation;
     wl_columnar_memory_reservation_t growth_reservation;
+    wl_columnar_memory_reservation_t moved_reservation;
     uint64_t value;
 
     TEST("typed admission, growth overlap, arithmetic, and token identity");
     make_resolution(&resolution, 1000, 900);
     wl_columnar_memory_reservation_init(&reservation);
+    wl_columnar_memory_reservation_init(&second);
     if (wl_columnar_memory_governor_init(&governor, &resolution) != 0
         || wl_columnar_memory_size_add(UINT64_MAX, 1, &value)
         || wl_columnar_memory_size_mul(UINT64_MAX, 2, &value)
@@ -298,6 +301,7 @@ test_checked_admission(void)
     }
     wl_columnar_memory_reservation_init(&old_reservation);
     wl_columnar_memory_reservation_init(&growth_reservation);
+    wl_columnar_memory_reservation_init(&moved_reservation);
     if (!wl_columnar_memory_reserve(&governor, 100, &old_reservation)
         || wl_columnar_memory_reserve_growth(&governor, 100, 200,
         &growth_reservation) != WL_COLUMNAR_MEMORY_ADMISSION_OK
@@ -305,6 +309,18 @@ test_checked_admission(void)
         || !wl_columnar_memory_release(&growth_reservation)
         || !wl_columnar_memory_release(&old_reservation)) {
         FAIL("growth did not reserve a distinct overlapping footprint");
+        return 1;
+    }
+    if (!wl_columnar_memory_reserve(&governor, 100, &old_reservation)
+        || !wl_columnar_memory_reserve(&governor, 50, &second)
+        || wl_columnar_memory_reservation_move(&second, &old_reservation)
+        || !wl_columnar_memory_release(&second)
+        || !wl_columnar_memory_reservation_move(&moved_reservation,
+        &old_reservation)
+        || wl_columnar_memory_release(&old_reservation)
+        || !wl_columnar_memory_release(&moved_reservation)
+        || wl_columnar_memory_reserved(&governor) != 0) {
+        FAIL("reservation move did not preserve token ownership");
         return 1;
     }
     make_resolution(&resolution, 1000, 900);

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -220,6 +220,41 @@ arr_ledger_bytes(const col_arrangement_t *arr)
     return (uint64_t)bytes;
 }
 
+static bool
+arr_reserve_bytes(col_arrangement_t *arr, uint64_t bytes,
+    wl_columnar_memory_reservation_t *pending)
+{
+    wl_columnar_memory_governor_t *governor;
+
+    if (!arr || !pending || bytes == 0)
+        return bytes == 0;
+    governor = wl_columnar_memory_governor_ref_get(arr->memory_governor);
+    if (!governor)
+        return true;
+    wl_columnar_memory_reservation_init(pending);
+    if (!wl_columnar_memory_reserve(governor, bytes, pending)
+        || !wl_columnar_memory_commit(pending, arr)) {
+        (void)wl_columnar_memory_release(pending);
+        return false;
+    }
+    return true;
+}
+
+static void
+arr_publish_reservation(col_arrangement_t *arr,
+    wl_columnar_memory_reservation_t *pending, uint64_t bytes)
+{
+    if (!arr || !arr->memory_governor)
+        return;
+    if (bytes == arr->reserved_bytes) {
+        (void)wl_columnar_memory_release(pending);
+        return;
+    }
+    (void)wl_columnar_memory_release(&arr->reservation);
+    (void)wl_columnar_memory_reservation_move(&arr->reservation, pending);
+    arr->reserved_bytes = bytes;
+}
+
 /*
  * arr_ledger_sync: charge or credit the difference between @before and the
  * arrangement's current footprint under ARRANGEMENT (Issue #1380).
@@ -248,6 +283,27 @@ col_arr_attach_ledger(col_arrangement_t *arr, wl_mem_ledger_t *ledger)
 }
 
 void
+col_arr_attach_memory_governor(col_arrangement_t *arr,
+    wl_columnar_memory_governor_ref_t *memory_governor)
+{
+    if (!arr || arr->memory_governor || !memory_governor)
+        return;
+    arr->memory_governor = memory_governor;
+    wl_columnar_memory_governor_ref_retain(memory_governor);
+}
+
+void
+col_arr_detach_memory_governor(col_arrangement_t *arr)
+{
+    if (!arr)
+        return;
+    (void)wl_columnar_memory_release(&arr->reservation);
+    arr->reserved_bytes = 0;
+    wl_columnar_memory_governor_ref_release(arr->memory_governor);
+    arr->memory_governor = NULL;
+}
+
+void
 arr_free_contents(col_arrangement_t *arr)
 {
     if (!arr)
@@ -260,6 +316,8 @@ arr_free_contents(col_arrangement_t *arr)
     }
     free(arr->ht_head);
     free(arr->ht_next);
+    (void)wl_columnar_memory_release(&arr->reservation);
+    arr->reserved_bytes = 0;
     arr->ht_head = NULL;
     arr->ht_next = NULL;
     arr->nbuckets = 0;
@@ -318,6 +376,11 @@ arr_build_full_impl(col_arrangement_t *arr, const col_rel_t *rel)
     uint64_t *new_head = NULL;
     uint32_t *new_next = NULL;
     uint32_t new_cap = arr->ht_cap;
+    size_t prospective_head_bytes;
+    size_t prospective_next_bytes;
+    uint64_t prospective_bytes;
+    wl_columnar_memory_reservation_t pending;
+    bool pending_valid = false;
 
     /* Prepare every potentially failing allocation before publishing any
      * part of the new arrangement.  This keeps a failed rebuild usable. */
@@ -325,11 +388,6 @@ arr_build_full_impl(col_arrangement_t *arr, const col_rel_t *rel)
         size_t head_bytes = (size_t)nbuckets * sizeof(uint64_t);
         if (nbuckets != 0 && head_bytes / sizeof(uint64_t) != nbuckets)
             return ENOMEM;
-        new_head = (uint64_t *)malloc(head_bytes);
-        if (!new_head)
-            return ENOMEM;
-        /* Zero has generation zero, which cannot match a live generation. */
-        memset(new_head, 0, head_bytes);
     }
     /* Grow chain array if needed. */
     if (nrows > arr->ht_cap) {
@@ -343,9 +401,44 @@ arr_build_full_impl(col_arrangement_t *arr, const col_rel_t *rel)
             free(new_head);
             return ENOMEM;
         }
+    }
+
+    prospective_head_bytes = (size_t)nbuckets * sizeof(uint64_t);
+    prospective_next_bytes = (size_t)new_cap * sizeof(uint32_t);
+    if ((nbuckets != 0
+        && prospective_head_bytes / sizeof(uint64_t) != nbuckets)
+        || (new_cap != 0
+        && prospective_next_bytes / sizeof(uint32_t) != new_cap)
+        || prospective_head_bytes > SIZE_MAX - prospective_next_bytes) {
+        free(new_head);
+        return ENOMEM;
+    }
+    prospective_bytes = (uint64_t)(prospective_head_bytes
+        + prospective_next_bytes);
+    if (nbuckets != arr->nbuckets || new_cap != arr->ht_cap) {
+        if (!arr_reserve_bytes(arr, prospective_bytes, &pending)) {
+            free(new_head);
+            return ENOMEM;
+        }
+        pending_valid = arr->memory_governor != NULL;
+    }
+    if (nbuckets != arr->nbuckets) {
+        new_head = (uint64_t *)malloc(prospective_head_bytes);
+        if (!new_head) {
+            if (pending_valid)
+                (void)wl_columnar_memory_release(&pending);
+            return ENOMEM;
+        }
+        /* Zero has generation zero, which cannot match a live generation. */
+        memset(new_head, 0, prospective_head_bytes);
+    }
+    if (new_cap != arr->ht_cap) {
+        size_t next_bytes = prospective_next_bytes;
         new_next = (uint32_t *)malloc(next_bytes);
         if (!new_next) {
             free(new_head);
+            if (pending_valid)
+                (void)wl_columnar_memory_release(&pending);
             return ENOMEM;
         }
     }
@@ -360,6 +453,8 @@ arr_build_full_impl(col_arrangement_t *arr, const col_rel_t *rel)
         arr->ht_next = new_next;
         arr->ht_cap = new_cap;
     }
+    if (pending_valid)
+        arr_publish_reservation(arr, &pending, prospective_bytes);
 
     /* Start a new epoch.  Only wraparound needs a full clear; normal rebuilds
      * lazily replace each bucket head as that bucket receives its first row. */
@@ -428,12 +523,33 @@ arr_update_incremental_impl(col_arrangement_t *arr, const col_rel_t *rel,
     /* Grow chain array if needed. */
     if (nrows > arr->ht_cap) {
         uint32_t new_cap = nrows * 2u < 16u ? 16u : nrows * 2u;
-        uint32_t *nxt
-            = (uint32_t *)realloc(arr->ht_next, new_cap * sizeof(uint32_t));
-        if (!nxt)
+        size_t next_bytes = (size_t)new_cap * sizeof(uint32_t);
+        size_t head_bytes = (size_t)arr->nbuckets * sizeof(uint64_t);
+        uint64_t target_bytes;
+        wl_columnar_memory_reservation_t pending;
+        bool pending_valid;
+        if (new_cap != 0 && next_bytes / sizeof(uint32_t) != new_cap)
             return ENOMEM;
+        if (head_bytes > SIZE_MAX - next_bytes)
+            return ENOMEM;
+        target_bytes = (uint64_t)(head_bytes + next_bytes);
+        if (!arr_reserve_bytes(arr, target_bytes, &pending))
+            return ENOMEM;
+        pending_valid = arr->memory_governor != NULL;
+        uint32_t *nxt = (uint32_t *)malloc(next_bytes);
+        if (!nxt){
+            if (pending_valid)
+                (void)wl_columnar_memory_release(&pending);
+            return ENOMEM;
+        }
+        if (arr->ht_next && arr->ht_cap > 0)
+            memcpy(nxt, arr->ht_next,
+                (size_t)arr->ht_cap * sizeof(uint32_t));
+        free(arr->ht_next);
         arr->ht_next = nxt;
         arr->ht_cap = new_cap;
+        if (pending_valid)
+            arr_publish_reservation(arr, &pending, target_bytes);
     }
 
     uint32_t nb = arr->nbuckets;
@@ -624,10 +740,12 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
         /* Reuse tombstone: free its old ownership before overwriting. */
         free(cs->arr_entries[slot].rel_name);
         free(cs->arr_entries[slot].key_cols);
+        col_arr_detach_memory_governor(&cs->arr_entries[slot].arr);
     }
 
     col_arr_entry_t *e = &cs->arr_entries[slot];
     memset(e, 0, sizeof(*e));
+    wl_columnar_memory_reservation_init(&e->arr.reservation);
 
     e->rel_name = wl_strdup(rel_name);
     if (!e->rel_name) {
@@ -649,9 +767,12 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
     e->arr.key_cols = e->key_cols; /* shared view; key_cols owned by entry */
     e->arr.key_count = key_count;
     e->arr.ledger = &cs->mem_ledger; /* Issue #1380: ARRANGEMENT accounting */
+    col_arr_attach_memory_governor(&e->arr, cs->memory_governor);
 
     /* Initial build. */
     if (arr_build_full(&e->arr, rel) != 0) {
+        arr_free_contents(&e->arr);
+        col_arr_detach_memory_governor(&e->arr);
         free(e->rel_name);
         free(e->key_cols);
         memset(e, 0, sizeof(*e));
@@ -661,6 +782,7 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
     }
     if (!arr_memory_bytes(&e->arr, &e->mem_bytes)) {
         arr_free_contents(&e->arr);
+        col_arr_detach_memory_governor(&e->arr);
         free(e->rel_name);
         free(e->key_cols);
         memset(e, 0, sizeof(*e));
@@ -801,6 +923,7 @@ col_session_free_delta_arrangements(wl_col_session_t *cs)
         free(e->rel_name);
         free(e->key_cols);
         arr_free_contents(&e->arr);
+        col_arr_detach_memory_governor(&e->arr);
     }
     free(cs->darr_entries);
     cs->darr_entries = NULL;
@@ -850,9 +973,12 @@ col_session_get_delta_arrangement(wl_col_session_t *cs, const char *rel_name,
             continue;
         /* Found: rebuild if stale (delta changed size). */
         if (e->arr.indexed_rows != delta_rel->nrows) {
-            arr_free_contents(&e->arr);
-            if (delta_rel->nrows > 0 && arr_build_full(&e->arr, delta_rel) != 0)
-                return NULL;
+            if (delta_rel->nrows > 0) {
+                if (arr_build_full(&e->arr, delta_rel) != 0)
+                    return NULL;
+            } else {
+                arr_free_contents(&e->arr);
+            }
         }
         return &e->arr;
     }
@@ -870,6 +996,7 @@ col_session_get_delta_arrangement(wl_col_session_t *cs, const char *rel_name,
 
     col_arr_entry_t *e = &cs->darr_entries[cs->darr_count];
     memset(e, 0, sizeof(*e));
+    wl_columnar_memory_reservation_init(&e->arr.reservation);
 
     e->rel_name = wl_strdup(rel_name);
     if (!e->rel_name)
@@ -886,10 +1013,13 @@ col_session_get_delta_arrangement(wl_col_session_t *cs, const char *rel_name,
     e->arr.key_cols = e->key_cols; /* shared view; owned by entry */
     e->arr.key_count = key_count;
     e->arr.ledger = &cs->mem_ledger; /* Issue #1380 */
+    col_arr_attach_memory_governor(&e->arr, cs->memory_governor);
     cs->darr_count++;
 
     /* Initial build. */
     if (delta_rel->nrows > 0 && arr_build_full(&e->arr, delta_rel) != 0) {
+        arr_free_contents(&e->arr);
+        col_arr_detach_memory_governor(&e->arr);
         cs->darr_count--;
         free(e->rel_name);
         free(e->key_cols);
@@ -962,10 +1092,12 @@ col_session_get_filt_arrangement(wl_col_session_t *cs, const char *rel_name,
             continue;
         /* Found: rebuild if stale (filtered_rel grew since last build). */
         if (e->arr.indexed_rows != filtered_rel->nrows) {
-            arr_free_contents(&e->arr);
-            if (filtered_rel->nrows > 0
-                && arr_build_full(&e->arr, filtered_rel) != 0)
-                return NULL;
+            if (filtered_rel->nrows > 0) {
+                if (arr_build_full(&e->arr, filtered_rel) != 0)
+                    return NULL;
+            } else {
+                arr_free_contents(&e->arr);
+            }
         }
         return &e->arr;
     }
@@ -983,6 +1115,7 @@ col_session_get_filt_arrangement(wl_col_session_t *cs, const char *rel_name,
 
     col_filt_arr_entry_t *e = &cs->filt_arr_entries[cs->filt_arr_count];
     memset(e, 0, sizeof(*e));
+    wl_columnar_memory_reservation_init(&e->arr.reservation);
 
     e->rel_name = wl_strdup(rel_name);
     if (!e->rel_name)
@@ -1000,10 +1133,13 @@ col_session_get_filt_arrangement(wl_col_session_t *cs, const char *rel_name,
     e->arr.key_cols = e->key_cols; /* shared view; owned by entry */
     e->arr.key_count = key_count;
     e->arr.ledger = &cs->mem_ledger; /* Issue #1380 */
+    col_arr_attach_memory_governor(&e->arr, cs->memory_governor);
     cs->filt_arr_count++;
 
     if (filtered_rel->nrows > 0
         && arr_build_full(&e->arr, filtered_rel) != 0) {
+        arr_free_contents(&e->arr);
+        col_arr_detach_memory_governor(&e->arr);
         cs->filt_arr_count--;
         free(e->rel_name);
         free(e->key_cols);
@@ -1028,6 +1164,7 @@ col_session_free_filt_arrangements(wl_col_session_t *cs)
         free(cs->filt_arr_entries[i].rel_name);
         free(cs->filt_arr_entries[i].key_cols);
         arr_free_contents(&cs->filt_arr_entries[i].arr);
+        col_arr_detach_memory_governor(&cs->filt_arr_entries[i].arr);
     }
     free(cs->filt_arr_entries);
     cs->filt_arr_entries = NULL;

--- a/wirelog/columnar/columnar_nanoarrow.h
+++ b/wirelog/columnar/columnar_nanoarrow.h
@@ -43,6 +43,7 @@
 
 #include "../backend.h"
 #include "../exec_plan.h"
+#include "columnar/memory_governor.h"
 
 /* ======================================================================== */
 /* K-Fusion Metadata                                                        */
@@ -254,6 +255,11 @@ typedef struct {
      * reported under WL_MEM_SUBSYS_ARRANGEMENT.  Set by the registry that
      * owns the entry; NULL for arrangements built outside a session. */
     struct wl_mem_ledger *ledger;
+    /* Arrangement-owned admission lifetime.  The reservation covers only
+     * ht_head/ht_next; the reference survives tombstone rebuilds. */
+    wl_columnar_memory_governor_ref_t *memory_governor;
+    wl_columnar_memory_reservation_t reservation;
+    uint64_t reserved_bytes;
 } col_arrangement_t;
 
 /**

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1946,6 +1946,13 @@ arr_free_contents(col_arrangement_t *arr);
  */
 void
 col_arr_attach_ledger(col_arrangement_t *arr, wl_mem_ledger_t *ledger);
+
+void
+col_arr_attach_memory_governor(col_arrangement_t *arr,
+    wl_columnar_memory_governor_ref_t *memory_governor);
+
+void
+col_arr_detach_memory_governor(col_arrangement_t *arr);
 col_arrangement_t *
 col_session_get_delta_arrangement(wl_col_session_t *cs, const char *rel_name,
     const col_rel_t *delta_rel,
@@ -1970,7 +1977,8 @@ col_session_free_diff_arrangements(wl_col_session_t *cs);
 /* Issue #260: Deep-copy arrangement entries for K-fusion worker isolation. */
 int
 col_arr_entries_clone(const col_arr_entry_t *src, uint32_t count,
-    col_arr_entry_t **out_entries, uint32_t *out_cap);
+    col_arr_entry_t **out_entries, uint32_t *out_cap,
+    wl_columnar_memory_governor_ref_t *memory_governor);
 /* Issue #274: Deep-copy differential arrangement entries for K-fusion worker isolation. */
 int
 col_diff_arr_entries_clone(const col_diff_arr_entry_t *src, uint32_t count,

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -242,7 +242,8 @@ col_rel_merge_k(col_rel_t **relations, uint32_t k)
  * Returns 0 on success; dst is memset-zeroed before returning on failure.
  */
 static int
-col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst)
+col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst,
+    wl_columnar_memory_governor_ref_t *memory_governor)
 {
     size_t head_bytes = 0;
     size_t next_bytes = 0;
@@ -273,53 +274,60 @@ col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst)
     dst->arr.nbuckets = src->arr.nbuckets;
     dst->arr.ht_cap = src->arr.ht_cap;
     dst->arr.generation = src->arr.generation;
+    col_arr_attach_memory_governor(&dst->arr, memory_governor);
+    if (dst->arr.memory_governor && src->mem_bytes > 0) {
+        wl_columnar_memory_governor_t *governor
+            = wl_columnar_memory_governor_ref_get(memory_governor);
+        wl_columnar_memory_reservation_init(&dst->arr.reservation);
+        if (!wl_columnar_memory_reserve(governor, src->mem_bytes,
+            &dst->arr.reservation)
+            || !wl_columnar_memory_commit(&dst->arr.reservation, dst)) {
+            (void)wl_columnar_memory_release(&dst->arr.reservation);
+            col_arr_detach_memory_governor(&dst->arr);
+            free(dst->key_cols);
+            free(dst->rel_name);
+            memset(dst, 0, sizeof(*dst));
+            return ENOMEM;
+        }
+        dst->arr.reserved_bytes = src->mem_bytes;
+    }
     /* Issue #216: copy LRU metadata so worker clones inherit access state. */
     dst->lru_clock = src->lru_clock;
     dst->mem_bytes = src->mem_bytes;
 
     if (src->arr.nbuckets > 0 && src->arr.ht_head) {
         head_bytes = (size_t)src->arr.nbuckets * sizeof(uint64_t);
-        if (head_bytes / sizeof(uint64_t) != src->arr.nbuckets) {
-            free(dst->key_cols);
-            free(dst->rel_name);
-            memset(dst, 0, sizeof(*dst));
-            return ENOMEM;
-        }
+        if (head_bytes / sizeof(uint64_t) != src->arr.nbuckets)
+            goto fail;
         dst->arr.ht_head
             = (uint64_t *)malloc(head_bytes);
-        if (!dst->arr.ht_head) {
-            free(dst->key_cols);
-            free(dst->rel_name);
-            memset(dst, 0, sizeof(*dst));
-            return ENOMEM;
-        }
+        if (!dst->arr.ht_head)
+            goto fail;
         memcpy(dst->arr.ht_head, src->arr.ht_head,
             head_bytes);
     }
 
     if (src->arr.ht_cap > 0 && src->arr.ht_next) {
         next_bytes = (size_t)src->arr.ht_cap * sizeof(uint32_t);
-        if (next_bytes / sizeof(uint32_t) != src->arr.ht_cap) {
-            free(dst->arr.ht_head);
-            free(dst->key_cols);
-            free(dst->rel_name);
-            memset(dst, 0, sizeof(*dst));
-            return ENOMEM;
-        }
+        if (next_bytes / sizeof(uint32_t) != src->arr.ht_cap)
+            goto fail;
         dst->arr.ht_next
             = (uint32_t *)malloc(next_bytes);
-        if (!dst->arr.ht_next) {
-            free(dst->arr.ht_head);
-            free(dst->key_cols);
-            free(dst->rel_name);
-            memset(dst, 0, sizeof(*dst));
-            return ENOMEM;
-        }
+        if (!dst->arr.ht_next)
+            goto fail;
         memcpy(dst->arr.ht_next, src->arr.ht_next,
             next_bytes);
     }
 
     return 0;
+
+fail:
+    arr_free_contents(&dst->arr);
+    col_arr_detach_memory_governor(&dst->arr);
+    free(dst->key_cols);
+    free(dst->rel_name);
+    memset(dst, 0, sizeof(*dst));
+    return ENOMEM;
 }
 
 /**
@@ -331,7 +339,8 @@ col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst)
  */
 int
 col_arr_entries_clone(const col_arr_entry_t *src, uint32_t count,
-    col_arr_entry_t **out_entries, uint32_t *out_cap)
+    col_arr_entry_t **out_entries, uint32_t *out_cap,
+    wl_columnar_memory_governor_ref_t *memory_governor)
 {
     *out_entries = NULL;
     *out_cap = 0;
@@ -345,12 +354,14 @@ col_arr_entries_clone(const col_arr_entry_t *src, uint32_t count,
         return ENOMEM;
 
     for (uint32_t i = 0; i < count; i++) {
-        int clone_rc = col_arr_entry_clone(&src[i], &cloned[i]);
+        int clone_rc = col_arr_entry_clone(&src[i], &cloned[i],
+                memory_governor);
         if (clone_rc != 0) {
             for (uint32_t j = 0; j < i; j++) {
                 free(cloned[j].rel_name);
                 free(cloned[j].key_cols);
                 arr_free_contents(&cloned[j].arr);
+                col_arr_detach_memory_governor(&cloned[j].arr);
             }
             free(cloned);
             return clone_rc;
@@ -983,6 +994,7 @@ cleanup_wq:
             free(e->rel_name);
             free(e->key_cols);
             arr_free_contents(&e->arr);
+            col_arr_detach_memory_governor(&e->arr);
         }
         free(worker_sess[d].arr_entries);
         /* Free worker's private delta-arrangement cache (darr_*). */

--- a/wirelog/columnar/memory_governor.c
+++ b/wirelog/columnar/memory_governor.c
@@ -482,6 +482,43 @@ reservation_identity_valid(const wl_columnar_memory_reservation_t *reservation)
 }
 
 bool
+wl_columnar_memory_reservation_move(
+    wl_columnar_memory_reservation_t *destination,
+    wl_columnar_memory_reservation_t *source)
+{
+    uint64_t destination_state;
+    uint64_t state;
+
+    if (!destination || !source || destination == source
+        || !reservation_identity_valid(destination)
+        || !reservation_identity_valid(source))
+        return false;
+    destination_state = atomic_load_explicit(&destination->state,
+            memory_order_acquire);
+    if (destination_state != WL_COLUMNAR_MEMORY_RESERVATION_EMPTY
+        && destination_state != WL_COLUMNAR_MEMORY_RESERVATION_RELEASED)
+        return false;
+    state = atomic_load_explicit(&source->state, memory_order_acquire);
+    if (state != WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+        && state != WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED)
+        return false;
+    destination->governor = source->governor;
+    destination->bytes = source->bytes;
+    atomic_store_explicit(&destination->owner_bits,
+        atomic_load_explicit(&source->owner_bits, memory_order_relaxed),
+        memory_order_relaxed);
+    atomic_store_explicit(&destination->state, state, memory_order_release);
+    destination->identity = destination;
+    source->governor = NULL;
+    source->bytes = 0;
+    atomic_store_explicit(&source->owner_bits, 0, memory_order_relaxed);
+    atomic_store_explicit(&source->state,
+        WL_COLUMNAR_MEMORY_RESERVATION_EMPTY, memory_order_release);
+    source->identity = source;
+    return true;
+}
+
+bool
 wl_columnar_memory_size_add(uint64_t left, uint64_t right, uint64_t *out)
 {
     if (!out || left > UINT64_MAX - right)

--- a/wirelog/columnar/memory_governor.h
+++ b/wirelog/columnar/memory_governor.h
@@ -128,6 +128,12 @@ void
 wl_columnar_memory_reservation_init(
     wl_columnar_memory_reservation_t *reservation);
 
+/* Move an active token to another caller-owned storage location. */
+bool
+wl_columnar_memory_reservation_move(
+    wl_columnar_memory_reservation_t *destination,
+    wl_columnar_memory_reservation_t *source);
+
 const char *
 wl_columnar_memory_source_name(wl_columnar_memory_source_t source);
 

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1568,6 +1568,7 @@ col_session_destroy(wl_session_t *session)
         free(sess->arr_entries[i].rel_name);
         free(sess->arr_entries[i].key_cols);
         arr_free_contents(&sess->arr_entries[i].arr);
+        col_arr_detach_memory_governor(&sess->arr_entries[i].arr);
     }
     free(sess->arr_entries);
     col_session_free_delta_arrangements(sess);
@@ -1816,7 +1817,7 @@ col_worker_session_create(wl_col_session_t *coordinator,
     if (coordinator->arr_count > 0) {
         int rc = col_arr_entries_clone(coordinator->arr_entries,
                 coordinator->arr_count, &out_worker->arr_entries,
-                &out_worker->arr_cap);
+                &out_worker->arr_cap, out_worker->memory_governor);
         if (rc != 0)
             goto cleanup;
         out_worker->arr_count = coordinator->arr_count;
@@ -1880,6 +1881,7 @@ col_worker_session_destroy(wl_col_session_t *worker)
         free(worker->arr_entries[i].rel_name);
         free(worker->arr_entries[i].key_cols);
         arr_free_contents(&worker->arr_entries[i].arr);
+        col_arr_detach_memory_governor(&worker->arr_entries[i].arr);
     }
     free(worker->arr_entries);
     col_session_free_delta_arrangements(worker);


### PR DESCRIPTION
Closes #1425

- reserve hash arrangement head/next storage before allocation
- preserve the previous index when stale rebuild admission is denied
- retain governor lifetime across arrangement and worker cleanup
- move reservation tokens without copying identity-bound state
- add admission and reservation lifecycle regression coverage

Validation: focused arrangement, delta, filtered-cache, worker-session, and memory-governor tests pass; git diff --check passes.