### PR TITLE
fix: enforce compound arena mutation windows

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -487,7 +487,22 @@ WL_MEM_REPORT=1 ./build/bench/bench_flowlog --workload doop \
     --data-doop bench/data/doop --workers 1 --repeat 1 --format json
 ```
 
-## 8. Related
+## 8. Compound-arena mutation window (#1423)
+
+The coordinator owns compound-arena mutation and its governor reservations.
+Workers acquire a non-copyable read lease before using a borrowed arena; the
+lease remains active for the lifetime of any lookup pointer. Allocation,
+retain, freeze/unfreeze, epoch GC, and destruction acquire the exclusive
+mutation gate and therefore fail while a worker lease is active. The
+coordinator must close all worker leases before destroying the arena.
+
+Compound payload, entry-offset, and multiplicity growth is staged as one
+transaction. A failure at any staging allocation frees only the new buffers,
+rolls back pending reservations, and leaves the old pointers, counters and
+governor charge unchanged. The unmanaged constructor remains independent of
+the governor and the standalone fuzz target.
+
+## 9. Related
 
 - Issue #1380 (this instrumentation), #1385 (DOOP under a budget),
   #1367 / #1368 (memory governor and admission), #1375 (K-fusion

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -228,7 +228,7 @@ These exist so struct fields can be declared portably; the audit in
 
 Every `atomic_*` call site in `wirelog/` production sources. Counted
 mechanically by `scripts/ci/check-threading-doc.sh`; row count must
-match the script's count (currently **79**).
+match the script's count (currently **91**).
 
 Format: `file:function[#N]` | field | operation | order | justification.
 
@@ -373,8 +373,28 @@ representation so transfer cannot race a release with a data race.
 | `memory_governor.c:finish_reservation#3` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `release`/`relaxed` | Return exactly this token's bytes without underflow |
 | `memory_governor.c:wl_columnar_memory_reserve_growth` | `reservation->state` | `atomic_load_explicit` | `acquire` | Validate the source token before creating a distinct growth reservation |
 | `memory_governor.c:wl_columnar_memory_reserved` | `reserved_bytes` | `atomic_load_explicit` | `acquire` | Read a coherent observable reservation total |
+| `memory_governor.c:wl_columnar_memory_reservation_move` | `destination->state` | `atomic_load_explicit` | `acquire` | Validate the destination token before moving ownership |
+| `memory_governor.c:wl_columnar_memory_reservation_move#2` | `source->state` | `atomic_load_explicit` | `acquire` | Validate the source token before transferring ownership |
+| `memory_governor.c:wl_columnar_memory_reservation_move#3` | `destination->owner_bits` | `atomic_store_explicit` | `relaxed` | Copy the logical owner into the destination token before publishing its state |
+| `memory_governor.c:wl_columnar_memory_reservation_move#4` | `source->owner_bits` | `atomic_load_explicit` | `relaxed` | Read the source owner while transferring the token |
+| `memory_governor.c:wl_columnar_memory_reservation_move#5` | `destination->state` | `atomic_store_explicit` | `release` | Publish the moved reservation after its owner and governor fields are initialized |
+| `memory_governor.c:wl_columnar_memory_reservation_move#6` | `source->owner_bits` | `atomic_store_explicit` | `relaxed` | Clear the source owner after ownership has moved |
+| `memory_governor.c:wl_columnar_memory_reservation_move#7` | `source->state` | `atomic_store_explicit` | `release` | Publish the empty source state after clearing its ownership |
 
-### 5.9 `wirelog/intern.c` — shared symbol table (3 rows)
+### 5.9 `wirelog/arena/compound_arena.c` — mutation gate (5 rows)
+
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
+|---|---|---|---|---|
+| `compound_arena.c:compound_gate_load` | `arena->access_gate` | `atomic_load_explicit` | `acquire` | Observe the writer/readers gate before acquiring a read lease or validating mutation teardown |
+| `compound_arena.c:compound_gate_store` | `arena->access_gate` | `atomic_store_explicit` | `release` | Initialize the gate before publication; on portable builds this helper is also the release-side gate store |
+| `compound_arena.c:wl_compound_arena_borrow` | `arena->access_gate` | `atomic_compare_exchange_weak_explicit` | `acquire`/`relaxed` | Admit one reader only while no writer owns the gate |
+| `compound_arena.c:wl_compound_arena_borrow_release` | `arena->access_gate` | `atomic_compare_exchange_weak_explicit` | `release`/`relaxed` | Remove exactly one reader lease without reopening a writer-owned gate |
+| `compound_arena.c:wl_compound_arena_mutation_begin` | `arena->access_gate` | `atomic_compare_exchange_weak_explicit` | `acquire`/`relaxed` | Claim exclusive mutation ownership after all reader leases have drained |
+
+On MSVC the helper load/store use interlocked intrinsics because the shared
+`wl_atomic_u64` compatibility type cannot use C11 atomic operations directly.
+
+### 5.10 `wirelog/intern.c` — shared symbol table (3 rows)
 
 The intern table is shared, unsynchronized, by every parallel worker
 (Issue #958). Writers (`wl_intern_put`, `wl_intern_get`) serialize on
@@ -390,9 +410,9 @@ named in the justification.
 | `intern.c:WL_INTERN_LOAD_RELAXED` | `intern->count` | `atomic_load_explicit` | `relaxed` | `WL_INTERN_LOAD_RELAXED`, used by `wl_intern_put`, `intern_resize` and `wl_intern_free`. The writer holds `intern->lock` (or, in `free`, has exclusive access), so no edge is needed |
 | `intern.c:WL_INTERN_STORE_RELEASE` | `intern->count` | `atomic_store_explicit` | `release` | `WL_INTERN_STORE_RELEASE`, used by `wl_intern_put` after the string and its segment pointer are written. Publishing the count first would let a lock-free reader dereference an unwritten slot |
 
-### 5.9 Total
+### 5.11 Total
 
-21 + 4 + 2 + 19 + 1 + 1 + 1 + 3 + 27 = **79 atomic call sites**.
+21 + 4 + 2 + 19 + 1 + 1 + 1 + 3 + 27 + 7 + 5 = **91 atomic call sites**.
 
 The `#N` suffix counts all atomic sites in a symbol, regardless of operation;
 the first site remains unsuffixed. `scripts/ci/check-threading-doc.sh` uses
@@ -821,6 +841,20 @@ advisory leg); issue #826 (native TSan SEGV triage);
 `.github/workflows/ci-pr.yml` `tsan-native` job.
 
 ---
+
+## 11. Compound-arena read leases and mutation windows (#1423)
+
+`wl_compound_arena_t` has one coordinator mutation gate. A worker must hold a
+`wl_compound_arena_borrow_t` while using a lookup result; copying or releasing
+the lease twice is rejected. The coordinator cannot allocate, retain, freeze,
+unfreeze, advance the epoch, or destroy the arena while any read lease is
+active. Coordinator mutation must be completed before worker leases are
+opened, and workers must release their leases before coordinator teardown.
+
+This gate protects pointer lifetime across both append-only metadata changes
+and replacement-buffer growth. `frozen` remains a semantic read-only guard,
+not a synchronization primitive. The unmanaged compound-arena constructor
+and standalone fuzz target do not link the memory governor.
 
 ## 12. References
 

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -19,7 +19,7 @@ fi
 rows="$tmp_dir/rows"
 sed -nE 's/^\| `([^`]+:[A-Za-z_][A-Za-z0-9_]*(#[0-9]+)?)` \| [^|]* \| `([^`]*)` \|.*/\1\t\3/p' "$doc" >"$rows"
 row_count=$(wc -l <"$rows")
-expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-79}"
+expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-91}"
 [ "$row_count" -eq "$expected_rows" ] || {
     echo "check-threading-doc: FAIL: expected $expected_rows audit rows, found $row_count" >&2
     exit 1

--- a/tests/test_memory_admission_compound.c
+++ b/tests/test_memory_admission_compound.c
@@ -236,6 +236,128 @@ test_publish_failure_rollback(void)
 }
 
 static void
+test_allocator_failpoints(void)
+{
+    const wl_compound_alloc_failpoint_t failpoints[] = {
+        WL_COMPOUND_FAIL_PAYLOAD,
+        WL_COMPOUND_FAIL_ENTRY_OFFSETS,
+        WL_COMPOUND_FAIL_MULTIPLICITY,
+    };
+
+    for (size_t p = 0; p < sizeof(failpoints) / sizeof(failpoints[0]); p++) {
+        wl_columnar_memory_resolution_t resolution;
+        wl_columnar_memory_governor_t governor;
+        wl_compound_arena_t *arena;
+        wl_compound_gen_t *gen;
+        uint8_t *old_base;
+        uint32_t *old_offsets;
+        int64_t *old_multiplicity;
+        uint32_t old_capacity;
+        uint32_t old_used;
+        uint32_t old_entry_count;
+        uint32_t old_entry_cap;
+        uint64_t old_reserved;
+
+        make_resolution(&resolution, 1u << 20);
+        CHECK(wl_columnar_memory_governor_init(&governor, &resolution)
+            == WL_COLUMNAR_MEMORY_OK, "failpoint governor initialization");
+        arena = wl_compound_arena_create_managed(13,
+                p == 0 ? 64 : 256, 1, &governor);
+        CHECK(arena != NULL, "failpoint arena creation");
+        if (!arena)
+            continue;
+        if (p == 0) {
+            CHECK(wl_compound_arena_alloc(arena, 16) != 0,
+                "payload failpoint setup");
+        } else {
+            for (uint32_t i = 0; i < 16; i++)
+                CHECK(wl_compound_arena_alloc(arena, 8) != 0,
+                    "entry failpoint setup");
+        }
+        gen = &arena->gens[0];
+        old_base = gen->base;
+        old_offsets = gen->entry_offsets;
+        old_multiplicity = gen->multiplicity;
+        old_capacity = gen->capacity;
+        old_used = gen->used;
+        old_entry_count = gen->entry_count;
+        old_entry_cap = gen->entry_cap;
+        old_reserved = wl_columnar_memory_reserved(&governor);
+        wl_compound_arena_test_fail_next(arena, failpoints[p]);
+        CHECK(wl_compound_arena_alloc(arena, p == 0 ? 64 : 8) == 0,
+            "injected allocator failure was not reported");
+        CHECK(gen->base == old_base && gen->entry_offsets == old_offsets
+            && gen->multiplicity == old_multiplicity
+            && gen->capacity == old_capacity && gen->used == old_used
+            && gen->entry_count == old_entry_count
+            && gen->entry_cap == old_entry_cap,
+            "allocator failure changed generation state");
+        CHECK(wl_columnar_memory_reserved(&governor) == old_reserved,
+            "allocator failure changed reservation accounting");
+        wl_compound_arena_free(arena);
+        CHECK(wl_columnar_memory_reserved(&governor) == 0,
+            "allocator failure leaked a reservation at destroy");
+    }
+}
+
+static void
+test_mutation_window(void)
+{
+    wl_compound_arena_t *arena = wl_compound_arena_create(17, 64, 2);
+    wl_compound_arena_borrow_t borrow = { 0 };
+    wl_compound_arena_borrow_t copied;
+    wl_compound_arena_mutation_t mutation = { 0 };
+    uint64_t handle;
+    uint32_t size = 0;
+
+    CHECK(arena != NULL, "mutation-window arena creation");
+    if (!arena)
+        return;
+    handle = wl_compound_arena_alloc(arena, 16);
+    CHECK(handle != WL_COMPOUND_HANDLE_NULL, "mutation-window setup handle");
+    CHECK(wl_compound_arena_borrow(arena, &borrow),
+        "read lease acquisition");
+    copied = borrow;
+    CHECK(wl_compound_arena_lookup_borrowed(&borrow, handle, &size) != NULL
+        && size == 16, "leased lookup remains valid");
+    CHECK(wl_compound_arena_mutation_begin(arena, &mutation) == false,
+        "mutation window opened while a reader was active");
+    CHECK(wl_compound_arena_alloc(arena, 16) == WL_COMPOUND_HANDLE_NULL,
+        "allocation bypassed an active read lease");
+    CHECK(!wl_compound_arena_borrow_release(&copied),
+        "copied read lease released the active lease");
+    CHECK(wl_compound_arena_borrow_release(&borrow),
+        "read lease release");
+    CHECK(wl_compound_arena_borrow(arena, &borrow),
+        "read lease can be reacquired after release");
+    copied = borrow;
+    CHECK(wl_compound_arena_borrow_release(&borrow),
+        "second read lease release");
+    CHECK(wl_compound_arena_borrow(arena, &borrow),
+        "read lease can be reacquired after stale copy");
+    CHECK(!wl_compound_arena_borrow_release(&copied),
+        "stale copied lease released a reacquired lease");
+    CHECK(!wl_compound_arena_mutation_begin(arena, &mutation),
+        "mutation window ignored the reacquired lease");
+    CHECK(wl_compound_arena_borrow_release(&borrow),
+        "reacquired read lease release");
+    CHECK(wl_compound_arena_mutation_begin(arena, &mutation),
+        "mutation window did not open after reader release");
+    CHECK(wl_compound_arena_mutation_end(&mutation),
+        "mutation window release");
+    CHECK(!wl_compound_arena_mutation_end(&mutation),
+        "double mutation release was accepted");
+    CHECK(wl_compound_arena_borrow(arena, &borrow),
+        "read lease before teardown check");
+    CHECK(!wl_compound_arena_free_checked(arena),
+        "arena teardown ignored an active lease");
+    CHECK(wl_compound_arena_borrow_release(&borrow),
+        "teardown-check read lease release");
+    CHECK(wl_compound_arena_free_checked(arena),
+        "arena teardown after lease release");
+}
+
+static void
 test_denial_and_legacy_contract(void)
 {
     wl_columnar_memory_resolution_t resolution;
@@ -280,6 +402,8 @@ main(void)
     test_growth_peak_and_rollback();
     test_entry_growth();
     test_publish_failure_rollback();
+    test_allocator_failpoints();
+    test_mutation_window();
     test_denial_and_legacy_contract();
     if (failures != 0)
         return 1;

--- a/tests/test_worker_arena_borrow.c
+++ b/tests/test_worker_arena_borrow.c
@@ -213,8 +213,8 @@ test_worker_borrows_coordinator_arena(void)
      * resolves through the worker's borrowed pointer. */
     if (ok) {
         uint32_t out_size = 0;
-        const void *payload = wl_compound_arena_lookup(
-            worker.compound_arena, handle, &out_size);
+        const void *payload = wl_compound_arena_lookup_borrowed(
+            &worker.compound_borrow, handle, &out_size);
         if (!payload || out_size != 64u)
             ok = 0;
     }
@@ -440,10 +440,9 @@ test_worker_observes_frozen_arena(void)
         return 1;
     }
 
-    /* Build a partition + worker the way K-Fusion does, then freeze the
-     * coordinator's arena.  Order matters: we want the worker to observe
-     * the freeze through the borrowed pointer, so the freeze is the last
-     * coordinator-side mutation before the assertions. */
+    /* Freeze the arena before opening the worker read window.  Once a worker
+     * holds its read lease, coordinator mutations (including freeze changes)
+     * are rejected until the worker is released. */
     int64_t rows[] = { 1, 2 };
     if (insert_edges(coord, rows, 1) != 0) {
         cleanup_coordinator(coord, plan, prog);
@@ -459,6 +458,8 @@ test_worker_observes_frozen_arena(void)
         return 1;
     }
 
+    wl_compound_arena_freeze(coord->compound_arena);
+
     wl_col_session_t worker;
     memset(&worker, 0, sizeof(worker));
     rc = col_worker_session_create(coord, 0, parts, 1, &worker);
@@ -468,8 +469,6 @@ test_worker_observes_frozen_arena(void)
         FAIL("col_worker_session_create");
         return 1;
     }
-
-    wl_compound_arena_freeze(coord->compound_arena);
 
     int ok = (worker.compound_arena == coord->compound_arena
         && worker.compound_arena != NULL
@@ -485,8 +484,8 @@ test_worker_observes_frozen_arena(void)
     /* Lookup of the pre-freeze sentinel must still succeed via worker. */
     if (ok) {
         uint32_t out_size = 0;
-        const void *payload = wl_compound_arena_lookup(
-            worker.compound_arena, sentinel, &out_size);
+        const void *payload = wl_compound_arena_lookup_borrowed(
+            &worker.compound_borrow, sentinel, &out_size);
         if (!payload || out_size != 48u)
             ok = 0;
     }
@@ -495,9 +494,8 @@ test_worker_observes_frozen_arena(void)
      * cleanup against a frozen arena (defensive: the destroy path
      * shouldn't care, but keeping the test isolated avoids cross-
      * coupling future changes). */
-    wl_compound_arena_unfreeze(coord->compound_arena);
-
     col_worker_session_destroy(&worker);
+    wl_compound_arena_unfreeze(coord->compound_arena);
     cleanup_coordinator(coord, plan, prog);
 
     if (!ok) {

--- a/tests/test_worker_borrow_w2_tsan.c
+++ b/tests/test_worker_borrow_w2_tsan.c
@@ -166,8 +166,9 @@ worker_fn(void *ctx)
     /* (3) Lookup of pre-freeze sentinel succeeds via borrowed ptr. */
     if (arena) {
         uint32_t out_size = 0;
-        const void *payload = wl_compound_arena_lookup(arena,
-                t->sentinel_handle, &out_size);
+        const void *payload = wl_compound_arena_lookup_borrowed(
+            &t->worker_session->compound_borrow,
+            t->sentinel_handle, &out_size);
         t->lookup_ok = (payload != NULL
             && out_size == t->expected_payload_size);
     } else {
@@ -210,34 +211,8 @@ test_w2_borrow_freeze_lookup(void)
         return;
     }
 
-    /* Two worker sessions, R-5 borrow.  num_partitions=0 keeps the
-     * fixture minimal: we are not testing partition transfer here,
-     * just the borrowed-arena access pattern. */
     wl_col_session_t workers[2];
     memset(workers, 0, sizeof(workers));
-    int rc = col_worker_session_create(coord, 0u, NULL, 0u, &workers[0]);
-    if (rc != 0) {
-        cleanup_coordinator(coord, plan, prog);
-        FAIL("col_worker_session_create #0");
-        return;
-    }
-    rc = col_worker_session_create(coord, 1u, NULL, 0u, &workers[1]);
-    if (rc != 0) {
-        col_worker_session_destroy(&workers[0]);
-        cleanup_coordinator(coord, plan, prog);
-        FAIL("col_worker_session_create #1");
-        return;
-    }
-
-    /* Sanity: R-5 borrow holds at construction time. */
-    if (workers[0].compound_arena != coord->compound_arena
-        || workers[1].compound_arena != coord->compound_arena) {
-        col_worker_session_destroy(&workers[0]);
-        col_worker_session_destroy(&workers[1]);
-        cleanup_coordinator(coord, plan, prog);
-        FAIL("R-5 borrow violated at construction");
-        return;
-    }
 
     wl_work_queue_t *wq = wl_workqueue_create(2u);
     if (!wq) {
@@ -262,6 +237,25 @@ test_w2_borrow_freeze_lookup(void)
         }
 
         wl_compound_arena_freeze(coord->compound_arena);
+
+        /* Open the worker read window only after the coordinator mutation
+         * for this epoch has completed. */
+        int rc = col_worker_session_create(coord, 0u, NULL, 0u,
+                &workers[0]);
+        if (rc == 0)
+            rc = col_worker_session_create(coord, 1u, NULL, 0u,
+                    &workers[1]);
+        if (rc != 0) {
+            printf(" ... FAIL: iter %u worker construction\n", r);
+            verdict = 1;
+            break;
+        }
+        if (workers[0].compound_arena != coord->compound_arena
+            || workers[1].compound_arena != coord->compound_arena) {
+            printf(" ... FAIL: iter %u worker arena mismatch\n", r);
+            verdict = 1;
+            break;
+        }
 
         for (uint32_t k = 0; k < 2u; k++) {
             tasks[k].worker_session = &workers[k];
@@ -316,6 +310,8 @@ test_w2_borrow_freeze_lookup(void)
         if (verdict)
             break;
 
+        col_worker_session_destroy(&workers[0]);
+        col_worker_session_destroy(&workers[1]);
         wl_compound_arena_unfreeze(coord->compound_arena);
         (void)wl_compound_arena_gc_epoch_boundary(coord->compound_arena);
     }

--- a/wirelog/arena/compound_arena.c
+++ b/wirelog/arena/compound_arena.c
@@ -29,6 +29,35 @@
 /* Initial entry-index capacity per generation.  Small (16) because we
  * lazy-grow; most epochs with a handful of compounds pay only this much. */
 #define WL_COMPOUND_DEFAULT_ENTRY_CAP 16u
+#define WL_COMPOUND_GATE_WRITER UINT64_MAX
+#define WL_COMPOUND_GATE_READERS_MAX (WL_COMPOUND_GATE_WRITER - 1u)
+
+#ifdef _MSC_VER
+static uint64_t
+compound_gate_load(const wl_atomic_u64 *gate)
+{
+    return (uint64_t)_InterlockedCompareExchange64(
+        (volatile __int64 *)gate, 0, 0);
+}
+
+static void
+compound_gate_store(wl_atomic_u64 *gate, uint64_t value)
+{
+    (void)_InterlockedExchange64((volatile __int64 *)gate, (__int64)value);
+}
+#else
+static uint64_t
+compound_gate_load(const wl_atomic_u64 *gate)
+{
+    return atomic_load_explicit(gate, memory_order_acquire);
+}
+
+static void
+compound_gate_store(wl_atomic_u64 *gate, uint64_t value)
+{
+    atomic_store_explicit(gate, value, memory_order_release);
+}
+#endif
 
 /* ======================================================================== */
 /* Internal helpers                                                         */
@@ -42,6 +71,16 @@ compound_admission_prepare(wl_compound_arena_t *arena, uint64_t old_bytes,
         return 0;
     return arena->admission_prepare(arena->admission_context, old_bytes,
                new_bytes, reservation);
+}
+
+static bool
+compound_failpoint(wl_compound_arena_t *arena,
+    wl_compound_alloc_failpoint_t failpoint)
+{
+    if (!arena || arena->test_failpoint != (uint32_t)failpoint)
+        return false;
+    arena->test_failpoint = WL_COMPOUND_FAIL_NONE;
+    return true;
 }
 
 static void
@@ -151,6 +190,8 @@ gen_reserve(wl_compound_arena_t *arena, wl_compound_gen_t *gen,
         return -1;
     }
     if (grow_payload) {
+        if (compound_failpoint(arena, WL_COMPOUND_FAIL_PAYLOAD))
+            goto fail;
         new_base = (uint8_t *)malloc(new_payload_cap);
         if (!new_base)
             goto fail;
@@ -158,8 +199,12 @@ gen_reserve(wl_compound_arena_t *arena, wl_compound_gen_t *gen,
             memcpy(new_base, gen->base, gen->used);
     }
     if (grow_entries) {
+        if (compound_failpoint(arena, WL_COMPOUND_FAIL_ENTRY_OFFSETS))
+            goto fail;
         new_offsets = (uint32_t *)malloc(
             (size_t)new_entry_cap * sizeof(uint32_t));
+        if (compound_failpoint(arena, WL_COMPOUND_FAIL_MULTIPLICITY))
+            goto fail;
         new_multiplicity = (int64_t *)malloc(
             (size_t)new_entry_cap * sizeof(int64_t));
         if (!new_offsets || !new_multiplicity)
@@ -291,6 +336,8 @@ compound_arena_create_impl(uint32_t session_seed, uint32_t default_gen_cap,
     arena->default_gen_cap = default_gen_cap;
     arena->frozen = false;
     arena->live_handles = 0;
+    compound_gate_store(&arena->access_gate, 0);
+    arena->test_failpoint = WL_COMPOUND_FAIL_NONE;
     arena->admission_context = admission_context;
     arena->admission_release = admission_release;
     arena->admission_prepare = admission_prepare_fn;
@@ -323,11 +370,110 @@ wl_compound_arena_create_with_admission(uint32_t session_seed,
                release_reservation);
 }
 
-void
-wl_compound_arena_free(wl_compound_arena_t *arena)
+bool
+wl_compound_arena_borrow(wl_compound_arena_t *arena,
+    wl_compound_arena_borrow_t *borrow)
 {
+    uint64_t observed;
+
+    if (!arena || !borrow || borrow->arena || borrow->identity != 0)
+        return false;
+    observed = compound_gate_load(&arena->access_gate);
+    for (;;) {
+        if (observed == WL_COMPOUND_GATE_WRITER
+            || observed >= WL_COMPOUND_GATE_READERS_MAX)
+            return false;
+        if (atomic_compare_exchange_weak_explicit(&arena->access_gate,
+            &observed, observed + 1u, memory_order_acquire,
+            memory_order_relaxed))
+            break;
+    }
+    borrow->arena = arena;
+    borrow->identity = (uintptr_t)borrow;
+    return true;
+}
+
+bool
+wl_compound_arena_borrow_release(wl_compound_arena_borrow_t *borrow)
+{
+    wl_compound_arena_t *arena;
+    uint64_t observed;
+
+    if (!borrow || !borrow->arena
+        || borrow->identity != (uintptr_t)borrow)
+        return false;
+    arena = borrow->arena;
+    observed = compound_gate_load(&arena->access_gate);
+    for (;;) {
+        if (observed == 0 || observed == WL_COMPOUND_GATE_WRITER)
+            return false;
+        if (atomic_compare_exchange_weak_explicit(&arena->access_gate,
+            &observed, observed - 1u, memory_order_release,
+            memory_order_relaxed))
+            break;
+    }
+    borrow->arena = NULL;
+    borrow->identity = 0;
+    return true;
+}
+
+bool
+wl_compound_arena_mutation_begin(wl_compound_arena_t *arena,
+    wl_compound_arena_mutation_t *mutation)
+{
+    uint64_t expected = 0;
+
+    if (!arena || !mutation || mutation->arena || mutation->identity != 0)
+        return false;
+    for (;;) {
+        expected = 0;
+        if (atomic_compare_exchange_weak_explicit(&arena->access_gate,
+            &expected, WL_COMPOUND_GATE_WRITER, memory_order_acquire,
+            memory_order_relaxed))
+            break;
+        if (expected != 0)
+            return false;
+    }
+    mutation->arena = arena;
+    mutation->identity = (uintptr_t)mutation;
+    return true;
+}
+
+bool
+wl_compound_arena_mutation_end(wl_compound_arena_mutation_t *mutation)
+{
+    wl_compound_arena_t *arena;
+
+    if (!mutation || !mutation->arena
+        || mutation->identity != (uintptr_t)mutation)
+        return false;
+    arena = mutation->arena;
+    if (compound_gate_load(&arena->access_gate)
+        != WL_COMPOUND_GATE_WRITER)
+        return false;
+    compound_gate_store(&arena->access_gate, 0);
+    mutation->arena = NULL;
+    mutation->identity = 0;
+    return true;
+}
+
+void
+wl_compound_arena_test_fail_next(wl_compound_arena_t *arena,
+    wl_compound_alloc_failpoint_t failpoint)
+{
+    if (arena)
+        arena->test_failpoint = (uint32_t)failpoint;
+}
+
+bool
+wl_compound_arena_free_checked(wl_compound_arena_t *arena)
+{
+    wl_compound_arena_mutation_t mutation = { 0 };
+
     if (!arena)
-        return;
+        return true;
+    if (!wl_compound_arena_mutation_begin(arena, &mutation))
+        return false;
     if (arena->gens) {
         for (uint32_t e = 0; e < arena->max_epochs; e++)
             gen_release_admission(arena, &arena->gens[e]);
@@ -337,11 +483,21 @@ wl_compound_arena_free(wl_compound_arena_t *arena)
     }
     if (arena->admission_release)
         arena->admission_release(arena->admission_context);
+    /* Keep the writer gate held until the final free.  No caller can observe
+     * the local mutation token after this function returns, so publishing a
+     * reader-available gate would only create a teardown race. */
     free(arena);
+    return true;
 }
 
-uint64_t
-wl_compound_arena_alloc(wl_compound_arena_t *arena, uint32_t size)
+void
+wl_compound_arena_free(wl_compound_arena_t *arena)
+{
+    (void)wl_compound_arena_free_checked(arena);
+}
+
+static uint64_t
+wl_compound_arena_alloc_mutating(wl_compound_arena_t *arena, uint32_t size)
 {
     if (!arena || size == 0 || arena->frozen)
         return WL_COMPOUND_HANDLE_NULL;
@@ -397,6 +553,19 @@ wl_compound_arena_alloc(wl_compound_arena_t *arena, uint32_t size)
     return handle;
 }
 
+uint64_t
+wl_compound_arena_alloc(wl_compound_arena_t *arena, uint32_t size)
+{
+    wl_compound_arena_mutation_t mutation = { 0 };
+    uint64_t handle;
+
+    if (!wl_compound_arena_mutation_begin(arena, &mutation))
+        return WL_COMPOUND_HANDLE_NULL;
+    handle = wl_compound_arena_alloc_mutating(arena, size);
+    (void)wl_compound_arena_mutation_end(&mutation);
+    return handle;
+}
+
 /* Internal: locate the entry slot for a handle.  Returns the entry index or
  * (uint32_t)-1 if the handle cannot be resolved.  The offset field matches
  * entry_offsets[i] exactly because alloc returns them verbatim. */
@@ -445,6 +614,17 @@ wl_compound_arena_lookup(const wl_compound_arena_t *arena, uint64_t handle,
     return gen->base + offset;
 }
 
+const void *
+wl_compound_arena_lookup_borrowed(
+    const wl_compound_arena_borrow_t *borrow, uint64_t handle,
+    uint32_t *out_size)
+{
+    if (!borrow || !borrow->arena
+        || borrow->identity != (uintptr_t)borrow)
+        return NULL;
+    return wl_compound_arena_lookup(borrow->arena, handle, out_size);
+}
+
 int64_t
 wl_compound_arena_multiplicity(const wl_compound_arena_t *arena,
     uint64_t handle)
@@ -456,8 +636,8 @@ wl_compound_arena_multiplicity(const wl_compound_arena_t *arena,
     return gen->multiplicity[idx];
 }
 
-int
-wl_compound_arena_retain(wl_compound_arena_t *arena, uint64_t handle,
+static int
+wl_compound_arena_retain_mutating(wl_compound_arena_t *arena, uint64_t handle,
     int64_t delta)
 {
     if (!arena || delta == 0)
@@ -480,30 +660,54 @@ wl_compound_arena_retain(wl_compound_arena_t *arena, uint64_t handle,
     return 0;
 }
 
+int
+wl_compound_arena_retain(wl_compound_arena_t *arena, uint64_t handle,
+    int64_t delta)
+{
+    wl_compound_arena_mutation_t mutation = { 0 };
+    int result;
+
+    if (!wl_compound_arena_mutation_begin(arena, &mutation))
+        return -1;
+    result = wl_compound_arena_retain_mutating(arena, handle, delta);
+    (void)wl_compound_arena_mutation_end(&mutation);
+    return result;
+}
+
 void
 wl_compound_arena_freeze(wl_compound_arena_t *arena)
 {
+    wl_compound_arena_mutation_t mutation = { 0 };
+
     if (!arena)
+        return;
+    if (!wl_compound_arena_mutation_begin(arena, &mutation))
         return;
     arena->frozen = true;
     WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
         "lifecycle event=freeze epoch=%u live_handles=%" PRIu64,
         arena->current_epoch, arena->live_handles);
+    (void)wl_compound_arena_mutation_end(&mutation);
 }
 
 void
 wl_compound_arena_unfreeze(wl_compound_arena_t *arena)
 {
+    wl_compound_arena_mutation_t mutation = { 0 };
+
     if (!arena)
+        return;
+    if (!wl_compound_arena_mutation_begin(arena, &mutation))
         return;
     arena->frozen = false;
     WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
         "lifecycle event=unfreeze epoch=%u live_handles=%" PRIu64,
         arena->current_epoch, arena->live_handles);
+    (void)wl_compound_arena_mutation_end(&mutation);
 }
 
-uint32_t
-wl_compound_arena_gc_epoch_boundary(wl_compound_arena_t *arena)
+static uint32_t
+wl_compound_arena_gc_epoch_boundary_mutating(wl_compound_arena_t *arena)
 {
     if (!arena)
         return (uint32_t)-1;
@@ -566,4 +770,17 @@ wl_compound_arena_gc_epoch_boundary(wl_compound_arena_t *arena)
             arena->current_epoch, arena->max_epochs);
     }
     return reclaimed;
+}
+
+uint32_t
+wl_compound_arena_gc_epoch_boundary(wl_compound_arena_t *arena)
+{
+    wl_compound_arena_mutation_t mutation = { 0 };
+    uint32_t result;
+
+    if (!wl_compound_arena_mutation_begin(arena, &mutation))
+        return arena ? arena->current_epoch : (uint32_t)-1;
+    result = wl_compound_arena_gc_epoch_boundary_mutating(arena);
+    (void)wl_compound_arena_mutation_end(&mutation);
+    return result;
 }

--- a/wirelog/arena/compound_arena.h
+++ b/wirelog/arena/compound_arena.h
@@ -140,6 +140,26 @@ typedef struct {
     wl_columnar_memory_reservation_t *entries_admission;
 } wl_compound_gen_t;
 
+struct wl_compound_arena;
+typedef struct wl_compound_arena wl_compound_arena_t;
+
+typedef struct {
+    wl_compound_arena_t *arena;
+    uintptr_t identity;
+} wl_compound_arena_borrow_t;
+
+typedef struct {
+    wl_compound_arena_t *arena;
+    uintptr_t identity;
+} wl_compound_arena_mutation_t;
+
+typedef enum {
+    WL_COMPOUND_FAIL_NONE = 0,
+    WL_COMPOUND_FAIL_PAYLOAD = 1,
+    WL_COMPOUND_FAIL_ENTRY_OFFSETS = 2,
+    WL_COMPOUND_FAIL_MULTIPLICITY = 3,
+} wl_compound_alloc_failpoint_t;
+
 typedef int (*wl_compound_admission_prepare_fn)(void *context,
     uint64_t old_bytes, uint64_t new_bytes,
     wl_columnar_memory_reservation_t *reservation);
@@ -169,7 +189,7 @@ typedef int (*wl_compound_admission_release_fn)(void *context,
  * @live_handles: Total live handles (multiplicity > 0) across all epochs,
  *                maintained by arena_alloc/inc/dec/gc for test introspection.
  */
-typedef struct {
+struct wl_compound_arena {
     uint32_t session_seed;
     uint32_t current_epoch;
     wl_compound_gen_t *gens;
@@ -184,7 +204,9 @@ typedef struct {
     wl_compound_admission_publish_fn admission_publish;
     wl_compound_admission_abort_fn admission_abort;
     wl_compound_admission_release_fn admission_release_reservation;
-} wl_compound_arena_t;
+    wl_atomic_u64 access_gate;
+    uint32_t test_failpoint;
+};
 
 /* ======================================================================== */
 /* API                                                                      */
@@ -223,12 +245,29 @@ wl_compound_arena_create_with_admission(uint32_t session_seed,
     wl_compound_admission_abort_fn abort,
     wl_compound_admission_release_fn release_reservation);
 
+bool
+wl_compound_arena_borrow(wl_compound_arena_t *arena,
+    wl_compound_arena_borrow_t *borrow);
+bool
+wl_compound_arena_borrow_release(wl_compound_arena_borrow_t *borrow);
+bool
+wl_compound_arena_mutation_begin(wl_compound_arena_t *arena,
+    wl_compound_arena_mutation_t *mutation);
+bool
+wl_compound_arena_mutation_end(wl_compound_arena_mutation_t *mutation);
+bool
+wl_compound_arena_free_checked(wl_compound_arena_t *arena);
+void
+wl_compound_arena_test_fail_next(wl_compound_arena_t *arena,
+    wl_compound_alloc_failpoint_t failpoint);
+
 /**
  * wl_compound_arena_free:
  * @arena: (transfer full): arena to free. NULL-safe.
  *
  * Free the arena and all per-generation buffers.  Any handle previously
- * returned by wl_compound_arena_alloc becomes invalid.
+ * returned by wl_compound_arena_alloc becomes invalid.  Callers which need
+ * to observe an active worker lease must use free_checked().
  */
 void
 wl_compound_arena_free(wl_compound_arena_t *arena);
@@ -263,6 +302,10 @@ wl_compound_arena_alloc(wl_compound_arena_t *arena, uint32_t size);
  */
 const void *
 wl_compound_arena_lookup(const wl_compound_arena_t *arena, uint64_t handle,
+    uint32_t *out_size);
+const void *
+wl_compound_arena_lookup_borrowed(
+    const wl_compound_arena_borrow_t *borrow, uint64_t handle,
     uint32_t *out_size);
 
 /**

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1516,6 +1516,8 @@ typedef struct wl_col_session_t {
      * The session_seed passed at create time is a placeholder constant; the
      * remap-aware seed will land in the rotation work tracked by #586+. */
     wl_compound_arena_t *compound_arena;
+    /* Worker-owned read lease for the coordinator arena. */
+    wl_compound_arena_borrow_t compound_borrow;
     /* Filtered relation cache (Issue #386): caches apply_right_filter results
      * keyed by (relation_name, filter_expr hash + full content). Prevents
      * redundant O(N) filter scans on each fixpoint iteration when

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -802,6 +802,16 @@ col_op_k_fusion_dispatch(const wl_plan_op_t *op, eval_stack_t *stack,
                     (uint64_t)dp->slot_cap * dp->slot_size + dp->arena_cap);
             }
         }
+        /* Acquire the borrowed arena only after coordinator-owned fields have
+        * been nulled, so failed acquisition can use common cleanup safely. */
+        memset(&worker_sess[d].compound_borrow, 0,
+            sizeof(worker_sess[d].compound_borrow));
+        if (worker_sess[d].compound_arena
+            && !wl_compound_arena_borrow(worker_sess[d].compound_arena,
+            &worker_sess[d].compound_borrow)) {
+            rc = EBUSY;
+            goto cleanup_wq;
+        }
 
         workers[d].plan_data.name = "<k_fusion_copy>";
         workers[d].plan_data.ops = meta->k_ops[branch_idx];
@@ -964,6 +974,8 @@ cleanup_wq:
      * its isolated cache — no races at cleanup time. */
     for (uint32_t d = 0; d < live_count; d++) {
         eval_stack_drain(&workers[d].stack);
+        (void)wl_compound_arena_borrow_release(
+            &worker_sess[d].compound_borrow);
         /* Issue #196: worker mat_cache starts empty (zeroed above), so ALL
          * entries were created by this worker — free from index 0.  The
          * worker cache has no ledger (Issue #1380), so this is a plain

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1477,7 +1477,7 @@ oom:
     wl_workqueue_destroy(sess->wq);       /* NULL-safe */
     delta_pool_destroy(sess->delta_pool); /* NULL-safe */
     wl_arena_free(sess->eval_arena);      /* NULL-safe; releases admission */
-    wl_compound_arena_free(sess->compound_arena); /* NULL-safe (Issue #559) */
+    (void)wl_compound_arena_free_checked(sess->compound_arena);
     wl_columnar_memory_governor_ref_release(sess->memory_governor);
     free(sess);
     return ENOMEM;
@@ -1636,7 +1636,9 @@ col_session_destroy(wl_session_t *session)
         sess->compound_arena
             ? (unsigned long long)sess->compound_arena->live_handles
             : 0ULL);
-    wl_compound_arena_free(sess->compound_arena);
+    if (!wl_compound_arena_free_checked(sess->compound_arena))
+        WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_ERROR,
+            "compound arena still has active worker leases");
     wl_columnar_memory_governor_ref_release(sess->memory_governor);
     free(sess);
 }
@@ -1715,6 +1717,12 @@ col_worker_session_create(wl_col_session_t *coordinator,
      * (Issue #561) guarantees the arena is frozen for the duration
      * of worker access. */
     out_worker->compound_arena = coordinator->compound_arena;
+    memset(&out_worker->compound_borrow, 0,
+        sizeof(out_worker->compound_borrow));
+    if (out_worker->compound_arena
+        && !wl_compound_arena_borrow(out_worker->compound_arena,
+        &out_worker->compound_borrow))
+        goto cleanup;
     memset(&out_worker->mat_cache, 0, sizeof(col_mat_cache_t));
     /* Exchange buffers are owned by coordinator; worker inherits borrowed ptr */
     out_worker->exchange_bufs = NULL;
@@ -1922,6 +1930,8 @@ col_worker_session_destroy(wl_col_session_t *worker)
     /* compound_arena is BORROWED from coordinator (Issue #579 / R-5).
      * DO NOT call wl_compound_arena_free here — the coordinator owns it
      * and frees it in its own col_session_destroy path. */
+    if (worker->compound_borrow.arena)
+        (void)wl_compound_arena_borrow_release(&worker->compound_borrow);
 
     /* Issue #386: Free filtered relation cache (workers own their own copy) */
     for (uint32_t i = 0; i < worker->filt_cache_count; i++) {


### PR DESCRIPTION
## Summary
- enforce coordinator-only compound-arena mutation windows with explicit worker read leases
- make growth admission and allocator failpoints transactional across payload and metadata arrays
- wire leases through worker and K-Fusion paths, with teardown and documentation coverage

## Validation
- `meson compile -C builddir-1423 -j 4`
- `meson test -C builddir-1423 wirelog:memory_admission_compound wirelog:session_compound_arena_lifecycle wirelog:compound_side_relation wirelog:compound_arena_freeze_cycle_stress wirelog:worker_borrow_w2_tsan wirelog:worker_arena_borrow --print-errorlogs`
- `bash scripts/ci/check-threading-doc.sh`

Closes #1423