### PR TITLE
feat(#1384): pin primary arrangements during joins

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -546,3 +546,24 @@ the governor and the standalone fuzz target.
 - `docs/THREADING.md` §5.1 audits every atomic in `mem_ledger.c`.
 - `docs/STRESS_BASELINE.md` §Issue #598 for the rotation canary that
   asserts `current_bytes` is unchanged across `wl_arena_reset()`.
+
+## 10. Primary arrangement leases (#1384)
+
+Primary hash arrangements are session-owned cache entries. A join that probes
+one through `col_session_pin_arrangement()` holds a non-public lease until the
+probe has finished; the lease protects both the hash-table buffers and the
+embedded entry identity from cache eviction. The flat entry registry is never
+grown while a lease is active, so a caller that needs a new slot falls back to
+an ephemeral arrangement. `col_arrangement_pin_release()` must be called
+exactly once, including on allocation and join-error paths.
+
+| Event | Pinned entry | Unpinned entry |
+|---|---|---|
+| LRU eviction | skip and defer reclamation | reclaim normally |
+| relation invalidation | mark rebuild deferred; keep the old index readable | invalidate immediately |
+| final lease release | apply deferred invalidation | no action |
+
+This is an internal coordinator/worker-session contract, not a public API or a
+general concurrent-reader mechanism. Filtered, differential, sorted and
+materialization-cache lifetimes, plus relation-generation validation, remain
+tracked separately in issue #1435.

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -891,3 +891,20 @@ and standalone fuzz target do not link the memory governor.
 - Commit `61e081b` — `fix(#579)`: skip compound-arena GC dispatch
   in worker context (the live gate invariant).
 - Test pin: `tests/test_worker_arena_borrow.c`.
+
+## 13. Primary arrangement lease contract (#1384)
+
+The primary arrangement cache is not independently thread-safe. Within an
+operator's session, a keyed join acquires a `col_arrangement_pin_t` before
+using the arrangement and releases it after the probe completes. Eviction and
+relation invalidation inspect the lease count: eviction skips pinned entries,
+and invalidation is deferred until the final release. This keeps the
+arrangement buffers and their embedded cache-entry identity stable for the
+borrower's lifetime. The flat registry refuses `realloc()` while any lease is
+active; callers that cannot obtain a new cache slot must use their ephemeral
+fallback until the lease is released.
+
+The lease is internal and must not be copied or released twice. It does not
+cover filtered/differential/sorted/materialization caches or relation
+generation checks; those extensions are tracked by issue #1435. No claim of
+general multi-threaded access is made by this contract.

--- a/tests/test_arrangement_lru_eviction.c
+++ b/tests/test_arrangement_lru_eviction.c
@@ -344,6 +344,66 @@ test_total_bytes_accounting(void)
 }
 
 /* ================================================================
+ * Test 5: pinned arrangements defer invalidation until the lease ends
+ * ================================================================ */
+static void
+test_pinned_invalidation(void)
+{
+    TEST("pinned arrangement defers invalidation until release");
+
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+        "edge(10, 1). edge(20, 2). edge(30, 3).\n"
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n";
+
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    ASSERT(make_session(src, &sess, &plan, &prog) == 0,
+        "session creation failed");
+
+    wl_col_session_t *cs = COL_SESSION(sess);
+    uint32_t key_cols[1] = { 0 };
+    col_arrangement_pin_t pin;
+    col_arrangement_t *arr = col_session_get_arrangement(sess, "edge",
+            key_cols, 1);
+    ASSERT(arr != NULL && arr->indexed_rows == 3,
+        "arrangement must be built before pinning");
+    ASSERT(col_session_pin_arrangement(sess, "edge", key_cols, 1, &pin) == 0,
+        "arrangement pin must succeed");
+
+    /* Force the registry to need a realloc while the only resident entry is
+     * pinned.  It must refuse the growth rather than move the lease target. */
+    cs->arr_cap = cs->arr_count;
+    uint32_t alternate_key[1] = { 1 };
+    ASSERT(col_session_get_arrangement(sess, "edge", alternate_key, 1)
+        == NULL,
+        "registry growth must be deferred while an entry is pinned");
+    ASSERT(pin.entry->mem_bytes > 0 && pin.entry->pin_count == 1
+        && pin.entry->arr.indexed_rows == 3,
+        "a pinned arrangement must remain valid while growth is deferred");
+
+    col_session_invalidate_arrangements(sess, "edge");
+    ASSERT(pin.entry != NULL && pin.entry->pin_count == 1
+        && pin.entry->rebuild_deferred,
+        "invalidation must be deferred while pinned");
+    ASSERT(arr->indexed_rows == 3,
+        "pinned arrangement must remain readable until release");
+
+    col_arrangement_pin_release(&pin);
+    ASSERT(pin.active == false, "release must deactivate the lease");
+    ASSERT(arr->indexed_rows == 0,
+        "deferred invalidation must take effect on final release");
+
+    arr = col_session_get_arrangement(sess, "edge", key_cols, 1);
+    ASSERT(arr != NULL && arr->indexed_rows == 3,
+        "next access must rebuild the invalidated arrangement");
+
+    free_session(sess, plan, prog);
+    PASS();
+}
+
+/* ================================================================
  * main
  * ================================================================ */
 int
@@ -355,6 +415,7 @@ main(void)
     test_env_var_limit();
     test_tombstone_rebuild();
     test_total_bytes_accounting();
+    test_pinned_invalidation();
 
     printf("\n%d/%d tests passed", pass_count, test_count);
     if (fail_count > 0)

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -603,6 +603,10 @@ col_arr_cache_evict_lru(wl_col_session_t *cs, size_t target_bytes)
             col_arr_entry_t *e = &cs->arr_entries[i];
             if (e->mem_bytes == 0)
                 continue; /* already tombstoned, nothing to free */
+            if (e->pin_count > 0) {
+                e->evict_deferred = true;
+                continue;
+            }
 
             /* Prefer indexed_rows == 0 (invalidated) entries first. */
             if (e->arr.indexed_rows == 0) {
@@ -623,7 +627,20 @@ col_arr_cache_evict_lru(wl_col_session_t *cs, size_t target_bytes)
         cs->arr_total_bytes -= e->mem_bytes;
         arr_free_contents(&e->arr);
         e->mem_bytes = 0;
+        e->evict_deferred = false;
     }
+}
+
+static col_arr_entry_t *
+col_arr_entry_for_arr(wl_col_session_t *cs, const col_arrangement_t *arr)
+{
+    if (!cs || !arr)
+        return NULL;
+    for (uint32_t i = 0; i < cs->arr_count; i++) {
+        if (&cs->arr_entries[i].arr == arr)
+            return &cs->arr_entries[i];
+    }
+    return NULL;
 }
 
 /* ======================================================================== */
@@ -727,6 +744,13 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
     if (slot == cs->arr_count) {
         /* No tombstone available: grow the registry. */
         if (cs->arr_count >= cs->arr_cap) {
+            /* A lease contains pointers into this flat registry.  Do not
+            * move it underneath an active borrower; callers can fall back
+            * to an ephemeral arrangement until the lease is released. */
+            for (uint32_t i = 0; i < cs->arr_count; i++) {
+                if (cs->arr_entries[i].pin_count > 0)
+                    return NULL;
+            }
             uint32_t new_cap = cs->arr_cap ? cs->arr_cap * 2u : 8u;
             col_arr_entry_t *ne = (col_arr_entry_t *)realloc(
                 cs->arr_entries, new_cap * sizeof(col_arr_entry_t));
@@ -793,6 +817,57 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
     cs->arr_total_bytes += e->mem_bytes;
     e->lru_clock = ++cs->arr_clock;
     return &e->arr;
+}
+
+int
+col_session_pin_arrangement(wl_session_t *sess, const char *rel_name,
+    const uint32_t *key_cols, uint32_t key_count, col_arrangement_pin_t *pin)
+{
+    col_arrangement_t *arr;
+    col_arr_entry_t *entry;
+
+    if (!pin)
+        return EINVAL;
+    memset(pin, 0, sizeof(*pin));
+    arr = col_session_get_arrangement(sess, rel_name, key_cols, key_count);
+    if (!arr)
+        return ENOMEM;
+    entry = col_arr_entry_for_arr(COL_SESSION(sess), arr);
+    if (!entry)
+        return EINVAL;
+    entry->pin_count++;
+    pin->entry = entry;
+    pin->arr = arr;
+    pin->session = COL_SESSION(sess);
+    pin->active = true;
+    return 0;
+}
+
+void
+col_arrangement_pin_release(col_arrangement_pin_t *pin)
+{
+    col_arr_entry_t *entry;
+    wl_col_session_t *cs;
+    bool evict_deferred;
+
+    if (!pin || !pin->active || !pin->entry)
+        return;
+    entry = pin->entry;
+    cs = pin->session;
+    if (entry->pin_count > 0)
+        entry->pin_count--;
+    if (entry->pin_count == 0 && entry->rebuild_deferred) {
+        entry->arr.indexed_rows = 0;
+        entry->rebuild_deferred = false;
+    }
+    evict_deferred = entry->pin_count == 0 && entry->evict_deferred;
+    if (evict_deferred)
+        entry->evict_deferred = false;
+    memset(pin, 0, sizeof(*pin));
+    if (evict_deferred && cs) {
+        size_t target = (cs->arr_cache_limit_bytes / 4u) * 3u;
+        col_arr_cache_evict_lru(cs, target);
+    }
 }
 
 uint32_t
@@ -872,8 +947,12 @@ col_session_invalidate_arrangements(wl_session_t *sess, const char *rel_name)
         return;
     wl_col_session_t *cs = COL_SESSION(sess);
     for (uint32_t i = 0; i < cs->arr_count; i++) {
-        if (strcmp(cs->arr_entries[i].rel_name, rel_name) == 0)
-            cs->arr_entries[i].arr.indexed_rows = 0; /* force full rebuild */
+        if (strcmp(cs->arr_entries[i].rel_name, rel_name) == 0) {
+            if (cs->arr_entries[i].pin_count > 0)
+                cs->arr_entries[i].rebuild_deferred = true;
+            else
+                cs->arr_entries[i].arr.indexed_rows = 0;
+        }
     }
 
     /* Issue #433: Also invalidate filtered arrangement cache entries.

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -972,7 +972,18 @@ typedef struct {
     col_arrangement_t arr; /* embedded arrangement           */
     uint64_t lru_clock;    /* logical time of last access (Issue #216) */
     size_t mem_bytes;      /* bytes used by ht_head + ht_next arrays   */
+    uint32_t pin_count;    /* active internal reader leases */
+    bool rebuild_deferred; /* invalidation waits for readers */
+    bool evict_deferred;   /* reclaim was requested while pinned */
 } col_arr_entry_t;
+
+/* Non-public lease for a primary arrangement borrowed by an operator. */
+typedef struct {
+    col_arr_entry_t *entry;
+    col_arrangement_t *arr;
+    struct wl_col_session_t *session;
+    bool active;
+} col_arrangement_pin_t;
 
 /*
  * col_sorted_arr_t: cached sorted copy of a relation by a single key column.
@@ -1598,6 +1609,12 @@ col_rel_set_column_types(col_rel_t *r,
 uint32_t
 col_arrangement_find_first_typed(const col_arrangement_t *arr,
     const col_rel_t *rel, const int64_t *key_row);
+int
+col_session_pin_arrangement(wl_session_t *sess, const char *rel_name,
+    const uint32_t *key_cols, uint32_t key_count,
+    col_arrangement_pin_t *pin);
+void
+col_arrangement_pin_release(col_arrangement_pin_t *pin);
 int
 col_rel_alloc(col_rel_t **out, const char *name);
 

--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -1209,6 +1209,7 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
          * fall back to an ephemeral hash table for delta substitution or when
          * the arrangement cannot be allocated. */
         col_arrangement_t *arr = NULL;
+        col_arrangement_pin_t arr_pin = { 0 };
         uint32_t nbuckets_ep = 0;
         uint32_t *ht_head_ep = NULL;
         uint32_t *ht_next_ep = NULL;
@@ -1219,8 +1220,9 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
 
         if (!used_right_delta && op->right_relation && kc > 0) {
             if (op->right_filter_expr.size == 0) {
-                arr = col_session_get_arrangement(&sess->base,
-                        op->right_relation, rk, kc);
+                if (col_session_pin_arrangement(&sess->base,
+                    op->right_relation, rk, kc, &arr_pin) == 0)
+                    arr = arr_pin.arr;
             } else {
                 /* Issue #433: filtered right arrangement cache.
                  * `right` is the cached filtered relation from filt_cache;
@@ -1297,6 +1299,7 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
             key_row = (int64_t *)malloc(
                 sizeof(int64_t) * (right->ncols > 0 ? right->ncols : 1));
             if (!key_row) {
+                col_arrangement_pin_release(&arr_pin);
                 free(ht_head_ep);
                 free(ht_next_ep);
                 free(tmp);
@@ -1405,9 +1408,11 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
                 col_rel_destroy(right_filtered);
             if (left_e.owned)
                 col_rel_destroy(left);
+            col_arrangement_pin_release(&arr_pin);
             return join_rc;
         }
         WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_DEBUG, "Merge-join succeeded");
+        col_arrangement_pin_release(&arr_pin);
     }
 
     free(tmp);


### PR DESCRIPTION
## Summary

- add internal leases for primary arrangement probes
- defer eviction and relation invalidation while a join holds a lease
- refuse arrangement-registry growth during an active lease so entry pointers cannot be moved by `realloc`
- document the lifetime contract and add focused regression coverage

## Validation

- `uncrustify --check -c uncrustify.cfg wirelog/columnar/arrangement.c wirelog/columnar/internal.h wirelog/columnar/join.c tests/test_arrangement_lru_eviction.c`
- `meson test -C builddir-1384 arrangement arrangement_pow2_overflow join_arrangement arrangement_cache_reuse arrangement_lru_eviction filt_cache phase3c_join_integration arrangement_incr_invalidation diff_arrangement diff_join diff_recursive_arrangement --print-errorlogs`

Issue #1384 remains open for the remaining cache classes and generation validation tracked in #1435.
