### PR TITLE
feat(#1431): admit program-owned intern storage

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -40,6 +40,7 @@ optimizer_src = files(
 # Meson deduplicates against targets that already list thread_src.
 intern_src = [
   files('../wirelog/intern.c'),
+  files('../wirelog/columnar/memory_governor.c'),
   wirelog_thread_src,
 ]
 
@@ -1300,6 +1301,19 @@ test_intern_exe = executable(
 )
 
 test('intern', test_intern_exe)
+
+test_memory_admission_intern_exe = executable(
+  'test_memory_admission_intern',
+  files('test_memory_admission_intern.c',
+    '../wirelog/columnar/memory_governor.c'),
+  intern_src,
+  thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
+)
+
+test('memory_admission_intern', test_memory_admission_intern_exe,
+     suite: 'unit')
 
 # Issue #1381: execute the memory-ledger arithmetic contract.  This remains
 # accounting-only; reservation/admission is owned by the #1368/#1369 units.

--- a/tests/test_memory_admission_intern.c
+++ b/tests/test_memory_admission_intern.c
@@ -1,0 +1,167 @@
+/* Program-owned intern-table admission tests for issue #1431. */
+
+#include "../wirelog/columnar/memory_governor.h"
+#include "../wirelog/intern.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdint.h>
+
+static wl_columnar_memory_governor_ref_t *
+test_governor(uint64_t usable_bytes)
+{
+    wl_columnar_memory_resolution_t resolution = {
+        .budget_bytes = usable_bytes,
+        .headroom_bytes = 0,
+        .usable_bytes = usable_bytes,
+        .mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING,
+        .source = WL_COLUMNAR_MEMORY_SOURCE_ENV,
+        .status = WL_COLUMNAR_MEMORY_OK,
+    };
+    return wl_columnar_memory_governor_ref_create(&resolution);
+}
+
+static int
+test_attach_and_release(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref = test_governor(256);
+    wl_columnar_memory_governor_t *governor;
+    int rc;
+
+    if (!intern || !ref)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    rc = wl_intern_attach_memory_governor(intern, ref);
+    if (rc != 0 || wl_columnar_memory_reserved(governor) != 256) {
+        wl_intern_free(intern);
+        wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_intern_free(intern);
+    if (wl_columnar_memory_reserved(governor) != 0) {
+        wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    return 0;
+}
+
+static int
+test_denied_growth_preserves_table(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref = test_governor(256);
+    wl_columnar_memory_governor_t *governor;
+    int64_t id;
+
+    if (!intern || !ref)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    if (wl_intern_attach_memory_governor(intern, ref) != 0)
+        return 1;
+    id = wl_intern_put(intern, "new-symbol");
+    if (id != -1 || wl_intern_count(intern) != 0
+        || wl_intern_get(intern, "new-symbol") != -1
+        || wl_columnar_memory_reserved(governor) != 256) {
+        wl_intern_free(intern);
+        wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_intern_free(intern);
+    wl_columnar_memory_governor_ref_release(ref);
+    return 0;
+}
+
+static int
+test_duplicate_is_uncharged(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref = test_governor(4096);
+    wl_columnar_memory_governor_t *governor;
+    uint64_t before;
+    int64_t first;
+    int64_t duplicate;
+
+    if (!intern || !ref)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    if (wl_intern_attach_memory_governor(intern, ref) != 0)
+        return 1;
+    first = wl_intern_put(intern, "same-symbol");
+    before = wl_columnar_memory_reserved(governor);
+    duplicate = wl_intern_put(intern, "same-symbol");
+    if (first < 0 || duplicate != first
+        || wl_columnar_memory_reserved(governor) != before) {
+        wl_intern_free(intern);
+        wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_intern_free(intern);
+    wl_columnar_memory_governor_ref_release(ref);
+    return 0;
+}
+
+static int
+test_conflicting_governor_is_rejected(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *first = test_governor(4096);
+    wl_columnar_memory_governor_ref_t *second = test_governor(4096);
+    int rc;
+
+    if (!intern || !first || !second)
+        return 1;
+    if (wl_intern_attach_memory_governor(intern, first) != 0)
+        return 1;
+    rc = wl_intern_attach_memory_governor(intern, second);
+    wl_intern_free(intern);
+    wl_columnar_memory_governor_ref_release(first);
+    wl_columnar_memory_governor_ref_release(second);
+    return rc == EBUSY ? 0 : 1;
+}
+
+static int
+test_same_governor_is_idempotent_and_detachable(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref = test_governor(4096);
+    wl_columnar_memory_governor_t *governor;
+    int rc;
+
+    if (!intern || !ref)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    if (wl_intern_attach_memory_governor(intern, ref) != 0)
+        return 1;
+    rc = wl_intern_attach_memory_governor(intern, ref);
+    if (rc != EALREADY || wl_columnar_memory_reserved(governor) == 0)
+        return 1;
+    if (wl_intern_detach_memory_governor(intern, ref) != 0
+        || wl_columnar_memory_reserved(governor) != 0) {
+        wl_intern_free(intern);
+        wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_intern_free(intern);
+    wl_columnar_memory_governor_ref_release(ref);
+    return 0;
+}
+
+int
+main(void)
+{
+    int failures = 0;
+    failures += test_attach_and_release();
+    failures += test_denied_growth_preserves_table();
+    failures += test_duplicate_is_uncharged();
+    failures += test_conflicting_governor_is_rejected();
+    failures += test_same_governor_is_idempotent_and_detachable();
+    if (failures != 0) {
+        fprintf(stderr, "memory admission intern tests failed: %d\n",
+            failures);
+        return 1;
+    }
+    puts("memory admission intern tests passed");
+    return 0;
+}

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -311,6 +311,10 @@ has_tuple(const tuple_collector_t *c, const char *relation,
 /* Helper: Build plan from Datalog source                                   */
 /* ======================================================================== */
 
+#define TEST_MAX_HELD_PROGRAMS 32
+static wirelog_program_t *held_programs[TEST_MAX_HELD_PROGRAMS];
+static size_t held_program_count;
+
 static wl_plan_t *
 build_plan(const char *src)
 {
@@ -325,10 +329,24 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0 || !plan || held_program_count == TEST_MAX_HELD_PROGRAMS) {
+        wirelog_program_free(prog);
+        if (plan)
+            wl_plan_free(plan);
         return NULL;
+    }
+    /* wl_plan_t and the session borrow the program's intern table.  Keep the
+     * parsed program alive until every test session and plan has been freed;
+     * this is the lifetime promised by wirelog_session_create(). */
+    held_programs[held_program_count++] = prog;
     return plan;
+}
+
+static void
+release_held_programs(void)
+{
+    while (held_program_count > 0)
+        wirelog_program_free(held_programs[--held_program_count]);
 }
 
 /* ======================================================================== */
@@ -1121,5 +1139,6 @@ main(void)
 
     printf("\n  %d tests: %d passed, %d failed\n", tests_run, tests_passed,
         tests_failed);
+    release_held_programs();
     return tests_failed > 0 ? 1 : 0;
 }

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1017,6 +1017,7 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
 {
     wl_columnar_memory_resolution_t memory_resolution;
     wl_columnar_memory_governor_ref_t *memory_governor;
+    bool intern_attached_here = false;
     const char *memory_budget = getenv("WIRELOG_MEMORY_BUDGET");
 
     if (!plan || !out)
@@ -1086,6 +1087,23 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
 
     sess->plan = plan;
     sess->intern = plan->intern;
+    if (sess->intern) {
+        int intern_rc = wl_intern_attach_memory_governor(
+            sess->intern, sess->memory_governor);
+        /* A program-owned table may already be attached to the governor of
+        * an earlier session.  Its reservation must remain with the program;
+        * this session continues with its own governor for session-owned
+        * storage and must not rebind or double-charge the intern table. */
+        intern_attached_here = intern_rc == 0;
+        if (intern_rc != 0 && intern_rc != EALREADY && intern_rc != EBUSY) {
+            (void)wl_intern_detach_memory_governor(
+                sess->intern, sess->memory_governor);
+            wl_columnar_memory_governor_ref_release(
+                sess->memory_governor);
+            free(sess);
+            return intern_rc;
+        }
+    }
     sess->num_workers = num_workers > 0 ? num_workers : 1;
     WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO, "session created num_workers=%u",
         sess->num_workers);
@@ -1150,6 +1168,9 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
                     "(set WIRELOG_MAX_WORKERS to override, max %u)\n",
                     sess->num_workers, effective_cap,
                     WL_MAX_WORKERS_HARD_LIMIT);
+                if (intern_attached_here)
+                    (void)wl_intern_detach_memory_governor(
+                        sess->intern, sess->memory_governor);
                 wl_columnar_memory_governor_ref_release(
                     sess->memory_governor);
                 free(sess);
@@ -1217,6 +1238,9 @@ col_session_create(const wl_plan_t *plan, uint32_t num_workers,
     sess->pending_input_change = true;
     sess->rels = (col_rel_t **)calloc(sess->rel_cap, sizeof(col_rel_t *));
     if (!sess->rels) {
+        if (intern_attached_here)
+            (void)wl_intern_detach_memory_governor(
+                sess->intern, sess->memory_governor);
         wl_columnar_memory_governor_ref_release(sess->memory_governor);
         free(sess);
         return ENOMEM;
@@ -1483,6 +1507,9 @@ oom:
     delta_pool_destroy(sess->delta_pool); /* NULL-safe */
     wl_arena_free(sess->eval_arena);      /* NULL-safe; releases admission */
     (void)wl_compound_arena_free_checked(sess->compound_arena);
+    if (intern_attached_here)
+        (void)wl_intern_detach_memory_governor(
+            sess->intern, sess->memory_governor);
     wl_columnar_memory_governor_ref_release(sess->memory_governor);
     free(sess);
     return ENOMEM;

--- a/wirelog/intern.c
+++ b/wirelog/intern.c
@@ -52,9 +52,12 @@
 
 #include "intern.h"
 
+#include "columnar/memory_governor.h"
+
 #include "thread.h"
 
 #include <stdint.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -146,7 +149,77 @@ struct wl_intern {
 
     /* Writers only.  Readers (reverse/count) never take it. */
     mutex_t lock;
+
+    /* Interned strings are program-owned and may outlive any session. */
+    wl_columnar_memory_governor_ref_t *memory_governor;
+    wl_columnar_memory_reservation_t reservation;
+    uint64_t reserved_bytes;
 };
+
+static inline uint32_t intern_seg_size(uint32_t seg);
+static inline char *intern_string_at(const wl_intern_t *intern,
+    uint32_t id);
+
+static uint64_t
+intern_retained_bytes_locked(const wl_intern_t *intern)
+{
+    uint64_t total = (uint64_t)intern->slot_capacity
+        * sizeof(wl_intern_slot_t);
+    uint32_t count = WL_INTERN_LOAD_RELAXED(&intern->count);
+
+    for (uint32_t seg = 0; seg < INTERN_MAX_SEGMENTS; seg++) {
+        if (intern->segments[seg]) {
+            uint64_t bytes = (uint64_t)intern_seg_size(seg)
+                * sizeof(char *);
+            if (UINT64_MAX - total < bytes)
+                return UINT64_MAX;
+            total += bytes;
+        }
+    }
+    for (uint32_t i = 0; i < count; i++) {
+        const char *str = intern_string_at(intern, i);
+        size_t len = strlen(str);
+        if (len == SIZE_MAX)
+            return UINT64_MAX;
+        len++;
+        if ((uint64_t)len > UINT64_MAX - total)
+            return UINT64_MAX;
+        total += (uint64_t)len;
+    }
+    return total;
+}
+
+static int
+intern_publish_reservation(wl_intern_t *intern,
+    wl_columnar_memory_reservation_t *pending, uint64_t bytes)
+{
+    wl_columnar_memory_reservation_t previous;
+    if (!intern || !pending || !intern->memory_governor)
+        return EINVAL;
+    if (!wl_columnar_memory_commit(pending, intern))
+        return ENOMEM;
+    wl_columnar_memory_reservation_init(&previous);
+    if (intern->reserved_bytes > 0
+        && !wl_columnar_memory_reservation_move(
+            &previous, &intern->reservation)) {
+        (void)wl_columnar_memory_release(pending);
+        return ENOMEM;
+    }
+    if (!wl_columnar_memory_reservation_move(
+            &intern->reservation, pending)) {
+        if (intern->reserved_bytes > 0) {
+            wl_columnar_memory_reservation_init(&intern->reservation);
+            (void)wl_columnar_memory_reservation_move(
+                &intern->reservation, &previous);
+        }
+        (void)wl_columnar_memory_release(pending);
+        return ENOMEM;
+    }
+    if (intern->reserved_bytes > 0)
+        (void)wl_columnar_memory_release(&previous);
+    intern->reserved_bytes = bytes;
+    return 0;
+}
 
 /* ======================================================================== */
 /* FNV-1a Hash                                                              */
@@ -220,26 +293,6 @@ intern_string_at(const wl_intern_t *intern, uint32_t id)
     return intern->segments[seg][id - intern_seg_base(seg)];
 }
 
-/* Make sure the segment holding @id exists.  Caller holds @lock. */
-static int
-intern_seg_ensure(wl_intern_t *intern, uint32_t id)
-{
-    uint32_t seg = intern_seg_of(id);
-
-    if (seg >= INTERN_MAX_SEGMENTS)
-        return -1;
-    if (intern->segments[seg])
-        return 0;
-
-    char **block = (char **)calloc((size_t)intern_seg_size(seg),
-            sizeof(char *));
-    if (!block)
-        return -1;
-
-    intern->segments[seg] = block;
-    return 0;
-}
-
 /* ======================================================================== */
 /* Internal Helpers                                                         */
 /* ======================================================================== */
@@ -252,14 +305,19 @@ intern_seg_ensure(wl_intern_t *intern, uint32_t id)
  * be freed here.
  */
 static int
-intern_resize(wl_intern_t *intern)
+intern_resize_prepare(const wl_intern_t *intern,
+    wl_intern_slot_t **out_slots, uint32_t *out_capacity)
 {
-    uint32_t count = WL_INTERN_LOAD_RELAXED(&intern->count);
+    uint32_t count;
+    wl_intern_slot_t *new_slots;
+    uint32_t new_cap;
 
-    if (intern->slot_capacity > UINT32_MAX / 2U)
+    if (!intern || !out_slots || !out_capacity
+        || intern->slot_capacity > UINT32_MAX / 2U)
         return -1;
-    uint32_t new_cap = intern->slot_capacity * 2U;
-    wl_intern_slot_t *new_slots
+    count = WL_INTERN_LOAD_RELAXED(&intern->count);
+    new_cap = intern->slot_capacity * 2U;
+    new_slots
         = (wl_intern_slot_t *)malloc((size_t)new_cap
             * sizeof(wl_intern_slot_t));
     if (!new_slots)
@@ -275,9 +333,8 @@ intern_resize(wl_intern_t *intern)
         new_slots[h].string_id = i;
     }
 
-    free(intern->slots);
-    intern->slots = new_slots;
-    intern->slot_capacity = new_cap;
+    *out_slots = new_slots;
+    *out_capacity = new_cap;
     return 0;
 }
 
@@ -322,6 +379,8 @@ wl_intern_create(void)
         return NULL;
     }
 
+    wl_columnar_memory_reservation_init(&intern->reservation);
+
     WL_INTERN_STORE_RELEASE(&intern->count, 0u);
 
     intern->slot_capacity = INTERN_INITIAL_CAP;
@@ -339,13 +398,95 @@ wl_intern_create(void)
     return intern;
 }
 
+int
+wl_intern_attach_memory_governor(
+    wl_intern_t *intern,
+    wl_columnar_memory_governor_ref_t *governor_ref)
+{
+    wl_columnar_memory_reservation_t pending;
+    wl_columnar_memory_admission_status_t status;
+    wl_columnar_memory_governor_t *governor;
+    uint64_t bytes;
+
+    if (!intern || !governor_ref)
+        return EINVAL;
+
+    mutex_lock(&intern->lock);
+    if (intern->memory_governor) {
+        int rc = intern->memory_governor == governor_ref ? EALREADY : EBUSY;
+        mutex_unlock(&intern->lock);
+        return rc;
+    }
+
+    governor = wl_columnar_memory_governor_ref_get(governor_ref);
+    bytes = intern_retained_bytes_locked(intern);
+    if (!governor || bytes == UINT64_MAX) {
+        mutex_unlock(&intern->lock);
+        return ENOMEM;
+    }
+    wl_columnar_memory_reservation_init(&pending);
+    status = wl_columnar_memory_reserve_checked(governor, bytes, &pending);
+    if (status != WL_COLUMNAR_MEMORY_ADMISSION_OK
+        && status != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY) {
+        mutex_unlock(&intern->lock);
+        return status == WL_COLUMNAR_MEMORY_ADMISSION_DENIED
+            ? ENOMEM : EOVERFLOW;
+    }
+    if (!wl_columnar_memory_commit(&pending, intern)) {
+        (void)wl_columnar_memory_release(&pending);
+        mutex_unlock(&intern->lock);
+        return ENOMEM;
+    }
+    wl_columnar_memory_governor_ref_retain(governor_ref);
+    intern->memory_governor = governor_ref;
+    (void)wl_columnar_memory_reservation_move(
+        &intern->reservation, &pending);
+    intern->reserved_bytes = bytes;
+    mutex_unlock(&intern->lock);
+    return 0;
+}
+
+int
+wl_intern_detach_memory_governor(
+    wl_intern_t *intern,
+    wl_columnar_memory_governor_ref_t *governor_ref)
+{
+    if (!intern || !governor_ref)
+        return EINVAL;
+    mutex_lock(&intern->lock);
+    if (!intern->memory_governor) {
+        mutex_unlock(&intern->lock);
+        return 0;
+    }
+    if (intern->memory_governor != governor_ref) {
+        mutex_unlock(&intern->lock);
+        return EBUSY;
+    }
+    if (intern->reserved_bytes > 0)
+        (void)wl_columnar_memory_release(&intern->reservation);
+    intern->reserved_bytes = 0;
+    intern->memory_governor = NULL;
+    wl_columnar_memory_governor_ref_release(governor_ref);
+    mutex_unlock(&intern->lock);
+    return 0;
+}
+
 void
 wl_intern_free(wl_intern_t *intern)
 {
     if (!intern)
         return;
 
-    uint32_t count = WL_INTERN_LOAD_RELAXED(&intern->count);
+    uint32_t count;
+
+    mutex_lock(&intern->lock);
+    count = WL_INTERN_LOAD_RELAXED(&intern->count);
+    if (intern->reserved_bytes > 0)
+        (void)wl_columnar_memory_release(&intern->reservation);
+    intern->reserved_bytes = 0;
+    wl_columnar_memory_governor_ref_release(intern->memory_governor);
+    intern->memory_governor = NULL;
+    mutex_unlock(&intern->lock);
     for (uint32_t i = 0; i < count; i++)
         free(intern_string_at(intern, i));
 
@@ -360,71 +501,129 @@ wl_intern_free(wl_intern_t *intern)
 int64_t
 wl_intern_put(wl_intern_t *intern, const char *str)
 {
+    wl_columnar_memory_reservation_t pending;
+    bool pending_valid = false;
+    char *copy = NULL;
+    char **new_segment = NULL;
+    wl_intern_slot_t *new_slots = NULL;
+    uint32_t h = 0;
+    uint32_t new_id;
+    uint32_t seg;
+    uint32_t new_cap;
+    bool needs_segment;
+    bool needs_resize;
+    uint64_t old_bytes = 0;
+    uint64_t new_bytes = 0;
+    size_t slen;
+    size_t copy_bytes;
+    int64_t existing;
+
     if (!intern || !str)
         return -1;
-
-    /* Prepare the owned copy before taking the writer lock.  strlen/malloc/
-     * memcpy are independent of the table and used to make every worker wait
-     * behind the lock while doing allocation and copying (#961).  A duplicate
-     * discovered below simply releases this speculative copy. */
-    size_t slen = strlen(str);
-    char *copy = (char *)malloc(slen + 1);
-    if (!copy)
-        return -1;
-    memcpy(copy, str, slen + 1);
-
     mutex_lock(&intern->lock);
-
-    /* Check if already interned */
-    uint32_t h = 0;
-    int64_t existing = intern_lookup_locked(intern, str, &h);
+    existing = intern_lookup_locked(intern, str, &h);
     if (existing >= 0) {
-        free(copy);
         mutex_unlock(&intern->lock);
         return existing;
     }
-
-    /* New string: make room for it in the segmented storage. */
-    uint32_t new_id = WL_INTERN_LOAD_RELAXED(&intern->count);
-    if (new_id >= INTERN_MAX_STRINGS
-        || intern_seg_ensure(intern, new_id) != 0) {
-        free(copy);
+    slen = strlen(str);
+    if (slen == SIZE_MAX) {
         mutex_unlock(&intern->lock);
         return -1;
     }
+    copy_bytes = slen + 1;
+    new_id = WL_INTERN_LOAD_RELAXED(&intern->count);
+    if (new_id >= INTERN_MAX_STRINGS) {
+        mutex_unlock(&intern->lock);
+        return -1;
+    }
+    seg = intern_seg_of(new_id);
+    needs_segment = intern->segments[seg] == NULL;
+    needs_resize = (uint64_t)(new_id + 1U) * INTERN_LOAD_FACTOR_DEN
+        > (uint64_t)intern->slot_capacity * INTERN_LOAD_FACTOR_NUM;
+    if (needs_resize && intern->slot_capacity > UINT32_MAX / 2U) {
+        mutex_unlock(&intern->lock);
+        return -1;
+    }
+    new_cap = needs_resize ? intern->slot_capacity * 2U
+                           : intern->slot_capacity;
 
-    /* Resize hash table before insertion if the new entry would exceed the load factor. */
-    if ((uint64_t)(new_id + 1U) * INTERN_LOAD_FACTOR_DEN
-        > (uint64_t)intern->slot_capacity * INTERN_LOAD_FACTOR_NUM) {
-        if (intern_resize(intern) != 0) {
-            free(copy);
+    if (intern->memory_governor) {
+        uint64_t segment_bytes = needs_segment
+            ? (uint64_t)intern_seg_size(seg) * sizeof(char *) : 0;
+        uint64_t slot_bytes = needs_resize
+            ? (uint64_t)new_cap * sizeof(wl_intern_slot_t) : 0;
+        old_bytes = intern_retained_bytes_locked(intern);
+        if (old_bytes == UINT64_MAX
+            || segment_bytes > SIZE_MAX || slot_bytes > SIZE_MAX
+            || (uint64_t)copy_bytes > UINT64_MAX - old_bytes
+            || segment_bytes > UINT64_MAX - old_bytes - (uint64_t)copy_bytes
+            || slot_bytes > UINT64_MAX - old_bytes - (uint64_t)copy_bytes
+            - segment_bytes) {
             mutex_unlock(&intern->lock);
             return -1;
         }
-        uint32_t mask = intern->slot_capacity - 1U;
-        h = fnv1a(str) & mask;
-        while (intern->slots[h].string_id != SLOT_EMPTY)
-            h = (h + 1U) & mask;
+        new_bytes = old_bytes + (uint64_t)copy_bytes
+            + segment_bytes + slot_bytes;
+        wl_columnar_memory_reservation_init(&pending);
+        wl_columnar_memory_admission_status_t status
+            = wl_columnar_memory_reserve_growth(
+                wl_columnar_memory_governor_ref_get(
+                    intern->memory_governor), old_bytes, new_bytes,
+                &pending);
+        if (status != WL_COLUMNAR_MEMORY_ADMISSION_OK
+            && status != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY) {
+            mutex_unlock(&intern->lock);
+            return -1;
+        }
+        pending_valid = true;
     }
 
-    uint32_t seg = intern_seg_of(new_id);
+    copy = (char *)malloc(copy_bytes);
+    if (!copy)
+        goto fail;
+    memcpy(copy, str, copy_bytes);
+    if (needs_segment) {
+        new_segment = (char **)calloc((size_t)intern_seg_size(seg),
+                sizeof(char *));
+        if (!new_segment)
+            goto fail;
+    }
+    if (needs_resize
+        && intern_resize_prepare(intern, &new_slots, &new_cap) != 0)
+        goto fail;
+    if (pending_valid
+        && intern_publish_reservation(intern, &pending, new_bytes) != 0)
+        goto fail;
+    pending_valid = false;
+    if (new_slots) {
+        free(intern->slots);
+        intern->slots = new_slots;
+        intern->slot_capacity = new_cap;
+        new_slots = NULL;
+    }
+    if (needs_resize) {
+        h = fnv1a(str) & (intern->slot_capacity - 1U);
+        while (intern->slots[h].string_id != SLOT_EMPTY)
+            h = (h + 1U) & (intern->slot_capacity - 1U);
+    }
+    if (new_segment)
+        intern->segments[seg] = new_segment;
     intern->segments[seg][new_id - intern_seg_base(seg)] = copy;
-
-    /* Release store: any reader that acquire-loads a count greater than
-     * new_id also sees the segment pointer and the string above.  The
-     * entry must be complete before the count is published, never the
-     * other way round. */
-    /* Release is sufficient only because EVERY store to count happens
-     * under intern->lock: another writer's segment and slot writes are
-     * ordered before its unlock, which is ordered before our lock and
-     * therefore before this store.  An unlocked count store would break
-     * the transitivity a lock-free reverse() depends on. */
-    WL_INTERN_STORE_RELEASE(&intern->count, new_id + 1U);
-
+    copy = NULL;
     intern->slots[h].string_id = new_id;
-
+    WL_INTERN_STORE_RELEASE(&intern->count, new_id + 1U);
     mutex_unlock(&intern->lock);
     return (int64_t)new_id;
+
+fail:
+    free(copy);
+    free(new_segment);
+    free(new_slots);
+    if (pending_valid)
+        (void)wl_columnar_memory_rollback(&pending);
+    mutex_unlock(&intern->lock);
+    return -1;
 }
 
 int64_t

--- a/wirelog/intern.h
+++ b/wirelog/intern.h
@@ -34,6 +34,21 @@
 #include <stdint.h>
 
 typedef struct wl_intern wl_intern_t;
+typedef struct wl_columnar_memory_governor_ref
+    wl_columnar_memory_governor_ref_t;
+
+/* Attach program-owned intern storage to a retained governor.  Existing
+ * bytes are admitted transactionally; EBUSY means another governor already
+ * owns the table and the caller must continue using that owner. */
+int
+wl_intern_attach_memory_governor(
+    wl_intern_t *intern,
+    wl_columnar_memory_governor_ref_t *governor);
+
+int
+wl_intern_detach_memory_governor(
+    wl_intern_t *intern,
+    wl_columnar_memory_governor_ref_t *governor);
 
 /**
  * wl_intern_create:


### PR DESCRIPTION
## Summary
- attach program-owned intern tables to a retained memory governor
- admit existing intern storage at attachment and reserve unique string, segment, and hash-table growth before allocation
- keep duplicate interning uncharged and preserve table state on denial/partial failure
- release retained reservations at program-table destruction and roll back session attachment on failed initialization
- add normal and sanitizer-focused admission/lifetime tests

## Dependency
- Stacked on PR #1444, which is stacked on PR #1433
- The base branch contains the retained relation/COW admission units; this PR does not modify those units
- Conflicting governor attachment returns `EBUSY`; repeated attachment of the same governor returns `EALREADY`

## Validation
- normal: `memory_admission_intern`, `intern`, `session`
- ASan/UBSan: same three tests
- `git diff --check`

Refs #1431
