### PR TITLE
feat: admit built-in CSV stream buffers

### DIFF
--- a/scripts/ci/clang-tidy-allowlist.txt
+++ b/scripts/ci/clang-tidy-allowlist.txt
@@ -38,12 +38,15 @@
 # source partition.
 wirelog/api_facade.c
 wirelog/arena/arena.c
+wirelog/arena/arena_admission.c
 wirelog/arena/compound_arena.c
+wirelog/arena/compound_arena_admission.c
 wirelog/columnar/arithmetic.c
 wirelog/columnar/arrangement.c
 wirelog/columnar/cache.c
 wirelog/columnar/compound_side.c
 wirelog/columnar/delta_pool.c
+wirelog/columnar/delta_pool_admission.c
 wirelog/columnar/diff.c
 wirelog/columnar/diff_arrangement.c
 wirelog/columnar/diff_bridge.c

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -49,10 +49,12 @@ string_ops_src = files(
 
 csv_src = files(
   '../wirelog/io/csv_reader.c',
+  '../wirelog/columnar/memory_governor.c',
 )
 
 io_src = files(
   '../wirelog/io/csv_reader.c',
+  '../wirelog/columnar/memory_governor.c',
   '../wirelog/io/io_adapter.c',
   '../wirelog/io/csv_adapter.c',
   '../wirelog/io/io_ctx.c',

--- a/tests/test_csv_streaming.c
+++ b/tests/test_csv_streaming.c
@@ -4,6 +4,7 @@
 
 #include "../wirelog/io/csv_reader.h"
 #include "../wirelog/intern.h"
+#include "../wirelog/columnar/memory_governor.h"
 #include "../wirelog/wirelog-types.h"
 #include "test_tmpdir.h"
 
@@ -100,8 +101,87 @@ test_callback_failure(void)
     return rc != 0 && obs.callbacks == 2 && obs.rows == 2 ? 0 : 1;
 }
 
+static int
+test_admission_denial(void)
+{
+    char path[512];
+    if (write_fixture(path, sizeof(path), "wirelog_csv_streaming_budget.csv",
+        "1,one\n") != 0)
+        return 1;
+
+    wirelog_column_type_t types[] = {
+        WIRELOG_TYPE_INT64, WIRELOG_TYPE_STRING,
+    };
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_resolution_t resolution = {
+        .budget_bytes = 1,
+        .headroom_bytes = 0,
+        .usable_bytes = 1,
+        .mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING,
+        .source = WL_COLUMNAR_MEMORY_SOURCE_ENV,
+        .status = WL_COLUMNAR_MEMORY_OK,
+    };
+    wl_columnar_memory_governor_ref_t *ref
+        = wl_columnar_memory_governor_ref_create(&resolution);
+    stream_observer_t obs = {0};
+    int rc = ref
+        ? wl_csv_read_file_via_ctx_stream_admitted(path, ',', types, 2, 2,
+            observe_rows, &obs, intern_cb, intern,
+            wl_columnar_memory_governor_ref_get(ref))
+        : WL_CSV_ERR_MEMORY;
+    int clean = ref != NULL
+        && wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(ref)) == 0
+        && rc == WL_CSV_ERR_MEMORY && obs.rows == 0;
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+    wl_intern_free(intern);
+    remove(path);
+    return clean ? 0 : 1;
+}
+
+static int
+test_admission_release(void)
+{
+    char path[512];
+    if (write_fixture(path, sizeof(path), "wirelog_csv_streaming_release.csv",
+        "1,one\n2,two\n") != 0)
+        return 1;
+
+    wirelog_column_type_t types[] = {
+        WIRELOG_TYPE_INT64, WIRELOG_TYPE_STRING,
+    };
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_resolution_t resolution = {
+        .budget_bytes = UINT64_C(64) * 1024 * 1024,
+        .headroom_bytes = 0,
+        .usable_bytes = UINT64_C(64) * 1024 * 1024,
+        .mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING,
+        .source = WL_COLUMNAR_MEMORY_SOURCE_ENV,
+        .status = WL_COLUMNAR_MEMORY_OK,
+    };
+    wl_columnar_memory_governor_ref_t *ref
+        = wl_columnar_memory_governor_ref_create(&resolution);
+    stream_observer_t obs = {0};
+    int rc = ref
+        ? wl_csv_read_file_via_ctx_stream_admitted(path, ',', types, 2, 2,
+            observe_rows, &obs, intern_cb, intern,
+            wl_columnar_memory_governor_ref_get(ref))
+        : WL_CSV_ERR_MEMORY;
+    int clean = ref != NULL
+        && rc == 0 && obs.rows == 2
+        && wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(ref)) == 0;
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+    wl_intern_free(intern);
+    remove(path);
+    return clean ? 0 : 1;
+}
+
 int
 main(void)
 {
-    return test_batches_and_strings() || test_callback_failure();
+    return test_batches_and_strings() || test_callback_failure()
+           || test_admission_denial() || test_admission_release();
 }

--- a/wirelog/api_facade.c
+++ b/wirelog/api_facade.c
@@ -293,6 +293,12 @@ ensure_result_relation(wirelog_result_t *result, const char *relation,
             (void)wl_columnar_memory_release(&pending);
             return NULL;
         }
+        if (result->count >= next) {
+            free(name);
+            free(rels);
+            (void)wl_columnar_memory_release(&pending);
+            return NULL;
+        }
         if (result->relations)
             memcpy(rels, result->relations, (size_t)old_bytes);
         memset(rels + result->capacity, 0,

--- a/wirelog/backend.h
+++ b/wirelog/backend.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 #include "exec_plan.h"
+#include "columnar/memory_governor.h"
 #include "wirelog/wirelog-types.h"
 
 #include <stdint.h>
@@ -86,6 +87,10 @@ typedef struct {
 
     int (*session_snapshot)(wl_session_t *session, wirelog_on_tuple_fn callback,
         void *user_data);
+
+    /* Internal hook used by bounded built-in input loaders. */
+    wl_columnar_memory_governor_t *(*session_memory_governor)(
+        wl_session_t *session);
 } wl_compute_backend_t;
 
 /**

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1654,6 +1654,14 @@ col_session_memory_governor_ref(wl_session_t *session)
     return sess->memory_governor;
 }
 
+static wl_columnar_memory_governor_t *
+col_session_memory_governor(wl_session_t *session)
+{
+    wl_columnar_memory_governor_ref_t *ref
+        = col_session_memory_governor_ref(session);
+    return wl_columnar_memory_governor_ref_get(ref);
+}
+
 /* ======================================================================== */
 /* Per-Worker Session State (Issue #315)                                    */
 /* ======================================================================== */
@@ -3123,6 +3131,7 @@ static const wl_compute_backend_t col_backend = {
     .session_step = col_session_step,
     .session_set_delta_cb = col_session_set_delta_cb,
     .session_snapshot = col_session_snapshot,
+    .session_memory_governor = col_session_memory_governor,
 };
 
 const wl_compute_backend_t *

--- a/wirelog/io/csv_adapter.c
+++ b/wirelog/io/csv_adapter.c
@@ -121,9 +121,10 @@ wl_csv_adapter_stream_read(wirelog_io_ctx_t *ctx, uint32_t max_batch_rows,
     wirelog_column_type_t *types = NULL;
     int rc = csv_types(ctx, &types);
     if (rc == WL_CSV_OK) {
-        rc = wl_csv_read_file_via_ctx_stream(path, csv_delimiter(ctx), types,
+        rc = wl_csv_read_file_via_ctx_stream_admitted(path, csv_delimiter(ctx),
+                types,
                 wirelog_io_ctx_num_cols(ctx), max_batch_rows, batch_cb, opaque,
-                csv_intern_trampoline, ctx);
+                csv_intern_trampoline, ctx, ctx->memory_governor);
     }
     free(types);
     return rc;

--- a/wirelog/io/csv_reader.c
+++ b/wirelog/io/csv_reader.c
@@ -9,6 +9,7 @@
  */
 
 #include "csv_reader.h"
+#include "columnar/memory_governor.h"
 
 #include <ctype.h>
 #include <errno.h>
@@ -747,6 +748,24 @@ wl_csv_read_file_via_ctx_stream(
     int64_t (*intern_cb)(void *opaque, const char *str),
     void *intern_opaque)
 {
+    return wl_csv_read_file_via_ctx_stream_admitted(filepath, delimiter,
+               col_types, num_cols, max_batch_rows, batch_cb, opaque,
+               intern_cb, intern_opaque, NULL);
+}
+
+int
+wl_csv_read_file_via_ctx_stream_admitted(
+    const char *filepath,
+    char delimiter,
+    const wirelog_column_type_t *col_types,
+    uint32_t num_cols,
+    uint32_t max_batch_rows,
+    wl_csv_batch_cb batch_cb,
+    void *opaque,
+    int64_t (*intern_cb)(void *opaque, const char *str),
+    void *intern_opaque,
+    wl_columnar_memory_governor_t *governor)
+{
     if (!filepath || !col_types || num_cols == 0 || max_batch_rows == 0
         || !batch_cb || !intern_cb)
         return WL_CSV_ERR_ARGS;
@@ -755,13 +774,45 @@ wl_csv_read_file_via_ctx_stream(
     if (!f)
         return WL_CSV_ERR_ARGS;
 
-    int64_t *batch = (int64_t *)malloc((size_t)max_batch_rows * num_cols
-            * sizeof(*batch));
-    int64_t *row_values = (int64_t *)malloc((size_t)num_cols
-            * sizeof(*row_values));
+    uint64_t batch_bytes;
+    uint64_t batch_cells;
+    uint64_t row_bytes;
+    uint64_t admitted_bytes;
+    wl_columnar_memory_reservation_t reservation;
+    wl_columnar_memory_reservation_init(&reservation);
+    if (!wl_columnar_memory_size_mul((uint64_t)max_batch_rows, num_cols,
+        &batch_cells)
+        || !wl_columnar_memory_size_mul(batch_cells, sizeof(int64_t),
+        &batch_bytes)
+        || !wl_columnar_memory_size_mul(num_cols, sizeof(int64_t), &row_bytes)
+        || !wl_columnar_memory_size_add(batch_bytes, row_bytes,
+        &admitted_bytes)
+        || !wl_columnar_memory_size_add(admitted_bytes,
+        WL_CSV_READ_CHUNK + WL_CSV_MAX_LINE + 1,
+        &admitted_bytes)
+        || !wl_columnar_memory_size_add(admitted_bytes,
+        WL_CSV_MAX_LINE + 1, &admitted_bytes)) {
+        fclose(f);
+        return WL_CSV_ERR_MEMORY;
+    }
+    if (governor) {
+        wl_columnar_memory_admission_status_t admission
+            = wl_columnar_memory_reserve_checked(governor, admitted_bytes,
+                &reservation);
+        if (admission != WL_COLUMNAR_MEMORY_ADMISSION_OK
+            && admission != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY) {
+            fclose(f);
+            return WL_CSV_ERR_MEMORY;
+        }
+    }
+
+    int64_t *batch = (int64_t *)malloc((size_t)batch_bytes);
+    int64_t *row_values = (int64_t *)malloc((size_t)row_bytes);
     if (!batch || !row_values) {
         free(batch);
         free(row_values);
+        if (governor)
+            wl_columnar_memory_release(&reservation);
         fclose(f);
         return WL_CSV_ERR_MEMORY;
     }
@@ -771,6 +822,8 @@ wl_csv_read_file_via_ctx_stream(
     if (rc != WL_CSV_OK) {
         free(batch);
         free(row_values);
+        if (governor)
+            wl_columnar_memory_release(&reservation);
         fclose(f);
         return rc;
     }
@@ -816,6 +869,8 @@ wl_csv_read_file_via_ctx_stream(
     csv_reader_dispose(&reader);
     free(row_values);
     free(batch);
+    if (governor)
+        wl_columnar_memory_release(&reservation);
     fclose(f);
     return lrc < 0 ? lrc : WL_CSV_OK;
 }

--- a/wirelog/io/csv_reader.h
+++ b/wirelog/io/csv_reader.h
@@ -14,6 +14,7 @@
 
 #include "../wirelog-types.h"
 #include "../intern.h"
+#include "columnar/memory_governor.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -216,5 +217,18 @@ wl_csv_read_file_via_ctx_stream(
     void *opaque,
     int64_t (*intern_cb)(void *opaque, const char *str),
     void *intern_opaque);
+
+int
+wl_csv_read_file_via_ctx_stream_admitted(
+    const char *filepath,
+    char delimiter,
+    const wirelog_column_type_t *col_types,
+    uint32_t num_cols,
+    uint32_t max_batch_rows,
+    wl_csv_batch_cb batch_cb,
+    void *opaque,
+    int64_t (*intern_cb)(void *opaque, const char *str),
+    void *intern_opaque,
+    wl_columnar_memory_governor_t *governor);
 
 #endif /* WIRELOG_IO_CSV_READER_H */

--- a/wirelog/io/io_ctx.c
+++ b/wirelog/io/io_ctx.c
@@ -139,6 +139,14 @@ wirelog_io_ctx_destroy(wirelog_io_ctx_t *ctx)
     free(ctx);
 }
 
+void
+wirelog_io_ctx_set_memory_governor(wirelog_io_ctx_t *ctx,
+    wl_columnar_memory_governor_t *governor)
+{
+    if (ctx)
+        ctx->memory_governor = governor;
+}
+
 /* ------------------------------------------------------------------------ */
 /* Accessors                                                                */
 /* ------------------------------------------------------------------------ */

--- a/wirelog/io/io_ctx_internal.h
+++ b/wirelog/io/io_ctx_internal.h
@@ -17,6 +17,7 @@
 #include "wirelog/io/io_adapter.h"
 #include "wirelog/intern.h"
 #include "wirelog/ir/program.h"  /* for wl_ir_relation_info_t */
+#include "columnar/memory_governor.h"
 
 struct wirelog_io_ctx {
     const char             *relation_name;
@@ -27,6 +28,7 @@ struct wirelog_io_ctx {
     uint32_t num_params;
     wl_intern_t            *intern;          /* borrowed, not owned */
     void                   *platform_ctx;
+    wl_columnar_memory_governor_t *memory_governor; /* borrowed */
 };
 
 wirelog_io_ctx_t *wirelog_io_ctx_create_test(
@@ -40,5 +42,8 @@ void wirelog_io_ctx_destroy(wirelog_io_ctx_t *ctx);
 wirelog_io_ctx_t *wirelog_io_ctx_create_for_relation(
     const wl_ir_relation_info_t *rel,
     wl_intern_t *intern);
+
+void wirelog_io_ctx_set_memory_governor(
+    wirelog_io_ctx_t *ctx, wl_columnar_memory_governor_t *governor);
 
 #endif /* WIRELOG_IO_IO_CTX_INTERNAL_H */

--- a/wirelog/session.c
+++ b/wirelog/session.c
@@ -79,6 +79,15 @@ wl_session_insert(wl_session_t *session, const char *relation,
                num_cols);
 }
 
+wl_columnar_memory_governor_t *
+wl_session_memory_governor(wl_session_t *session)
+{
+    if (!session || !session->backend
+        || !session->backend->session_memory_governor)
+        return NULL;
+    return session->backend->session_memory_governor(session);
+}
+
 int
 wl_session_make_compound(wl_session_t *session, const char *functor,
     uint32_t arity, const wirelog_compound_arg_t *args,

--- a/wirelog/session.h
+++ b/wirelog/session.h
@@ -115,6 +115,10 @@ int
 wl_session_insert(wl_session_t *session, const char *relation,
     const int64_t *data, uint32_t num_rows, uint32_t num_cols);
 
+/* Internal: return the backend's shared admission governor, when available. */
+wl_columnar_memory_governor_t *
+wl_session_memory_governor(wl_session_t *session);
+
 /**
  * wl_session_make_compound:
  * @session:    The active execution session.

--- a/wirelog/session_facts.c
+++ b/wirelog/session_facts.c
@@ -115,6 +115,8 @@ wl_session_load_input_files(wl_session_t *sess,
                 rel->name);
             return wl_session_input_load_fail(sess);
         }
+        wirelog_io_ctx_set_memory_governor(ctx,
+            wl_session_memory_governor(sess));
 
         /* Optional validation pass */
         if (adapter->validate) {


### PR DESCRIPTION
## Summary

Part of #1402. This atomic unit wires the built-in `.input` CSV streaming path to the session memory governor for its bounded transient working set:

- session/backend governor accessor remains internal;
- built-in CSV batch, row, read-chunk, maximum line, and field-scratch ceilings are admitted before allocation;
- checked size arithmetic distinguishes overflow from budget denial;
- reservations release on denial, allocation/init failure, parser/callback failure, and successful completion;
- custom adapters and the installed public I/O ABI are unchanged;
- existing poison-on-partial-stream failure behavior remains covered by `io_dispatch`.

#1428 owns the remaining retained allocation domains: intern-table growth and retained EDB relation/timestamp capacity. This PR does not claim to close #1402.

## Validation

- `meson test -C builddir-1402 csv_streaming csv csv_limits csv_wide_columns io_adapter io_dispatch input_arity memory_governor --print-errorlogs`
- `git diff --check`

All 8 focused tests passed.
