### PR TITLE
fix(ci): build test_wirelog_result_oom from sources instead of the LTO archive

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5404,11 +5404,21 @@ test_wirelog_public_api_exe = executable(
 test('wirelog_public_api', test_wirelog_public_api_exe)
 
 if host_machine.system() == 'linux'
+  # Compile the library sources into the test itself instead of linking
+  # libwirelog_static.a.  Under the project default b_lto=true that archive
+  # holds LLVM bitcode when the compiler is clang, and this target is
+  # b_lto=false (the portable guarantee that --wrap interposition is applied,
+  # see test_jpp above), so a plain non-LTO clang link cannot read it:
+  # "libwirelog_static.a: error adding symbols: file format not recognized".
+  # gcc only survived because its driver always loads the LTO plugin.  Same
+  # pattern as test_program_oom / test_plan_gen_oom.
   test_wirelog_result_oom_exe = executable(
     'test_wirelog_result_oom',
     files('test_wirelog_result_oom.c'),
+    wirelog_sources,
+    config_h_file,
     include_directories: [wirelog_inc, wirelog_src_inc],
-    link_with: wirelog_static_lib,
+    c_args: ['-DWIRELOG_BUILDING'],
     dependencies: [threads_dep, zlib_dep, nanoarrow_dep, xxhash_dep,
                     mbedtls_dep, math_dep],
     link_args: ['-Wl,--wrap=malloc', '-Wl,--wrap=calloc',


### PR DESCRIPTION
Fixes the `Build / ubuntu-latest / clang` failure on `main` introduced by b7d19c9b (#1424).

## Cause

`test_wirelog_result_oom` links `libwirelog_static.a` with `override_options: ['b_lto=false']` (needed so `-Wl,--wrap=malloc/calloc/realloc` is applied portably). With the project default `b_lto=true` that archive holds LLVM bitcode when built by clang, and a non-LTO clang link calls plain `ld` without the LLVM plugin:

```
/usr/bin/ld: libwirelog_static.a: error adding symbols: file format not recognized
```

gcc passed only because its driver always loads the LTO plugin, so the failure appeared on the clang job alone.

## Fix

Compile `wirelog_sources` (+ `config.h`, `-DWIRELOG_BUILDING`) into the test executable, the same pattern `test_program_oom` and `test_plan_gen_oom` use, so `b_lto=false` covers the library objects too. Linux-only target, one extra non-LTO compile of the library.

## Verification

- Unmodified `main` + `CC=clang meson setup -Dtests=true -DmbedTLS=disabled`: reproduces the link error.
- With this change: `tests/test_wirelog_result_oom` builds and reports `OK` under both clang and gcc.
- `link_with: wirelog_static_lib` has no other users in `tests/meson.build`.
