### PR TITLE
test(#1454): define TDD multi-batch protocol harness

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -471,6 +471,20 @@ test_csv_streaming_exe = executable(
 
 test('csv_streaming', test_csv_streaming_exe)
 
+# Issue #1454: executable-only fake protocol contract.  This deliberately does
+# not enter wirelog_backend_src: it is a harness for handoff points #1373,
+# #1372, #1369, and #1451, not a production transport implementation.
+test_tdd_multi_batch_protocol_exe = executable(
+  'test_tdd_multi_batch_protocol',
+  files('test_tdd_multi_batch_protocol.c'),
+  files('../wirelog/columnar/tdd_protocol.c'),
+  thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
+)
+test('tdd_multi_batch_protocol', test_tdd_multi_batch_protocol_exe,
+     suite: 'unit')
+
 # Issue #508: bench_argv shim unit tests. Header-only, portable by
 # construction; runs on every platform including MSVC.
 test_bench_argv_exe = executable(

--- a/tests/test_tdd_multi_batch_protocol.c
+++ b/tests/test_tdd_multi_batch_protocol.c
@@ -1,0 +1,257 @@
+/* Fake/internal TDD multi-batch protocol contract tests for issue #1454. */
+#include "../wirelog/columnar/tdd_protocol.h"
+#include "../wirelog/thread.h"
+
+#include <assert.h>
+#ifndef _MSC_VER
+#include <stdatomic.h>
+#else
+#include <windows.h>
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+
+#define BLOCKED_TIMEOUT_MS 1000u
+
+#ifndef _MSC_VER
+typedef atomic_size_t submitted_count_t;
+#define submitted_load(ptr) atomic_load(ptr)
+#define submitted_increment(ptr) atomic_fetch_add((ptr), 1)
+#else
+/* MSVC does not provide C11 atomics; match the established test fallback. */
+typedef volatile LONG submitted_count_t;
+#define submitted_load(ptr) (*(ptr))
+#define submitted_increment(ptr) InterlockedIncrement((ptr))
+#endif
+
+typedef struct {
+    wl_columnar_tdd_protocol_t *protocol;
+    wl_columnar_tdd_payload_t *payloads;
+    size_t start;
+    size_t count;
+    submitted_count_t submitted;
+    submitted_count_t started;
+    submitted_count_t finished;
+} producer_arg_t;
+
+static void *producer(void *opaque)
+{
+    producer_arg_t *arg = opaque;
+    size_t i;
+    for (i = arg->start; i < arg->start + arg->count; i++) {
+        submitted_increment(&arg->started);
+        wl_columnar_tdd_submit_result_t result =
+            wl_columnar_tdd_protocol_submit(arg->protocol, &arg->payloads[i]);
+        submitted_increment(&arg->finished);
+        if (result != WL_COLUMNAR_TDD_SUBMITTED)
+            break;
+        submitted_increment(&arg->submitted);
+    }
+    return NULL;
+}
+
+static wl_columnar_tdd_payload_t *payloads(size_t count,
+    wl_columnar_tdd_reservation_t *reservations)
+{
+    wl_columnar_tdd_payload_t *items = calloc(count, sizeof(*items));
+    size_t i;
+    assert(items != NULL);
+    for (i = 0; i < count; i++) {
+        items[i] = (wl_columnar_tdd_payload_t){
+            i + 1, 7, 3, 11, (uint32_t)i, &reservations[i]
+        };
+        reservations[i].id = i + 1;
+    }
+    return items;
+}
+
+static void consume(wl_columnar_tdd_message_t *message)
+{
+    wl_columnar_tdd_message_release(message);
+}
+
+static void test_order_and_empty(void)
+{
+    wl_columnar_tdd_reservation_t reservations[3] = {{0}};
+    wl_columnar_tdd_payload_t *items = payloads(3, reservations);
+    wl_columnar_tdd_protocol_t *protocol = wl_columnar_tdd_protocol_create(4);
+    wl_columnar_tdd_message_t message;
+    assert(wl_columnar_tdd_protocol_pump(protocol,
+        &message) == WL_COLUMNAR_TDD_EMPTY);
+    assert(wl_columnar_tdd_protocol_submit(protocol,
+        &items[0]) == WL_COLUMNAR_TDD_SUBMITTED);
+    assert(wl_columnar_tdd_protocol_submit(protocol,
+        &items[1]) == WL_COLUMNAR_TDD_SUBMITTED);
+    assert(wl_columnar_tdd_protocol_submit(protocol,
+        &items[2]) == WL_COLUMNAR_TDD_SUBMITTED);
+    assert(wl_columnar_tdd_protocol_complete(protocol) ==
+        WL_COLUMNAR_TDD_SUBMITTED);
+    for (size_t i = 0; i < 3; i++) {
+        assert(wl_columnar_tdd_protocol_pump(protocol,
+            &message) == WL_COLUMNAR_TDD_DATA);
+        assert(message.payload == &items[i]);
+        consume(&message);
+    }
+    assert(wl_columnar_tdd_protocol_pump(protocol,
+        &message) == WL_COLUMNAR_TDD_COMPLETE);
+    assert(wl_columnar_tdd_protocol_pump(protocol,
+        &message) == WL_COLUMNAR_TDD_EMPTY);
+    for (size_t i = 0; i < 3; i++) {
+        assert(items[i].release_count == 1);
+        assert(reservations[i].transfer_count == 1);
+        assert(reservations[i].release_count == 1);
+    }
+    wl_columnar_tdd_protocol_destroy(protocol);
+    free(items);
+}
+
+static void test_null_pump_preserves_data(void)
+{
+    wl_columnar_tdd_reservation_t reservations[1] = {{0}};
+    wl_columnar_tdd_payload_t *items = payloads(1, reservations);
+    wl_columnar_tdd_protocol_t *protocol = wl_columnar_tdd_protocol_create(2);
+    wl_columnar_tdd_message_t message;
+    assert(wl_columnar_tdd_protocol_submit(protocol,
+        &items[0]) == WL_COLUMNAR_TDD_SUBMITTED);
+    assert(wl_columnar_tdd_protocol_pump(protocol,
+        NULL) == WL_COLUMNAR_TDD_DATA);
+    assert(items[0].release_count == 0);
+    assert(reservations[0].release_count == 0);
+    assert(wl_columnar_tdd_protocol_pump(protocol,
+        &message) == WL_COLUMNAR_TDD_DATA);
+    assert(message.payload == &items[0]);
+    consume(&message);
+    assert(items[0].release_count == 1);
+    assert(reservations[0].release_count == 1);
+    wl_columnar_tdd_protocol_destroy(protocol);
+    free(items);
+}
+
+static void test_progress_with_blocked_producer(void)
+{
+    wl_columnar_tdd_reservation_t reservations[6] = {{0}};
+    wl_columnar_tdd_payload_t *items = payloads(6, reservations);
+    wl_columnar_tdd_protocol_t *protocol = wl_columnar_tdd_protocol_create(2);
+    producer_arg_t arg = {protocol, items, 0, 6, 0, 0, 0};
+    thread_t thread;
+    wl_columnar_tdd_message_t message;
+    size_t expected;
+    assert(thread_create(&thread, producer, &arg) == 0);
+
+    if (!wl_columnar_tdd_protocol_wait_full_with_blocked_submitter(protocol,
+        BLOCKED_TIMEOUT_MS)) {
+        wl_columnar_tdd_protocol_cancel(protocol);
+        assert(thread_join(&thread) == 0);
+        wl_columnar_tdd_protocol_destroy(protocol);
+        free(items);
+        fprintf(stderr,
+            "test_progress_with_blocked_producer: producer was not observed "
+            "blocked in a full queue within %u ms\n",
+            BLOCKED_TIMEOUT_MS);
+        abort();
+    }
+    assert(submitted_load(&arg.submitted) == 2);
+    assert(submitted_load(&arg.started) == 3);
+    assert(submitted_load(&arg.finished) == 2);
+
+    for (expected = 3; expected <= 5; expected++) {
+        assert(wl_columnar_tdd_protocol_pump(protocol,
+            &message) == WL_COLUMNAR_TDD_DATA);
+        consume(&message);
+        if (!wl_columnar_tdd_protocol_wait_full_with_blocked_submitter(
+                protocol, BLOCKED_TIMEOUT_MS)) {
+            wl_columnar_tdd_protocol_cancel(protocol);
+            assert(thread_join(&thread) == 0);
+            wl_columnar_tdd_protocol_destroy(protocol);
+            free(items);
+            fprintf(stderr,
+                "test_progress_with_blocked_producer: did not observe "
+                "%zu submissions followed by a blocked full queue within "
+                "%u ms\n",
+                expected, BLOCKED_TIMEOUT_MS);
+            abort();
+        }
+        assert(submitted_load(&arg.submitted) == expected);
+        assert(submitted_load(&arg.started) == expected + 1);
+        assert(submitted_load(&arg.finished) == expected);
+    }
+
+    assert(wl_columnar_tdd_protocol_pump(protocol,
+        &message) == WL_COLUMNAR_TDD_DATA);
+    consume(&message);
+    assert(thread_join(&thread) == 0);
+    assert(submitted_load(&arg.submitted) == 6);
+    assert(submitted_load(&arg.started) == 6);
+    assert(submitted_load(&arg.finished) == 6);
+    while (wl_columnar_tdd_protocol_pump(protocol,
+        &message) == WL_COLUMNAR_TDD_DATA)
+        consume(&message);
+    assert(wl_columnar_tdd_protocol_complete(protocol) ==
+        WL_COLUMNAR_TDD_SUBMITTED);
+    while (wl_columnar_tdd_protocol_pump(protocol,
+        &message) == WL_COLUMNAR_TDD_DATA)
+        consume(&message);
+    assert(message.kind == WL_COLUMNAR_TDD_COMPLETE);
+    for (size_t i = 0; i < 6; i++)
+        assert(items[i].release_count == 1);
+    wl_columnar_tdd_protocol_destroy(protocol);
+    free(items);
+}
+
+static void test_cancel_partial_and_alias(void)
+{
+    wl_columnar_tdd_reservation_t reservations[3] = {{0}};
+    wl_columnar_tdd_payload_t *items = payloads(3, reservations);
+    wl_columnar_tdd_protocol_t *protocol = wl_columnar_tdd_protocol_create(2);
+    producer_arg_t arg = {protocol, items, 2, 1, 0, 0, 0};
+    thread_t thread;
+    assert(wl_columnar_tdd_protocol_submit(protocol,
+        &items[0]) == WL_COLUMNAR_TDD_SUBMITTED);
+    assert(wl_columnar_tdd_protocol_submit(protocol,
+        &items[1]) == WL_COLUMNAR_TDD_SUBMITTED);
+    assert(wl_columnar_tdd_protocol_submit(protocol,
+        &items[0]) == WL_COLUMNAR_TDD_DUPLICATE);
+    items[2].reservation = items[0].reservation;
+    assert(wl_columnar_tdd_protocol_submit(protocol,
+        &items[2]) == WL_COLUMNAR_TDD_DUPLICATE);
+    items[2].reservation = &reservations[2];
+    assert(thread_create(&thread, producer, &arg) == 0);
+    if (!wl_columnar_tdd_protocol_wait_full_with_blocked_submitter(protocol,
+        BLOCKED_TIMEOUT_MS)) {
+        wl_columnar_tdd_protocol_cancel(protocol);
+        assert(thread_join(&thread) == 0);
+        wl_columnar_tdd_protocol_destroy(protocol);
+        free(items);
+        fprintf(stderr,
+            "test_cancel_partial_and_alias: producer was not observed "
+            "blocked in a full queue within %u ms\n",
+            BLOCKED_TIMEOUT_MS);
+        abort();
+    }
+    assert(submitted_load(&arg.started) == 1);
+    assert(submitted_load(&arg.finished) == 0);
+    wl_columnar_tdd_protocol_cancel(protocol);
+    assert(thread_join(&thread) == 0);
+    assert(submitted_load(&arg.finished) == 1);
+    assert(submitted_load(&arg.submitted) == 0);
+    assert(items[0].release_count == 1);
+    assert(reservations[0].release_count == 1);
+    assert(items[1].release_count == 1);
+    assert(reservations[1].release_count == 1);
+    assert(items[2].release_count == 0);
+    assert(reservations[2].release_count == 0);
+    assert(wl_columnar_tdd_protocol_pump(protocol,
+        NULL) == WL_COLUMNAR_TDD_CANCELLED);
+    wl_columnar_tdd_protocol_destroy(protocol);
+    free(items);
+}
+
+int main(void)
+{
+    test_order_and_empty();
+    test_null_pump_preserves_data();
+    test_progress_with_blocked_producer();
+    test_cancel_partial_and_alias();
+    puts("TDD multi-batch protocol harness: PASS");
+    return 0;
+}

--- a/wirelog/columnar/tdd_protocol.c
+++ b/wirelog/columnar/tdd_protocol.c
@@ -1,0 +1,347 @@
+/*
+ * tdd_protocol.c - bounded fake TDD publication protocol.
+ *
+ * INTERNAL TEST HARNESS ONLY.  It deliberately models a protocol boundary,
+ * not the evaluator or any production queue.  Producers may block on the
+ * bounded channel; the coordinator must pump concurrently to make progress.
+ */
+#include "tdd_protocol.h"
+
+#include "../thread.h"
+
+#if defined(WL_HAVE_C11_THREADS) || (!defined(_WIN32) && !defined(_WIN64))
+#include <time.h>
+#endif
+#include <stdlib.h>
+#include <stdint.h>
+
+typedef struct {
+    wl_columnar_tdd_pump_result_t kind;
+    wl_columnar_tdd_payload_t *payload;
+} wl_columnar_tdd_entry_t;
+
+struct wl_columnar_tdd_protocol {
+    mutex_t mutex;
+    cond_t can_submit;
+    cond_t state_changed;
+    size_t capacity;
+    size_t count;
+    size_t head;
+    size_t tail;
+    size_t blocked_submitters;
+    wl_columnar_tdd_entry_t *entries;
+    bool cancelled;
+    bool complete_requested;
+};
+
+static uint64_t
+wl_columnar_tdd_now_ms(void)
+{
+#if defined(WL_HAVE_C11_THREADS) || (!defined(_WIN32) && !defined(_WIN64))
+    struct timespec now;
+    if (timespec_get(&now, TIME_UTC) != TIME_UTC)
+        return 0;
+    return (uint64_t)now.tv_sec * 1000u +
+           (uint64_t)now.tv_nsec / 1000000u;
+#else
+    return (uint64_t)GetTickCount64();
+#endif
+}
+
+#if defined(WL_HAVE_C11_THREADS) || (!defined(_WIN32) && !defined(_WIN64))
+static struct timespec
+wl_columnar_tdd_deadline_from_now(unsigned timeout_ms)
+{
+    struct timespec now;
+    struct timespec deadline;
+    if (timespec_get(&now, TIME_UTC) != TIME_UTC)
+        now = (struct timespec){0, 0};
+    deadline = now;
+    deadline.tv_sec += timeout_ms / 1000u;
+    deadline.tv_nsec += (long)(timeout_ms % 1000u) * 1000000L;
+    if (deadline.tv_nsec >= 1000000000L) {
+        deadline.tv_sec++;
+        deadline.tv_nsec -= 1000000000L;
+    }
+    return deadline;
+}
+#endif
+
+static int
+wl_columnar_tdd_cond_timedwait(cond_t *cond, mutex_t *mutex,
+    unsigned timeout_ms)
+{
+#if defined(WL_HAVE_C11_THREADS)
+    struct timespec deadline = wl_columnar_tdd_deadline_from_now(timeout_ms);
+    return cnd_timedwait(&cond->c, &mutex->m, &deadline) == thrd_success
+        ? 0 : -1;
+#elif defined(_WIN32) || defined(_WIN64)
+    if (SleepConditionVariableCS(&cond->cv, &mutex->cs, timeout_ms))
+        return 0;
+    return -1;
+#else
+    struct timespec deadline = wl_columnar_tdd_deadline_from_now(timeout_ms);
+    int rc = pthread_cond_timedwait(&cond->c, &mutex->m, &deadline);
+    return rc == 0 ? 0 : -1;
+#endif
+}
+
+static bool
+wl_columnar_tdd_full_with_blocked_submitter(
+    const wl_columnar_tdd_protocol_t *protocol)
+{
+    return protocol->count == protocol->capacity &&
+           protocol->blocked_submitters != 0;
+}
+
+static bool
+wl_columnar_tdd_queue_contains(const wl_columnar_tdd_protocol_t *protocol,
+    const wl_columnar_tdd_payload_t *payload)
+{
+    size_t i;
+    size_t index;
+    for (i = 0, index = protocol->head; i < protocol->count; i++) {
+        const wl_columnar_tdd_entry_t *entry = &protocol->entries[index];
+        if (entry->kind == WL_COLUMNAR_TDD_DATA &&
+            (entry->payload == payload ||
+            entry->payload->reservation == payload->reservation))
+            return true;
+        index = (index + 1) % protocol->capacity;
+    }
+    return false;
+}
+
+static void
+wl_columnar_tdd_discard(wl_columnar_tdd_payload_t *payload)
+{
+    if (payload == NULL)
+        return;
+    wl_columnar_tdd_payload_release(payload);
+    if (payload->reservation != NULL)
+        payload->reservation->release_count++;
+}
+
+wl_columnar_tdd_protocol_t *
+wl_columnar_tdd_protocol_create(size_t capacity)
+{
+    wl_columnar_tdd_protocol_t *protocol;
+    if (capacity == 0)
+        return NULL;
+    protocol = calloc(1, sizeof(*protocol));
+    if (protocol == NULL)
+        return NULL;
+    protocol->entries = calloc(capacity, sizeof(*protocol->entries));
+    if (protocol->entries == NULL) {
+        free(protocol);
+        return NULL;
+    }
+    protocol->capacity = capacity;
+    if (mutex_init(&protocol->mutex) != 0) {
+        free(protocol->entries);
+        free(protocol);
+        return NULL;
+    }
+    if (cond_init(&protocol->can_submit) != 0) {
+        mutex_destroy(&protocol->mutex);
+        free(protocol->entries);
+        free(protocol);
+        return NULL;
+    }
+    if (cond_init(&protocol->state_changed) != 0) {
+        cond_destroy(&protocol->can_submit);
+        mutex_destroy(&protocol->mutex);
+        free(protocol->entries);
+        free(protocol);
+        return NULL;
+    }
+    return protocol;
+}
+
+void
+wl_columnar_tdd_protocol_cancel(wl_columnar_tdd_protocol_t *protocol)
+{
+    if (protocol == NULL)
+        return;
+    mutex_lock(&protocol->mutex);
+    if (!protocol->cancelled) {
+        protocol->cancelled = true;
+        while (protocol->count != 0) {
+            wl_columnar_tdd_entry_t *entry = &protocol->entries[protocol->head];
+            wl_columnar_tdd_discard(entry->payload);
+            entry->payload = NULL;
+            protocol->head = (protocol->head + 1) % protocol->capacity;
+            protocol->count--;
+        }
+        cond_broadcast(&protocol->can_submit);
+        cond_broadcast(&protocol->state_changed);
+    }
+    mutex_unlock(&protocol->mutex);
+}
+
+void
+wl_columnar_tdd_protocol_destroy(wl_columnar_tdd_protocol_t *protocol)
+{
+    if (protocol == NULL)
+        return;
+    wl_columnar_tdd_protocol_cancel(protocol);
+    cond_destroy(&protocol->state_changed);
+    cond_destroy(&protocol->can_submit);
+    mutex_destroy(&protocol->mutex);
+    free(protocol->entries);
+    free(protocol);
+}
+
+wl_columnar_tdd_submit_result_t
+wl_columnar_tdd_protocol_submit(wl_columnar_tdd_protocol_t *protocol,
+    wl_columnar_tdd_payload_t *payload)
+{
+    if (protocol == NULL || payload == NULL || payload->reservation == NULL)
+        return WL_COLUMNAR_TDD_DUPLICATE;
+    mutex_lock(&protocol->mutex);
+    if (wl_columnar_tdd_queue_contains(protocol, payload)) {
+        mutex_unlock(&protocol->mutex);
+        return WL_COLUMNAR_TDD_DUPLICATE;
+    }
+    while (protocol->count == protocol->capacity && !protocol->cancelled &&
+        !protocol->complete_requested) {
+        protocol->blocked_submitters++;
+        cond_broadcast(&protocol->state_changed);
+        cond_wait(&protocol->can_submit, &protocol->mutex);
+        protocol->blocked_submitters--;
+        cond_broadcast(&protocol->state_changed);
+    }
+    if (protocol->cancelled) {
+        mutex_unlock(&protocol->mutex);
+        return WL_COLUMNAR_TDD_SUBMIT_CANCELLED;
+    }
+    if (protocol->complete_requested) {
+        mutex_unlock(&protocol->mutex);
+        return WL_COLUMNAR_TDD_ALREADY_COMPLETE;
+    }
+    if (wl_columnar_tdd_queue_contains(protocol, payload)) {
+        mutex_unlock(&protocol->mutex);
+        return WL_COLUMNAR_TDD_DUPLICATE;
+    }
+    payload->reservation->transfer_count++;
+    protocol->entries[protocol->tail] = (wl_columnar_tdd_entry_t){
+        WL_COLUMNAR_TDD_DATA, payload
+    };
+    protocol->tail = (protocol->tail + 1) % protocol->capacity;
+    protocol->count++;
+    cond_broadcast(&protocol->can_submit);
+    cond_broadcast(&protocol->state_changed);
+    mutex_unlock(&protocol->mutex);
+    return WL_COLUMNAR_TDD_SUBMITTED;
+}
+
+wl_columnar_tdd_submit_result_t
+wl_columnar_tdd_protocol_complete(wl_columnar_tdd_protocol_t *protocol)
+{
+    wl_columnar_tdd_submit_result_t result;
+    if (protocol == NULL)
+        return WL_COLUMNAR_TDD_SUBMIT_CANCELLED;
+    mutex_lock(&protocol->mutex);
+    if (protocol->cancelled) {
+        mutex_unlock(&protocol->mutex);
+        return WL_COLUMNAR_TDD_SUBMIT_CANCELLED;
+    }
+    if (protocol->complete_requested) {
+        mutex_unlock(&protocol->mutex);
+        return WL_COLUMNAR_TDD_ALREADY_COMPLETE;
+    }
+    protocol->complete_requested = true;
+    while (protocol->count == protocol->capacity && !protocol->cancelled)
+        cond_wait(&protocol->can_submit, &protocol->mutex);
+    if (!protocol->cancelled) {
+        protocol->entries[protocol->tail] =
+            (wl_columnar_tdd_entry_t){WL_COLUMNAR_TDD_COMPLETE, NULL};
+        protocol->tail = (protocol->tail + 1) % protocol->capacity;
+        protocol->count++;
+    }
+    cond_broadcast(&protocol->can_submit);
+    cond_broadcast(&protocol->state_changed);
+    result = protocol->cancelled ? WL_COLUMNAR_TDD_SUBMIT_CANCELLED
+                                 : WL_COLUMNAR_TDD_SUBMITTED;
+    mutex_unlock(&protocol->mutex);
+    return result;
+}
+
+wl_columnar_tdd_pump_result_t
+wl_columnar_tdd_protocol_pump(wl_columnar_tdd_protocol_t *protocol,
+    wl_columnar_tdd_message_t *message)
+{
+    wl_columnar_tdd_entry_t entry;
+    if (message != NULL)
+        *message = (wl_columnar_tdd_message_t){WL_COLUMNAR_TDD_EMPTY, NULL};
+    if (protocol == NULL)
+        return WL_COLUMNAR_TDD_CANCELLED;
+    mutex_lock(&protocol->mutex);
+    if (protocol->count == 0) {
+        wl_columnar_tdd_pump_result_t result =
+            protocol->cancelled ? WL_COLUMNAR_TDD_CANCELLED :
+            WL_COLUMNAR_TDD_EMPTY;
+        mutex_unlock(&protocol->mutex);
+        return result;
+    }
+    entry = protocol->entries[protocol->head];
+    if (message == NULL && entry.kind == WL_COLUMNAR_TDD_DATA) {
+        mutex_unlock(&protocol->mutex);
+        return WL_COLUMNAR_TDD_DATA;
+    }
+    protocol->head = (protocol->head + 1) % protocol->capacity;
+    protocol->count--;
+    cond_broadcast(&protocol->can_submit);
+    cond_broadcast(&protocol->state_changed);
+    mutex_unlock(&protocol->mutex);
+    if (message != NULL)
+        *message = (wl_columnar_tdd_message_t){entry.kind, entry.payload};
+    return entry.kind;
+}
+
+bool
+wl_columnar_tdd_protocol_wait_full_with_blocked_submitter(
+    wl_columnar_tdd_protocol_t *protocol,
+    unsigned timeout_ms)
+{
+    uint64_t deadline;
+    bool observed = false;
+    if (protocol == NULL)
+        return false;
+    deadline = wl_columnar_tdd_now_ms() + timeout_ms;
+    mutex_lock(&protocol->mutex);
+    while (!wl_columnar_tdd_full_with_blocked_submitter(protocol) &&
+        !protocol->cancelled && !protocol->complete_requested) {
+        uint64_t now = wl_columnar_tdd_now_ms();
+        unsigned remaining;
+        if (timeout_ms == 0 || now >= deadline)
+            break;
+        remaining = (unsigned)(deadline - now);
+        if (remaining == 0)
+            remaining = 1;
+        if (wl_columnar_tdd_cond_timedwait(&protocol->state_changed,
+            &protocol->mutex, remaining) != 0)
+            break;
+    }
+    observed = wl_columnar_tdd_full_with_blocked_submitter(protocol);
+    mutex_unlock(&protocol->mutex);
+    return observed;
+}
+
+void
+wl_columnar_tdd_payload_release(wl_columnar_tdd_payload_t *payload)
+{
+    if (payload != NULL)
+        payload->release_count++;
+}
+
+void
+wl_columnar_tdd_message_release(wl_columnar_tdd_message_t *message)
+{
+    if (message == NULL || message->kind != WL_COLUMNAR_TDD_DATA ||
+        message->payload == NULL)
+        return;
+    wl_columnar_tdd_payload_release(message->payload);
+    if (message->payload->reservation != NULL)
+        message->payload->reservation->release_count++;
+    message->payload = NULL;
+}

--- a/wirelog/columnar/tdd_protocol.h
+++ b/wirelog/columnar/tdd_protocol.h
@@ -1,0 +1,74 @@
+/*
+ * tdd_protocol.h - fake TDD publication protocol contract for tests
+ *
+ * INTERNAL TEST HARNESS ONLY.  This is a small executable model of the
+ * ownership and ordering contract discussed by issues #1454, #1373, #1372,
+ * #1369, and #1451.  It is not the production evaluator transport.
+ */
+#ifndef WL_COLUMNAR_TDD_PROTOCOL_H
+#define WL_COLUMNAR_TDD_PROTOCOL_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct wl_columnar_tdd_protocol wl_columnar_tdd_protocol_t;
+
+typedef struct wl_columnar_tdd_reservation {
+    uint64_t id;
+    unsigned transfer_count;
+    unsigned release_count;
+} wl_columnar_tdd_reservation_t;
+
+typedef struct wl_columnar_tdd_payload {
+    uint64_t id;
+    uint32_t worker;
+    uint32_t relation;
+    uint32_t round;
+    uint32_t batch;
+    wl_columnar_tdd_reservation_t *reservation;
+    unsigned release_count;
+} wl_columnar_tdd_payload_t;
+
+typedef enum wl_columnar_tdd_submit_result {
+    WL_COLUMNAR_TDD_SUBMITTED = 0,
+    WL_COLUMNAR_TDD_DUPLICATE = 1,
+    WL_COLUMNAR_TDD_SUBMIT_CANCELLED = 2,
+    WL_COLUMNAR_TDD_ALREADY_COMPLETE = 3
+} wl_columnar_tdd_submit_result_t;
+
+typedef enum wl_columnar_tdd_pump_result {
+    WL_COLUMNAR_TDD_EMPTY = 0, /* temporary: publication is still possible */
+    WL_COLUMNAR_TDD_DATA = 1,
+    WL_COLUMNAR_TDD_COMPLETE = 2,
+    WL_COLUMNAR_TDD_CANCELLED = 3
+} wl_columnar_tdd_pump_result_t;
+
+typedef struct wl_columnar_tdd_message {
+    wl_columnar_tdd_pump_result_t kind;
+    wl_columnar_tdd_payload_t *payload; /* owned by caller after DATA */
+} wl_columnar_tdd_message_t;
+
+wl_columnar_tdd_protocol_t *wl_columnar_tdd_protocol_create(size_t capacity);
+void wl_columnar_tdd_protocol_cancel(wl_columnar_tdd_protocol_t *protocol);
+void wl_columnar_tdd_protocol_destroy(wl_columnar_tdd_protocol_t *protocol);
+
+wl_columnar_tdd_submit_result_t wl_columnar_tdd_protocol_submit(
+    wl_columnar_tdd_protocol_t *protocol,
+    wl_columnar_tdd_payload_t *payload);
+wl_columnar_tdd_submit_result_t wl_columnar_tdd_protocol_complete(
+    wl_columnar_tdd_protocol_t *protocol);
+
+wl_columnar_tdd_pump_result_t wl_columnar_tdd_protocol_pump(
+    wl_columnar_tdd_protocol_t *protocol,
+    wl_columnar_tdd_message_t *message);
+
+bool wl_columnar_tdd_protocol_wait_full_with_blocked_submitter(
+    wl_columnar_tdd_protocol_t *protocol,
+    unsigned timeout_ms);
+
+/* Release is used by both the consumer and cancellation/discard paths. */
+void wl_columnar_tdd_payload_release(wl_columnar_tdd_payload_t *payload);
+void wl_columnar_tdd_message_release(wl_columnar_tdd_message_t *message);
+
+#endif


### PR DESCRIPTION
## Summary
- add an internal bounded fake TDD multi-batch publication protocol harness
- cover ordering, explicit completion, bounded pump progress, cancellation, ownership, and alias deduplication
- keep production evaluator and public API unchanged

## Validation
- `meson test -C build-1454 tdd_multi_batch_protocol --print-errorlogs`
- `meson test -C build-1454-asan tdd_multi_batch_protocol --print-errorlogs`
- `meson test -C build-1454-tsan-posix-review tdd_multi_batch_protocol --print-errorlogs`
- `git diff --check HEAD^ HEAD`

Closes #1454
