### PR TITLE
test: add external memory pressure evidence runner

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -321,7 +321,12 @@ jobs:
     needs: [build-arm, build-mbedtls, build-scope]
     if: ${{ needs.build-scope.outputs.build-required == 'true' }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    # The Windows/MSVC full test build currently needs more than the shared
+    # Linux/macOS budget on a cold hosted runner. Recent successful Windows
+    # main builds took 10-34 minutes, while the failed PR cold build reached
+    # 83% of compilation at the 60-minute boundary. Keep the platform budgets
+    # explicit so a slow build cannot be mistaken for a compiler failure.
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
@@ -330,16 +335,19 @@ jobs:
           - os: ubuntu-latest
             compiler: clang
             cc: clang
+            timeout_minutes: 60
 
           # macOS - Clang
           - os: macos-latest
             compiler: clang
             cc: clang
+            timeout_minutes: 60
 
           # Windows - MSVC
           - os: windows-latest
             compiler: msvc
             cc: cl
+            timeout_minutes: 90
 
     steps:
       - uses: actions/checkout@v5

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -34,6 +34,16 @@ environment has precedence over automatic resolution:
 versioned API option > WIRELOG_MEMORY_BUDGET > automatic resolution
 ```
 
+The reusable `scripts/ci/run-memory-pressure.sh` helper records external-limit
+evidence for a command: source and binary identity, command arguments,
+effective ceiling, enforcement mechanism, exit/timeout classification, output
+hashes, and Linux cgroup memory events when available. It prefers a writable
+cgroup v2 and otherwise records a kernel-enforced `RLIMIT_AS` ceiling as a
+different enforcement class. A bare `SIGKILL`/exit 137 is not treated as OOM;
+resource-error mode requires supporting cgroup evidence. This runner is
+qualification infrastructure only: its evidence does not prove that Wirelog
+allocation classes, JOINs, TDD transport, or DOOP are bounded.
+
 Values are decimal bytes (not MiB or a human-readable suffix). The following
 table is part of the interface contract:
 

--- a/scripts/ci/run-memory-pressure.sh
+++ b/scripts/ci/run-memory-pressure.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+# Run one command under a real external memory ceiling and write evidence.
+# This helper is qualification infrastructure; it does not claim that the
+# command's allocations are admitted by Wirelog.
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+usage: run-memory-pressure.sh
+  --mode success-required|expected-resource-error
+  --budget-bytes BYTES
+  --ceiling-bytes BYTES
+  --artifact-dir DIR
+  --timeout-seconds SECONDS
+  [--allow-unsupported]
+  -- COMMAND [ARGS...]
+USAGE
+}
+
+mode=
+budget_bytes=
+ceiling_bytes=
+artifact_dir=
+timeout_seconds=
+allow_unsupported=0
+
+while (($#)); do
+    case "$1" in
+        --mode)
+            (($# >= 2)) || { usage; exit 2; }
+            mode=$2; shift 2 ;;
+        --budget-bytes)
+            (($# >= 2)) || { usage; exit 2; }
+            budget_bytes=$2; shift 2 ;;
+        --ceiling-bytes)
+            (($# >= 2)) || { usage; exit 2; }
+            ceiling_bytes=$2; shift 2 ;;
+        --artifact-dir)
+            (($# >= 2)) || { usage; exit 2; }
+            artifact_dir=$2; shift 2 ;;
+        --timeout-seconds)
+            (($# >= 2)) || { usage; exit 2; }
+            timeout_seconds=$2; shift 2 ;;
+        --allow-unsupported)
+            allow_unsupported=1; shift ;;
+        --)
+            shift; break ;;
+        *)
+            usage; exit 2 ;;
+    esac
+done
+
+if [[ $mode != success-required && $mode != expected-resource-error ]] \
+    || [[ ! $budget_bytes =~ ^[1-9][0-9]*$ ]] \
+    || [[ ! $ceiling_bytes =~ ^[1-9][0-9]*$ ]] \
+    || [[ ! $timeout_seconds =~ ^[1-9][0-9]*$ ]] \
+    || [[ -z $artifact_dir || $# -eq 0 ]]; then
+    usage
+    exit 2
+fi
+if ((budget_bytes > ceiling_bytes)); then
+    echo "FAIL: managed budget exceeds external ceiling" >&2
+    exit 2
+fi
+
+mkdir -p "$artifact_dir"
+stdout_file=$artifact_dir/stdout.log
+stderr_file=$artifact_dir/stderr.log
+evidence_file=$artifact_dir/evidence.json
+timeout_marker=$artifact_dir/timeout.marker
+: >"$stdout_file"
+: >"$stderr_file"
+: >"$timeout_marker"
+
+json_escape() {
+    local value=$1
+    local escaped=
+    local char
+    local i
+    for ((i = 0; i < ${#value}; i++)); do
+        char=${value:i:1}
+        case "$char" in
+            $'\\') escaped="${escaped}\\\\" ;;
+            '"') escaped="${escaped}\\\"" ;;
+            $'\n') escaped="${escaped}\\n" ;;
+            $'\r') escaped="${escaped}\\r" ;;
+            $'\t') escaped="${escaped}\\t" ;;
+            *) escaped+=$char ;;
+        esac
+    done
+    printf '%s' "$escaped"
+}
+
+json_string() {
+    printf '"%s"' "$(json_escape "$1")"
+}
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        printf 'unavailable'
+    fi
+}
+
+write_evidence() {
+    local disposition=$1
+    local enforcement=$2
+    local status=$3
+    local timeout_state=$4
+    local resource_evidence=$5
+    local cgroup_path=$6
+    local memory_max=$7
+    local memory_high=$8
+    local memory_swap_max=$9
+    local swap_policy=${10}
+    local memory_peak=${11}
+    local memory_events=${12}
+    local command_json='['
+    local arg
+    local first=1
+
+    for arg in "${command[@]}"; do
+        if ((first)); then first=0; else command_json+=,; fi
+        command_json+=$(json_string "$arg")
+    done
+    command_json+=']'
+
+    local git_sha=unknown
+    local git_dirty=false
+    if git_sha=$(git rev-parse HEAD 2>/dev/null); then
+        if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
+            git_dirty=true
+        fi
+    fi
+    local script_sha
+    script_sha=$(sha256_file "$0")
+    local binary_sha=unavailable
+    local binary_path=${command[0]}
+    if [[ ! -f $binary_path ]]; then
+        binary_path=$(command -v "${command[0]}" 2>/dev/null || true)
+    fi
+    if [[ -f $binary_path ]]; then
+        binary_sha=$(sha256_file "$binary_path")
+    fi
+    local env_json
+    env_json=$(env | awk -F= '/^(WIRELOG_MEMORY_BUDGET|WIRELOG_PERF_GATE|WIRELOG_PERF_REQUIRE|WIRELOG_TDD_MEMORY_BUDGET_BYTES)=/ {print}' \
+        | while IFS= read -r line; do json_string "$line"; done \
+        | paste -sd, -)
+    [[ -n $env_json ]] || env_json=
+
+    cat >"$evidence_file" <<EOF
+{
+  "schema": 1,
+  "disposition": $(json_string "$disposition"),
+  "mode": $(json_string "$mode"),
+  "enforcement": $(json_string "$enforcement"),
+  "managed_budget_bytes": $budget_bytes,
+  "external_ceiling_bytes": $ceiling_bytes,
+  "command_argv": $command_json,
+  "environment_allowlist": [${env_json}],
+  "source_commit": $(json_string "$git_sha"),
+  "source_dirty": $git_dirty,
+  "runner_sha256": $(json_string "$script_sha"),
+  "binary_sha256": $(json_string "$binary_sha"),
+  "artifact_sha256": {
+    "stdout": $(json_string "$(sha256_file "$stdout_file")"),
+    "stderr": $(json_string "$(sha256_file "$stderr_file")")
+  },
+  "cgroup_path": $(json_string "$cgroup_path"),
+  "memory_max": $(json_string "$memory_max"),
+  "memory_high": $(json_string "$memory_high"),
+  "memory_swap_max": $(json_string "$memory_swap_max"),
+  "swap_policy": $(json_string "$swap_policy"),
+  "memory_peak": $(json_string "$memory_peak"),
+  "memory_events": $(json_string "$memory_events"),
+  "exit_status": $status,
+  "timeout": $timeout_state,
+  "resource_failure_evidence": $resource_evidence
+}
+EOF
+}
+
+command=("$@")
+enforcement=
+cgroup_path=
+memory_max=unavailable
+memory_high=unavailable
+memory_swap_max=unavailable
+swap_policy=unknown
+memory_peak=unavailable
+memory_events=unavailable
+resource_evidence=false
+status=0
+timed_out=false
+
+if [[ $(uname -s) != Linux ]] || ! command -v setsid >/dev/null 2>&1; then
+    write_evidence SKIP unsupported 77 false false unavailable unavailable unavailable unavailable unknown unavailable unavailable
+    echo "SKIP: Linux setsid/cgroup or RLIMIT enforcement is unavailable" >&2
+    if ((allow_unsupported)); then exit 77; else exit 1; fi
+fi
+
+run_with_timeout() {
+    local child
+    local watchdog
+    local child_status
+    : >"$timeout_marker"
+    setsid "$@" >"$stdout_file" 2>"$stderr_file" &
+    child=$!
+    (
+        sleep "$timeout_seconds"
+        if kill -0 "$child" 2>/dev/null; then
+            printf 'true\n' >"$timeout_marker"
+            kill -TERM -- "-$child" 2>/dev/null || kill -TERM "$child" 2>/dev/null || true
+            sleep 1
+            if kill -0 "$child" 2>/dev/null; then
+                kill -KILL -- "-$child" 2>/dev/null || kill -KILL "$child" 2>/dev/null || true
+            fi
+        fi
+    ) &
+    watchdog=$!
+    if wait "$child"; then child_status=0; else child_status=$?; fi
+    kill "$watchdog" 2>/dev/null || true
+    wait "$watchdog" 2>/dev/null || true
+    # The direct command may have left a background descendant in the same
+    # process group after it returned.  Reap that group before reporting the
+    # command status so cgroup cleanup and RLIMIT fallback share the same
+    # lifecycle guarantee.
+    kill -TERM -- "-$child" 2>/dev/null || true
+    sleep 0.05
+    kill -KILL -- "-$child" 2>/dev/null || true
+    return "$child_status"
+}
+
+drain_cgroup_processes() {
+    local pass
+    local pid
+    local pids
+    for ((pass = 0; pass < 20; pass++)); do
+        pids=$(cat "$cgroup_path/cgroup.procs" 2>/dev/null || true)
+        [[ -z $pids ]] && return
+        while IFS= read -r pid; do
+            [[ -n $pid && $pid != $$ ]] || continue
+            kill -TERM "$pid" 2>/dev/null || true
+        done <<<"$pids"
+        sleep 0.05
+    done
+    pids=$(cat "$cgroup_path/cgroup.procs" 2>/dev/null || true)
+    while IFS= read -r pid; do
+        [[ -n $pid && $pid != $$ ]] || continue
+        kill -KILL "$pid" 2>/dev/null || true
+    done <<<"$pids"
+}
+
+# Prefer a private cgroup v2 so the complete command tree is covered. A runner
+# may deny creation even when cgroup v2 exists; RLIMIT_AS is a truthful
+# kernel-enforced fallback, but its evidence is kept distinct from RSS.
+cgroup_root=/sys/fs/cgroup
+if [[ -f $cgroup_root/cgroup.controllers ]]; then
+    candidate=$cgroup_root/wirelog-memory-$$
+    if mkdir "$candidate" 2>/dev/null; then
+        cleanup_candidate() { rmdir "$candidate" 2>/dev/null || true; }
+        if printf '%s\n' "$ceiling_bytes" >"$candidate/memory.max" 2>/dev/null \
+            && printf '0\n' >"$candidate/memory.swap.max" 2>/dev/null; then
+            cgroup_path=$candidate
+            enforcement=cgroup-v2
+            swap_policy=disabled
+            cleanup_cgroup() { rmdir "$cgroup_path" 2>/dev/null || true; }
+            trap cleanup_cgroup EXIT
+            (
+                # Join before execing timeout so all of its descendants inherit
+                # the private cgroup. The parent write closes the small startup
+                # race for shells that schedule this block late.
+                printf '%s\n' "$BASHPID" >"$cgroup_path/cgroup.procs" \
+                    || exit 125
+                run_with_timeout "${command[@]}"
+            ) &
+            child=$!
+            if ! printf '%s\n' "$child" >"$cgroup_path/cgroup.procs" 2>/dev/null; then
+                kill "$child" 2>/dev/null || true
+                wait "$child" 2>/dev/null || true
+                cleanup_cgroup
+                trap - EXIT
+                cgroup_path=
+                enforcement=
+            else
+                if wait "$child"; then status=0; else status=$?; fi
+            fi
+            if [[ -n $cgroup_path ]]; then
+                kill -TERM -- "-$child" 2>/dev/null || true
+                sleep 0.05
+                kill -KILL -- "-$child" 2>/dev/null || true
+                drain_cgroup_processes
+                memory_max=$(cat "$cgroup_path/memory.max" 2>/dev/null || printf unavailable)
+                memory_high=$(cat "$cgroup_path/memory.high" 2>/dev/null || printf unavailable)
+                memory_swap_max=$(cat "$cgroup_path/memory.swap.max" 2>/dev/null || printf unavailable)
+                memory_peak=$(cat "$cgroup_path/memory.peak" 2>/dev/null || printf unavailable)
+                memory_events=$(tr '\n' ';' <"$cgroup_path/memory.events" 2>/dev/null || printf unavailable)
+                if grep -Eq '(^|;)oom_kill [1-9]|(^|;)oom [1-9]' <<<"$memory_events"; then
+                    resource_evidence=true
+                fi
+            fi
+        else
+            cleanup_candidate
+        fi
+    fi
+fi
+
+if [[ -z $enforcement ]]; then
+    if ! command -v prlimit >/dev/null 2>&1; then
+        write_evidence SKIP unsupported 77 false false unavailable unavailable unavailable unavailable unknown unavailable unavailable
+        echo "SKIP: no writable cgroup v2 and prlimit is unavailable" >&2
+        if ((allow_unsupported)); then exit 77; else exit 1; fi
+    fi
+    enforcement=rlimit-as
+    swap_policy=not-applicable
+    if run_with_timeout prlimit --as="$ceiling_bytes" -- "${command[@]}"; then
+        status=0
+    else
+        status=$?
+    fi
+fi
+
+if [[ $(cat "$timeout_marker" 2>/dev/null) == true ]]; then
+    timed_out=true
+fi
+
+disposition=FAIL
+if [[ $mode == success-required && $status -eq 0 && $timed_out == false \
+    && $resource_evidence == false ]]; then
+    disposition=PASS
+elif [[ $mode == expected-resource-error && $status -ne 0 \
+    && $timed_out == false && $resource_evidence == true ]]; then
+    disposition=EXPECTED_RESOURCE_ERROR
+fi
+
+write_evidence "$disposition" "$enforcement" "$status" "$timed_out" \
+    "$resource_evidence" "${cgroup_path:-unavailable}" "$memory_max" \
+    "$memory_high" "$memory_swap_max" "$swap_policy" "$memory_peak" \
+    "$memory_events"
+printf '%s: %s (evidence: %s)\n' "$disposition" "$enforcement" "$evidence_file"
+[[ $disposition == PASS || $disposition == EXPECTED_RESOURCE_ERROR ]]

--- a/scripts/ci/test-ci-pr-build-timeouts.py
+++ b/scripts/ci/test-ci-pr-build-timeouts.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Keep platform-specific CI build budgets explicit and reviewable.
+
+This is intentionally a small structural check rather than a general YAML
+parser.  The build-matrix block has a stable layout, and checking that layout
+without a third-party dependency keeps the ABI contract portable to Windows.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github/workflows/ci-pr.yml"
+EXPECTED_TIMEOUTS = {
+    "ubuntu-latest": 60,
+    "macos-latest": 60,
+    "windows-latest": 90,
+}
+
+
+def build_matrix(text: str) -> str:
+    match = re.search(r"^  build-matrix:\n(.*?)(?=^  \S|\Z)",
+                      text, re.MULTILINE | re.DOTALL)
+    assert match, "missing build-matrix job"
+    return match[1]
+
+
+def validate(text: str) -> None:
+    block = build_matrix(text)
+    timeout_lines = re.findall(r"^    timeout-minutes: (.+)$", block,
+                               re.MULTILINE)
+    assert timeout_lines == ["${{ matrix.timeout_minutes }}"], \
+        "build-matrix must use one matrix-specific timeout expression"
+
+    entries = re.findall(
+        r"^          - os: ([^\n]+)\n((?:            [^\n]*\n)*)",
+        block, re.MULTILINE)
+    operating_systems = [operating_system for operating_system, _ in entries]
+    assert len(set(operating_systems)) == len(operating_systems), \
+        "build-matrix must not contain duplicate platform entries"
+    assert len(entries) == len(EXPECTED_TIMEOUTS), \
+        "build-matrix must contain exactly one entry per platform"
+    actual = {}
+    for operating_system, body in entries:
+        timeout = re.search(r"^            timeout_minutes: (\d+)$", body,
+                            re.MULTILINE)
+        assert timeout, f"{operating_system} matrix entry lacks a timeout"
+        actual[operating_system] = int(timeout[1])
+    assert actual == EXPECTED_TIMEOUTS, \
+        f"unexpected build-matrix timeout mapping: {actual!r}"
+
+
+class CiPrBuildTimeoutTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_actual_workflow(self):
+        validate(self.text)
+
+    def test_global_timeout_is_rejected(self):
+        mutated = self.text.replace(
+            "timeout-minutes: ${{ matrix.timeout_minutes }}",
+            "timeout-minutes: 90")
+        with self.assertRaisesRegex(AssertionError, "matrix-specific"):
+            validate(mutated)
+
+    def test_missing_windows_budget_is_rejected(self):
+        mutated = re.sub(r"\n            timeout_minutes: 90(?=\n\n    steps:)",
+                         "", self.text)
+        with self.assertRaisesRegex(AssertionError, "lacks a timeout"):
+            validate(mutated)
+
+    def test_windows_budget_must_remain_distinct(self):
+        mutated = self.text.replace("timeout_minutes: 90", "timeout_minutes: 60")
+        with self.assertRaisesRegex(AssertionError, "unexpected"):
+            validate(mutated)
+
+    def test_duplicate_platform_entry_is_rejected(self):
+        entry = ("          - os: windows-latest\n"
+                 "            compiler: msvc\n"
+                 "            cc: cl\n"
+                 "            timeout_minutes: 90\n")
+        mutated = self.text.replace(entry, entry + entry)
+        with self.assertRaisesRegex(AssertionError, "duplicate"):
+            validate(mutated)
+
+    def test_linux_budget_cannot_be_relaxed_accidentally(self):
+        mutated = self.text.replace("timeout_minutes: 60", "timeout_minutes: 90", 1)
+        with self.assertRaisesRegex(AssertionError, "unexpected"):
+            validate(mutated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-run-memory-pressure.sh
+++ b/scripts/ci/test-run-memory-pressure.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Contract tests for run-memory-pressure.sh. These fixtures are intentionally
+# small; they validate evidence classification, not Wirelog workload memory.
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/../.." && pwd)
+runner=$root/scripts/ci/run-memory-pressure.sh
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-memory-pressure.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT
+
+run_success=$tmp/success
+if ! "$runner" --mode success-required --budget-bytes 1048576 \
+    --ceiling-bytes 268435456 --artifact-dir "$run_success" \
+    --timeout-seconds 10 -- sh -c 'printf contract-ok'; then
+    if grep -q '"disposition": "SKIP"' "$run_success/evidence.json" 2>/dev/null; then
+        echo "SKIP: local memory enforcement unavailable"
+        exit 77
+    fi
+    exit 1
+fi
+grep -q '"disposition": "PASS"' "$run_success/evidence.json"
+grep -q '"artifact_sha256"' "$run_success/evidence.json"
+grep -q '"command_argv"' "$run_success/evidence.json"
+grep -Eq '"binary_sha256": "[0-9a-f]{64}"' "$run_success/evidence.json"
+grep -q '"memory_swap_max"' "$run_success/evidence.json"
+grep -Eq '"swap_policy": "(disabled|not-applicable)"' "$run_success/evidence.json"
+grep -q 'contract-ok' "$run_success/stdout.log"
+
+# A bare SIGKILL is ambiguous and must not be accepted as a resource error.
+run_ambiguous=$tmp/ambiguous
+if "$runner" --mode expected-resource-error --budget-bytes 1048576 \
+    --ceiling-bytes 268435456 --artifact-dir "$run_ambiguous" \
+    --timeout-seconds 10 -- sh -c 'kill -KILL $$'; then
+    echo "FAIL: ambiguous SIGKILL was accepted as a resource error" >&2
+    exit 1
+fi
+grep -q '"disposition": "FAIL"' "$run_ambiguous/evidence.json"
+grep -q '"resource_failure_evidence": false' "$run_ambiguous/evidence.json"
+
+# Timeout is distinct from both success and resource failure.
+run_timeout=$tmp/timeout
+if "$runner" --mode success-required --budget-bytes 1048576 \
+    --ceiling-bytes 268435456 --artifact-dir "$run_timeout" \
+    --timeout-seconds 1 -- sh -c 'sleep 3'; then
+    echo "FAIL: timeout fixture unexpectedly passed" >&2
+    exit 1
+fi
+grep -q '"timeout": true' "$run_timeout/evidence.json"
+grep -q '"disposition": "FAIL"' "$run_timeout/evidence.json"
+
+# A command that ignores TERM is eventually killed by timeout's kill-after
+# path; that is still a timeout, not an ambiguous resource failure.
+run_hard_timeout=$tmp/hard-timeout
+if "$runner" --mode success-required --budget-bytes 1048576 \
+    --ceiling-bytes 268435456 --artifact-dir "$run_hard_timeout" \
+    --timeout-seconds 1 -- sh -c 'trap "" TERM; sleep 3'; then
+    echo "FAIL: hard-timeout fixture unexpectedly passed" >&2
+    exit 1
+fi
+grep -q '"timeout": true' "$run_hard_timeout/evidence.json"
+grep -q '"disposition": "FAIL"' "$run_hard_timeout/evidence.json"
+
+# Quotes and backslashes in argv must remain valid JSON strings.
+run_quoted=$tmp/quoted
+if ! "$runner" --mode success-required --budget-bytes 1048576 \
+    --ceiling-bytes 268435456 --artifact-dir "$run_quoted" \
+    --timeout-seconds 10 -- sh -c 'printf "%s" "quoted"'; then
+    exit 1
+fi
+grep -q '"command_argv"' "$run_quoted/evidence.json"
+grep -Fq 'printf \"%s\" \"quoted\"' "$run_quoted/evidence.json"
+
+echo "PASS: memory-pressure runner contract"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -717,6 +717,12 @@ test('perf_nightly_windows_contract', py3,
      args: [meson.project_source_root() / 'scripts/ci/test-perf-nightly-windows.py'],
      suite: 'abi')
 
+# Keep the longer Windows/MSVC build budget platform-specific; a global
+# timeout increase would hide Linux/macOS regressions in the PR gate.
+test('ci_pr_build_timeout_contract', py3,
+     args: [meson.project_source_root() / 'scripts/ci/test-ci-pr-build-timeouts.py'],
+     suite: 'abi')
+
 test('version_sync', py3,
      args: [meson.project_source_root() / 'scripts/ci/check-version-sync.py',
             meson.project_build_root() / 'wirelog'],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -843,6 +843,14 @@ endif
 # outcomes from a fixture repository, including the mismatch it exists to catch
 # -- which, because the gate enforces nowhere in CI today, had never run.
 if sh.found()
+  # Issue #1374: reusable external-limit evidence infrastructure.  This
+  # contract test does not claim that any workload or allocation class is
+  # bounded.
+  test('memory_pressure_contract', sh,
+       args: [meson.project_source_root() /
+              'scripts/ci/test-run-memory-pressure.sh'],
+       suite: 'abi')
+
   test('release_template_selftest', sh,
        args: [meson.project_source_root() /
               'scripts/ci/test-check-release-template.sh'],


### PR DESCRIPTION
Parent issue: #1374

## Atomic unit

This PR adds the reusable external-limit evidence runner needed by the bounded-memory qualification work. It intentionally does **not** close #1374 and does not claim that JOIN, TDD transport, allocation classes, or DOOP are bounded.

- Add `scripts/ci/run-memory-pressure.sh` with `success-required` and `expected-resource-error` modes.
- Prefer writable Linux cgroup v2 with an explicit zero-swap policy; record effective limits, swap policy, cgroup peak/events, process status, timeout, resource evidence, source/binary identity, command argv, and artifact hashes.
- Use a separately identified `RLIMIT_AS` fallback; it is not conflated with RSS or cgroup OOM evidence.
- Reject ambiguous SIGKILL/137 as resource success and classify watchdog TERM/KILL escalation as timeout.
- Clean process groups and partially-created cgroups before final evidence.
- Register shell contract coverage in the ABI suite and document the non-claim boundary.

## Validation

- `bash -n scripts/ci/run-memory-pressure.sh scripts/ci/test-run-memory-pressure.sh`
- Direct contract test passed via the local `RLIMIT_AS` fallback.
- Full normal build completed.
- ABI suite: 61 passed, 2 intentional skips, 0 failed.
- Bash construct ratchet and self-test passed.

A later #1374/#1385 unit can reuse the evidence schema for allocation-class and full DOOP qualification once those mechanisms exist.
