### PR TITLE
fix(ci): link memory_governor.c into tests that compile csv_reader.c

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -253,6 +253,7 @@ if get_option('enable_fuzz')
         files('fuzz/csv_reader_fuzz.c'),
         files(
           '../wirelog/io/csv_reader.c',
+          '../wirelog/columnar/memory_governor.c',
           '../wirelog/intern.c',
         ),
         wirelog_thread_src,
@@ -5535,7 +5536,7 @@ endif
 
 test_io_adapter_exe = executable(
   'test_io_adapter',
-  files('test_io_adapter.c', '../wirelog/io/io_adapter.c', '../wirelog/io/csv_adapter.c', '../wirelog/io/csv_reader.c', '../wirelog/io/io_ctx.c', '../wirelog/intern.c'),
+  files('test_io_adapter.c', '../wirelog/io/io_adapter.c', '../wirelog/io/csv_adapter.c', '../wirelog/io/csv_reader.c', '../wirelog/columnar/memory_governor.c', '../wirelog/io/io_ctx.c', '../wirelog/intern.c'),
   thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
   c_args: ['-DWIRELOG_BUILDING'],
@@ -5759,6 +5760,7 @@ test_io_adapter_concurrent_exe = executable(
         '../wirelog/io/io_adapter.c',
         '../wirelog/io/csv_adapter.c',
         '../wirelog/io/csv_reader.c',
+        '../wirelog/columnar/memory_governor.c',
         '../wirelog/io/io_ctx.c',
         '../wirelog/intern.c'),
   thread_src,
@@ -5781,6 +5783,7 @@ test_io_adapter_asan_exe = executable(
         '../wirelog/io/io_adapter.c',
         '../wirelog/io/csv_adapter.c',
         '../wirelog/io/csv_reader.c',
+        '../wirelog/columnar/memory_governor.c',
         '../wirelog/io/io_ctx.c',
         '../wirelog/intern.c'),
   thread_src,
@@ -5821,6 +5824,7 @@ if io_plugin_dlopen_option == 'enabled' and not is_windows
           '../wirelog/io/io_adapter.c',
           '../wirelog/io/csv_adapter.c',
           '../wirelog/io/csv_reader.c',
+          '../wirelog/columnar/memory_governor.c',
           '../wirelog/io/io_ctx.c',
           '../wirelog/intern.c'),
     thread_src,


### PR DESCRIPTION
Fixes the `Build / windows-latest / msvc` failure on `main` (run 34226576290, commit 407bb625), introduced by c143539e (#1429).

## Cause

```
tests\test_io_adapter.exe : fatal error LNK1120: 5 unresolved externals
csv_reader.c.obj : error LNK2001: wl_columnar_memory_release
csv_reader.c.obj : error LNK2001: wl_columnar_memory_reservation_init
csv_reader.c.obj : error LNK2001: wl_columnar_memory_reserve_checked
csv_reader.c.obj : error LNK2001: wl_columnar_memory_size_add
csv_reader.c.obj : error LNK2001: wl_columnar_memory_size_mul
```

#1429 made `io/csv_reader.c` call the memory governor and added `memory_governor.c` to the shared `io_src` list, but five test targets list `csv_reader.c` individually and never got it: `test_io_adapter`, `test_io_adapter_concurrent`, `test_io_adapter_asan`, `test_plugin_loader`, `csv_reader_fuzz`. The Linux gcc/clang jobs did not notice because the project default `b_lto=true` drops the unreferenced governor calls before link time; MSVC links without LTO. The two `main` runs before c143539e (ae3aba69, b7d19c9b) passed the MSVC job.

## Fix

Add `../wirelog/columnar/memory_governor.c` to each of those five targets. `tests/meson.build` only.

## Verification

- Unmodified `main`, Linux, `-Db_lto=false`: reproduces the same five `undefined reference` errors for `test_io_adapter`.
- With this change, `-Db_lto=false`: `test_io_adapter` and `test_io_adapter_concurrent` link and pass; `test_io_adapter_asan` builds under `-Db_sanitize=address,undefined`. (`test_plugin_loader` and `csv_reader_fuzz` are option-gated targets; the edit is the same one-line addition.)
- The Windows job on this PR is the real check.
