### PR TITLE
Admit retained EDB relation growth under the memory budget

### DIFF
--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -81,6 +81,116 @@ test_session_hash_overflow_rejected(void)
     PASS();
 }
 
+static void
+test_retained_relation_admission(void)
+{
+    const uint64_t initial_bytes = 64u * sizeof(int64_t)
+        + 64u * sizeof(col_delta_timestamp_t);
+    const uint64_t grown_bytes = 128u * sizeof(int64_t)
+        + 128u * sizeof(col_delta_timestamp_t);
+    const uint64_t exact_budget = initial_bytes + grown_bytes;
+    wl_columnar_memory_resolution_t resolution = { 0 };
+    wl_columnar_memory_governor_ref_t *ref = NULL;
+    col_rel_t *rel = NULL;
+    int64_t row = 7;
+    int rc;
+
+    TEST("retained relation growth admits peak and releases on destroy");
+    resolution.budget_bytes = exact_budget;
+    resolution.usable_bytes = exact_budget;
+    resolution.mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING;
+    resolution.source = WL_COLUMNAR_MEMORY_SOURCE_ENV;
+    resolution.status = WL_COLUMNAR_MEMORY_OK;
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    if (!ref || col_rel_alloc(&rel, "retained") != 0
+        || col_rel_attach_memory_governor(rel, ref) != 0) {
+        if (rel)
+            col_rel_destroy(rel);
+        if (ref)
+            wl_columnar_memory_governor_ref_release(ref);
+        FAIL("retained relation setup failed");
+        return;
+    }
+    rc = col_rel_set_schema(rel, 1, NULL);
+    if (rc == 0)
+        rc = col_rel_enable_timestamps(rel);
+    for (uint32_t i = 0; rc == 0 && i < 64u; i++)
+        rc = col_rel_append_row(rel, &row);
+    if (rc == 0)
+        rc = col_rel_append_row(rel, &row);
+    if (rc != 0 || rel->capacity != 128u || rel->nrows != 65u
+        || rel->timestamps[0].iteration != 0
+        || wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(ref)) != grown_bytes) {
+        col_rel_destroy(rel);
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("exact-fit retained growth was not committed");
+        return;
+    }
+    rel->nrows = 0;
+    col_rel_compact(rel);
+    if (rel->capacity != 0u
+        || wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(ref)) != 0u
+        || col_rel_append_row(rel, &row) != 0
+        || rel->capacity != 64u
+        || wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(ref))
+        != 64u * sizeof(int64_t)) {
+        col_rel_destroy(rel);
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("empty compaction left a stale retained admission");
+        return;
+    }
+    col_rel_destroy(rel);
+    if (wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(ref)) != 0) {
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("retained reservation leaked after destroy");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+
+    TEST("retained relation denial preserves old rows and capacity");
+    resolution.usable_bytes = exact_budget - 1u;
+    resolution.budget_bytes = exact_budget - 1u;
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    rel = NULL;
+    if (!ref || col_rel_alloc(&rel, "retained-denied") != 0
+        || col_rel_attach_memory_governor(rel, ref) != 0) {
+        if (rel)
+            col_rel_destroy(rel);
+        if (ref)
+            wl_columnar_memory_governor_ref_release(ref);
+        FAIL("denial setup failed");
+        return;
+    }
+    rc = col_rel_set_schema(rel, 1, NULL);
+    if (rc == 0)
+        rc = col_rel_enable_timestamps(rel);
+    for (uint32_t i = 0; rc == 0 && i < 64u; i++)
+        rc = col_rel_append_row(rel, &row);
+    rc = rc == 0 ? col_rel_append_row(rel, &row) : rc;
+    if (rc != ENOMEM || rel->capacity != 64u || rel->nrows != 64u
+        || wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(ref)) != initial_bytes) {
+        col_rel_destroy(rel);
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("denied retained growth changed relation state");
+        return;
+    }
+    col_rel_destroy(rel);
+    if (wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(ref)) != 0) {
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("denied relation reservation leaked after destroy");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+}
+
 /* ======================================================================== */
 /* Delta Collector                                                          */
 /* ======================================================================== */
@@ -989,6 +1099,7 @@ main(void)
     printf("test_session: persistent columnar session delta tests\n");
 
     test_session_hash_overflow_rejected();
+    test_retained_relation_admission();
     test_session_create_destroy();
     test_session_create_destroy_columnar();
     test_session_create_multi_worker_rejected();

--- a/wirelog/api_facade.c
+++ b/wirelog/api_facade.c
@@ -303,6 +303,12 @@ ensure_result_relation(wirelog_result_t *result, const char *relation,
             memcpy(rels, result->relations, (size_t)old_bytes);
         memset(rels + result->capacity, 0,
             (next - result->capacity) * sizeof(wl_result_relation_t));
+        if (result->count >= next) {
+            free(name);
+            free(rels);
+            (void)wl_columnar_memory_release(&pending);
+            return NULL;
+        }
         rels[result->count].name = name;
         rels[result->count].cols = cols;
         if (!result_publish_admission(result, &pending, target)) {

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1520,19 +1520,14 @@ tdd_worker_subpass_fn(void *arg)
             }
 
             /* Enable target timestamps */
-            if (!r->timestamps && r->capacity > 0) {
-                r->timestamps = (col_delta_timestamp_t *)calloc(
-                    r->capacity, sizeof(col_delta_timestamp_t));
-                if (!r->timestamps) {
-                    free(delta->timestamps);
-                    col_rel_destroy(delta);
-                    ctx->rc = ENOMEM;
-                    free(snap);
-                    sess->tdd_subpass_active = saved_tdd_subpass;
-                    sess->tdd_outbound_only_active = saved_outbound_only;
-                    sess->diff_operators_active = saved_diff;
-                    TDD_WORKER_RETURN();
-                }
+            if (col_rel_enable_timestamps(r) != 0) {
+                col_rel_destroy(delta);
+                ctx->rc = ENOMEM;
+                free(snap);
+                sess->tdd_subpass_active = saved_tdd_subpass;
+                sess->tdd_outbound_only_active = saved_outbound_only;
+                sess->diff_operators_active = saved_diff;
+                TDD_WORKER_RETURN();
             }
 
             /* Issue #410, Commit 5: Queue-only transport.

--- a/wirelog/columnar/eval_serial.c
+++ b/wirelog/columnar/eval_serial.c
@@ -732,15 +732,10 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                     /* Phase 4: Enable timestamp tracking on target relation to
                      * preserve provenance through consolidation.  This enables
                      * frontier computation to determine convergence. */
-                    if (!r->timestamps && r->capacity > 0) {
-                        r->timestamps = (col_delta_timestamp_t *)calloc(
-                            r->capacity, sizeof(col_delta_timestamp_t));
-                        if (!r->timestamps) {
-                            free(delta->timestamps);
-                            col_rel_destroy(delta);
-                            outer_rc = ENOMEM;
-                            goto stride_error;
-                        }
+                    if (col_rel_enable_timestamps(r) != 0) {
+                        col_rel_destroy(delta);
+                        outer_rc = ENOMEM;
+                        goto stride_error;
                     }
 
                     delta_rels[ri] = delta;

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -346,6 +346,12 @@ typedef struct {
      * WL_MEM_SUBSYS_RELATION.  Set by operators that produce output
      * relations (e.g. col_op_join).  NULL for EDB and pool temporaries. */
     wl_mem_ledger_t *mem_ledger;
+    /* Retained EDB admission.  This is deliberately separate from the
+     * accounting ledger: the token represents the relation's live heap
+     * footprint and is only attached to session-owned input relations. */
+    wl_columnar_memory_governor_ref_t *memory_governor;
+    wl_columnar_memory_reservation_t retained_reservation;
+    uint64_t retained_reserved_bytes;
     /* Bytes currently charged to WL_MEM_SUBSYS_TIMESTAMP for this relation's
      * timestamps[] array (Issue #1380).  Maintained by
      * col_rel_ledger_reconcile()/col_rel_ledger_release(); always 0 when
@@ -1617,6 +1623,11 @@ void
 col_arrangement_pin_release(col_arrangement_pin_t *pin);
 int
 col_rel_alloc(col_rel_t **out, const char *name);
+int
+col_rel_attach_memory_governor(col_rel_t *rel,
+    wl_columnar_memory_governor_ref_t *memory_governor);
+int
+col_rel_enable_timestamps(col_rel_t *rel);
 
 /* ------------------------------------------------------------------------ */
 /* Compound-column layout (Issue #532 Task 2).                              */

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -532,6 +532,7 @@ col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names)
 {
     wl_columnar_memory_reservation_t pending;
     int pending_rc;
+    int failure_rc = EINVAL;
     uint64_t retained_bytes = 0;
 
     if (!r)
@@ -550,11 +551,13 @@ col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names)
         r->capacity = COL_REL_INIT_CAP;
         r->columns = col_columns_alloc(ncols, r->capacity);
         if (!r->columns) {
+            failure_rc = ENOMEM;
             goto fail;
         }
 
         r->col_names = (char **)calloc(ncols, sizeof(char *));
         if (!r->col_names) {
+            failure_rc = ENOMEM;
             goto fail;
         }
         for (uint32_t i = 0; i < ncols; i++) {
@@ -566,6 +569,7 @@ col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names)
                 r->col_names[i] = wl_strdup(buf);
             }
             if (!r->col_names[i]) {
+                failure_rc = ENOMEM;
                 goto fail;
             }
         }
@@ -603,6 +607,7 @@ col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names)
             r->timestamps != NULL, &retained_bytes)
             || col_rel_publish_retained_reservation(r, &pending,
             retained_bytes) != 0) {
+            failure_rc = ENOMEM;
             goto fail;
         }
     }
@@ -626,7 +631,7 @@ fail:
     }
     r->capacity = 0;
     r->ncols = 0;
-    return EINVAL;
+    return failure_rc;
 }
 
 int

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -166,6 +166,240 @@ col_rel_transport_bytes(const col_rel_t *r)
     return cols + ts;
 }
 
+static bool
+col_rel_retained_bytes(uint32_t ncols, uint32_t capacity, bool timestamps,
+    uint64_t *out)
+{
+    uint64_t columns;
+    uint64_t timestamp_bytes = 0;
+
+    if (!out || !wl_columnar_memory_size_mul(ncols, capacity, &columns)
+        || !wl_columnar_memory_size_mul(columns, sizeof(int64_t), &columns))
+        return false;
+    if (timestamps
+        && (!wl_columnar_memory_size_mul(capacity,
+        sizeof(col_delta_timestamp_t), &timestamp_bytes)
+        || !wl_columnar_memory_size_add(columns, timestamp_bytes, out)))
+        return false;
+    if (!timestamps)
+        *out = columns;
+    return true;
+}
+
+static void
+col_rel_reservation_rollback(wl_columnar_memory_reservation_t *reservation)
+{
+    if (!reservation)
+        return;
+    (void)wl_columnar_memory_release(reservation);
+}
+
+static int
+col_rel_reserve_retained_shape(const col_rel_t *r, uint32_t capacity,
+    bool timestamps, wl_columnar_memory_reservation_t *pending)
+{
+    uint64_t bytes;
+    wl_columnar_memory_admission_status_t status;
+
+    if (!r || !pending)
+        return -1;
+    wl_columnar_memory_reservation_init(pending);
+    if (!r->memory_governor)
+        return 0;
+    /* Shared and arena-backed relations are deliberately not attached by
+     * the retained-EDB path yet; their ownership transitions are separate
+     * admission units. */
+    if (r->arena_owned || r->col_shared)
+        return -1;
+    if (!col_rel_retained_bytes(r->ncols, capacity, timestamps, &bytes))
+        return -1;
+    /* A consolidation or bulk append may have reduced the physical
+     * capacity while the committed token still covers the larger shape.
+     * Keep that conservative token: no new admission is needed until the
+     * relation grows beyond it. */
+    if (bytes <= r->retained_reserved_bytes)
+        return 0;
+    if (bytes == 0)
+        return 0;
+    status = wl_columnar_memory_reserve_growth(
+        wl_columnar_memory_governor_ref_get(r->memory_governor),
+        r->retained_reserved_bytes, bytes, pending);
+    if (status != WL_COLUMNAR_MEMORY_ADMISSION_OK
+        && status != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY)
+        return -1;
+    return 1;
+}
+
+static int
+col_rel_reserve_retained(const col_rel_t *r, uint32_t capacity,
+    wl_columnar_memory_reservation_t *pending)
+{
+    return col_rel_reserve_retained_shape(r, capacity,
+               r->timestamps != NULL, pending);
+}
+
+static int
+col_rel_publish_retained_reservation(col_rel_t *r,
+    wl_columnar_memory_reservation_t *pending, uint64_t bytes)
+{
+    uint64_t old_bytes;
+    wl_columnar_memory_reservation_t previous;
+
+    if (!r || !pending)
+        return EINVAL;
+    if (!r->memory_governor || bytes == 0)
+        return 0;
+    if (!wl_columnar_memory_commit(pending, r))
+        return ENOMEM;
+    old_bytes = r->retained_reserved_bytes;
+    wl_columnar_memory_reservation_init(&previous);
+    if (old_bytes > 0
+        && !wl_columnar_memory_reservation_move(
+            &previous, &r->retained_reservation)) {
+        (void)wl_columnar_memory_release(pending);
+        return ENOMEM;
+    }
+    if (!wl_columnar_memory_reservation_move(&r->retained_reservation,
+        pending)) {
+        if (old_bytes > 0) {
+            wl_columnar_memory_reservation_init(&r->retained_reservation);
+            (void)wl_columnar_memory_reservation_move(
+                &r->retained_reservation, &previous);
+        }
+        (void)wl_columnar_memory_release(pending);
+        return ENOMEM;
+    }
+    if (old_bytes > 0)
+        (void)wl_columnar_memory_release(&previous);
+    r->retained_reserved_bytes = bytes;
+    return 0;
+}
+
+int
+col_rel_attach_memory_governor(col_rel_t *r,
+    wl_columnar_memory_governor_ref_t *memory_governor)
+{
+    if (!r || !memory_governor)
+        return EINVAL;
+    if (r->memory_governor == memory_governor)
+        return 0;
+    if (r->memory_governor || r->retained_reserved_bytes != 0)
+        return EBUSY;
+    r->memory_governor = memory_governor;
+    wl_columnar_memory_governor_ref_retain(memory_governor);
+    wl_columnar_memory_reservation_init(&r->retained_reservation);
+    return 0;
+}
+
+int
+col_rel_enable_timestamps(col_rel_t *r)
+{
+    wl_columnar_memory_reservation_t pending;
+    int reserve_rc;
+    uint64_t new_bytes;
+    col_delta_timestamp_t *timestamps;
+
+    if (!r)
+        return EINVAL;
+    if (r->timestamps || r->capacity == 0)
+        return 0;
+    if (!r->memory_governor) {
+        r->timestamps = (col_delta_timestamp_t *)calloc(
+            r->capacity, sizeof(*r->timestamps));
+        return r->timestamps ? 0 : ENOMEM;
+    }
+    reserve_rc = col_rel_reserve_retained_shape(
+        r, r->capacity, true, &pending);
+    if (reserve_rc < 0)
+        return ENOMEM;
+    if (!col_rel_retained_bytes(r->ncols, r->capacity, true, &new_bytes))
+        goto fail;
+    timestamps = (col_delta_timestamp_t *)calloc(
+        r->capacity, sizeof(*timestamps));
+    if (!timestamps)
+        goto fail;
+    r->timestamps = timestamps;
+    if (reserve_rc > 0
+        && col_rel_publish_retained_reservation(r, &pending, new_bytes) != 0) {
+        r->timestamps = NULL;
+        free(timestamps);
+        goto fail;
+    }
+    col_rel_ledger_reconcile(r, col_rel_owned_ledger_bytes(r));
+    return 0;
+
+fail:
+    col_rel_reservation_rollback(&pending);
+    return ENOMEM;
+}
+
+static int
+col_rel_grow_heap_admitted(col_rel_t *r, uint32_t new_cap)
+{
+    wl_columnar_memory_reservation_t pending;
+    int pending_rc;
+    uint32_t old_cap = r->capacity;
+    uint64_t new_bytes;
+    int64_t **new_columns = NULL;
+    col_delta_timestamp_t *new_timestamps = NULL;
+    int64_t **old_columns;
+    col_delta_timestamp_t *old_timestamps;
+
+    pending_rc = col_rel_reserve_retained(r, new_cap, &pending);
+    if (pending_rc < 0)
+        return ENOMEM;
+    if (!col_rel_retained_bytes(r->ncols, new_cap, r->timestamps != NULL,
+        &new_bytes)) {
+        col_rel_reservation_rollback(&pending);
+        return ENOMEM;
+    }
+    new_columns = col_columns_alloc(r->ncols, new_cap);
+    if (!new_columns)
+        goto fail;
+    if (old_cap > 0 && r->columns) {
+        for (uint32_t c = 0; c < r->ncols; c++)
+            memcpy(new_columns[c], r->columns[c],
+                (size_t)r->nrows * sizeof(int64_t));
+    }
+    if (r->timestamps) {
+        new_timestamps = (col_delta_timestamp_t *)malloc(
+            (size_t)new_cap * sizeof(*new_timestamps));
+        if (!new_timestamps)
+            goto fail;
+        if (old_cap > 0)
+            memcpy(new_timestamps, r->timestamps,
+                (size_t)r->capacity * sizeof(*new_timestamps));
+    }
+
+    old_columns = r->columns;
+    old_timestamps = r->timestamps;
+    r->columns = new_columns;
+    r->timestamps = new_timestamps;
+    r->capacity = new_cap;
+    if (pending_rc > 0
+        && col_rel_publish_retained_reservation(r, &pending, new_bytes) != 0) {
+        r->columns = old_columns;
+        r->timestamps = old_timestamps;
+        r->capacity = old_cap;
+        goto fail_after_publish;
+    }
+    col_columns_free(old_columns, r->ncols);
+    free(old_timestamps);
+    return 0;
+
+fail:
+    col_rel_reservation_rollback(&pending);
+    col_columns_free(new_columns, r->ncols);
+    free(new_timestamps);
+    return ENOMEM;
+
+fail_after_publish:
+    col_rel_reservation_rollback(&pending);
+    col_columns_free(new_columns, r->ncols);
+    free(new_timestamps);
+    return ENOMEM;
+}
+
 /*
  * ledger_sync_timestamps: bring the TIMESTAMP charge for r->timestamps in
  * line with its current size (Issue #1380).  Every relation.c growth and
@@ -226,6 +460,13 @@ col_rel_free_contents(col_rel_t *r)
 {
     if (!r)
         return;
+    if (r->memory_governor) {
+        if (r->retained_reserved_bytes > 0)
+            (void)wl_columnar_memory_release(&r->retained_reservation);
+        r->retained_reserved_bytes = 0;
+        wl_columnar_memory_governor_ref_release(r->memory_governor);
+        r->memory_governor = NULL;
+    }
     /* Release only currently heap-owned, non-borrowed data buffers. */
     col_rel_ledger_release(r);
     free(r->name);
@@ -289,22 +530,32 @@ col_rel_destroy(col_rel_t *r)
 int
 col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names)
 {
+    wl_columnar_memory_reservation_t pending;
+    int pending_rc;
+    uint64_t retained_bytes = 0;
+
+    if (!r)
+        return EINVAL;
     if (r->ncols != 0)
         return 0; /* already initialised */
 
     r->ncols = ncols;
+    pending_rc = col_rel_reserve_retained(r, COL_REL_INIT_CAP, &pending);
+    if (pending_rc < 0) {
+        r->ncols = 0;
+        return ENOMEM;
+    }
 
     if (ncols > 0) {
         r->capacity = COL_REL_INIT_CAP;
         r->columns = col_columns_alloc(ncols, r->capacity);
-        if (!r->columns)
-            return ENOMEM;
+        if (!r->columns) {
+            goto fail;
+        }
 
         r->col_names = (char **)calloc(ncols, sizeof(char *));
         if (!r->col_names) {
-            col_columns_free(r->columns, ncols);
-            r->columns = NULL;
-            return ENOMEM;
+            goto fail;
         }
         for (uint32_t i = 0; i < ncols; i++) {
             if (col_names && col_names[i]) {
@@ -315,13 +566,7 @@ col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names)
                 r->col_names[i] = wl_strdup(buf);
             }
             if (!r->col_names[i]) {
-                for (uint32_t j = 0; j < i; j++)
-                    free(r->col_names[j]);
-                free((void *)r->col_names);
-                col_columns_free(r->columns, ncols);
-                r->col_names = NULL;
-                r->columns = NULL;
-                return ENOMEM;
+                goto fail;
             }
         }
     }
@@ -337,9 +582,7 @@ col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names)
     }
     ArrowSchemaInit(&r->schema);
     if (ArrowSchemaSetTypeStruct(&r->schema, (int64_t)ncols) != NANOARROW_OK) {
-        ArrowSchemaRelease(&r->schema);
-        /* cleanup names/data done by caller via col_rel_free_contents */
-        return EINVAL;
+        goto fail;
     }
     for (uint32_t i = 0; i < ncols; i++) {
         enum ArrowType arrow_type = r->column_types
@@ -348,15 +591,42 @@ col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names)
         ArrowSchemaRelease(r->schema.children[i]);
         if (ArrowSchemaInitFromType(r->schema.children[i], arrow_type)
             != NANOARROW_OK) {
-            ArrowSchemaRelease(&r->schema);
-            return EINVAL;
+            goto fail;
         }
         const char *cname
             = (r->col_names && r->col_names[i]) ? r->col_names[i] : "";
         ArrowSchemaSetName(r->schema.children[i], cname);
     }
     r->schema_ok = true;
+    if (pending_rc > 0) {
+        if (!col_rel_retained_bytes(r->ncols, r->capacity,
+            r->timestamps != NULL, &retained_bytes)
+            || col_rel_publish_retained_reservation(r, &pending,
+            retained_bytes) != 0) {
+            goto fail;
+        }
+    }
     return 0;
+
+fail:
+    col_rel_reservation_rollback(&pending);
+    /* ArrowSchemaSetTypeStruct/InitFromType can fail after partially
+     * initializing the freshly-created schema while schema_ok is still
+     * false.  Release unconditionally: ArrowSchemaRelease is the matching
+     * cleanup for every initialized schema state. */
+    ArrowSchemaRelease(&r->schema);
+    r->schema_ok = false;
+    col_columns_free(r->columns, ncols);
+    r->columns = NULL;
+    if (r->col_names) {
+        for (uint32_t i = 0; i < ncols; i++)
+            free(r->col_names[i]);
+        free((void *)r->col_names);
+        r->col_names = NULL;
+    }
+    r->capacity = 0;
+    r->ncols = 0;
+    return EINVAL;
 }
 
 int
@@ -660,52 +930,59 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
         uint32_t new_cap = r->capacity ? r->capacity * 2 : COL_REL_INIT_CAP;
         if (new_cap <= r->capacity) /* overflow guard */
             return ENOMEM;
-        /* COW: unshare shared columns before in-place growth (Issue #396) */
-        if (r->col_shared) {
-            int cow_rc = col_rel_cow_unshare(r, 0);
-            if (cow_rc != 0)
-                return cow_rc;
-        }
-        /* Grow timestamps first (if tracking) so we can roll back cleanly
-         * on a subsequent data realloc failure. */
-        if (r->timestamps) {
-            col_delta_timestamp_t *new_ts = (col_delta_timestamp_t *)realloc(
-                r->timestamps, new_cap * sizeof(col_delta_timestamp_t));
-            if (!new_ts) {
-                col_rel_ledger_reconcile(r, ledger_before);
+        if (r->memory_governor && !r->arena_owned && !r->col_shared) {
+            if (col_rel_grow_heap_admitted(r, new_cap) != 0)
                 return ENOMEM;
-            }
-            r->timestamps = new_ts;
-        }
-        if (r->arena_owned) {
-            /* Arena data cannot be realloc'd; migrate to heap */
-            int64_t **new_cols = col_columns_alloc(r->ncols, new_cap);
-            if (!new_cols) {
-                col_rel_ledger_reconcile(r, ledger_before);
-                return ENOMEM;
-            }
-            for (uint32_t c = 0; c < r->ncols; c++)
-                memcpy(new_cols[c], r->columns[c],
-                    sizeof(int64_t) * r->nrows);
-            /* Don't free arena columns; just free the columns array */
-            free((void *)r->columns);
-            r->columns = new_cols;
-            r->arena_owned = false;
-        } else if (r->columns) {
-            if (col_columns_realloc_atomic(r->columns, r->ncols, r->capacity,
-                new_cap) != 0) {
-                col_rel_ledger_reconcile(r, ledger_before);
-                return ENOMEM;
-            }
         } else {
-            r->columns = col_columns_alloc(r->ncols, new_cap);
-            if (!r->columns) {
-                col_rel_ledger_reconcile(r, ledger_before);
-                return ENOMEM;
+            /* COW: unshare shared columns before in-place growth (Issue #396) */
+            if (r->col_shared) {
+                int cow_rc = col_rel_cow_unshare(r, 0);
+                if (cow_rc != 0)
+                    return cow_rc;
             }
+            /* Grow timestamps first (if tracking) so we can roll back cleanly
+             * on a subsequent data realloc failure. */
+            if (r->timestamps) {
+                col_delta_timestamp_t *new_ts =
+                    (col_delta_timestamp_t *)realloc(
+                    r->timestamps, new_cap * sizeof(col_delta_timestamp_t));
+                if (!new_ts) {
+                    col_rel_ledger_reconcile(r, ledger_before);
+                    return ENOMEM;
+                }
+                r->timestamps = new_ts;
+            }
+            if (r->arena_owned) {
+                /* Arena data cannot be realloc'd; migrate to heap */
+                int64_t **new_cols = col_columns_alloc(r->ncols, new_cap);
+                if (!new_cols) {
+                    col_rel_ledger_reconcile(r, ledger_before);
+                    return ENOMEM;
+                }
+                for (uint32_t c = 0; c < r->ncols; c++)
+                    memcpy(new_cols[c], r->columns[c],
+                        sizeof(int64_t) * r->nrows);
+                /* Don't free arena columns; just free the columns array */
+                free((void *)r->columns);
+                r->columns = new_cols;
+                r->arena_owned = false;
+            } else if (r->columns) {
+                if (col_columns_realloc_atomic(r->columns, r->ncols,
+                    r->capacity,
+                    new_cap) != 0) {
+                    col_rel_ledger_reconcile(r, ledger_before);
+                    return ENOMEM;
+                }
+            } else {
+                r->columns = col_columns_alloc(r->ncols, new_cap);
+                if (!r->columns) {
+                    col_rel_ledger_reconcile(r, ledger_before);
+                    return ENOMEM;
+                }
+            }
+            r->capacity = new_cap;
+            col_rel_ledger_reconcile(r, ledger_before);
         }
-        r->capacity = new_cap;
-        col_rel_ledger_reconcile(r, ledger_before);
     }
     if (r->timestamps)
         memset(&r->timestamps[r->nrows], 0, sizeof(col_delta_timestamp_t));
@@ -932,6 +1209,18 @@ col_rel_compact(col_rel_t *r)
 
     if (r->nrows == 0) {
         col_rel_ledger_release(r);
+        if (r->memory_governor) {
+            /* Empty compaction drops every retained buffer.  Release the
+             * matching admission before allowing a later append to start a
+             * new capacity; otherwise reserve_growth() would compare the
+             * new shape with a stale, larger token. */
+            if (r->retained_reserved_bytes > 0)
+                (void)wl_columnar_memory_release(
+                    &r->retained_reservation);
+            r->retained_reserved_bytes = 0;
+            wl_columnar_memory_reservation_init(
+                &r->retained_reservation);
+        }
         if (!r->arena_owned) {
             if (r->col_shared && r->columns) {
                 /* COW: free only non-shared columns (Issue #396) */
@@ -964,6 +1253,15 @@ col_rel_compact(col_rel_t *r)
     /* Only compact when buffer is more than 4x oversized.
      * Cast to uint64_t to prevent overflow when nrows > UINT32_MAX/4. */
     if (r->capacity <= (uint64_t)r->nrows * 4)
+        goto free_merge_buf;
+
+    /* A retained relation's admission token covers the complete live heap
+     * shape.  The governor has no atomic shrink operation: reserving the
+     * replacement while the old token is committed would incorrectly charge
+     * the temporary overlap, while releasing first would make compaction
+     * failure observable.  Keep the existing buffers in this case; this is
+     * conservative and preserves an exact token for subsequent growth. */
+    if (r->memory_governor)
         goto free_merge_buf;
 
     {

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1359,6 +1359,11 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
         int rc = col_rel_alloc(&r, plan->edb_relations[i]);
         if (rc != 0)
             goto oom;
+        rc = col_rel_attach_memory_governor(r, sess->memory_governor);
+        if (rc != 0) {
+            col_rel_destroy(r);
+            goto oom;
+        }
         /* Issue #535: propagate graph-column metadata from plan to col_rel_t.
          * Guard on non-NULL array to stay compatible with callers that have
          * not populated edb_has_graph_column (defensive; wl_plan_from_program
@@ -1425,6 +1430,12 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
             int rc = col_rel_alloc(&meta, "__graph_metadata");
             if (rc != 0)
                 goto oom;
+            rc = col_rel_attach_memory_governor(meta,
+                    sess->memory_governor);
+            if (rc != 0) {
+                col_rel_destroy(meta);
+                goto oom;
+            }
             static const char *const meta_cols[6] = {
                 "graph_id", "tenant", "timestamp", "location", "risk",
                 "description"


### PR DESCRIPTION
## Summary

Implements the heap-owned, session-retained EDB admission unit for #1430.

- Attaches session EDB relations to the shared memory governor.
- Admits schema allocation, append growth, and evaluator timestamp allocation.
- Publishes replacement reservations transactionally and releases them on destroy.
- Handles consolidation capacity reductions conservatively and resets admission after empty compaction.
- Adds exact-fit, denial, reappend, and release tests.
- Fixes timestamp failure-path double-free cleanup.

COW/arena ownership migration and attached bulk-append admission remain a separate follow-up unit; this PR does not merge or silently bypass those ownership semantics.

## Rebase and CI analysis

Rebased onto `main` (3cc49ca4) without conflicts, carrying both commits (`feat: admit retained relation growth` and `fix(#1430): restore CI ratchet and schema errors`); the allowlist hunk of the second commit dissolved because `main` already lists those sources, so the allowlist is identical to `main`. The previous run failed two checks:

1. **`Build / ubuntu-latest / gcc` → clang-tidy ratchet gate.** The partition check (`allowlist ∪ backlog == libwirelog.so sources`) failed because the branch was based on a `main` that predated the allowlist registration of the admission sources (#1422's `ci: add admission sources to the clang-tidy allowlist`, then 50e9bf3d). This PR adds no library sources, so the rebase alone resolves it; on the rebased tree `meson test clang_tidy_ratchet` passes (73 files clean).
2. **`Perf Suite` → `crdt_perf_gate`**: median 38,598.5 ms vs target 38,120 ms (+1.3%, CoV 0.56%). Not attributable to this change:
   - The gate's target is a 5% envelope over a median (36,303 ms) calibrated on a pinned Xeon E5-2696 v4 with the `performance` governor and `-Dwirelog_log_max_level=error` (docs/CRDT_PERF_BASELINE.md); the Perf Suite workflow runs on a hosted runner with `-Dwirelog_log_max_level=trace`. The only recent run where the gate actually executed (#1423, 2026-09-08) passed with ~37.2 s per trial, i.e. about 2.4% of headroom, and every other recent run skipped it, so there is no CI sample of its noise band.
   - Local A/B of the same workload (`bench_flowlog --workload crdt --workers 1 --repeat 5`, `taskset`-pinned, release build), two interleaved rounds, median wall ms:

     | round | main | this branch |
     |---|---:|---:|
     | 1 | 42,473.7 | 43,604.2 |
     | 2 | 44,030.4 | 43,671.9 |

     The branch is +2.7% in one round and −0.8% in the other, while `main` itself moved +3.7% between rounds; the delta is inside the run-to-run noise.
   - Code-wise the only hot-path change is that governed session relations grow by allocate + `memcpy` + free instead of `realloc` (`col_rel_grow_heap_admitted`); that happens per capacity doubling, not per row, and no per-row work was added.

   Recalibrating the gate for the hosted runner (or gating on an A/B against `main` rather than an absolute target) is a separate follow-up.

3. **`Build / windows-latest / msvc`** (second run, after the first attempt timed out on an sccache outage): `test_io_adapter.exe` failed with five unresolved `wl_columnar_memory_*` symbols. That is the `main` breakage from #1429 fixed by #1439 (413cdc60); the branch was rebased onto 407bb625, one commit before that fix. Rebasing onto 3cc49ca4 picks it up. Verified on Linux with `-Db_lto=false` (the configuration in which the missing symbols surface): `test_io_adapter` and `test_io_adapter_concurrent` link.

## Validation

- `ninja -C builddir-1430 -j2`
- `meson test -C builddir-1430 session delta_timestamp relation_append compaction tdd_recursive tdd_integration worker_session worker_arena_borrow memory_governor --print-errorlogs`
- `git diff --check`
- After rebase (release config): `memory_governor relation_append delta_timestamp compaction session wirelog_public_api mem_instrumentation_default worker_session tdd_decision_stats clang_tidy_ratchet` all pass; `uncrustify --check` and `git diff --check` clean.

This PR is intentionally not being merged by the implementation agent.

