### PR TITLE
feat(#1371): add pin-safe cache reclaimer contract

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2558,6 +2558,25 @@ test_arrangement_lru_eviction_exe = executable(
 test('arrangement_lru_eviction', test_arrangement_lru_eviction_exe)
 
 # ============================================================================
+# Pin-safe Materialization Cache Reclaimer Tests (Issue #1371)
+# ============================================================================
+
+test_cache_reclaimer_exe = executable(
+  'test_cache_reclaimer',
+  files('test_cache_reclaimer.c'),
+  backend_src,
+  intern_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('cache_reclaimer', test_cache_reclaimer_exe, suite: 'unit')
+
+# ============================================================================
 # Filtered Relation Cache Tests (Issue #386)
 # ============================================================================
 

--- a/tests/test_cache_reclaimer.c
+++ b/tests/test_cache_reclaimer.c
@@ -1,0 +1,213 @@
+/*
+ * test_cache_reclaimer.c - pin/generation-safe materialization cache reclaim
+ *
+ * Issue #1371: the reclaimer must release only cache-owned capacity at a
+ * quiescent point and must remain safe across pinning, stale generations, and
+ * owner teardown.
+ */
+
+#include "columnar/internal.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+static col_rel_t *
+make_relation(int64_t value)
+{
+    col_rel_t *rel = col_rel_new_auto("cache_reclaim", 1);
+    assert(rel != NULL);
+    int64_t row[] = { value };
+    assert(col_rel_append_row(rel, row) == 0);
+    return rel;
+}
+
+static wl_mem_reclaim_result_t
+count_callback(void *owner)
+{
+    uint32_t *calls = (uint32_t *)owner;
+    (*calls)++;
+    wl_mem_reclaim_result_t result = { 0, 0 };
+    return result;
+}
+
+static void
+test_unregister_during_teardown(void)
+{
+    wl_mem_ledger_t ledger;
+    wl_mem_ledger_init(&ledger, 1);
+    uint32_t calls = 0;
+    wl_mem_reclaimer_handle_t handle = 0;
+
+    assert(wl_mem_ledger_register_reclaimer(&ledger, count_callback, &calls,
+        &handle) == 0);
+    assert(handle != 0);
+    wl_mem_ledger_unregister_reclaimer(&ledger, handle);
+    wl_mem_reclaim_result_t result = wl_mem_ledger_reclaim(&ledger);
+    assert(result.bytes_released == 0 && result.candidates == 0);
+    assert(calls == 0);
+}
+
+static void
+test_pin_generation_and_idempotence(void)
+{
+    wl_mem_ledger_t ledger;
+    wl_mem_ledger_init(&ledger, 0);
+    col_mat_cache_t cache;
+    memset(&cache, 0, sizeof(cache));
+    cache.ledger = &ledger;
+    assert(col_mat_cache_attach_reclaimer(&cache) == 0);
+
+    col_rel_t *result = make_relation(7);
+    assert(col_mat_cache_insert(&cache, result, result, result) == 0);
+    assert(cache.count == 1);
+    assert(cache.entries[0].owns_result);
+    uint64_t capacity = col_rel_transport_bytes(cache.entries[0].result);
+    assert(capacity > 0);
+
+    assert(col_mat_cache_lookup(&cache, result, result) == result);
+    assert(cache.entries[0].pin_count == 1);
+    /* Repeated hits in one evaluation epoch take only one pin. */
+    assert(col_mat_cache_lookup(&cache, result, result) == result);
+    assert(cache.entries[0].pin_count == 1);
+    wl_mem_reclaim_result_t reclaim = wl_mem_ledger_reclaim(&ledger);
+    assert(reclaim.bytes_released == 0 && reclaim.candidates == 0);
+    assert(cache.count == 1);
+
+    col_mat_cache_release_pins(&cache);
+    assert(cache.entries[0].pin_count == 0);
+    reclaim = wl_mem_ledger_reclaim(&ledger);
+    assert(reclaim.bytes_released == capacity);
+    assert(reclaim.candidates == 1 && cache.count == 0);
+
+    reclaim = wl_mem_ledger_reclaim(&ledger);
+    assert(reclaim.bytes_released == 0 && reclaim.candidates == 0);
+    col_mat_cache_detach_reclaimer(&cache);
+}
+
+static void
+test_generation_mismatch(void)
+{
+    wl_mem_ledger_t ledger;
+    wl_mem_ledger_init(&ledger, 0);
+    col_mat_cache_t cache;
+    memset(&cache, 0, sizeof(cache));
+    cache.ledger = &ledger;
+    col_rel_t *result = make_relation(11);
+    assert(col_mat_cache_insert(&cache, result, result, result) == 0);
+    uint64_t generation = cache.entries[0].generation;
+
+    wl_mem_reclaim_result_t reclaim
+        = col_mat_cache_reclaim_entry(&cache, 0, generation + 1);
+    assert(reclaim.bytes_released == 0 && reclaim.candidates == 0);
+    assert(cache.count == 1);
+
+    reclaim = col_mat_cache_reclaim_entry(&cache, 0, generation);
+    assert(reclaim.bytes_released > 0 && reclaim.candidates == 1);
+    assert(cache.count == 0);
+}
+
+static void
+test_shared_storage_is_not_reclaimable(void)
+{
+    wl_mem_ledger_t ledger;
+    wl_mem_ledger_init(&ledger, 0);
+    col_mat_cache_t cache;
+    memset(&cache, 0, sizeof(cache));
+    cache.ledger = &ledger;
+    assert(col_mat_cache_attach_reclaimer(&cache) == 0);
+
+    col_rel_t *source = make_relation(19);
+    col_rel_t *view = col_rel_new_like("cache_view", source);
+    assert(view != NULL);
+    assert(col_rel_install_shared_view(view, source) == 0);
+    assert(col_mat_cache_insert(&cache, source, source, view) == 0);
+    assert(cache.count == 1);
+    assert(!cache.entries[0].owns_result);
+
+    wl_mem_reclaim_result_t reclaim = wl_mem_ledger_reclaim(&ledger);
+    assert(reclaim.bytes_released == 0 && reclaim.candidates == 0);
+    assert(cache.count == 1);
+
+    col_mat_cache_detach_reclaimer(&cache);
+    col_mat_cache_clear(&cache);
+    col_rel_destroy(source);
+}
+
+static void
+test_lru_evicts_oldest_unpinned_entry(void)
+{
+    col_mat_cache_t cache;
+    memset(&cache, 0, sizeof(cache));
+
+    col_rel_t *oldest = make_relation(1);
+    col_rel_t *newest = make_relation(2);
+    assert(col_mat_cache_insert(&cache, oldest, oldest, oldest) == 0);
+    assert(col_mat_cache_insert(&cache, newest, newest, newest) == 0);
+    assert(cache.count == 2);
+    size_t before = cache.total_bytes;
+
+    col_mat_cache_evict_until(&cache, before);
+    assert(cache.count == 1);
+    assert(col_rel_get(cache.entries[0].result, 0, 0) == 2);
+
+    col_mat_cache_clear(&cache);
+}
+
+static void
+test_quiescent_step_release_makes_entry_evictable(void)
+{
+    col_mat_cache_t cache;
+    memset(&cache, 0, sizeof(cache));
+
+    col_rel_t *result = make_relation(3);
+    assert(col_mat_cache_insert(&cache, result, result, result) == 0);
+    assert(col_mat_cache_lookup(&cache, result, result) == result);
+    assert(cache.entries[0].pin_count == 1);
+
+    /* Model the quiescent boundary used after a session step/sub-pass. */
+    col_mat_cache_release_pins(&cache);
+    assert(cache.entries[0].pin_count == 0);
+    col_mat_cache_evict_until(&cache, 0);
+    assert(cache.count == 0);
+}
+
+static void
+test_pinned_insert_preserves_caller_ownership(void)
+{
+    col_mat_cache_t cache;
+    memset(&cache, 0, sizeof(cache));
+
+    col_rel_t *existing[COL_MAT_CACHE_MAX];
+    for (uint32_t i = 0; i < COL_MAT_CACHE_MAX; i++) {
+        existing[i] = make_relation((int64_t)i);
+        assert(col_mat_cache_insert(&cache, existing[i], existing[i],
+            existing[i]) == 0);
+        cache.entries[i].pin_count = 1;
+    }
+
+    col_rel_t *result = make_relation(1000);
+    assert(col_mat_cache_insert(&cache, result, result, result) == ENOSPC);
+    assert(cache.count == COL_MAT_CACHE_MAX);
+    assert(result->nrows == 1 && col_rel_get(result, 0, 0) == 1000);
+
+    for (uint32_t i = 0; i < cache.count; i++)
+        cache.entries[i].pin_count = 0;
+    col_mat_cache_clear(&cache);
+    col_rel_destroy(result);
+}
+
+int
+main(void)
+{
+    test_unregister_during_teardown();
+    test_pin_generation_and_idempotence();
+    test_generation_mismatch();
+    test_shared_storage_is_not_reclaimable();
+    test_lru_evicts_oldest_unpinned_entry();
+    test_quiescent_step_release_makes_entry_evictable();
+    test_pinned_insert_preserves_caller_ownership();
+    puts("cache reclaimer tests passed");
+    return 0;
+}

--- a/tests/test_mat_cache_lifetime.c
+++ b/tests/test_mat_cache_lifetime.c
@@ -136,7 +136,10 @@ test_lru_preserves_pinned_entry(void)
     ASSERT_TRUE(col_mat_cache_lookup(&cache, left[0], right[0]) == result[0],
         "LRU preserves the pinned entry");
     col_mat_cache_pin_release(&pin);
+    /* The legacy lookup above also holds a pin until the epoch ends. */
+    col_mat_cache_release_pins(&cache);
     col_mat_cache_clear(&cache);
+    ASSERT_TRUE(cache.count == 0, "quiescent cache clear releases all entries");
 
     /* Entries inserted into the cache are cache-owned after success. */
     for (size_t i = 0; i < COL_MAT_CACHE_MAX + 1; i++) {

--- a/wirelog/columnar/cache.c
+++ b/wirelog/columnar/cache.c
@@ -159,6 +159,9 @@ mat_cache_entry_destroy(col_mat_cache_t *cache, col_mat_entry_t *e)
     e->result = NULL;
     e->mem_bytes = 0;
     e->eviction_deferred = false;
+    e->owner_alive = false;
+    e->owns_result = false;
+    e->epoch_pin_count = 0;
 }
 
 static void
@@ -221,6 +224,31 @@ col_mat_cache_clear(col_mat_cache_t *cache)
 }
 
 void
+col_mat_cache_release_pins(col_mat_cache_t *cache)
+{
+    if (!cache)
+        return;
+    for (uint32_t i = 0; i < cache->count;) {
+        col_mat_entry_t *entry = &cache->entries[i];
+        if (entry->epoch_pin_count > 0) {
+            assert(entry->pin_count >= entry->epoch_pin_count);
+            entry->pin_count -= entry->epoch_pin_count;
+            assert(cache->active_pins >= entry->epoch_pin_count);
+            cache->active_pins -= entry->epoch_pin_count;
+            entry->epoch_pin_count = 0;
+            entry->pin_epoch = 0;
+        }
+        if (entry->pin_count == 0 && entry->eviction_deferred)
+            mat_cache_remove_at(cache, i);
+        else
+            i++;
+    }
+    cache->pin_epoch++;
+    if (cache->pin_epoch == 0)
+        cache->pin_epoch++;
+}
+
+void
 col_mat_cache_truncate(col_mat_cache_t *cache, uint32_t keep_count)
 {
     /* keep_count is a visible-prefix target.  Pinned suffix entries may keep
@@ -263,6 +291,10 @@ col_rel_t *
 col_mat_cache_lookup(col_mat_cache_t *cache, const col_rel_t *left,
     const col_rel_t *right)
 {
+    if (!cache)
+        return NULL;
+    if (cache->pin_epoch == 0)
+        cache->pin_epoch = 1;
     uint64_t lh = col_mat_cache_key_content(left);
     uint64_t rh = col_mat_cache_key_content(right);
     for (uint32_t i = 0; i < cache->count; i++) {
@@ -270,9 +302,18 @@ col_mat_cache_lookup(col_mat_cache_t *cache, const col_rel_t *left,
             && cache->entries[i].right_hash == rh
             && cache->entries[i].result != NULL
             && !cache->entries[i].eviction_deferred) {
+            col_mat_entry_t *entry = &cache->entries[i];
+            if (entry->owner_alive && entry->generation != 0
+                && entry->pin_epoch != cache->pin_epoch) {
+                entry->pin_count++;
+                entry->epoch_pin_count++;
+                entry->pin_epoch = cache->pin_epoch;
+                assert(cache->active_pins < UINT32_MAX);
+                cache->active_pins++;
+            }
             cache->entries[i].lru_clock = ++cache->clock;
             cache->hits++;
-            return cache->entries[i].result;
+            return entry->result;
         }
     }
     cache->misses++;
@@ -376,7 +417,22 @@ col_mat_cache_insert_pin(col_mat_cache_t *cache, const col_rel_t *left,
     if (e->identity == 0)
         e->identity = ++cache->next_identity;
     e->pin_count = 0;
+    e->epoch_pin_count = 0;
     e->eviction_deferred = false;
+    e->pin_epoch = 0;
+    e->generation = ++cache->next_generation;
+    if (e->generation == 0)
+        e->generation = ++cache->next_generation;
+    e->owner_alive = true;
+    e->owns_result = !result->pool_owned && !result->arena_owned;
+    if (e->owns_result && result->col_shared) {
+        for (uint32_t c = 0; c < result->ncols; c++) {
+            if (result->col_shared[c]) {
+                e->owns_result = false;
+                break;
+            }
+        }
+    }
     cache->total_bytes += result_bytes;
 
     /* Issue #1380: the cache now owns result, so its bytes move from
@@ -409,4 +465,74 @@ col_mat_cache_insert(col_mat_cache_t *cache, const col_rel_t *left,
     const col_rel_t *right, col_rel_t *result)
 {
     return col_mat_cache_insert_pin(cache, left, right, result, NULL);
+}
+
+static wl_mem_reclaim_result_t
+mat_cache_reclaimer(void *owner)
+{
+    col_mat_cache_t *cache = (col_mat_cache_t *)owner;
+    wl_mem_reclaim_result_t total = { 0, 0 };
+    if (!cache || !cache->reclaimer_owner_alive)
+        return total;
+    uint32_t index = 0;
+    while (index < cache->count) {
+        uint64_t generation = cache->entries[index].generation;
+        wl_mem_reclaim_result_t one
+            = col_mat_cache_reclaim_entry(cache, index, generation);
+        if (one.candidates > 0) {
+            total.bytes_released += one.bytes_released;
+            total.candidates += one.candidates;
+        } else {
+            index++;
+        }
+    }
+    return total;
+}
+
+int
+col_mat_cache_attach_reclaimer(col_mat_cache_t *cache)
+{
+    if (!cache || !cache->ledger)
+        return EINVAL;
+    if (cache->reclaimer_handle != 0)
+        return 0;
+    int rc = wl_mem_ledger_register_reclaimer(cache->ledger,
+        mat_cache_reclaimer, cache, &cache->reclaimer_handle);
+    if (rc == 0)
+        cache->reclaimer_owner_alive = true;
+    return rc;
+}
+
+void
+col_mat_cache_detach_reclaimer(col_mat_cache_t *cache)
+{
+    if (!cache)
+        return;
+    cache->reclaimer_owner_alive = false;
+    if (cache->ledger && cache->reclaimer_handle != 0)
+        wl_mem_ledger_unregister_reclaimer(cache->ledger,
+            cache->reclaimer_handle);
+    cache->reclaimer_handle = 0;
+}
+
+wl_mem_reclaim_result_t
+col_mat_cache_reclaim_entry(col_mat_cache_t *cache, uint32_t index,
+    uint64_t expected_generation)
+{
+    wl_mem_reclaim_result_t result = { 0, 0 };
+    if (!cache || index >= cache->count)
+        return result;
+    col_mat_entry_t *entry = &cache->entries[index];
+    if (entry->generation != expected_generation || !entry->owner_alive
+        || !entry->owns_result || !entry->result || entry->pin_count != 0)
+        return result;
+    /* Re-read ownership and pin state immediately before removal. */
+    if (entry->generation != expected_generation || !entry->owner_alive
+        || entry->pin_count != 0)
+        return result;
+    uint64_t released = col_rel_transport_bytes(entry->result);
+    mat_cache_remove_at(cache, index);
+    result.bytes_released = released;
+    result.candidates = 1;
+    return result;
 }

--- a/wirelog/columnar/cache.c
+++ b/wirelog/columnar/cache.c
@@ -497,7 +497,7 @@ col_mat_cache_attach_reclaimer(col_mat_cache_t *cache)
     if (cache->reclaimer_handle != 0)
         return 0;
     int rc = wl_mem_ledger_register_reclaimer(cache->ledger,
-        mat_cache_reclaimer, cache, &cache->reclaimer_handle);
+            mat_cache_reclaimer, cache, &cache->reclaimer_handle);
     if (rc == 0)
         cache->reclaimer_owner_alive = true;
     return rc;

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -1588,6 +1588,7 @@ tdd_worker_subpass_fn(void *arg)
     col_session_mem_sample(sess);
 
     /* Reset per-sub-pass allocators and cache (eval_serial.c:701-712) */
+    col_mat_cache_release_pins(&sess->mat_cache);
     delta_pool_reset(sess->delta_pool);
     sess->rotation_ops->rotate_eval_arena(sess);
     if (sess->cache_evict_threshold == 0) {

--- a/wirelog/columnar/eval_serial.c
+++ b/wirelog/columnar/eval_serial.c
@@ -286,6 +286,7 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
                     return rc;
             }
         }
+        col_mat_cache_release_pins(&sess->mat_cache);
         assert(sess->mat_cache.active_pins == 0);
         col_mat_cache_clear(&sess->mat_cache);
         assert(sess->mat_cache.active_pins == 0);
@@ -780,10 +781,12 @@ col_eval_stratum(const wl_plan_stratum_t *sp, wl_col_session_t *sess,
              * - If 0: clear entire cache each sub-pass (backward compatible)
              * - If > 0: evict LRU entries when cache exceeds threshold */
             if (sess->cache_evict_threshold == 0) {
+                col_mat_cache_release_pins(&sess->mat_cache);
                 assert(sess->mat_cache.active_pins == 0);
                 col_mat_cache_clear(&sess->mat_cache);
                 assert(sess->mat_cache.active_pins == 0);
             } else {
+                col_mat_cache_release_pins(&sess->mat_cache);
                 col_mat_cache_evict_until(&sess->mat_cache,
                     sess->cache_evict_threshold);
             }
@@ -902,6 +905,7 @@ stride_error:
     col_session_mem_sample(sess); /* Issue #1380 */
     delta_pool_reset(sess->delta_pool);
     sess->rotation_ops->rotate_eval_arena(sess);
+    col_mat_cache_release_pins(&sess->mat_cache);
     assert(sess->mat_cache.active_pins == 0);
     col_mat_cache_clear(&sess->mat_cache);
     assert(sess->mat_cache.active_pins == 0);

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1080,6 +1080,13 @@ typedef struct {
     uint64_t identity;
     uint32_t pin_count;
     bool eviction_deferred;
+    /* Reclaimer metadata is independent from relation/arrangement
+     * generations.  It is valid only for an owned, unshared result. */
+    uint64_t pin_epoch;
+    uint32_t epoch_pin_count;
+    uint64_t generation;
+    bool owner_alive;
+    bool owns_result;
 } col_mat_entry_t;
 
 typedef struct {
@@ -1101,9 +1108,13 @@ typedef struct col_mat_cache {
      * NULL disables accounting (K-fusion branch sessions). */
     wl_mem_ledger_t *ledger;
     uint64_t next_identity;
+    uint64_t next_generation;
+    uint64_t pin_epoch;
     /* Every lookup_pin/insert_pin handle must be released before its owning
      * session, worker, or cache is destroyed. */
     uint32_t active_pins;
+    wl_mem_reclaimer_handle_t reclaimer_handle;
+    bool reclaimer_owner_alive;
 } col_mat_cache_t;
 
 /* ======================================================================== */
@@ -2079,6 +2090,10 @@ col_mat_cache_lookup_pin(col_mat_cache_t *cache, const col_rel_t *left,
     const col_rel_t *right, col_mat_cache_pin_t *pin);
 void
 col_mat_cache_pin_release(col_mat_cache_pin_t *pin);
+/* Release only implicit epoch pins from the legacy lookup path.  Explicit
+ * col_mat_cache_pin_t handles remain owned by their callers. */
+void
+col_mat_cache_release_pins(col_mat_cache_t *cache);
 /*
  * col_mat_cache_truncate: keep_count is the visible-prefix target.  Destroy
  * entries [keep_count, count) when they are unpinned and keep total_bytes and
@@ -2089,6 +2104,15 @@ col_mat_cache_pin_release(col_mat_cache_pin_t *pin);
  */
 void
 col_mat_cache_truncate(col_mat_cache_t *cache, uint32_t keep_count);
+
+/* Internal pin/generation-safe cache reclaim contract. */
+int
+col_mat_cache_attach_reclaimer(col_mat_cache_t *cache);
+void
+col_mat_cache_detach_reclaimer(col_mat_cache_t *cache);
+wl_mem_reclaim_result_t
+col_mat_cache_reclaim_entry(col_mat_cache_t *cache, uint32_t index,
+    uint64_t expected_generation);
 
 /* ======================================================================== */
 /* Memory instrumentation (Issue #1380, columnar/session.c)                 */

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -403,6 +403,7 @@ cleanup:
     /* Trim mat_cache back to pre-dispatch baseline. Entries added by branches
      * are owned by the cache and must be freed the same way the parallel path
      * frees its worker caches. */
+    col_mat_cache_release_pins(&sess->mat_cache);
     col_mat_cache_truncate(&sess->mat_cache, mat_base);
     /* Sweep any pool slots allocated during branch eval (#549 ASAN fix).
      * Slots whose relations were already col_rel_destroy'd upstream are
@@ -589,6 +590,11 @@ col_op_k_fusion_dispatch(const wl_plan_op_t *op, eval_stack_t *stack,
         worker_sess[d].tdd_workers = NULL;
         worker_sess[d].tdd_workers_cap = 0;
         worker_sess[d].tdd_workers_count = 0;
+        /* The shallow session copy must not retain coordinator reclaimer
+         * callbacks after the worker cache is replaced below. */
+        memset(worker_sess[d].mem_ledger.reclaimers, 0,
+            sizeof(worker_sess[d].mem_ledger.reclaimers));
+        worker_sess[d].mem_ledger.next_reclaimer_handle = 0;
         if (worker_sess[d].join_output_limit > 0 && live_count > 1) {
             /* Issue #959: share one budget instead of splitting it. */
             worker_sess[d].join_output_shared_count = &shared_join_count;
@@ -836,6 +842,7 @@ cleanup_wq:
          * worker cache has no ledger (Issue #1380), so this is a plain
          * destroy of every entry. */
         assert(worker_sess[d].mat_cache.active_pins == 0);
+        col_mat_cache_release_pins(&worker_sess[d].mat_cache);
         col_mat_cache_clear(&worker_sess[d].mat_cache);
         assert(worker_sess[d].mat_cache.active_pins == 0);
         /* Issue #216: merge worker lru_clocks back into coordinator so

--- a/wirelog/columnar/mem_ledger.c
+++ b/wirelog/columnar/mem_ledger.c
@@ -12,6 +12,7 @@
 
 #include "columnar/mem_ledger.h"
 
+#include <errno.h>
 #ifndef _MSC_VER
 #include <stdatomic.h>
 #endif
@@ -188,6 +189,81 @@ wl_mem_ledger_free(wl_mem_ledger_t *ledger, int subsys, uint64_t bytes)
 
     counter_sub_clamped(&ledger->subsys_bytes[subsys], bytes);
     counter_sub_clamped(&ledger->current_bytes, bytes);
+}
+
+int
+wl_mem_ledger_register_reclaimer(wl_mem_ledger_t *ledger,
+    wl_mem_reclaimer_fn fn, void *owner, wl_mem_reclaimer_handle_t *out)
+{
+    if (!ledger || !fn || !out)
+        return EINVAL;
+
+    for (uint32_t i = 0; i < WL_MEM_LEDGER_MAX_RECLAIMERS; i++) {
+        wl_mem_reclaimer_slot_t *slot = &ledger->reclaimers[i];
+        if (slot->active)
+            continue;
+        wl_mem_reclaimer_handle_t handle = ++ledger->next_reclaimer_handle;
+        if (handle == 0)
+            handle = ++ledger->next_reclaimer_handle;
+        slot->fn = fn;
+        slot->owner = owner;
+        slot->handle = handle;
+        slot->active = true;
+        *out = handle;
+        return 0;
+    }
+    *out = 0;
+    return ENOSPC;
+}
+
+void
+wl_mem_ledger_unregister_reclaimer(wl_mem_ledger_t *ledger,
+    wl_mem_reclaimer_handle_t handle)
+{
+    if (!ledger || handle == 0)
+        return;
+    for (uint32_t i = 0; i < WL_MEM_LEDGER_MAX_RECLAIMERS; i++) {
+        wl_mem_reclaimer_slot_t *slot = &ledger->reclaimers[i];
+        if (!slot->active || slot->handle != handle)
+            continue;
+        /* Clear the owner before making the slot reusable.  A quiescent
+         * caller therefore cannot observe a live callback with a dead owner. */
+        slot->fn = NULL;
+        slot->owner = NULL;
+        slot->handle = 0;
+        slot->active = false;
+        return;
+    }
+}
+
+wl_mem_reclaim_result_t
+wl_mem_ledger_reclaim(wl_mem_ledger_t *ledger)
+{
+    wl_mem_reclaim_result_t total = { 0, 0 };
+    if (!ledger)
+        return total;
+
+    /* The owner supplies the quiescent point.  Copying the callback and
+     * context before invocation lets a callback unregister itself safely;
+     * its owner remains responsible for surviving until this call returns. */
+    for (uint32_t i = 0; i < WL_MEM_LEDGER_MAX_RECLAIMERS; i++) {
+        wl_mem_reclaimer_fn fn = ledger->reclaimers[i].active
+            ? ledger->reclaimers[i].fn : NULL;
+        void *owner = ledger->reclaimers[i].active
+            ? ledger->reclaimers[i].owner : NULL;
+        if (!fn)
+            continue;
+        wl_mem_reclaim_result_t result = fn(owner);
+        if (UINT64_MAX - total.bytes_released < result.bytes_released)
+            total.bytes_released = UINT64_MAX;
+        else
+            total.bytes_released += result.bytes_released;
+        if (UINT32_MAX - total.candidates < result.candidates)
+            total.candidates = UINT32_MAX;
+        else
+            total.candidates += result.candidates;
+    }
+    return total;
 }
 
 void

--- a/wirelog/columnar/mem_ledger.h
+++ b/wirelog/columnar/mem_ledger.h
@@ -110,6 +110,27 @@ wl_atomic_compare_exchange_weak_internal(volatile __int64 *ptr,
 typedef _Atomic uint64_t wl_atomic_u64;
 #endif
 
+/* Reclaimers are invoked only at an owner-defined quiescent point.  The
+ * registry deliberately has fixed storage: registering or unregistering a
+ * callback must not allocate while the process is under memory pressure. */
+#define WL_MEM_LEDGER_MAX_RECLAIMERS 8u
+
+typedef uint64_t wl_mem_reclaimer_handle_t;
+
+typedef struct {
+    uint64_t bytes_released; /* measured bytes actually returned to allocator */
+    uint32_t candidates;     /* candidates examined by the callback(s) */
+} wl_mem_reclaim_result_t;
+
+typedef wl_mem_reclaim_result_t (*wl_mem_reclaimer_fn)(void *owner);
+
+typedef struct {
+    wl_mem_reclaimer_fn fn;
+    void *owner;
+    wl_mem_reclaimer_handle_t handle;
+    bool active;
+} wl_mem_reclaimer_slot_t;
+
 /* ======================================================================== */
 /* Subsystem IDs                                                            */
 /* ======================================================================== */
@@ -180,6 +201,8 @@ typedef struct wl_mem_ledger {
     wl_atomic_u64 peak_bytes;
     wl_atomic_u64 subsys_bytes[WL_MEM_SUBSYS_COUNT];
     wl_atomic_u64 subsys_peak[WL_MEM_SUBSYS_COUNT];
+    wl_mem_reclaimer_slot_t reclaimers[WL_MEM_LEDGER_MAX_RECLAIMERS];
+    wl_mem_reclaimer_handle_t next_reclaimer_handle;
 } wl_mem_ledger_t;
 
 /*
@@ -238,6 +261,21 @@ wl_mem_ledger_alloc(wl_mem_ledger_t *ledger, int subsys, uint64_t bytes);
  */
 void
 wl_mem_ledger_free(wl_mem_ledger_t *ledger, int subsys, uint64_t bytes);
+
+/* Register/unregister a callback used by a quiescent owner to release
+ * reclaimable capacity.  Unregister before destroying @owner.  A stale
+ * handle cannot unregister a later callback that reused the slot. */
+int
+wl_mem_ledger_register_reclaimer(wl_mem_ledger_t *ledger,
+    wl_mem_reclaimer_fn fn, void *owner, wl_mem_reclaimer_handle_t *out);
+void
+wl_mem_ledger_unregister_reclaimer(wl_mem_ledger_t *ledger,
+    wl_mem_reclaimer_handle_t handle);
+
+/* Invoke currently registered reclaimers.  Callers must provide a quiescent
+ * point for every owner and keep owners alive until this function returns. */
+wl_mem_reclaim_result_t
+wl_mem_ledger_reclaim(wl_mem_ledger_t *ledger);
 
 /*
  * wl_mem_ledger_over_budget:

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -2428,8 +2428,7 @@ col_session_step(wl_session_t *session)
 
     if (sess->delta_cb && !sess->pending_input_change
         && sess->last_inserted_relation == NULL
-        && sess->last_removed_relation == NULL)
-    {
+        && sess->last_removed_relation == NULL){
         col_session_reclaim_quiescent(sess);
         return 0;
     }
@@ -2695,7 +2694,7 @@ col_session_reclaim_quiescent(wl_col_session_t *sess)
         return;
     if (!wl_mem_ledger_over_budget(&sess->mem_ledger)
         && !wl_mem_ledger_subsys_over_budget(&sess->mem_ledger,
-            WL_MEM_SUBSYS_CACHE))
+        WL_MEM_SUBSYS_CACHE))
         return;
     (void)wl_mem_ledger_reclaim(&sess->mem_ledger);
 }

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -113,6 +113,7 @@ static void
 session_invalidate_relation_caches(wl_col_session_t *sess, const char *name)
 {
     col_session_invalidate_arrangements(&sess->base, name);
+    col_mat_cache_release_pins(&sess->mat_cache);
     assert(sess->mat_cache.active_pins == 0);
     col_mat_cache_clear(&sess->mat_cache);
     assert(sess->mat_cache.active_pins == 0);
@@ -1268,6 +1269,7 @@ col_session_create_internal(const wl_plan_t *plan, uint32_t num_workers,
      * results onto this ledger from here on. */
     sess->mem_report_level = col_session_mem_report_level();
     sess->mat_cache.ledger = &sess->mem_ledger;
+    (void)col_mat_cache_attach_reclaimer(&sess->mat_cache);
     ledger_charge_allocators(sess);
 
     /* Issue #264: Initialize differential path master switch.
@@ -1576,6 +1578,8 @@ col_session_destroy(wl_session_t *session)
     free((void *)sess->rels);
     /* Free relation name hash table (Issue #281) */
     session_rel_free_hash(sess);
+    col_mat_cache_detach_reclaimer(&sess->mat_cache);
+    col_mat_cache_release_pins(&sess->mat_cache);
     assert(sess->mat_cache.active_pins == 0);
     col_mat_cache_clear(&sess->mat_cache);
     assert(sess->mat_cache.active_pins == 0);
@@ -1919,6 +1923,7 @@ col_worker_session_destroy(wl_col_session_t *worker)
     }
 
     /* Free mat_cache entries (all worker-owned since zeroed at create) */
+    col_mat_cache_release_pins(&worker->mat_cache);
     assert(worker->mat_cache.active_pins == 0);
     col_mat_cache_clear(&worker->mat_cache);
     assert(worker->mat_cache.active_pins == 0);
@@ -2412,6 +2417,8 @@ next_del_incr:;
  * @param session: wl_session_t* (cast to wl_col_session_t* internally)
  * @return 0 on success, non-zero on evaluation error
  */
+static void col_session_reclaim_quiescent(wl_col_session_t *sess);
+
 static int
 col_session_step(wl_session_t *session)
 {
@@ -2422,7 +2429,10 @@ col_session_step(wl_session_t *session)
     if (sess->delta_cb && !sess->pending_input_change
         && sess->last_inserted_relation == NULL
         && sess->last_removed_relation == NULL)
+    {
+        col_session_reclaim_quiescent(sess);
         return 0;
+    }
 
     /* Compute affected strata bitmask (Phase 4 incremental skip).
      * A step may carry both an insertion and a removal, and the two
@@ -2517,6 +2527,7 @@ col_session_step(wl_session_t *session)
                 sess->delta_event_transaction = false;
                 wl_columnar_delta_events_clear(sess);
             }
+            col_session_reclaim_quiescent(sess);
             return rc;
         }
     }
@@ -2560,6 +2571,7 @@ col_session_step(wl_session_t *session)
             r->base_nrows = r->nrows;
     }
     sess->snapshot_stable_valid = true;
+    col_session_reclaim_quiescent(sess);
     return 0;
 }
 
@@ -2664,9 +2676,28 @@ col_session_clear_idb_rows(const wl_plan_t *plan, wl_col_session_t *sess)
             col_session_invalidate_arrangements(&sess->base, r->name);
         }
     }
+    col_mat_cache_release_pins(&sess->mat_cache);
     assert(sess->mat_cache.active_pins == 0);
     col_mat_cache_clear(&sess->mat_cache);
     assert(sess->mat_cache.active_pins == 0);
+}
+
+/* Snapshot/step completion is the coordinator's quiescent boundary.  Explicit
+ * pins must already have been released by join.c; only then may the ledger
+ * callback reclaim owned cache entries under memory pressure. */
+static void
+col_session_reclaim_quiescent(wl_col_session_t *sess)
+{
+    if (!sess)
+        return;
+    col_mat_cache_release_pins(&sess->mat_cache);
+    if (!sess->mat_cache.reclaimer_owner_alive)
+        return;
+    if (!wl_mem_ledger_over_budget(&sess->mem_ledger)
+        && !wl_mem_ledger_subsys_over_budget(&sess->mem_ledger,
+            WL_MEM_SUBSYS_CACHE))
+        return;
+    (void)wl_mem_ledger_reclaim(&sess->mem_ledger);
 }
 
 static void
@@ -2745,6 +2776,7 @@ col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
         if (tdd_profile_active)
             wl_columnar_session_profile_begin(plan, 0, sess->num_workers, true);
         int rc = col_session_emit_snapshot(plan, sess, callback, user_data);
+        col_session_reclaim_quiescent(sess);
         if (tdd_profile_active && rc == 0)
             fprintf(stderr, "TDD snapshot complete evaluated_count=0 rc=0\n");
         return rc;
@@ -3116,6 +3148,7 @@ col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
             }
             sess->nrels = out;
             sess->tdd_decision_tracking_active = false;
+            col_session_reclaim_quiescent(sess);
             return rc;
         }
         if (sess->eval_arena)
@@ -3154,6 +3187,7 @@ col_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
 
     int snapshot_rc = col_session_emit_snapshot(plan, sess, callback,
             user_data);
+    col_session_reclaim_quiescent(sess);
     if (tdd_profile_active && snapshot_rc == 0)
         fprintf(stderr, "TDD snapshot complete evaluated_count=%u rc=0\n",
             tdd_profile_evaluated);


### PR DESCRIPTION
## Summary
- add a fixed-capacity internal mem_ledger reclaimer registry with measured reclaim results
- add a pin/generation/ownership-safe materialization-cache reclaimer at session, step, recursive, TDD, and K-fusion quiescent boundaries
- preserve caller ownership when cache insertion cannot evict pinned entries and fix LRU selection
- isolate K-fusion worker ledger callback registries from coordinator ownership
- add focused cache reclaimer and lifetime regression coverage

## Validation
- normal: cache_reclaimer, mem_ledger_contract, incremental_insertion, filt_cache, tdd_nonrecursive, tdd_recursive, tdd_convergence, tdd_exchange, join_hash_probe, diff_join, worker_session, k_fusion_memory
- ASan/UBSan: cache_reclaimer, mem_ledger_contract, incremental_insertion, filt_cache, tdd_nonrecursive, tdd_recursive, tdd_convergence, tdd_exchange, join_hash_probe, diff_join, worker_session, k_fusion_memory
- git diff --check

Relation and diff trace compaction, spill, continuation, and DOOP end-to-end behavior remain outside this atomic unit.

Refs #1371