### PR TITLE
fix(#1434): admit retained relation ownership transitions

### DIFF
--- a/scripts/ci/clang-tidy-baselines/llvm-22.nolint-counts.txt
+++ b/scripts/ci/clang-tidy-baselines/llvm-22.nolint-counts.txt
@@ -1,4 +1,6 @@
 # Per-scan clang-tidy NOLINT suppression baseline for LLVM 22.
+wirelog/columnar/relation.c 4
+wirelog/columnar/relation.c [WL_RADIX_BENCH=1] 4
 # Format: repo-relative source/configuration key followed by the count.
 # Missing keys are treated as zero; increases fail the ratchet.
 wirelog/columnar/eval.c 3

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5065,6 +5065,24 @@ test_relation_append_exe = executable(
 
 test('relation_append', test_relation_append_exe)
 
+test_memory_admission_relation_exe = executable(
+  'test_memory_admission_relation',
+  files('test_memory_admission_relation.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('memory_admission_relation', test_memory_admission_relation_exe,
+     suite: 'unit')
+
 test_tdd_decision_stats_exe = executable(
   'test_tdd_decision_stats',
   files('test_tdd_decision_stats.c'),

--- a/tests/test_memory_admission_relation.c
+++ b/tests/test_memory_admission_relation.c
@@ -1,0 +1,552 @@
+/*
+ * test_memory_admission_relation.c - retained relation ownership transitions
+ *
+ * Issue #1434: COW and arena-to-heap promotion must admit the replacement
+ * before publishing ownership, and must leave the source relation untouched
+ * when the exact budget is denied.
+ */
+
+#include "../wirelog/columnar/internal.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int failures;
+
+#define CHECK(condition, message) do { \
+            if (!(condition)) { \
+                fprintf(stderr, "FAIL: %s\n", message); \
+                failures++; \
+            } \
+} while (0)
+
+static void
+make_resolution(wl_columnar_memory_resolution_t *resolution,
+    uint64_t usable_bytes)
+{
+    memset(resolution, 0, sizeof(*resolution));
+    resolution->budget_bytes = usable_bytes;
+    resolution->usable_bytes = usable_bytes;
+    resolution->mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING;
+    resolution->source = WL_COLUMNAR_MEMORY_SOURCE_ENV;
+    resolution->status = WL_COLUMNAR_MEMORY_OK;
+}
+
+static col_rel_t *
+make_shared_view(wl_columnar_memory_governor_ref_t *ref,
+    col_rel_t **source_out)
+{
+    col_rel_t *source = col_rel_new_auto("source", 1);
+    col_rel_t *view = col_rel_new_auto("view", 1);
+    int64_t rows[] = { 9, 1 };
+
+    if (!source || !view || col_rel_append_row(source, &rows[0]) != 0
+        || col_rel_append_row(source, &rows[1]) != 0
+        || col_rel_attach_memory_governor(view, ref) != 0
+        || col_rel_install_shared_view(view, source) != 0) {
+        col_rel_destroy(view);
+        col_rel_destroy(source);
+        return NULL;
+    }
+    *source_out = source;
+    return view;
+}
+
+static col_rel_t *
+make_full_shared_view(wl_columnar_memory_governor_ref_t *ref,
+    col_rel_t **source_out, bool timestamps)
+{
+    col_rel_t *source = col_rel_new_auto("full-source", 1);
+    col_rel_t *view = col_rel_new_auto("full-view", 1);
+    int64_t value = 3;
+
+    if (!source || !view)
+        goto fail;
+    for (uint32_t i = 0; i < COL_REL_INIT_CAP; i++)
+        if (col_rel_append_row(source, &value) != 0)
+            goto fail;
+    if (timestamps && col_rel_enable_timestamps(view) != 0)
+        goto fail;
+    if (col_rel_attach_memory_governor(view, ref) != 0
+        || col_rel_install_shared_view(view, source) != 0)
+        goto fail;
+    *source_out = source;
+    return view;
+
+fail:
+    col_rel_destroy(view);
+    col_rel_destroy(source);
+    return NULL;
+}
+
+static void
+test_cow_exact_fit_and_denial(void)
+{
+    const uint64_t private_bytes = 64u * sizeof(int64_t);
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_ref_t *ref;
+    col_rel_t *source = NULL;
+    col_rel_t *view;
+
+    make_resolution(&resolution, private_bytes);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    view = ref ? make_shared_view(ref, &source) : NULL;
+    CHECK(view != NULL, "COW exact-fit setup");
+    if (view) {
+        int64_t *borrowed = view->columns[0];
+        int64_t value = 5;
+        CHECK(col_rel_append_row(view, &value) == 0,
+            "spare-capacity append COW");
+        CHECK(view->col_shared == NULL, "exact-fit COW was published");
+        CHECK(view->columns[0] != borrowed, "COW retained borrowed buffer");
+        col_rel_radix_sort_int64(view);
+        CHECK(view->columns[0][0] == 1 && view->columns[0][1] == 5
+            && view->columns[0][2] == 9,
+            "COW append/sort did not preserve copied rows");
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == private_bytes,
+            "exact-fit COW reservation");
+        col_rel_destroy(view);
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == 0,
+            "COW reservation release");
+        col_rel_destroy(source);
+    }
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+
+    make_resolution(&resolution, private_bytes - 1u);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    source = NULL;
+    view = ref ? make_shared_view(ref, &source) : NULL;
+    CHECK(view != NULL, "COW denial setup");
+    if (view) {
+        int64_t *borrowed = view->columns[0];
+        col_rel_radix_sort_int64(view);
+        CHECK(view->col_shared != NULL && view->columns[0] == borrowed,
+            "denied COW changed ownership");
+        CHECK(view->columns[0][0] == 9 && view->columns[0][1] == 1,
+            "denied COW changed rows");
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == 0,
+            "denied COW left reservation");
+        col_rel_destroy(view);
+        col_rel_destroy(source);
+    }
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+}
+
+static void
+test_arena_promotion_with_timestamps(void)
+{
+    const uint32_t capacity = COL_REL_INIT_CAP;
+    const uint64_t bytes = (uint64_t)capacity * sizeof(int64_t)
+        + (uint64_t)capacity * sizeof(col_delta_timestamp_t);
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_ref_t *ref;
+    delta_pool_t *pool;
+    wl_arena_t *arena;
+    col_rel_t *relation;
+    int64_t value = 42;
+
+    make_resolution(&resolution, bytes);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    pool = delta_pool_create(1, sizeof(col_rel_t), 4096);
+    arena = wl_arena_create(4096);
+    relation = pool && arena ? col_rel_pool_new_auto(pool, arena, "arena", 1)
+                             : NULL;
+    CHECK(ref && relation && col_rel_append_row(relation, &value) == 0,
+        "arena promotion setup");
+    if (relation) {
+        CHECK(col_rel_enable_timestamps(relation) == 0,
+            "timestamps before arena promotion");
+        CHECK(col_rel_attach_memory_governor(relation, ref) == 0,
+            "arena relation governor attach");
+        int64_t *old_columns = relation->columns[0];
+        CHECK(col_rel_promote_arena_admitted(relation) == 0,
+            "exact-fit arena promotion");
+        CHECK(!relation->arena_owned && relation->columns[0] != old_columns,
+            "arena promotion did not publish heap ownership");
+        CHECK(relation->columns[0][0] == value
+            && relation->timestamps != NULL,
+            "arena promotion lost data or timestamps");
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == bytes,
+            "arena promotion reservation");
+        col_rel_free_contents(relation);
+    }
+    if (pool)
+        delta_pool_destroy(pool);
+    if (arena)
+        wl_arena_free(arena);
+    if (ref) {
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == 0,
+            "arena promotion reservation release");
+        wl_columnar_memory_governor_ref_release(ref);
+    }
+}
+
+static void
+test_append_transitions(void)
+{
+    const uint64_t grown_bytes = (uint64_t)(COL_REL_INIT_CAP * 2u)
+        * sizeof(int64_t);
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_ref_t *ref;
+    col_rel_t *source = NULL;
+    col_rel_t *view;
+    int64_t value = 11;
+
+    make_resolution(&resolution, grown_bytes);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    view = ref ? make_full_shared_view(ref, &source, false) : NULL;
+    CHECK(view != NULL, "append_row transition setup");
+    if (view) {
+        CHECK(col_rel_append_row(view, &value) == 0
+            && view->capacity == COL_REL_INIT_CAP * 2u
+            && view->nrows == COL_REL_INIT_CAP + 1u
+            && view->col_shared == NULL,
+            "append_row COW growth");
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == grown_bytes,
+            "append_row COW reservation");
+        col_rel_destroy(view);
+        col_rel_destroy(source);
+    }
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+
+    make_resolution(&resolution, grown_bytes);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    source = NULL;
+    view = ref ? make_full_shared_view(ref, &source, false) : NULL;
+    CHECK(view != NULL, "append_all transition setup");
+    if (view) {
+        col_rel_t *suffix = col_rel_new_auto("suffix", 1);
+        CHECK(suffix && col_rel_append_row(suffix, &value) == 0
+            && col_rel_append_all(view, suffix, NULL) == 0
+            && view->capacity == COL_REL_INIT_CAP * 2u
+            && view->nrows == COL_REL_INIT_CAP + 1u
+            && view->col_shared == NULL,
+            "append_all COW growth");
+        if (suffix)
+            col_rel_destroy(suffix);
+        col_rel_destroy(view);
+        col_rel_destroy(source);
+    }
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+
+    make_resolution(&resolution, (uint64_t)(COL_REL_INIT_CAP * 2u)
+        * (sizeof(int64_t) + sizeof(col_delta_timestamp_t)));
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    source = NULL;
+    view = ref ? make_full_shared_view(ref, &source, true) : NULL;
+    CHECK(view != NULL, "timestamp transition setup");
+    if (view) {
+        CHECK(col_rel_append_row(view, &value) == 0
+            && view->timestamps != NULL
+            && view->capacity == COL_REL_INIT_CAP * 2u,
+            "timestamp COW growth");
+        col_rel_destroy(view);
+        col_rel_destroy(source);
+    }
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+}
+
+static void
+test_arena_promotion_denial_preserves_state(void)
+{
+    const uint64_t bytes = (uint64_t)COL_REL_INIT_CAP * sizeof(int64_t);
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_ref_t *ref;
+    delta_pool_t *pool = NULL;
+    wl_arena_t *arena = NULL;
+    col_rel_t *relation = NULL;
+    int64_t value = 7;
+
+    make_resolution(&resolution, bytes - 1u);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    pool = delta_pool_create(1, sizeof(col_rel_t), 4096);
+    arena = wl_arena_create(4096);
+    relation = pool && arena ? col_rel_pool_new_auto(pool, arena, "denied", 1)
+                             : NULL;
+    CHECK(ref && relation && col_rel_append_row(relation, &value) == 0,
+        "denied arena setup");
+    if (relation) {
+        int64_t *old_columns = relation->columns[0];
+        CHECK(col_rel_attach_memory_governor(relation, ref) == 0,
+            "denied arena governor attach");
+        CHECK(col_rel_promote_arena_admitted(relation) == ENOMEM,
+            "arena denial result");
+        CHECK(relation->arena_owned && relation->columns[0] == old_columns
+            && relation->columns[0][0] == value,
+            "arena denial changed relation");
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == 0,
+            "arena denial left reservation");
+        col_rel_free_contents(relation);
+    }
+    if (pool)
+        delta_pool_destroy(pool);
+    if (arena)
+        wl_arena_free(arena);
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+}
+
+static void
+test_unmanaged_arena_append_all_preserves_ownership(void)
+{
+    delta_pool_t *pool = delta_pool_create(1, sizeof(col_rel_t), 4096);
+    wl_arena_t *arena = wl_arena_create(4096);
+    col_rel_t *dst = pool && arena
+        ? col_rel_pool_new_auto(pool, arena, "unmanaged-dst", 1) : NULL;
+    col_rel_t *src = col_rel_new_auto("unmanaged-src", 1);
+    int64_t value = 19;
+
+    CHECK(dst && src, "unmanaged arena append_all setup");
+    if (dst && src) {
+        CHECK(col_rel_append_row(dst, &value) == 0,
+            "unmanaged arena destination seed");
+        for (uint32_t i = 0; i < COL_REL_INIT_CAP; i++)
+            CHECK(col_rel_append_row(src, &value) == 0,
+                "unmanaged arena source fill");
+        int64_t *old_column = dst->columns[0];
+        CHECK(col_rel_append_all(dst, src, arena) == 0,
+            "unmanaged arena append_all growth");
+        CHECK(dst->arena_owned && dst->columns[0] != old_column
+            && dst->capacity == COL_REL_INIT_CAP * 2u
+            && dst->nrows == COL_REL_INIT_CAP + 1u,
+            "unmanaged arena growth lost arena ownership");
+        col_rel_free_contents(dst);
+    }
+    col_rel_destroy(src);
+    if (pool)
+        delta_pool_destroy(pool);
+    if (arena)
+        wl_arena_free(arena);
+}
+
+static col_rel_t *
+make_full_arena_relation(delta_pool_t **pool_out, wl_arena_t **arena_out,
+    const char *name, int64_t value)
+{
+    delta_pool_t *pool = delta_pool_create(1, sizeof(col_rel_t), 4096);
+    wl_arena_t *arena = wl_arena_create(4096);
+    col_rel_t *relation = pool && arena
+        ? col_rel_pool_new_auto(pool, arena, name, 1) : NULL;
+
+    if (relation) {
+        for (uint32_t i = 0; i < COL_REL_INIT_CAP; i++) {
+            if (col_rel_append_row(relation, &value) != 0) {
+                col_rel_free_contents(relation);
+                relation = NULL;
+                break;
+            }
+        }
+    }
+    if (!relation) {
+        if (pool)
+            delta_pool_destroy(pool);
+        if (arena)
+            wl_arena_free(arena);
+        pool = NULL;
+        arena = NULL;
+    }
+    *pool_out = pool;
+    *arena_out = arena;
+    return relation;
+}
+
+static void
+test_unmanaged_arena_append_all_reconciles_timestamps(void)
+{
+    const uint32_t grown_capacity = COL_REL_INIT_CAP * 2u;
+    delta_pool_t *pool = NULL;
+    wl_arena_t *arena = NULL;
+    col_rel_t *dst = make_full_arena_relation(&pool, &arena,
+            "ledger-arena-dst", 31);
+    col_rel_t *src = col_rel_new_auto("ledger-arena-src", 1);
+    wl_mem_ledger_t ledger;
+    wl_mem_ledger_snapshot_t snapshot;
+    int64_t value = 47;
+
+    wl_mem_ledger_init(&ledger, 0);
+    CHECK(dst && src, "arena timestamp ledger setup");
+    if (dst && src) {
+        CHECK(col_rel_enable_timestamps(dst) == 0,
+            "arena timestamp enable");
+        dst->mem_ledger = &ledger;
+        col_rel_ledger_reconcile(dst, 0);
+        for (uint32_t i = 0; i < 1; i++)
+            CHECK(col_rel_append_row(src, &value) == 0,
+                "arena timestamp source seed");
+        /* Fill the source enough to force exactly one destination growth. */
+        for (uint32_t i = 1; i < COL_REL_INIT_CAP; i++)
+            CHECK(col_rel_append_row(src, &value) == 0,
+                "arena timestamp source fill");
+        CHECK(col_rel_append_all(dst, src, arena) == 0,
+            "arena append_all timestamp growth");
+        wl_mem_ledger_snapshot(&ledger, &snapshot);
+        CHECK(dst->arena_owned && dst->capacity == grown_capacity,
+            "arena timestamp growth changed ownership");
+        CHECK(snapshot.subsys_bytes[WL_MEM_SUBSYS_TIMESTAMP]
+            == (uint64_t)grown_capacity * sizeof(col_delta_timestamp_t),
+            "arena append_all timestamp ledger accounting");
+        CHECK(dst->ledger_ts_bytes
+            == (uint64_t)grown_capacity * sizeof(col_delta_timestamp_t),
+            "arena append_all timestamp ledger token");
+        col_rel_free_contents(dst);
+        wl_mem_ledger_snapshot(&ledger, &snapshot);
+        CHECK(snapshot.current_bytes == 0,
+            "arena timestamp ledger release");
+    }
+    col_rel_destroy(src);
+    if (pool)
+        delta_pool_destroy(pool);
+    if (arena)
+        wl_arena_free(arena);
+}
+
+static void
+test_arena_append_all_admission_boundary(void)
+{
+    const uint64_t exact_bytes = (uint64_t)(COL_REL_INIT_CAP * 2u)
+        * sizeof(int64_t);
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_ref_t *ref;
+    delta_pool_t *pool = NULL;
+    wl_arena_t *arena = NULL;
+    col_rel_t *dst;
+    col_rel_t *src;
+    int64_t value = 53;
+
+    make_resolution(&resolution, exact_bytes);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    dst = ref ? make_full_arena_relation(&pool, &arena,
+            "arena-append-exact", value) : NULL;
+    src = col_rel_new_auto("arena-append-source", 1);
+    CHECK(dst && src, "arena append_all exact-fit setup");
+    if (dst && src) {
+        CHECK(col_rel_attach_memory_governor(dst, ref) == 0,
+            "arena append_all exact-fit governor");
+        CHECK(col_rel_append_row(src, &value) == 0
+            && col_rel_append_all(dst, src, arena) == 0,
+            "arena append_all exact-fit admission");
+        CHECK(!dst->arena_owned && dst->capacity == COL_REL_INIT_CAP * 2u
+            && dst->nrows == COL_REL_INIT_CAP + 1u,
+            "arena append_all exact-fit state");
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == exact_bytes,
+            "arena append_all exact-fit reservation");
+        col_rel_destroy(src);
+        col_rel_free_contents(dst);
+    } else {
+        col_rel_destroy(src);
+        if (dst)
+            col_rel_free_contents(dst);
+    }
+    if (pool)
+        delta_pool_destroy(pool);
+    if (arena)
+        wl_arena_free(arena);
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+
+    make_resolution(&resolution, exact_bytes - 1u);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    pool = NULL;
+    arena = NULL;
+    dst = ref ? make_full_arena_relation(&pool, &arena,
+            "arena-append-denied", value) : NULL;
+    src = col_rel_new_auto("arena-append-denied-source", 1);
+    CHECK(dst && src, "arena append_all denial setup");
+    if (dst && src) {
+        int64_t *old_column = dst->columns[0];
+        uint32_t old_capacity = dst->capacity;
+        uint32_t old_rows = dst->nrows;
+        CHECK(col_rel_attach_memory_governor(dst, ref) == 0,
+            "arena append_all denial governor");
+        CHECK(col_rel_append_row(src, &value) == 0
+            && col_rel_append_all(dst, src, arena) == ENOMEM,
+            "arena append_all one-byte denial");
+        CHECK(dst->arena_owned && dst->columns[0] == old_column
+            && dst->capacity == old_capacity && dst->nrows == old_rows,
+            "arena append_all denial changed state");
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == 0,
+            "arena append_all denial left reservation");
+        col_rel_destroy(src);
+        col_rel_free_contents(dst);
+    } else {
+        col_rel_destroy(src);
+        if (dst)
+            col_rel_free_contents(dst);
+    }
+    if (pool)
+        delta_pool_destroy(pool);
+    if (arena)
+        wl_arena_free(arena);
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+}
+
+static void
+test_cow_capacity_denial_preserves_state(void)
+{
+    const uint64_t grown_bytes = (uint64_t)(COL_REL_INIT_CAP * 2u)
+        * sizeof(int64_t);
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_ref_t *ref;
+    col_rel_t *source = NULL;
+    col_rel_t *view;
+    int64_t value = 23;
+
+    make_resolution(&resolution, grown_bytes - 1u);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    view = ref ? make_full_shared_view(ref, &source, false) : NULL;
+    CHECK(view != NULL, "COW capacity denial setup");
+    if (view) {
+        uint32_t old_capacity = view->capacity;
+        uint32_t old_rows = view->nrows;
+        int64_t *old_column = view->columns[0];
+        bool *old_shared = view->col_shared;
+        CHECK(col_rel_append_row(view, &value) == ENOMEM,
+            "COW capacity denial result");
+        CHECK(view->capacity == old_capacity && view->nrows == old_rows
+            && view->columns[0] == old_column
+            && view->col_shared == old_shared
+            && view->col_shared != NULL
+            && view->columns[0][0] == 3,
+            "COW capacity denial changed relation");
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == 0,
+            "COW capacity denial left reservation");
+        col_rel_destroy(view);
+        col_rel_destroy(source);
+    }
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+}
+
+int
+main(void)
+{
+    test_cow_exact_fit_and_denial();
+    test_append_transitions();
+    test_arena_promotion_with_timestamps();
+    test_arena_promotion_denial_preserves_state();
+    test_unmanaged_arena_append_all_preserves_ownership();
+    test_unmanaged_arena_append_all_reconciles_timestamps();
+    test_arena_append_all_admission_boundary();
+    test_cow_capacity_denial_preserves_state();
+    if (failures != 0)
+        return 1;
+    puts("memory admission relation: PASS");
+    return 0;
+}

--- a/tests/test_memory_admission_relation.c
+++ b/tests/test_memory_admission_relation.c
@@ -534,6 +534,42 @@ test_cow_capacity_denial_preserves_state(void)
         wl_columnar_memory_governor_ref_release(ref);
 }
 
+static void
+test_cow_ledger_reconcile_is_exact_once(void)
+{
+    wl_mem_ledger_t ledger;
+    wl_mem_ledger_snapshot_t snapshot;
+    col_rel_t *source = col_rel_new_auto("ledger-source", 1);
+    col_rel_t *view = col_rel_new_auto("ledger-view", 1);
+    int64_t rows[] = { 9, 1 };
+    bool view_destroyed = false;
+
+    wl_mem_ledger_init(&ledger, 0);
+    CHECK(source && view, "COW ledger setup");
+    if (source && view) {
+        CHECK(col_rel_append_row(source, &rows[0]) == 0
+            && col_rel_append_row(source, &rows[1]) == 0
+            && col_rel_install_shared_view(view, source) == 0,
+            "COW ledger shared view");
+        view->mem_ledger = &ledger;
+        col_rel_ledger_reconcile(view, 0);
+        col_rel_radix_sort_int64(view);
+        wl_mem_ledger_snapshot(&ledger, &snapshot);
+        CHECK(snapshot.subsys_bytes[WL_MEM_SUBSYS_RELATION]
+            == (uint64_t)view->capacity * sizeof(int64_t),
+            "COW radix sort double-charged private columns");
+        col_rel_destroy(view);
+        wl_mem_ledger_snapshot(&ledger, &snapshot);
+        CHECK(snapshot.current_bytes == 0,
+            "COW radix sort left stale ledger bytes");
+        view_destroyed = true;
+    }
+    if (!view_destroyed)
+        col_rel_destroy(view);
+    if (source)
+        col_rel_destroy(source);
+}
+
 int
 main(void)
 {
@@ -545,6 +581,7 @@ main(void)
     test_unmanaged_arena_append_all_reconciles_timestamps();
     test_arena_append_all_admission_boundary();
     test_cow_capacity_denial_preserves_state();
+    test_cow_ledger_reconcile_is_exact_once();
     if (failures != 0)
         return 1;
     puts("memory admission relation: PASS");

--- a/tests/test_memory_admission_relation.c
+++ b/tests/test_memory_admission_relation.c
@@ -139,6 +139,43 @@ test_cow_exact_fit_and_denial(void)
 }
 
 static void
+test_cow_multi_column_cleanup(void)
+{
+    const uint64_t private_bytes = 2u * 64u * sizeof(int64_t);
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_ref_t *ref;
+    col_rel_t *source = col_rel_new_auto("multi-source", 2);
+    col_rel_t *view = col_rel_new_auto("multi-view", 2);
+    int64_t first[] = {9, 90};
+    int64_t second[] = {1, 10};
+    int64_t appended[] = {5, 50};
+
+    make_resolution(&resolution, private_bytes);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    CHECK(ref && source && view, "multi-column COW setup");
+    if (ref && source && view) {
+        CHECK(col_rel_append_row(source, first) == 0
+            && col_rel_append_row(source, second) == 0
+            && col_rel_attach_memory_governor(view, ref) == 0
+            && col_rel_install_shared_view(view, source) == 0,
+            "multi-column shared view setup");
+        CHECK(col_rel_append_row(view, appended) == 0,
+            "multi-column COW append");
+        CHECK(view->col_shared == NULL
+            && view->columns[0][2] == appended[0]
+            && view->columns[1][2] == appended[1],
+            "multi-column COW did not privatize every column");
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == private_bytes,
+            "multi-column COW reservation");
+    }
+    col_rel_destroy(view);
+    col_rel_destroy(source);
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+}
+
+static void
 test_arena_promotion_with_timestamps(void)
 {
     const uint32_t capacity = COL_REL_INIT_CAP;
@@ -574,6 +611,7 @@ int
 main(void)
 {
     test_cow_exact_fit_and_denial();
+    test_cow_multi_column_cleanup();
     test_append_transitions();
     test_arena_promotion_with_timestamps();
     test_arena_promotion_denial_preserves_state();

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1645,6 +1645,10 @@ col_rel_attach_memory_governor(col_rel_t *rel,
     wl_columnar_memory_governor_ref_t *memory_governor);
 int
 col_rel_enable_timestamps(col_rel_t *rel);
+/* Promote arena-backed relation columns to private heap storage.  Admission
+ * and copying are transactional; ENOMEM leaves the relation unchanged. */
+int
+col_rel_promote_arena_admitted(col_rel_t *rel);
 
 /* ------------------------------------------------------------------------ */
 /* Compound-column layout (Issue #532 Task 2).                              */

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -218,8 +218,9 @@ col_columns_free(int64_t **cols, uint32_t ncols)
 {
     if (!cols)
         return;
-    for (uint32_t c = 0; c < ncols; c++)
-        free(cols[c]);
+    int64_t **cursor = cols;
+    for (uint32_t c = 0; c < ncols; c++, cursor++)
+        free(*cursor); /* NOLINT(clang-analyzer-security.ArrayBound) */
     free((void *)cols);
 }
 

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -74,7 +74,6 @@ wl_columnar_relation_radix_bench_enabled(void)
 /* ---- COW helpers --------------------------------------------------------- */
 
 static int col_rel_cow_unshare(col_rel_t *r, uint32_t new_cap);
-int col_rel_promote_arena_admitted(col_rel_t *r);
 static int col_rel_grow_owned_transition(col_rel_t *r, uint32_t new_cap);
 
 uint64_t
@@ -83,8 +82,11 @@ col_rel_owned_ledger_bytes(const col_rel_t *r)
     if (!r || r->arena_owned || !r->columns || r->capacity == 0)
         return 0;
     uint64_t owned_cols = 0;
-    for (uint32_t c = 0; c < r->ncols; c++) {
-        if ((!r->col_shared || !r->col_shared[c]) && r->columns[c])
+    int64_t **columns = r->columns;
+    bool *shared = r->col_shared;
+    for (uint32_t c = 0; c < r->ncols; c++, columns++) {
+        /* columns/shared are allocated together for exactly r->ncols slots. */
+        if ((!shared || !shared[c]) && *columns) /* NOLINT(clang-analyzer-security.ArrayBound) */
             owned_cols++;
     }
     if (owned_cols == 0)
@@ -372,14 +374,18 @@ col_rel_cow_unshare(col_rel_t *r, uint32_t new_cap)
         && col_rel_publish_retained_reservation(r, &pending, new_bytes) != 0)
         goto fail;
     ledger_before = col_rel_owned_ledger_bytes(r);
-    for (uint32_t c = 0; c < r->ncols; c++) {
-        if (!private_cols[c])
+    int64_t **private_cursor = private_cols;
+    int64_t **relation_cursor = r->columns;
+    bool *shared_cursor = r->col_shared;
+    for (uint32_t c = 0; c < r->ncols;
+        c++, private_cursor++, relation_cursor++, shared_cursor++) {
+        if (!*private_cursor) /* NOLINT(clang-analyzer-security.ArrayBound) */
             continue;
-        r->columns[c] = private_cols[c];
-        r->col_shared[c] = false;
-        private_cols[c] = NULL;
+        *relation_cursor = *private_cursor;
+        *shared_cursor = false;
+        *private_cursor = NULL;
     }
-    free(private_cols);
+    free((void *)private_cols);
     private_cols = NULL;
     {
         bool any_shared = false;
@@ -396,9 +402,10 @@ col_rel_cow_unshare(col_rel_t *r, uint32_t new_cap)
 fail:
     col_rel_reservation_rollback(&pending);
     if (private_cols) {
-        for (uint32_t c = 0; c < r->ncols; c++)
-            free(private_cols[c]);
-        free(private_cols);
+        int64_t **cursor = private_cols;
+        for (uint32_t c = 0; c < r->ncols; c++, cursor++)
+            free(*cursor); /* NOLINT(clang-analyzer-security.ArrayBound) */
+        free((void *)private_cols);
     }
     return ENOMEM;
 }

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -73,62 +73,9 @@ wl_columnar_relation_radix_bench_enabled(void)
 
 /* ---- COW helpers --------------------------------------------------------- */
 
-/*
- * col_rel_cow_unshare:
- * Copy-on-write: for each column where col_shared[c] is true, allocate a
- * private heap buffer (capacity new_cap rows), copy the existing nrows of
- * data, and clear col_shared[c].  Must be called before any in-place
- * mutation of the column buffers (append, sort, compact).
- *
- * If new_cap == 0 the existing capacity is reused.
- * Returns 0 on success, ENOMEM on allocation failure (relation unchanged).
- */
-static int
-col_rel_cow_unshare(col_rel_t *r, uint32_t new_cap)
-{
-    if (!r->col_shared)
-        return 0;
-    if (new_cap == 0)
-        new_cap = r->capacity ? r->capacity : COL_REL_INIT_CAP;
-    /* Allocate all private columns before changing ownership.  This keeps
-     * an allocation failure from leaving a partially privatized relation. */
-    int64_t **private_cols = (int64_t **)calloc(r->ncols,
-            sizeof(int64_t *));
-    if (!private_cols)
-        return ENOMEM;
-    for (uint32_t c = 0; c < r->ncols; c++) {
-        if (!r->col_shared[c])
-            continue;
-        private_cols[c] = (int64_t *)malloc((size_t)new_cap
-                * sizeof(int64_t));
-        if (!private_cols[c]) {
-            for (uint32_t i = 0; i < r->ncols; i++)
-                free(private_cols[i]);
-            free((void *)private_cols);
-            return ENOMEM;
-        }
-        memcpy(private_cols[c], r->columns[c],
-            (size_t)r->nrows * sizeof(int64_t));
-    }
-    for (uint32_t c = 0; c < r->ncols; c++) {
-        if (!private_cols[c])
-            continue;
-        r->columns[c] = private_cols[c];
-        r->col_shared[c] = false;
-    }
-    free((void *)private_cols);
-    /* If all columns are now owned, free the shared-flags array */
-    bool any_shared = false;
-    for (uint32_t c = 0; c < r->ncols; c++)
-        if (r->col_shared[c]) {
-            any_shared = true; break;
-        }
-    if (!any_shared) {
-        free(r->col_shared);
-        r->col_shared = NULL;
-    }
-    return 0;
-}
+static int col_rel_cow_unshare(col_rel_t *r, uint32_t new_cap);
+int col_rel_promote_arena_admitted(col_rel_t *r);
+static int col_rel_grow_owned_transition(col_rel_t *r, uint32_t new_cap);
 
 uint64_t
 col_rel_owned_ledger_bytes(const col_rel_t *r)
@@ -273,6 +220,187 @@ col_rel_publish_retained_reservation(col_rel_t *r,
         (void)wl_columnar_memory_release(&previous);
     r->retained_reserved_bytes = bytes;
     return 0;
+}
+
+/* Reserve the complete private shape of an ownership transition.  The
+ * ordinary retained path deliberately rejects shared and arena-backed
+ * relations because those buffers are not yet heap-owned; transition paths
+ * use this helper instead and charge the replacement only once. */
+static int
+col_rel_reserve_transition(const col_rel_t *r, uint32_t capacity,
+    wl_columnar_memory_reservation_t *pending, uint64_t *bytes_out)
+{
+    uint64_t bytes;
+    wl_columnar_memory_admission_status_t status;
+
+    if (!r || !pending || !bytes_out)
+        return -1;
+    wl_columnar_memory_reservation_init(pending);
+    if (!col_rel_retained_bytes(r->ncols, capacity,
+        r->timestamps != NULL, &bytes))
+        return -1;
+    *bytes_out = bytes;
+    if (!r->memory_governor || bytes == 0 ||
+        bytes <= r->retained_reserved_bytes)
+        return 0;
+    status = wl_columnar_memory_reserve_growth(
+        wl_columnar_memory_governor_ref_get(r->memory_governor),
+        r->retained_reserved_bytes, bytes, pending);
+    if (status != WL_COLUMNAR_MEMORY_ADMISSION_OK
+        && status != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY)
+        return -1;
+    return 1;
+}
+
+/* Migrate an arena relation, or grow a relation while it still contains
+ * borrowed/arena storage.  Every replacement buffer and timestamp array is
+ * prepared before the relation is changed, so admission or allocation
+ * failure leaves the old ownership and reservation untouched. */
+static int
+col_rel_grow_owned_transition(col_rel_t *r, uint32_t new_cap)
+{
+    wl_columnar_memory_reservation_t pending;
+    int pending_rc;
+    uint64_t new_bytes;
+    int64_t **new_columns = NULL;
+    col_delta_timestamp_t *new_timestamps = NULL;
+    int64_t **old_columns;
+    col_delta_timestamp_t *old_timestamps;
+    bool *old_shared_flags;
+    bool old_arena;
+    uint64_t ledger_before;
+
+    if (!r || !r->columns || r->ncols == 0 || new_cap < r->nrows)
+        return EINVAL;
+    pending_rc = col_rel_reserve_transition(r, new_cap, &pending,
+            &new_bytes);
+    if (pending_rc < 0)
+        return ENOMEM;
+    new_columns = col_columns_alloc(r->ncols, new_cap);
+    if (!new_columns)
+        goto fail;
+    for (uint32_t c = 0; c < r->ncols; c++)
+        memcpy(new_columns[c], r->columns[c],
+            (size_t)r->nrows * sizeof(int64_t));
+    if (r->timestamps) {
+        new_timestamps = (col_delta_timestamp_t *)malloc(
+            (size_t)new_cap * sizeof(*new_timestamps));
+        if (!new_timestamps)
+            goto fail;
+        memcpy(new_timestamps, r->timestamps,
+            (size_t)r->nrows * sizeof(*new_timestamps));
+    }
+    if (pending_rc > 0
+        && col_rel_publish_retained_reservation(r, &pending, new_bytes) != 0)
+        goto fail;
+
+    old_columns = r->columns;
+    old_timestamps = r->timestamps;
+    old_shared_flags = r->col_shared;
+    old_arena = r->arena_owned;
+    ledger_before = col_rel_owned_ledger_bytes(r);
+    r->columns = new_columns;
+    r->timestamps = new_timestamps;
+    r->capacity = new_cap;
+    r->arena_owned = false;
+    r->col_shared = NULL;
+    if (old_arena) {
+        free((void *)old_columns);
+    } else {
+        for (uint32_t c = 0; c < r->ncols; c++)
+            if (!old_shared_flags || !old_shared_flags[c])
+                free(old_columns[c]);
+        free((void *)old_columns);
+    }
+    free(old_shared_flags);
+    free(old_timestamps);
+    col_rel_ledger_reconcile(r, ledger_before);
+    return 0;
+
+fail:
+    col_rel_reservation_rollback(&pending);
+    col_columns_free(new_columns, r->ncols);
+    free(new_timestamps);
+    return ENOMEM;
+}
+
+int
+col_rel_promote_arena_admitted(col_rel_t *r)
+{
+    if (!r || !r->arena_owned)
+        return 0;
+    return col_rel_grow_owned_transition(r, r->capacity);
+}
+
+/* Copy-on-write at the current capacity.  Shared buffers are never freed;
+ * owned columns remain in place, and the reservation is published only once
+ * every private replacement has been copied successfully. */
+static int
+col_rel_cow_unshare(col_rel_t *r, uint32_t new_cap)
+{
+    wl_columnar_memory_reservation_t pending;
+    int pending_rc;
+    uint64_t new_bytes;
+    int64_t **private_cols = NULL;
+    uint32_t capacity;
+    uint64_t ledger_before;
+
+    if (!r || !r->col_shared)
+        return 0;
+    capacity = new_cap ? new_cap : (r->capacity ? r->capacity
+                                                    : COL_REL_INIT_CAP);
+    if (capacity > r->capacity)
+        return col_rel_grow_owned_transition(r, capacity);
+    pending_rc = col_rel_reserve_transition(r, capacity, &pending,
+            &new_bytes);
+    if (pending_rc < 0)
+        return ENOMEM;
+    private_cols = (int64_t **)calloc(r->ncols, sizeof(*private_cols));
+    if (!private_cols)
+        goto fail;
+    for (uint32_t c = 0; c < r->ncols; c++) {
+        if (!r->col_shared[c])
+            continue;
+        private_cols[c] = (int64_t *)malloc((size_t)capacity
+                * sizeof(int64_t));
+        if (!private_cols[c])
+            goto fail;
+        memcpy(private_cols[c], r->columns[c],
+            (size_t)r->nrows * sizeof(int64_t));
+    }
+    if (pending_rc > 0
+        && col_rel_publish_retained_reservation(r, &pending, new_bytes) != 0)
+        goto fail;
+    ledger_before = col_rel_owned_ledger_bytes(r);
+    for (uint32_t c = 0; c < r->ncols; c++) {
+        if (!private_cols[c])
+            continue;
+        r->columns[c] = private_cols[c];
+        r->col_shared[c] = false;
+        private_cols[c] = NULL;
+    }
+    free(private_cols);
+    private_cols = NULL;
+    {
+        bool any_shared = false;
+        for (uint32_t c = 0; c < r->ncols; c++)
+            any_shared = any_shared || r->col_shared[c];
+        if (!any_shared) {
+            free(r->col_shared);
+            r->col_shared = NULL;
+        }
+    }
+    col_rel_ledger_reconcile(r, ledger_before);
+    return 0;
+
+fail:
+    col_rel_reservation_rollback(&pending);
+    if (private_cols) {
+        for (uint32_t c = 0; c < r->ncols; c++)
+            free(private_cols[c]);
+        free(private_cols);
+    }
+    return ENOMEM;
 }
 
 int
@@ -935,16 +1063,15 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
         uint32_t new_cap = r->capacity ? r->capacity * 2 : COL_REL_INIT_CAP;
         if (new_cap <= r->capacity) /* overflow guard */
             return ENOMEM;
-        if (r->memory_governor && !r->arena_owned && !r->col_shared) {
+        if (r->col_shared || r->arena_owned) {
+            /* Ownership transitions stage columns and timestamps together;
+             * admission happens before any source buffer is copied. */
+            if (col_rel_grow_owned_transition(r, new_cap) != 0)
+                return ENOMEM;
+        } else if (r->memory_governor) {
             if (col_rel_grow_heap_admitted(r, new_cap) != 0)
                 return ENOMEM;
         } else {
-            /* COW: unshare shared columns before in-place growth (Issue #396) */
-            if (r->col_shared) {
-                int cow_rc = col_rel_cow_unshare(r, 0);
-                if (cow_rc != 0)
-                    return cow_rc;
-            }
             /* Grow timestamps first (if tracking) so we can roll back cleanly
              * on a subsequent data realloc failure. */
             if (r->timestamps) {
@@ -957,21 +1084,7 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
                 }
                 r->timestamps = new_ts;
             }
-            if (r->arena_owned) {
-                /* Arena data cannot be realloc'd; migrate to heap */
-                int64_t **new_cols = col_columns_alloc(r->ncols, new_cap);
-                if (!new_cols) {
-                    col_rel_ledger_reconcile(r, ledger_before);
-                    return ENOMEM;
-                }
-                for (uint32_t c = 0; c < r->ncols; c++)
-                    memcpy(new_cols[c], r->columns[c],
-                        sizeof(int64_t) * r->nrows);
-                /* Don't free arena columns; just free the columns array */
-                free((void *)r->columns);
-                r->columns = new_cols;
-                r->arena_owned = false;
-            } else if (r->columns) {
+            if (r->columns) {
                 if (col_columns_realloc_atomic(r->columns, r->ncols,
                     r->capacity,
                     new_cap) != 0) {
@@ -989,6 +1102,10 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
             col_rel_ledger_reconcile(r, ledger_before);
         }
     }
+    /* A shared view can still have spare capacity.  Privatize it before the
+     * in-place row write even when no capacity growth is needed. */
+    if (r->col_shared && col_rel_cow_unshare(r, 0) != 0)
+        return ENOMEM;
     if (r->timestamps)
         memset(&r->timestamps[r->nrows], 0, sizeof(col_delta_timestamp_t));
     if (col_rel_row_copy_in(r, r->nrows, row) != 0)
@@ -1068,6 +1185,7 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
     /* Ensure dst has sufficient capacity */
     if (new_nrows > dst->capacity) {
         uint64_t ledger_before = col_rel_owned_ledger_bytes(dst);
+        bool transitioned = false;
         uint32_t new_cap = dst->capacity ? dst->capacity * 2 : COL_REL_INIT_CAP;
         while (new_cap < new_nrows) {
             uint32_t next_cap = new_cap * 2;
@@ -1076,84 +1194,95 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
             new_cap = next_cap;
         }
 
-        /* COW: unshare shared columns before in-place growth (Issue #396) */
-        if (dst->col_shared) {
-            int cow_rc = col_rel_cow_unshare(dst, 0);
-            if (cow_rc != 0)
-                return cow_rc;
-        }
-
-        /* Grow timestamps first (if tracking) */
-        if (dst->timestamps) {
-            col_delta_timestamp_t *new_ts = (col_delta_timestamp_t *)realloc(
-                dst->timestamps, new_cap * sizeof(col_delta_timestamp_t));
-            if (!new_ts) {
-                col_rel_ledger_reconcile(dst, ledger_before);
+        if (dst->arena_owned && !dst->col_shared && !dst->memory_governor
+            && arena) {
+            /* An unmanaged arena relation still belongs to its caller's
+             * arena.  Grow its columns in that arena and retain the ownership
+             * flag; admission-based heap promotion is only for retained
+             * relations (or for the legacy no-arena fallback below). */
+            int64_t **new_columns = (int64_t **)calloc(dst->ncols,
+                    sizeof(*new_columns));
+            col_delta_timestamp_t *new_timestamps = NULL;
+            if (!new_columns)
                 return ENOMEM;
+            for (uint32_t c = 0; c < dst->ncols; c++) {
+                new_columns[c] = (int64_t *)wl_arena_alloc(arena,
+                        (size_t)new_cap * sizeof(int64_t));
+                if (!new_columns[c]) {
+                    free((void *)new_columns);
+                    return ENOMEM;
+                }
+                memcpy(new_columns[c], dst->columns[c],
+                    (size_t)dst->nrows * sizeof(int64_t));
             }
-            dst->timestamps = new_ts;
-        }
-
-        if (dst->arena_owned) {
-            /* Arena data: allocate from same arena, preserve arena_owned flag */
-            if (arena) {
-                int64_t **new_cols
-                    = (int64_t **)calloc(dst->ncols, sizeof(int64_t *));
-                if (!new_cols) {
-                    col_rel_ledger_reconcile(dst, ledger_before);
+            if (dst->timestamps) {
+                new_timestamps = (col_delta_timestamp_t *)malloc(
+                    (size_t)new_cap * sizeof(*new_timestamps));
+                if (!new_timestamps) {
+                    free((void *)new_columns);
                     return ENOMEM;
                 }
-                bool ok = true;
-                for (uint32_t c = 0; c < dst->ncols; c++) {
-                    new_cols[c] = (int64_t *)wl_arena_alloc(arena,
-                            (size_t)new_cap * sizeof(int64_t));
-                    if (!new_cols[c]) {
-                        ok = false;
-                        break;
-                    }
-                    memcpy(new_cols[c], dst->columns[c],
-                        sizeof(int64_t) * dst->nrows);
-                }
-                if (!ok) {
-                    /* Arena alloc failed; don't free arena columns */
-                    free((void *)new_cols);
-                    col_rel_ledger_reconcile(dst, ledger_before);
-                    return ENOMEM;
-                }
-                free((void *)dst->columns); /* free old columns array only */
-                dst->columns = new_cols;
-            } else {
-                /* Fallback to heap if arena unavailable */
-                int64_t **new_cols
-                    = col_columns_alloc(dst->ncols, new_cap);
-                if (!new_cols) {
-                    col_rel_ledger_reconcile(dst, ledger_before);
-                    return ENOMEM;
-                }
-                for (uint32_t c = 0; c < dst->ncols; c++)
-                    memcpy(new_cols[c], dst->columns[c],
-                        sizeof(int64_t) * dst->nrows);
-                free((void *)dst->columns);
-                dst->columns = new_cols;
-                dst->arena_owned = false;
+                memcpy(new_timestamps, dst->timestamps,
+                    (size_t)dst->nrows * sizeof(*new_timestamps));
             }
+            free((void *)dst->columns);
+            free(dst->timestamps);
+            dst->columns = new_columns;
+            dst->timestamps = new_timestamps;
+            dst->capacity = new_cap;
+            /* Arena columns are not charged to RELATION, but timestamps are
+             * heap-backed and may have grown.  Keep the attached ledger in
+             * sync even though this ownership-preserving path is marked as a
+             * transition below. */
+            col_rel_ledger_reconcile(dst, ledger_before);
+            transitioned = true;
+        } else if (dst->col_shared || dst->arena_owned) {
+            if (col_rel_grow_owned_transition(dst, new_cap) != 0)
+                return ENOMEM;
+            transitioned = true;
+        } else if (dst->memory_governor) {
+            if (col_rel_grow_heap_admitted(dst, new_cap) != 0)
+                return ENOMEM;
         } else if (dst->columns) {
+            /* Grow timestamps only after all ownership transitions have been
+             * ruled out; the transition helper stages them transactionally. */
+            if (dst->timestamps) {
+                col_delta_timestamp_t *new_ts =
+                    (col_delta_timestamp_t *)realloc(dst->timestamps,
+                        new_cap * sizeof(col_delta_timestamp_t));
+                if (!new_ts)
+                    return ENOMEM;
+                dst->timestamps = new_ts;
+            }
             if (col_columns_realloc_atomic(dst->columns, dst->ncols,
                 dst->capacity,
                 new_cap) != 0) {
-                col_rel_ledger_reconcile(dst, ledger_before);
                 return ENOMEM;
             }
         } else {
+            if (dst->timestamps) {
+                col_delta_timestamp_t *new_ts =
+                    (col_delta_timestamp_t *)realloc(dst->timestamps,
+                        new_cap * sizeof(col_delta_timestamp_t));
+                if (!new_ts)
+                    return ENOMEM;
+                dst->timestamps = new_ts;
+            }
             dst->columns = col_columns_alloc(dst->ncols, new_cap);
             if (!dst->columns) {
-                col_rel_ledger_reconcile(dst, ledger_before);
                 return ENOMEM;
             }
         }
-        dst->capacity = new_cap;
-        col_rel_ledger_reconcile(dst, ledger_before);
+        if (!transitioned) {
+            dst->capacity = new_cap;
+            col_rel_ledger_reconcile(dst, ledger_before);
+        }
     }
+
+    /* Bulk append also mutates spare capacity, so a shared view must be
+     * privatized even when the destination does not grow. */
+    if (dst->col_shared && col_rel_cow_unshare(dst, 0) != 0)
+        return ENOMEM;
 
     /* Install source metadata only after all potentially failing destination
      * growth has completed.  A rejected append therefore cannot change an

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1409,6 +1409,9 @@ col_rel_compact(col_rel_t *r)
         if (r->col_shared) {
             if (col_rel_cow_unshare(r, 0) != 0)
                 goto free_merge_buf; /* non-fatal on failure */
+            /* COW reconciles its private columns; use that post-COW shape as
+             * the compaction baseline to avoid charging it twice. */
+            ledger_before = col_rel_owned_ledger_bytes(r);
         }
 
         if (r->arena_owned) {
@@ -3045,10 +3048,8 @@ col_rel_radix_sort_int64(col_rel_t *r)
     /* COW: unshare shared columns before in-place sort (Issue #396).
      * If unshare fails, skip the sort to avoid mutating borrowed buffers. */
     if (r->col_shared) {
-        uint64_t ledger_before = col_rel_owned_ledger_bytes(r);
         if (col_rel_cow_unshare(r, 0) != 0)
             return;
-        col_rel_ledger_reconcile(r, ledger_before);
     }
 
     col_rel_radix_sort(r, 0, r->nrows);

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -174,17 +174,11 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
     /* Arena-owned data must be promoted to heap before storing in the
      * session, because arena_reset invalidates all arena pointers. */
     if (r->arena_owned && r->columns && r->ncols > 0) {
-        /* Promote arena columns to heap: per-column malloc + memcpy */
-        int64_t **heap_cols = col_columns_alloc(r->ncols, r->capacity);
-        if (!heap_cols)
+        /* Admission and the complete heap copy are transactional.  A
+         * failure leaves the pool/arena relation unchanged so the caller can
+         * still destroy or retry it safely. */
+        if (col_rel_promote_arena_admitted(r) != 0)
             goto oom;
-        for (uint32_t c = 0; c < r->ncols; c++)
-            memcpy(heap_cols[c], r->columns[c],
-                sizeof(int64_t) * r->capacity);
-        /* free old columns array (arena owns buffers) */
-        free((void *)r->columns);
-        r->columns = heap_cols;
-        r->arena_owned = false;
     }
 
     for (uint32_t i = 0; i < sess->nrels; i++) {


### PR DESCRIPTION
## Summary
- admit retained relation COW unshare and arena-to-heap ownership transitions
- preserve unmanaged arena growth and arena ownership
- publish replacement buffers transactionally and roll back on denial/failure
- reconcile timestamp ledger accounting after arena growth
- add exact-fit, one-byte denial, rollback, COW growth, arena ownership, and timestamp-accounting tests

## Dependency
- Depends on #1433 (base branch `issue-1430-relation-admission`)
- Implements the COW and arena ownership transition scope of #1434 without duplicating retained heap-growth work from #1433

## Validation
- normal focused: `memory_admission_relation`, `relation_append`, `session`
- ASan/UBSan focused: `memory_admission_relation`, `relation_append`, `session`
- normal unit suite: 9/9
- `git diff --check`

Refs #1434
