### PR TITLE
fix(#1435): protect materialization cache lifetimes

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2135,6 +2135,24 @@ test_cse_cache_hit_rate_exe = executable(
 test('cse_cache_hit_rate', test_cse_cache_hit_rate_exe)
 
 # ============================================================================
+# Materialization Cache Lifetime Tests (Issue #1435)
+# ============================================================================
+
+test_mat_cache_lifetime_exe = executable(
+  'test_mat_cache_lifetime',
+  files('test_mat_cache_lifetime.c'),
+  backend_src,
+  intern_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('mat_cache_lifetime', test_mat_cache_lifetime_exe)
+
+# ============================================================================
 # K-way Merge CONSOLIDATE Tests (US-002 TDD RED Phase)
 # ============================================================================
 

--- a/tests/test_diff_join.c
+++ b/tests/test_diff_join.c
@@ -338,6 +338,21 @@ output_contains_row(const col_rel_t *r, const int64_t *row)
     return false;
 }
 
+static bool
+relation_contents_equal(const col_rel_t *left, const col_rel_t *right)
+{
+    if (!left || !right || left->nrows != right->nrows
+        || left->ncols != right->ncols)
+        return false;
+    for (uint32_t row = 0; row < left->nrows; row++) {
+        for (uint32_t col = 0; col < left->ncols; col++) {
+            if (col_rel_get(left, row, col) != col_rel_get(right, row, col))
+                return false;
+        }
+    }
+    return true;
+}
+
 /* ========================================================================
  * TEST CASES
  * ======================================================================== */
@@ -1280,7 +1295,7 @@ test_materialized_join_cleans_owned_left(void)
     ASSERT_TRUE(rc == 0, "materialized join output");
     eval_entry_t out = eval_stack_pop(&stack);
     ASSERT_TRUE(out.rel != NULL, "result relation exists");
-    ASSERT_TRUE(!out.owned, "materialized result is cache-owned");
+    ASSERT_TRUE(out.owned, "materialized result is an owned deep copy");
     ASSERT_TRUE(out.rel->nrows == 2, "materialized row count");
 
     col_rel_t *left_hit = make_project_left_rel();
@@ -1290,10 +1305,17 @@ test_materialized_join_cleans_owned_left(void)
     rc = col_op_join(&op, &stack, sess);
     ASSERT_TRUE(rc == 0, "materialized cache hit output");
     eval_entry_t hit = eval_stack_pop(&stack);
-    ASSERT_TRUE(hit.rel == out.rel, "cache hit reuses cached result");
-    ASSERT_TRUE(!hit.owned, "cache-hit result is cache-owned");
+    ASSERT_TRUE(hit.owned, "cache-hit result is an owned deep copy");
+    ASSERT_TRUE(hit.rel != out.rel,
+        "cache hit does not alias the first returned copy");
+    ASSERT_TRUE(relation_contents_equal(out.rel, hit.rel),
+        "cache-hit contents match the first returned copy");
     ASSERT_TRUE(hit.rel->nrows == 2, "cache-hit row count");
 
+    /* Both returned copies are caller-owned; the cached original remains
+     * owned by the session materialization cache until session teardown. */
+    col_rel_destroy(out.rel);
+    col_rel_destroy(hit.rel);
     destroy_mock_session(sess);
     PASS;
 }

--- a/tests/test_mat_cache_lifetime.c
+++ b/tests/test_mat_cache_lifetime.c
@@ -1,0 +1,259 @@
+/*
+ * test_mat_cache_lifetime.c - materialization-cache lifetime contracts
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ */
+
+#include "../wirelog/columnar/internal.h"
+
+#include <stdio.h>
+
+static int tests_run;
+static int tests_failed;
+
+#define ASSERT_TRUE(condition, message)                                      \
+        do {                                                                      \
+            if (!(condition)) {                                                   \
+                fprintf(stderr, "FAIL: %s\n", (message));                       \
+                tests_failed++;                                                  \
+                return;                                                           \
+            }                                                                     \
+        } while (0)
+
+static col_rel_t *
+make_relation(int64_t value)
+{
+    col_rel_t *rel = col_rel_new_auto("cache-test", 1);
+    if (!rel)
+        return NULL;
+    if (col_rel_append_row(rel, &value) != 0) {
+        col_rel_destroy(rel);
+        return NULL;
+    }
+    return rel;
+}
+
+static void
+test_lookup_clear_and_release(void)
+{
+    tests_run++;
+    col_mat_cache_t cache = { 0 };
+    col_rel_t *left = make_relation(1);
+    col_rel_t *right = make_relation(2);
+    col_rel_t *result = make_relation(3);
+    ASSERT_TRUE(left && right && result, "relations allocated");
+    ASSERT_TRUE(col_mat_cache_insert(&cache, left, right, result) == 0,
+        "cache insert succeeds");
+
+    col_mat_cache_pin_t pin = { 0 };
+    ASSERT_TRUE(col_mat_cache_lookup_pin(&cache, left, right, &pin) == result,
+        "lookup returns cached result");
+    ASSERT_TRUE(cache.active_pins == 1,
+        "lookup pin increments active-pin accounting");
+    col_mat_cache_clear(&cache);
+    ASSERT_TRUE(cache.count == 1 && cache.entries[0].result == result,
+        "clear defers destruction of pinned entry");
+    ASSERT_TRUE(col_mat_cache_lookup(&cache, left, right) == NULL,
+        "deferred entry is not visible to legacy lookup");
+    ASSERT_TRUE(cache.active_pins == 1,
+        "clear preserves active-pin accounting");
+    col_mat_cache_pin_release(&pin);
+    ASSERT_TRUE(cache.count == 0 && cache.total_bytes == 0,
+        "release destroys deferred entry and accounting is zero");
+    ASSERT_TRUE(cache.active_pins == 0,
+        "release decrements active-pin accounting exactly once");
+
+    col_rel_destroy(left);
+    col_rel_destroy(right);
+}
+
+static void
+test_pin_survives_compaction_and_truncate(void)
+{
+    tests_run++;
+    col_mat_cache_t cache = { 0 };
+    col_rel_t *left[3] = { make_relation(10), make_relation(20),
+                           make_relation(30) };
+    col_rel_t *right[3] = { make_relation(11), make_relation(21),
+                            make_relation(31) };
+    col_rel_t *result[3] = { make_relation(12), make_relation(22),
+                             make_relation(32) };
+    for (size_t i = 0; i < 3; i++)
+        ASSERT_TRUE(left[i] && right[i] && result[i], "relations allocated");
+    for (size_t i = 0; i < 3; i++)
+        ASSERT_TRUE(col_mat_cache_insert(&cache, left[i], right[i], result[i])
+            == 0,
+            "cache insert succeeds");
+
+    col_mat_cache_pin_t pin = { 0 };
+    ASSERT_TRUE(col_mat_cache_lookup_pin(&cache, left[1], right[1], &pin)
+        == result[1],
+        "middle entry is pinned");
+    col_mat_cache_truncate(&cache, 0);
+    ASSERT_TRUE(cache.count == 1 && cache.entries[0].result == result[1],
+        "truncate compacts around pinned entry");
+    ASSERT_TRUE(col_mat_cache_lookup(&cache, left[1], right[1]) == NULL,
+        "truncated pinned entry is hidden");
+    col_mat_cache_pin_release(&pin);
+    ASSERT_TRUE(cache.count == 0, "compacted pinned entry is released");
+    ASSERT_TRUE(cache.active_pins == 0,
+        "compaction pin release leaves no active pins");
+
+    for (size_t i = 0; i < 3; i++) {
+        col_rel_destroy(left[i]);
+        col_rel_destroy(right[i]);
+    }
+}
+
+static void
+test_lru_preserves_pinned_entry(void)
+{
+    tests_run++;
+    col_mat_cache_t cache = { 0 };
+    col_rel_t *left[COL_MAT_CACHE_MAX + 1];
+    col_rel_t *right[COL_MAT_CACHE_MAX + 1];
+    col_rel_t *result[COL_MAT_CACHE_MAX + 1];
+    for (size_t i = 0; i < COL_MAT_CACHE_MAX + 1; i++) {
+        left[i] = make_relation((int64_t)(1000 + i * 3));
+        right[i] = make_relation((int64_t)(1001 + i * 3));
+        result[i] = make_relation((int64_t)(1002 + i * 3));
+        ASSERT_TRUE(left[i] && right[i] && result[i], "relations allocated");
+    }
+    for (size_t i = 0; i < COL_MAT_CACHE_MAX; i++)
+        ASSERT_TRUE(col_mat_cache_insert(&cache, left[i], right[i], result[i])
+            == 0,
+            "cache fills to capacity");
+
+    col_mat_cache_pin_t pin = { 0 };
+    ASSERT_TRUE(col_mat_cache_lookup_pin(&cache, left[0], right[0], &pin)
+        == result[0],
+        "oldest entry is pinned");
+    cache.entries[0].lru_clock = 0;
+    ASSERT_TRUE(col_mat_cache_insert(&cache, left[COL_MAT_CACHE_MAX],
+        right[COL_MAT_CACHE_MAX], result[COL_MAT_CACHE_MAX]) == 0,
+        "full cache evicts an unpinned entry");
+    ASSERT_TRUE(col_mat_cache_lookup(&cache, left[0], right[0]) == result[0],
+        "LRU preserves the pinned entry");
+    col_mat_cache_pin_release(&pin);
+    col_mat_cache_clear(&cache);
+
+    /* Entries inserted into the cache are cache-owned after success. */
+    for (size_t i = 0; i < COL_MAT_CACHE_MAX + 1; i++) {
+        col_rel_destroy(left[i]);
+        col_rel_destroy(right[i]);
+    }
+}
+
+static void
+test_all_pinned_insert_retains_callers_ownership(void)
+{
+    tests_run++;
+    col_mat_cache_t cache = { 0 };
+    col_rel_t *left[COL_MAT_CACHE_MAX];
+    col_rel_t *right[COL_MAT_CACHE_MAX];
+    col_rel_t *result[COL_MAT_CACHE_MAX];
+    col_mat_cache_pin_t pins[COL_MAT_CACHE_MAX] = { 0 };
+    for (size_t i = 0; i < COL_MAT_CACHE_MAX; i++) {
+        left[i] = make_relation((int64_t)(3000 + i * 3));
+        right[i] = make_relation((int64_t)(3001 + i * 3));
+        result[i] = make_relation((int64_t)(3002 + i * 3));
+        ASSERT_TRUE(left[i] && right[i] && result[i],
+            "all-pinned relations allocated");
+        ASSERT_TRUE(col_mat_cache_insert(&cache, left[i], right[i], result[i])
+            == 0,
+            "all-pinned cache fills");
+    }
+    for (size_t i = 0; i < COL_MAT_CACHE_MAX; i++)
+        ASSERT_TRUE(col_mat_cache_lookup_pin(&cache, left[i], right[i],
+            &pins[i]) == result[i],
+            "each full-cache entry is pinned");
+    ASSERT_TRUE(cache.active_pins == COL_MAT_CACHE_MAX,
+        "full cache accounts for every active pin");
+
+    col_rel_t *candidate_left = make_relation(4000);
+    col_rel_t *candidate_right = make_relation(4001);
+    col_rel_t *candidate = make_relation(4002);
+    ASSERT_TRUE(candidate_left && candidate_right && candidate,
+        "candidate relations allocated");
+    ASSERT_TRUE(col_mat_cache_insert_pin(&cache, candidate_left,
+        candidate_right, candidate, NULL) == ENOSPC,
+        "all-pinned insertion reports ENOSPC");
+    ASSERT_TRUE(candidate->nrows == 1,
+        "failed insertion leaves candidate owned by caller");
+    col_rel_destroy(candidate);
+    col_rel_destroy(candidate_left);
+    col_rel_destroy(candidate_right);
+
+    size_t charged_bytes = cache.total_bytes;
+    ASSERT_TRUE(charged_bytes > 0, "pinned entries remain charged");
+    col_mat_cache_clear(&cache);
+    ASSERT_TRUE(cache.count == COL_MAT_CACHE_MAX,
+        "clear defers every pinned entry");
+    ASSERT_TRUE(cache.total_bytes == charged_bytes,
+        "clear preserves deferred-entry accounting");
+    for (size_t i = 0; i < COL_MAT_CACHE_MAX; i++)
+        ASSERT_TRUE(col_mat_cache_lookup(&cache, left[i], right[i]) == NULL,
+            "deferred entries are hidden from lookup");
+
+    for (size_t i = 0; i < COL_MAT_CACHE_MAX; i++)
+        col_mat_cache_pin_release(&pins[i]);
+    ASSERT_TRUE(cache.count == 0 && cache.total_bytes == 0,
+        "all pinned entries release their charge exactly once");
+    ASSERT_TRUE(cache.active_pins == 0,
+        "all pinned entries release active-pin accounting");
+    for (size_t i = 0; i < COL_MAT_CACHE_MAX; i++) {
+        col_rel_destroy(left[i]);
+        col_rel_destroy(right[i]);
+    }
+}
+
+static void
+test_copy_survives_cache_eviction(void)
+{
+    tests_run++;
+    col_mat_cache_t cache = { 0 };
+    col_rel_t *left = make_relation(5000);
+    col_rel_t *right = make_relation(5001);
+    col_rel_t *result = make_relation(5002);
+    ASSERT_TRUE(left && right && result, "copy relations allocated");
+    col_mat_cache_pin_t insert_pin = { 0 };
+    ASSERT_TRUE(col_mat_cache_insert_pin(&cache, left, right, result,
+        &insert_pin) == 0,
+        "copy cache insert succeeds");
+    ASSERT_TRUE(cache.active_pins == 1,
+        "insert pin increments active-pin accounting");
+    col_mat_cache_pin_release(&insert_pin);
+    ASSERT_TRUE(cache.active_pins == 0,
+        "insert pin can be released before the copy operation");
+
+    col_mat_cache_pin_t pin = { 0 };
+    col_rel_t *cached = col_mat_cache_lookup_pin(&cache, left, right, &pin);
+    ASSERT_TRUE(cached == result, "copy cache hit is pinned");
+    col_rel_t *copy = NULL;
+    ASSERT_TRUE(col_rel_deep_copy(cached, &copy, NULL) == 0 && copy,
+        "cache hit can be copied while pinned");
+    col_mat_cache_pin_release(&pin);
+    ASSERT_TRUE(cache.active_pins == 0,
+        "production-style copy releases its pin before clear");
+    col_mat_cache_clear(&cache);
+    ASSERT_TRUE(col_rel_get(copy, 0, 0) == 5002,
+        "independent copy survives cache eviction");
+
+    col_rel_destroy(copy);
+    col_rel_destroy(left);
+    col_rel_destroy(right);
+}
+
+int
+main(void)
+{
+    test_lookup_clear_and_release();
+    test_pin_survives_compaction_and_truncate();
+    test_lru_preserves_pinned_entry();
+    test_all_pinned_insert_retains_callers_ownership();
+    test_copy_survives_cache_eviction();
+    printf("materialization-cache lifetime: %d tests, %d failures\n",
+        tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/cache.c
+++ b/wirelog/columnar/cache.c
@@ -11,6 +11,7 @@
 
 #include "columnar/internal.h"
 
+#include <assert.h>
 #include <errno.h>
 #ifndef _MSC_VER
 #include <stdatomic.h>
@@ -156,46 +157,85 @@ mat_cache_entry_destroy(col_mat_cache_t *cache, col_mat_entry_t *e)
     e->ledger_bytes = 0;
     col_rel_destroy(e->result);
     e->result = NULL;
+    e->mem_bytes = 0;
+    e->eviction_deferred = false;
+}
+
+static void
+mat_cache_remove_at(col_mat_cache_t *cache, uint32_t index)
+{
+    col_mat_entry_t *entry = &cache->entries[index];
+    assert(entry->pin_count == 0);
+    cache->total_bytes -= entry->mem_bytes;
+    mat_cache_entry_destroy(cache, entry);
+    memmove(entry, entry + 1,
+        (cache->count - index - 1) * sizeof(col_mat_entry_t));
+    cache->count--;
 }
 
 /*
  * mat_cache_evict_lru: drop the least recently used entry.  Caller
- * guarantees cache->count > 0.
+ * guarantees cache->count > 0.  Pinned entries stay physically present and
+ * charged to total_bytes/ledger_bytes.  Pinned entries are skipped by LRU;
+ * when every entry is pinned, admission returns ENOSPC without changing
+ * ownership.  Clear and truncate defer destruction of pinned entries (and
+ * hide them from lookup); the final pin release removes them and their
+ * charge.
  */
-static void
+static bool
 mat_cache_evict_lru(col_mat_cache_t *cache)
 {
-    uint32_t lru = 0;
-    for (uint32_t i = 1; i < cache->count; i++) {
-        if (cache->entries[i].lru_clock < cache->entries[lru].lru_clock)
+    uint32_t lru = UINT32_MAX;
+    for (uint32_t i = 0; i < cache->count; i++) {
+        if (!cache->entries[i].result || cache->entries[i].eviction_deferred)
+            continue;
+        if (cache->entries[i].pin_count > 0)
+            continue;
+        if (lru == UINT32_MAX
+            || cache->entries[i].lru_clock < cache->entries[lru].lru_clock)
             lru = i;
     }
-    cache->total_bytes -= cache->entries[lru].mem_bytes;
-    mat_cache_entry_destroy(cache, &cache->entries[lru]);
-    memmove(&cache->entries[lru], &cache->entries[lru + 1],
-        (cache->count - lru - 1) * sizeof(col_mat_entry_t));
-    cache->count--;
+    if (lru != UINT32_MAX) {
+        mat_cache_remove_at(cache, lru);
+        return true;
+    }
+
+    /* All live entries are pinned.  Admission must fail without changing
+     * ownership or evicting a still-borrowed result. */
+    return false;
 }
 
 void
 col_mat_cache_clear(col_mat_cache_t *cache)
 {
-    for (uint32_t i = 0; i < cache->count; i++)
-        mat_cache_entry_destroy(cache, &cache->entries[i]);
-    cache->count = 0;
-    cache->total_bytes = 0;
+    if (!cache)
+        return;
+    for (uint32_t i = 0; i < cache->count;) {
+        if (cache->entries[i].pin_count > 0) {
+            cache->entries[i].eviction_deferred = true;
+            i++;
+        } else {
+            mat_cache_remove_at(cache, i);
+        }
+    }
 }
 
 void
 col_mat_cache_truncate(col_mat_cache_t *cache, uint32_t keep_count)
 {
+    /* keep_count is a visible-prefix target.  Pinned suffix entries may keep
+     * the physical count above it until their final borrowed reference ends,
+     * but are deferred and cannot be looked up or replaced. */
     if (!cache || keep_count >= cache->count)
         return;
-    for (uint32_t i = keep_count; i < cache->count; i++) {
-        cache->total_bytes -= cache->entries[i].mem_bytes;
-        mat_cache_entry_destroy(cache, &cache->entries[i]);
+    for (uint32_t i = keep_count; i < cache->count;) {
+        if (cache->entries[i].pin_count > 0) {
+            cache->entries[i].eviction_deferred = true;
+            i++;
+        } else {
+            mat_cache_remove_at(cache, i);
+        }
     }
-    cache->count = keep_count;
 }
 
 /**
@@ -213,8 +253,10 @@ col_mat_cache_truncate(col_mat_cache_t *cache, uint32_t keep_count)
 void
 col_mat_cache_evict_until(col_mat_cache_t *cache, size_t target_bytes)
 {
-    while (cache->count > 0 && cache->total_bytes >= target_bytes)
-        mat_cache_evict_lru(cache);
+    while (cache->count > 0 && cache->total_bytes >= target_bytes) {
+        if (!mat_cache_evict_lru(cache))
+            break;
+    }
 }
 
 col_rel_t *
@@ -225,7 +267,9 @@ col_mat_cache_lookup(col_mat_cache_t *cache, const col_rel_t *left,
     uint64_t rh = col_mat_cache_key_content(right);
     for (uint32_t i = 0; i < cache->count; i++) {
         if (cache->entries[i].left_hash == lh
-            && cache->entries[i].right_hash == rh) {
+            && cache->entries[i].right_hash == rh
+            && cache->entries[i].result != NULL
+            && !cache->entries[i].eviction_deferred) {
             cache->entries[i].lru_clock = ++cache->clock;
             cache->hits++;
             return cache->entries[i].result;
@@ -235,10 +279,74 @@ col_mat_cache_lookup(col_mat_cache_t *cache, const col_rel_t *left,
     return NULL;
 }
 
-void
-col_mat_cache_insert(col_mat_cache_t *cache, const col_rel_t *left,
-    const col_rel_t *right, col_rel_t *result)
+col_rel_t *
+col_mat_cache_lookup_pin(col_mat_cache_t *cache, const col_rel_t *left,
+    const col_rel_t *right, col_mat_cache_pin_t *pin)
 {
+    if (!cache || !left || !right || !pin)
+        return NULL;
+    memset(pin, 0, sizeof(*pin));
+    uint64_t lh = col_mat_cache_key_content(left);
+    uint64_t rh = col_mat_cache_key_content(right);
+    for (uint32_t i = 0; i < cache->count; i++) {
+        col_mat_entry_t *entry = &cache->entries[i];
+        if (entry->left_hash == lh && entry->right_hash == rh
+            && entry->result != NULL && !entry->eviction_deferred) {
+            entry->lru_clock = ++cache->clock;
+            cache->hits++;
+            entry->pin_count++;
+            assert(cache->active_pins < UINT32_MAX);
+            cache->active_pins++;
+            if (pin) {
+                pin->cache = cache;
+                pin->identity = entry->identity;
+                pin->active = true;
+            }
+            return entry->result;
+        }
+    }
+    cache->misses++;
+    return NULL;
+}
+
+void
+col_mat_cache_pin_release(col_mat_cache_pin_t *pin)
+{
+    if (!pin || !pin->active || !pin->cache)
+        return;
+    col_mat_cache_t *cache = pin->cache;
+    uint32_t index = UINT32_MAX;
+    for (uint32_t i = 0; i < cache->count; i++) {
+        if (cache->entries[i].identity == pin->identity) {
+            index = i;
+            break;
+        }
+    }
+    assert(index != UINT32_MAX);
+    if (index != UINT32_MAX) {
+        col_mat_entry_t *entry = &cache->entries[index];
+        assert(entry->pin_count > 0);
+        if (entry->pin_count > 0)
+            entry->pin_count--;
+        if (entry->pin_count == 0 && entry->eviction_deferred)
+            mat_cache_remove_at(cache, index);
+    }
+    assert(cache->active_pins > 0);
+    if (cache->active_pins > 0)
+        cache->active_pins--;
+    pin->cache = NULL;
+    pin->identity = 0;
+    pin->active = false;
+}
+
+int
+col_mat_cache_insert_pin(col_mat_cache_t *cache, const col_rel_t *left,
+    const col_rel_t *right, col_rel_t *result, col_mat_cache_pin_t *pin)
+{
+    if (!cache || !left || !right || !result)
+        return EINVAL;
+    if (pin)
+        memset(pin, 0, sizeof(*pin));
     size_t result_bytes
         = (result->nrows > 0 && result->ncols > 0)
               ? (size_t)result->nrows * result->ncols * sizeof(int64_t)
@@ -246,12 +354,16 @@ col_mat_cache_insert(col_mat_cache_t *cache, const col_rel_t *left,
 
     /* Evict LRU entries until within memory limit */
     while (cache->count > 0
-        && cache->total_bytes + result_bytes > COL_MAT_CACHE_LIMIT_BYTES)
-        mat_cache_evict_lru(cache);
+        && cache->total_bytes + result_bytes > COL_MAT_CACHE_LIMIT_BYTES) {
+        if (!mat_cache_evict_lru(cache))
+            return ENOSPC;
+    }
 
     /* Evict oldest entry if array is full */
-    if (cache->count >= COL_MAT_CACHE_MAX)
-        mat_cache_evict_lru(cache);
+    while (cache->count >= COL_MAT_CACHE_MAX) {
+        if (!mat_cache_evict_lru(cache))
+            return ENOSPC;
+    }
 
     col_mat_entry_t *e = &cache->entries[cache->count++];
     e->left_hash = col_mat_cache_key_content(left);
@@ -260,6 +372,11 @@ col_mat_cache_insert(col_mat_cache_t *cache, const col_rel_t *left,
     e->mem_bytes = result_bytes;
     e->lru_clock = ++cache->clock;
     e->ledger_bytes = 0;
+    e->identity = ++cache->next_identity;
+    if (e->identity == 0)
+        e->identity = ++cache->next_identity;
+    e->pin_count = 0;
+    e->eviction_deferred = false;
     cache->total_bytes += result_bytes;
 
     /* Issue #1380: the cache now owns result, so its bytes move from
@@ -276,4 +393,20 @@ col_mat_cache_insert(col_mat_cache_t *cache, const col_rel_t *left,
             wl_mem_ledger_alloc(cache->ledger, WL_MEM_SUBSYS_CACHE, bytes);
         e->ledger_bytes = bytes;
     }
+    if (pin) {
+        e->pin_count = 1;
+        assert(cache->active_pins < UINT32_MAX);
+        cache->active_pins++;
+        pin->cache = cache;
+        pin->identity = e->identity;
+        pin->active = true;
+    }
+    return 0;
+}
+
+int
+col_mat_cache_insert(col_mat_cache_t *cache, const col_rel_t *left,
+    const col_rel_t *right, col_rel_t *result)
+{
+    return col_mat_cache_insert_pin(cache, left, right, result, NULL);
 }

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1579,7 +1579,9 @@ tdd_worker_subpass_fn(void *arg)
     delta_pool_reset(sess->delta_pool);
     sess->rotation_ops->rotate_eval_arena(sess);
     if (sess->cache_evict_threshold == 0) {
+        assert(sess->mat_cache.active_pins == 0);
         col_mat_cache_clear(&sess->mat_cache);
+        assert(sess->mat_cache.active_pins == 0);
     } else {
         col_mat_cache_evict_until(&sess->mat_cache,
             sess->cache_evict_threshold);

--- a/wirelog/columnar/eval_serial.c
+++ b/wirelog/columnar/eval_serial.c
@@ -273,7 +273,9 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                     return rc;
             }
         }
+        assert(sess->mat_cache.active_pins == 0);
         col_mat_cache_clear(&sess->mat_cache);
+        assert(sess->mat_cache.active_pins == 0);
         col_session_mem_sample(sess); /* Issue #1380 */
         delta_pool_reset(sess->delta_pool);
         sess->rotation_ops->rotate_eval_arena(sess);
@@ -769,7 +771,9 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
              * - If 0: clear entire cache each sub-pass (backward compatible)
              * - If > 0: evict LRU entries when cache exceeds threshold */
             if (sess->cache_evict_threshold == 0) {
+                assert(sess->mat_cache.active_pins == 0);
                 col_mat_cache_clear(&sess->mat_cache);
+                assert(sess->mat_cache.active_pins == 0);
             } else {
                 col_mat_cache_evict_until(&sess->mat_cache,
                     sess->cache_evict_threshold);
@@ -889,7 +893,9 @@ stride_error:
     col_session_mem_sample(sess); /* Issue #1380 */
     delta_pool_reset(sess->delta_pool);
     sess->rotation_ops->rotate_eval_arena(sess);
+    assert(sess->mat_cache.active_pins == 0);
     col_mat_cache_clear(&sess->mat_cache);
+    assert(sess->mat_cache.active_pins == 0);
 
     return 0;
 }

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -926,9 +926,22 @@ typedef struct {
      * Capacity-based (col_rel_owned_ledger_bytes + timestamps), unlike
      * mem_bytes which is nrows-based and drives the eviction limit. */
     uint64_t ledger_bytes;
+    /* Stable identity and borrowed-result lifetime.  Entries are compacted
+     * with memmove, so handles must resolve by identity rather than address. */
+    uint64_t identity;
+    uint32_t pin_count;
+    bool eviction_deferred;
 } col_mat_entry_t;
 
 typedef struct {
+    /* The cache object must outlive this handle.  Production pins are
+     * synchronous; callers release them before session/worker teardown. */
+    struct col_mat_cache *cache;
+    uint64_t identity;
+    bool active;
+} col_mat_cache_pin_t;
+
+typedef struct col_mat_cache {
     col_mat_entry_t entries[COL_MAT_CACHE_MAX];
     uint32_t count;
     size_t total_bytes;
@@ -938,6 +951,10 @@ typedef struct {
     /* Ledger that cached results are re-parented to on insert (Issue #1380).
      * NULL disables accounting (K-fusion branch sessions). */
     wl_mem_ledger_t *ledger;
+    uint64_t next_identity;
+    /* Every lookup_pin/insert_pin handle must be released before its owning
+     * session, worker, or cache is destroyed. */
+    uint32_t active_pins;
 } col_mat_cache_t;
 
 /* ======================================================================== */
@@ -1876,13 +1893,30 @@ col_mat_cache_evict_until(col_mat_cache_t *cache, size_t target_bytes);
 col_rel_t *
 col_mat_cache_lookup(col_mat_cache_t *cache, const col_rel_t *left,
     const col_rel_t *right);
-void
+/* Legacy diagnostic lookup.  The returned relation is an unpinned borrowed
+ * pointer and must not outlive the immediate cache operation.  Production
+ * callers that need a stable result must use lookup_pin(), deep-copy while
+ * pinned, and release the pin before retaining the copy. */
+int
 col_mat_cache_insert(col_mat_cache_t *cache, const col_rel_t *left,
     const col_rel_t *right, col_rel_t *result);
+/* Insert takes ownership of result only on success.  On failure, the caller
+ * retains ownership and must destroy result or push it as owned. */
+int
+col_mat_cache_insert_pin(col_mat_cache_t *cache, const col_rel_t *left,
+    const col_rel_t *right, col_rel_t *result, col_mat_cache_pin_t *pin);
+col_rel_t *
+col_mat_cache_lookup_pin(col_mat_cache_t *cache, const col_rel_t *left,
+    const col_rel_t *right, col_mat_cache_pin_t *pin);
+void
+col_mat_cache_pin_release(col_mat_cache_pin_t *pin);
 /*
- * col_mat_cache_truncate: destroy entries [keep_count, count) and shrink the
- * cache back to keep_count entries, keeping total_bytes and the ledger in
- * step.  Used to roll back branch-added entries after serial K-fusion.
+ * col_mat_cache_truncate: keep_count is the visible-prefix target.  Destroy
+ * entries [keep_count, count) when they are unpinned and keep total_bytes and
+ * the ledger in step.  Pinned suffix entries may keep the physical count above
+ * keep_count; they are deferred, remain charged and hidden from lookup, and
+ * are removed only when their final pin is released.  Used to roll back
+ * branch-added entries after serial K-fusion.
  */
 void
 col_mat_cache_truncate(col_mat_cache_t *cache, uint32_t keep_count);

--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -995,9 +995,14 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
      * cache reuse in K-fusion worker sessions, eliminating redundant joins. */
     bool projected_join = op->project_count > 0 && op->project_indices;
     if (op->materialized && !projected_join) {
+        col_mat_cache_pin_t cache_pin = { 0 };
         col_rel_t *cached
-            = col_mat_cache_lookup(&sess->mat_cache, left_e.rel, right);
+            = col_mat_cache_lookup_pin(&sess->mat_cache, left_e.rel, right,
+                &cache_pin);
         if (cached) {
+            col_rel_t *copy = NULL;
+            int copy_rc = col_rel_deep_copy(cached, &copy, NULL);
+            col_mat_cache_pin_release(&cache_pin);
 #ifdef WL_PROFILE
             sess->profile.join_cache_hit_ns += now_ns() - _t0_join;
 #endif
@@ -1005,8 +1010,13 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
                 col_rel_destroy(right_filtered);
             if (left_e.owned)
                 col_rel_destroy(left_e.rel);
-            return eval_stack_push_delta(stack, cached, false,
-                       left_e.is_delta || used_right_delta);
+            if (copy_rc != 0)
+                return copy_rc;
+            int push_rc = eval_stack_push_delta(stack, copy, true,
+                    left_e.is_delta || used_right_delta);
+            if (push_rc != 0)
+                col_rel_destroy(copy);
+            return push_rc;
         }
     }
 
@@ -1424,13 +1434,21 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
     bool result_is_delta = projected_join ? false
         : (left_e.is_delta || used_right_delta);
 
-    /* Populate materialization cache when hint is set.
-     * Works with both stable and worker-owned relations.
-     * Cache takes ownership of out; we push a borrowed reference.
-     * This enables K-fusion workers to cache and reuse intermediate joins,
-     * reducing redundant computation across the K worker copies. */
+    /* Populate materialization cache when hint is set.  The cache owns the
+     * computed result only after a successful insert, so retain an independent
+     * copy for the evaluation stack.  This keeps cache lifetime entirely
+     * inside this operation and avoids borrowed stack entries. */
     if (op->materialized && !projected_join) {
-        col_mat_cache_insert(&sess->mat_cache, left, right, out);
+        col_rel_t *copy = NULL;
+        int copy_rc = col_rel_deep_copy(out, &copy, NULL);
+        if (copy_rc != 0) {
+            if (left_e.owned)
+                col_rel_destroy(left);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
+            return eval_stack_push_delta(stack, out, true, result_is_delta);
+        }
+        int cache_rc = col_mat_cache_insert(&sess->mat_cache, left, right, out);
 #ifdef WL_PROFILE
         if (out->nrows == 0)
             sess->profile.join_empty_out++;
@@ -1440,7 +1458,14 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
             col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
-        return eval_stack_push_delta(stack, out, false, result_is_delta);
+        if (cache_rc != 0) {
+            col_rel_destroy(copy);
+            return eval_stack_push_delta(stack, out, true, result_is_delta);
+        }
+        int push_rc = eval_stack_push_delta(stack, copy, true, result_is_delta);
+        if (push_rc != 0)
+            col_rel_destroy(copy);
+        return push_rc;
     }
     if (left_e.owned)
         col_rel_destroy(left);
@@ -2011,15 +2036,25 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
     /* Materialization cache check */
     bool projected_join = op->project_count > 0 && op->project_indices;
     if (op->materialized && !projected_join) {
+        col_mat_cache_pin_t cache_pin = { 0 };
         col_rel_t *cached
-            = col_mat_cache_lookup(&sess->mat_cache, left_e.rel, right);
+            = col_mat_cache_lookup_pin(&sess->mat_cache, left_e.rel, right,
+                &cache_pin);
         if (cached) {
+            col_rel_t *copy = NULL;
+            int copy_rc = col_rel_deep_copy(cached, &copy, NULL);
+            col_mat_cache_pin_release(&cache_pin);
             if (right_filtered)
                 col_rel_destroy(right_filtered);
             if (left_e.owned)
                 col_rel_destroy(left_e.rel);
-            return eval_stack_push_delta(stack, cached, false,
-                       left_e.is_delta || used_right_delta);
+            if (copy_rc != 0)
+                return copy_rc;
+            int push_rc = eval_stack_push_delta(stack, copy, true,
+                    left_e.is_delta || used_right_delta);
+            if (push_rc != 0)
+                col_rel_destroy(copy);
+            return push_rc;
         }
     }
 
@@ -2397,12 +2432,28 @@ join_success:
     /* Materialization cache: insert BEFORE destroying left, because
      * col_mat_cache_key_content dereferences left to compute content hash. */
     if (op->materialized && !projected_join) {
-        col_mat_cache_insert(&sess->mat_cache, left, right, out);
+        col_rel_t *copy = NULL;
+        int copy_rc = col_rel_deep_copy(out, &copy, NULL);
+        if (copy_rc != 0) {
+            if (left_e.owned)
+                col_rel_destroy(left);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
+            return eval_stack_push_delta(stack, out, true, result_is_delta);
+        }
+        int cache_rc = col_mat_cache_insert(&sess->mat_cache, left, right, out);
         if (left_e.owned)
             col_rel_destroy(left);
         if (right_filtered)
             col_rel_destroy(right_filtered);
-        return eval_stack_push_delta(stack, out, false, result_is_delta);
+        if (cache_rc != 0) {
+            col_rel_destroy(copy);
+            return eval_stack_push_delta(stack, out, true, result_is_delta);
+        }
+        int push_rc = eval_stack_push_delta(stack, copy, true, result_is_delta);
+        if (push_rc != 0)
+            col_rel_destroy(copy);
+        return push_rc;
     }
     if (left_e.owned)
         col_rel_destroy(left);

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -23,6 +23,7 @@
 
 #include "../wirelog-internal.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdint.h>
@@ -980,7 +981,9 @@ cleanup_wq:
          * entries were created by this worker — free from index 0.  The
          * worker cache has no ledger (Issue #1380), so this is a plain
          * destroy of every entry. */
+        assert(worker_sess[d].mat_cache.active_pins == 0);
         col_mat_cache_clear(&worker_sess[d].mat_cache);
+        assert(worker_sess[d].mat_cache.active_pins == 0);
         /* Issue #216: merge worker lru_clocks back into coordinator so
          * arrangements accessed by any worker are counted as recently used.
          * Worker entries were cloned in the same order as coordinator entries,

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -14,6 +14,7 @@
 
 #include "../wirelog-internal.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <math.h>
@@ -112,7 +113,9 @@ static void
 session_invalidate_relation_caches(wl_col_session_t *sess, const char *name)
 {
     col_session_invalidate_arrangements(&sess->base, name);
+    assert(sess->mat_cache.active_pins == 0);
     col_mat_cache_clear(&sess->mat_cache);
+    assert(sess->mat_cache.active_pins == 0);
 
     uint32_t out = 0;
     for (uint32_t i = 0; i < sess->filt_cache_count; i++) {
@@ -1561,7 +1564,9 @@ col_session_destroy(wl_session_t *session)
     free((void *)sess->rels);
     /* Free relation name hash table (Issue #281) */
     session_rel_free_hash(sess);
+    assert(sess->mat_cache.active_pins == 0);
     col_mat_cache_clear(&sess->mat_cache);
+    assert(sess->mat_cache.active_pins == 0);
     wl_workqueue_destroy(sess->wq);
     wl_kfusion_adaptive_destroy(sess->kfusion_adaptive);
     /* Free arrangement registry (Phase 3C) */
@@ -1902,7 +1907,9 @@ col_worker_session_destroy(wl_col_session_t *worker)
     }
 
     /* Free mat_cache entries (all worker-owned since zeroed at create) */
+    assert(worker->mat_cache.active_pins == 0);
     col_mat_cache_clear(&worker->mat_cache);
+    assert(worker->mat_cache.active_pins == 0);
 
     /* Free arrangement registries */
     for (uint32_t i = 0; i < worker->arr_count; i++) {
@@ -2624,7 +2631,9 @@ col_session_clear_idb_rows(const wl_plan_t *plan, wl_col_session_t *sess)
             col_session_invalidate_arrangements(&sess->base, r->name);
         }
     }
+    assert(sess->mat_cache.active_pins == 0);
     col_mat_cache_clear(&sess->mat_cache);
+    assert(sess->mat_cache.active_pins == 0);
 }
 
 static void


### PR DESCRIPTION
## Summary
- add pin-aware materialization-cache lifetime handling with stable identities and deferred clear/truncate destruction
- make production materialized-join cache hits deep-copy while pinned, so eval-stack results never borrow cache storage
- enforce active-pin accounting at session/worker cache teardown and update ownership regressions

## Validation
- `meson test -C builddir-1435 mat_cache_lifetime diff_join k_fusion_memory worker_session --print-errorlogs`
- `meson test -C builddir-1435-san mat_cache_lifetime diff_join k_fusion_memory worker_session --print-errorlogs`
- `meson test -C builddir-1435 clang_tidy_ratchet --print-errorlogs`
- `git diff --check`

All focused tests and sanitizer tests passed. This PR is stacked on #1436 and does not merge it.
