### PR TITLE
feat: thread Windows Job Object options into sessions

### DIFF
--- a/docs/ARCHITECTURE.ko.md
+++ b/docs/ARCHITECTURE.ko.md
@@ -122,7 +122,8 @@ Wirelog는 **순수 C11**로 구현된 **Timely-Differential 개념** 기반의 
 **원칙**: Compute backend는 깔끔한 vtable 추상화를 통해 교체 가능합니다. 핵심 엔진 (파서, 옵티마이저, 계획 생성)은 backend에 독립적입니다.
 
 **의미**:
-- `wirelog/backend.h:85-107`의 `wl_compute_backend_t` vtable은 7개의 연산을 정의합니다: `session_create`, `session_destroy`, `session_insert`, `session_remove`, `session_step`, `session_set_delta_cb`, `session_snapshot`
+- `wirelog/backend.h`의 `wl_compute_backend_t` vtable은 기본 세션 연산과 선택적인 내부 `session_create_with_options` 슬롯을 정의합니다. 이 슬롯은 기존 생성 콜백이나 설치되는 API를 변경하지 않고 버전이 지정된 호스트 옵션을 전달합니다.
+- `wirelog/session_options.h`는 내부 전용이며 설치되지 않습니다. Windows Job Object 필드는 동기 생성 중에만 사용하는 opaque borrowed handle이고, 세션은 호스트 handle을 저장하거나 닫지 않고 해석된 메모리 제한만 저장합니다.
 - 각 backend는 이 인터페이스의 구현을 제공합니다.
 - `wl_session_t`는 backend vtable에 대한 포인터만 포함하며; 모든 디스패치는 다형적입니다.
 - 미래 backend (FPGA, GPU, 분산)는 핵심 엔진 수정 없이 추가할 수 있습니다.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,7 +123,8 @@ This document describes the **invariant architectural principles** that must be 
 **Principle**: Compute backends are swappable via a clean vtable abstraction. The core engine (parser, optimizer, plan generation) is backend-agnostic.
 
 **What this means**:
-- `wl_compute_backend_t` vtable in `wirelog/backend.h:85-107` defines 7 operations: `session_create`, `session_destroy`, `session_insert`, `session_remove`, `session_step`, `session_set_delta_cb`, `session_snapshot`
+- `wl_compute_backend_t` vtable in `wirelog/backend.h` defines the core session operations plus an optional internal `session_create_with_options` slot. The latter carries versioned host options without changing the legacy creation callback or installed API.
+- `wirelog/session_options.h` is internal and non-installed. Its Windows Job Object field is a borrowed opaque handle used only during synchronous creation; the session stores only the resolved memory limit and never closes the host handle.
 - Each backend provides an implementation of this interface
 - `wl_session_t` contains only a pointer to the backend vtable; all dispatch is polymorphic
 - Future backends (FPGA, GPU, distributed) can be added without modifying core engine

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -45,7 +45,7 @@ stable for downstream code.
 | IR, programs, stratification, interning | `wirelog/ir/*`, `wirelog/intern.*` | Public IR wrappers, internal program representation, stratification, and string interning. |
 | Optimizer passes | `wirelog/passes/*` | Fusion, join plan placement, magic sets, sideways information passing, and subsumption passes. |
 | Execution plan generation | `wirelog/exec_plan*` | Backend-neutral execution-plan types and lowering from IR/program state. |
-| Session and backend abstraction | `wirelog/session.*`, `wirelog/session_facts.*`, `wirelog/backend.h` | Internal session lifecycle, inline fact seeding, and backend vtable boundary. |
+| Session and backend abstraction | `wirelog/session.*`, `wirelog/session_options.h`, `wirelog/session_facts.*`, `wirelog/backend.h` | Internal session lifecycle, versioned host options, inline fact seeding, and backend vtable boundary. |
 | Columnar backend | `wirelog/columnar/*` | Relations, arrangements, frontier/progress tracking, expression evaluation, diff traces, delta pools, partitioning, and columnar session execution. |
 | Arenas and compound storage | `wirelog/arena/*`, `wirelog/columnar/compound_side.*`, `wirelog/columnar/handle_remap*` | Arena allocation, compound arena handles, side relations, and handle remapping support. |
 | I/O adapters | `wirelog/io/*` | Public adapter ABI implementation, CSV reader/adapter code, and adapter context internals. |

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -66,6 +66,14 @@ read:
 4. supported Windows Job Object process-memory limits;
 5. no physical-RAM-only fallback for an enforcing guarantee.
 
+The internal `wl_session_create_with_options()` entry point accepts a
+versioned, non-installed options object. Its `windows_job_handle` is a
+borrowed opaque handle used only during synchronous creation; Wirelog stores
+the resolved byte limit and provenance in the governor, and never duplicates
+or closes the host handle. Missing, unsupported, or invalid handles clear the
+provider and leave automatic resolution advisory unless another finite source
+is available. `WIRELOG_MEMORY_BUDGET` remains higher precedence.
+
 An unlimited cgroup value, an absent optional source, and an unsupported
 platform are different observations. The resolver records which source was
 selected and whether the result is enforcing or advisory. Tests use injected

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5570,6 +5570,20 @@ test_session_extension_snapshot_exe = executable(
 )
 test('session_extension_snapshot', test_session_extension_snapshot_exe)
 
+# Internal session creation options remain outside the installed API.  The
+# fake backend verifies options dispatch without requiring a Windows host.
+test_session_options_exe = executable(
+  'test_session_options',
+  files('test_session_options.c', '../wirelog/session.c',
+        '../wirelog/extension_registry.c'),
+  thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  c_args: ['-DWIRELOG_BUILDING'],
+  dependencies: [threads_dep],
+  install: false,
+)
+test('session_options', test_session_options_exe)
+
 test_extension_filter_exe = executable(
   'test_extension_filter',
   files('test_extension_filter.c'),

--- a/tests/test_memory_governor.c
+++ b/tests/test_memory_governor.c
@@ -97,6 +97,12 @@ test_automatic_sources(void)
     memset(&sources, 0, sizeof(sources));
     sources.windows_job_available = true;
     sources.windows_job_limit = UINT64_C(512) * 1024 * 1024;
+    if (wl_columnar_memory_resolve(NULL, &sources, &result) != 0
+        || result.mode != WL_COLUMNAR_MEMORY_MODE_ENFORCING
+        || result.source != WL_COLUMNAR_MEMORY_SOURCE_WINDOWS_JOB) {
+        FAIL("Windows Job source was not selected from an injected limit");
+        return 1;
+    }
     if (wl_columnar_memory_probe_windows_job(NULL, &sources)
         != WL_COLUMNAR_MEMORY_UNAVAILABLE
         || sources.windows_job_available || sources.windows_job_limit != 0) {

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -17,6 +17,7 @@
 #include "../wirelog/passes/jpp.h"
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
+#include "../wirelog/columnar/memory_governor.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
 
@@ -25,6 +26,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 /* ======================================================================== */
 /* Portability Macros                                                       */
@@ -265,6 +270,124 @@ test_session_create_destroy_columnar(void)
     TEST("session(columnar): create and destroy (duplicate check)");
     test_session_create_destroy_impl(wl_backend_columnar());
 }
+
+static void
+test_session_create_with_options(void)
+{
+    TEST("session: internal host options are accepted");
+    wl_plan_t *ffi = build_plan(".decl a(x: int32)\n"
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
+    wl_session_options_t options;
+    wl_session_t *session = NULL;
+    if (!ffi) {
+        FAIL("could not generate FFI plan");
+        return;
+    }
+    wl_session_options_init(&options);
+    /* Invalid on every host, but safe: providers must fall back to advisory. */
+    options.windows_job_handle = (void *)(uintptr_t)1;
+    int rc = wl_session_create_with_options(wl_backend_columnar(), ffi, 1,
+            &options, &session);
+    if (rc != 0 || !session) {
+        wl_plan_free(ffi);
+        FAIL("session options creation failed");
+        return;
+    }
+    wl_session_destroy(session);
+    wl_plan_free(ffi);
+    PASS();
+}
+
+#ifdef _WIN32
+/*
+ * The provider and session plumbing must be tested with a real Job Object,
+ * not only with injected resolver fields.  The session borrows the handle
+ * during creation, so closing the caller's handle before destruction also
+ * verifies that the session does not retain or close it.
+ */
+static void
+test_session_windows_job_options(void)
+{
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits;
+    HANDLE job = NULL;
+    char *saved_budget = NULL;
+    size_t saved_budget_len = 0;
+    wl_plan_t *plan = NULL;
+    wl_session_t *session = NULL;
+    wl_session_options_t options;
+    wl_columnar_memory_governor_t *governor;
+    const uint64_t expected_budget = UINT64_C(512) * 1024 * 1024;
+    int ok = 0;
+
+    TEST("session: real Windows Job Object memory source");
+    if (_dupenv_s(&saved_budget, &saved_budget_len,
+        "WIRELOG_MEMORY_BUDGET") != 0)
+        saved_budget = NULL;
+    /* An explicit environment budget intentionally has precedence. */
+    if (_putenv_s("WIRELOG_MEMORY_BUDGET", "") != 0) {
+        FAIL("could not clear WIRELOG_MEMORY_BUDGET");
+        goto cleanup;
+    }
+
+    job = CreateJobObjectW(NULL, NULL);
+    if (!job) {
+        FAIL("CreateJobObjectW failed");
+        goto cleanup;
+    }
+    memset(&limits, 0, sizeof(limits));
+    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_PROCESS_MEMORY;
+    limits.ProcessMemoryLimit = (SIZE_T)expected_budget;
+    if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation,
+        &limits, sizeof(limits))) {
+        FAIL("SetInformationJobObject failed");
+        goto cleanup;
+    }
+
+    plan = build_plan(".decl a(x: int32)\n"
+            ".decl r(x: int32)\n"
+            "r(x) :- a(x).\n");
+    if (!plan) {
+        FAIL("could not generate Job Object test plan");
+        goto cleanup;
+    }
+    wl_session_options_init(&options);
+    options.windows_job_handle = (void *)job;
+    if (wl_session_create_with_options(wl_backend_columnar(), plan, 1,
+        &options, &session) != 0 || !session) {
+        FAIL("session creation with Job Object failed");
+        goto cleanup;
+    }
+
+    /* The session must have completed its synchronous probe by now. */
+    CloseHandle(job);
+    job = NULL;
+    governor = wl_session_memory_governor(session);
+    if (!governor
+        || governor->source != WL_COLUMNAR_MEMORY_SOURCE_WINDOWS_JOB
+        || governor->mode != WL_COLUMNAR_MEMORY_MODE_ENFORCING
+        || governor->budget_bytes != expected_budget) {
+        FAIL("session did not enforce the Job Object memory source");
+        goto cleanup;
+    }
+    ok = 1;
+
+cleanup:
+    if (job)
+        CloseHandle(job);
+    if (session)
+        wl_session_destroy(session);
+    if (plan)
+        wl_plan_free(plan);
+    if (saved_budget)
+        _putenv_s("WIRELOG_MEMORY_BUDGET", saved_budget);
+    else
+        _putenv_s("WIRELOG_MEMORY_BUDGET", "");
+    free(saved_budget);
+    if (ok)
+        PASS();
+}
+#endif
 
 /*
  * Test: num_workers > 1 is rejected.
@@ -991,6 +1114,10 @@ main(void)
     test_session_hash_overflow_rejected();
     test_session_create_destroy();
     test_session_create_destroy_columnar();
+    test_session_create_with_options();
+#ifdef _WIN32
+    test_session_windows_job_options();
+#endif
     test_session_create_multi_worker_rejected();
     test_session_step_initial_delta();
     test_session_step_incremental_delta();

--- a/tests/test_session_options.c
+++ b/tests/test_session_options.c
@@ -1,0 +1,92 @@
+/* Internal session options dispatch and validation tests. */
+
+#include "wirelog/session.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static int legacy_calls;
+static int options_calls;
+static void *observed_handle;
+
+static int
+fake_create(const wl_plan_t *plan, uint32_t num_workers, wl_session_t **out)
+{
+    (void)plan;
+    (void)num_workers;
+    legacy_calls++;
+    *out = (wl_session_t *)calloc(1, sizeof(**out));
+    return *out ? 0 : -1;
+}
+
+static int
+fake_create_with_options(const wl_plan_t *plan, uint32_t num_workers,
+    const wl_session_options_t *options, wl_session_t **out)
+{
+    (void)plan;
+    (void)num_workers;
+    options_calls++;
+    observed_handle = options ? options->windows_job_handle : NULL;
+    *out = (wl_session_t *)calloc(1, sizeof(**out));
+    return *out ? 0 : -1;
+}
+
+static void
+fake_destroy(wl_session_t *session)
+{
+    free(session);
+}
+
+int
+main(void)
+{
+    static int borrowed_handle;
+    const wl_compute_backend_t options_backend = {
+        .name = "options",
+        .session_create = fake_create,
+        .session_destroy = fake_destroy,
+        .session_create_with_options = fake_create_with_options,
+    };
+    const wl_compute_backend_t legacy_backend = {
+        .name = "legacy",
+        .session_create = fake_create,
+        .session_destroy = fake_destroy,
+    };
+    wl_session_options_t options;
+    wl_session_t *session = NULL;
+
+    wl_session_options_init(&options);
+    options.windows_job_handle = &borrowed_handle;
+    if (wl_session_create_with_options(&options_backend, NULL, 1, &options,
+        &session) != 0 || !session || options_calls != 1
+        || observed_handle != &borrowed_handle) {
+        fprintf(stderr, "options backend did not receive borrowed handle\n");
+        return 1;
+    }
+    wl_session_destroy(session);
+
+    session = NULL;
+    if (wl_session_create(&options_backend, NULL, 1, &session) != 0
+        || !session || legacy_calls != 1) {
+        fprintf(stderr, "legacy creation path was not preserved\n");
+        return 1;
+    }
+    wl_session_destroy(session);
+
+    options.version++;
+    session = NULL;
+    if (wl_session_create_with_options(&options_backend, NULL, 1, &options,
+        &session) == 0 || session || options_calls != 1) {
+        fprintf(stderr, "invalid options version was accepted\n");
+        return 1;
+    }
+
+    options.version = WL_SESSION_OPTIONS_VERSION;
+    if (wl_session_create_with_options(&legacy_backend, NULL, 1, &options,
+        &session) != 0 || !session || legacy_calls != 2) {
+        fprintf(stderr, "legacy backend did not ignore options\n");
+        return 1;
+    }
+    wl_session_destroy(session);
+    return 0;
+}

--- a/wirelog/backend.h
+++ b/wirelog/backend.h
@@ -29,6 +29,7 @@ extern "C" {
 
 #include "exec_plan.h"
 #include "columnar/memory_governor.h"
+#include "session_options.h"
 #include "wirelog/wirelog-types.h"
 
 #include <stdint.h>
@@ -91,6 +92,11 @@ typedef struct {
     /* Internal hook used by bounded built-in input loaders. */
     wl_columnar_memory_governor_t *(*session_memory_governor)(
         wl_session_t *session);
+
+    /* Optional internal creation path.  Legacy backends leave this NULL. */
+    int (*session_create_with_options)(const wl_plan_t *plan,
+        uint32_t num_workers, const wl_session_options_t *options,
+        wl_session_t **out);
 } wl_compute_backend_t;
 
 /**

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1018,16 +1018,23 @@ col_compute_worker_cap(uint64_t ram_bytes)
  * @see wl_col_session_t memory layout documentation above
  */
 static int
-col_session_create(const wl_plan_t *plan, uint32_t num_workers,
-    wl_session_t **out)
+col_session_create_internal(const wl_plan_t *plan, uint32_t num_workers,
+    const wl_session_options_t *options, wl_session_t **out)
 {
     wl_columnar_memory_resolution_t memory_resolution;
+    wl_columnar_memory_sources_t memory_sources;
     wl_columnar_memory_governor_ref_t *memory_governor;
     const char *memory_budget = getenv("WIRELOG_MEMORY_BUDGET");
 
     if (!plan || !out)
         return EINVAL;
-    if (wl_columnar_memory_resolve(memory_budget, NULL, &memory_resolution)
+    if (wl_columnar_memory_probe_sources(&memory_sources) != 0)
+        return EINVAL;
+    if (options && options->windows_job_handle)
+        (void)wl_columnar_memory_probe_windows_job(
+            options->windows_job_handle, &memory_sources);
+    if (wl_columnar_memory_resolve(memory_budget, &memory_sources,
+        &memory_resolution)
         != WL_COLUMNAR_MEMORY_OK)
         return EINVAL;
     memory_governor = wl_columnar_memory_governor_ref_create(
@@ -2019,6 +2026,20 @@ col_session_insert(wl_session_t *session, const char *relation,
     sess->pending_full_input_eval = true;
 
     return 0;
+}
+
+static int
+col_session_create(const wl_plan_t *plan, uint32_t num_workers,
+    wl_session_t **out)
+{
+    return col_session_create_internal(plan, num_workers, NULL, out);
+}
+
+static int
+col_session_create_with_options(const wl_plan_t *plan, uint32_t num_workers,
+    const wl_session_options_t *options, wl_session_t **out)
+{
+    return col_session_create_internal(plan, num_workers, options, out);
 }
 
 static bool
@@ -3132,6 +3153,7 @@ static const wl_compute_backend_t col_backend = {
     .session_set_delta_cb = col_session_set_delta_cb,
     .session_snapshot = col_session_snapshot,
     .session_memory_governor = col_session_memory_governor,
+    .session_create_with_options = col_session_create_with_options,
 };
 
 const wl_compute_backend_t *

--- a/wirelog/session.c
+++ b/wirelog/session.c
@@ -24,12 +24,31 @@
 #include <errno.h>
 #include <stddef.h>
 
+void
+wl_session_options_init(wl_session_options_t *options)
+{
+    if (!options)
+        return;
+    options->size = (uint32_t)sizeof(*options);
+    options->version = WL_SESSION_OPTIONS_VERSION;
+    options->windows_job_handle = NULL;
+}
+
+static int
+wl_session_options_valid(const wl_session_options_t *options)
+{
+    if (!options)
+        return 1;
+    return options->version == WL_SESSION_OPTIONS_VERSION
+           && options->size >= (uint32_t)sizeof(*options);
+}
+
 int
 wl_session_create(const wl_compute_backend_t *backend, const wl_plan_t *plan,
     uint32_t num_workers, wl_session_t **out)
 {
-    return wl_session_create_with_snapshot(backend, plan, num_workers, NULL,
-               out);
+    return wl_session_create_with_snapshot_options(backend, plan,
+               num_workers, NULL, NULL, out);
 }
 
 int
@@ -37,11 +56,35 @@ wl_session_create_with_snapshot(const wl_compute_backend_t *backend,
     const wl_plan_t *plan, uint32_t num_workers,
     wirelog_extension_snapshot_t *snapshot, wl_session_t **out)
 {
+    return wl_session_create_with_snapshot_options(backend, plan,
+               num_workers, snapshot, NULL, out);
+}
+
+int
+wl_session_create_with_options(const wl_compute_backend_t *backend,
+    const wl_plan_t *plan, uint32_t num_workers,
+    const wl_session_options_t *options, wl_session_t **out)
+{
+    return wl_session_create_with_snapshot_options(backend, plan,
+               num_workers, NULL, options, out);
+}
+
+int
+wl_session_create_with_snapshot_options(const wl_compute_backend_t *backend,
+    const wl_plan_t *plan, uint32_t num_workers,
+    wirelog_extension_snapshot_t *snapshot,
+    const wl_session_options_t *options, wl_session_t **out)
+{
     int rc;
-    if (!backend || !backend->session_create || !out)
+    if (!backend || !backend->session_create || !out
+        || !wl_session_options_valid(options))
         return -1;
 
-    rc = backend->session_create(plan, num_workers, out);
+    if (options && backend->session_create_with_options)
+        rc = backend->session_create_with_options(plan, num_workers, options,
+                out);
+    else
+        rc = backend->session_create(plan, num_workers, out);
     if (rc == 0 && *out) {
         /* Ensure the backend pointer is correctly bound */
         (*out)->backend = backend;

--- a/wirelog/session.h
+++ b/wirelog/session.h
@@ -87,6 +87,18 @@ wl_session_create_with_snapshot(const wl_compute_backend_t *backend,
     const wl_plan_t *plan, uint32_t num_workers,
     wirelog_extension_snapshot_t *snapshot, wl_session_t **out);
 
+/* Internal host path.  @options is borrowed for the duration of creation. */
+int
+wl_session_create_with_options(const wl_compute_backend_t *backend,
+    const wl_plan_t *plan, uint32_t num_workers,
+    const wl_session_options_t *options, wl_session_t **out);
+
+int
+wl_session_create_with_snapshot_options(const wl_compute_backend_t *backend,
+    const wl_plan_t *plan, uint32_t num_workers,
+    wirelog_extension_snapshot_t *snapshot,
+    const wl_session_options_t *options, wl_session_t **out);
+
 /**
  * wl_session_destroy:
  * @session:  The session to destroy (NULL-safe).

--- a/wirelog/session_options.h
+++ b/wirelog/session_options.h
@@ -1,0 +1,32 @@
+/*
+ * session_options.h - internal session creation options
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ *
+ * INTERNAL HEADER - not installed and not part of the public API.
+ */
+
+#ifndef WL_SESSION_OPTIONS_H
+#define WL_SESSION_OPTIONS_H
+
+#include <stdint.h>
+
+#define WL_SESSION_OPTIONS_VERSION UINT32_C(1)
+
+/*
+ * Options are valid only for the duration of session creation.  The Windows
+ * Job Object handle is borrowed by the backend, queried synchronously, and
+ * never stored or closed by Wirelog.  A void pointer keeps this header
+ * portable and prevents windows.h from reaching installed headers.
+ */
+typedef struct {
+    uint32_t size;
+    uint32_t version;
+    void *windows_job_handle;
+} wl_session_options_t;
+
+void
+wl_session_options_init(wl_session_options_t *options);
+
+#endif /* WL_SESSION_OPTIONS_H */


### PR DESCRIPTION
Closes #1415

## Summary

- Add an internal, versioned session-options path for hosts to provide a borrowed Windows Job Object handle.
- Probe the handle synchronously and feed its finite process-memory limit into the existing governor resolver, while preserving `WIRELOG_MEMORY_BUDGET` precedence.
- Keep public headers and existing session/backend creation paths unchanged; legacy backends ignore unsupported options safely.
- Document borrowed-handle ownership and add dispatch, invalid-handle, injected-source, and real Windows Job Object lifecycle coverage.

## Validation

- Normal focused tests: `session`, `session_options`, `memory_governor`, `intern` — passed.
- Sanitizer focused tests: same four targets — passed.
- ABI suite: 61 passed, 1 intentional skip.
- Full normal and Sanitizer builds completed successfully.
- Windows/MSVC real Job Object test is compiled under `_WIN32` and will execute in Windows CI.

The supplied handle is borrowed only during synchronous session creation; the session never stores or closes it.
