### PR TITLE
ci(#1462): unblock the Windows msvc job by fixing the abi shell-gate timeout budget

### DIFF
--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -26,33 +26,64 @@ expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-91}"
 }
 
 audit="$tmp_dir/audit"
-: >"$tmp_dir/keys"
-: >"$audit"
-while IFS=$'\t' read -r anchor operation; do
-    [[ "$operation" =~ ^atomic_[A-Za-z0-9_]+$ ]] || {
-        echo "check-threading-doc: FAIL: $anchor has invalid operation '$operation'" >&2
+# One awk pass replaces a per-row shell loop that ran awk, sed, wc, cut and grep
+# for every audit row -- nine processes per row counting the command
+# substitutions' own subshells, about 820 in all for the 91 rows.  Process
+# creation is cheap on Linux and expensive on Windows, so that loop was ~85% of
+# this gate's runtime and it grew with the audit inventory: the gate timed out
+# at 30.09s against meson's 30s default on the Windows msvc runner (#1462).
+# awk brings its own associative arrays, so the anchor and duplicate maps need
+# no bash 4 `declare -A` and the bash 3.2 floor this script targets is
+# unaffected.  The four checks below are emitted in the same order as the loop
+# they replace and stop at the first offending row, so the diagnostic text and
+# the exit behaviour are unchanged.  The order decides which diagnostic a row
+# failing more than one check reports, not whether it fails; the duplicate
+# check's position is pinned by scripts/ci/test-threading-doc.sh with two
+# duplicate rows, one that is also invalid and one that is merely documented
+# wrong.
+#
+# `FILENAME == ARGV[1]` rather than `NR == FNR`: an empty inventory would make
+# the first row line look like an inventory line.  Comparing against ARGV[1]
+# rather than a -v variable also avoids awk's escape processing on the assigned
+# value, which would mangle a $TMPDIR containing backslashes.
+#
+# Diagnostics go to /dev/stderr.  gawk, mawk and BWK awk all special-case that
+# path and write to the inherited fd 2 rather than opening the file, so the
+# regular-file stderr redirection the selftest uses is appended to, not
+# truncated.
+awk -F '\t' '
+FILENAME == ARGV[1] {
+    count[$5]++
+    resolved[$5] = $4
+    site[$5] = $0
+    next
+}
+{
+    anchor = $1
+    operation = $2
+    if (operation !~ /^atomic_[A-Za-z0-9_]+$/) {
+        printf("check-threading-doc: FAIL: %s has invalid operation \047%s\047\n",
+            anchor, operation) > "/dev/stderr"
         exit 1
     }
-    matches=$(awk -F '\t' -v anchor="$anchor" '$5 == anchor' \
-        "$tmp_dir/inventory")
-    count=$(printf '%s\n' "$matches" | sed '/^$/d' | wc -l)
-    [ "$count" -eq 1 ] || {
-        echo "check-threading-doc: FAIL: $anchor does not resolve uniquely to $operation" >&2
+    if (count[anchor] != 1) {
+        printf("check-threading-doc: FAIL: %s does not resolve uniquely to %s\n",
+            anchor, operation) > "/dev/stderr"
         exit 1
     }
-    resolved_operation=$(printf '%s\n' "$matches" | cut -f4)
-    [ "$resolved_operation" = "$operation" ] || {
-        echo "check-threading-doc: FAIL: $anchor resolves to $resolved_operation, documented $operation" >&2
+    if (resolved[anchor] != operation) {
+        printf("check-threading-doc: FAIL: %s resolves to %s, documented %s\n",
+            anchor, resolved[anchor], operation) > "/dev/stderr"
         exit 1
     }
-    key="$anchor"
-    if grep -Fqx "$key" "$tmp_dir/keys"; then
-        echo "check-threading-doc: FAIL: duplicate audit anchor $key" >&2
+    if (anchor in seen) {
+        printf("check-threading-doc: FAIL: duplicate audit anchor %s\n",
+            anchor) > "/dev/stderr"
         exit 1
-    fi
-    printf '%s\n' "$key" >>"$tmp_dir/keys"
-    printf '%s\n' "$matches" >>"$audit"
-done <"$rows"
+    }
+    seen[anchor] = 1
+    print site[anchor]
+}' "$tmp_dir/inventory" "$rows" >"$audit" || exit 1
 
 cut -f1,2,4 "$tmp_dir/inventory" | sort >"$tmp_dir/source-sites"
 cut -f1,2,4 "$audit" | sort >"$tmp_dir/audit-sites"

--- a/scripts/ci/test-threading-doc.sh
+++ b/scripts/ci/test-threading-doc.sh
@@ -22,6 +22,11 @@ run_checker() {
         WIRELOG_THREADING_EXPECTED_ROWS=3 "$BASH" "$checker"
 }
 
+run_checker_rows() {
+    WIRELOG_THREADING_DOC_ROOT="$fixture" \
+        WIRELOG_THREADING_EXPECTED_ROWS="$1" "$BASH" "$checker"
+}
+
 expect_failure() {
     local label=$1
     shift
@@ -99,6 +104,48 @@ cat >"$fixture/docs/THREADING.md" <<'EOF'
 EOF
 WIRELOG_THREADING_EXPECTED_ROWS=1 WIRELOG_THREADING_DOC_ROOT="$fixture" \
     "$BASH" "$checker" >/dev/null
+
+# The order of the four per-row checks is load-bearing, and until #1462 nothing
+# pinned it: the duplicate fixture above passes the uniqueness and operation
+# checks wherever the duplicate check sits, so a reordered implementation still
+# satisfied it.  Each row below is a duplicate that ALSO fails an earlier check,
+# so the earlier diagnostic is reported only if the order is right.
+make_fixture
+printf '%s\n' \
+    'int one(void) {' \
+    '    atomic_load_explicit(&value, memory_order_relaxed);' \
+    '}' >"$fixture/wirelog/foo.c"
+cat >"$fixture/docs/THREADING.md" <<'EOF'
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
+|---|---|---|---|---|
+| `foo.c:one` | value | `atomic_load_explicit` | relaxed | test |
+| `foo.c:one` | value | `not_atomic` | relaxed | test |
+EOF
+expect_failure 'has invalid operation' run_checker_rows 2
+
+sed 's/`not_atomic`/`atomic_store_explicit`/' "$fixture/docs/THREADING.md" \
+    >"$fixture/docs/THREADING.md.tmp" && mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"
+expect_failure 'resolves to atomic_load_explicit, documented atomic_store_explicit' \
+    run_checker_rows 2
+
+# A documented subset must not pass merely because every documented row
+# resolves.  This is the failure mode the suite never exercised, and it is the
+# one that depends on how the audit set is accumulated.
+make_fixture
+printf '%s\n' \
+    'int one(void) {' \
+    '    atomic_load_explicit(&value, memory_order_relaxed);' \
+    '}' \
+    'int two(void) {' \
+    '    atomic_load_explicit(&value, memory_order_relaxed);' \
+    '}' >"$fixture/wirelog/foo.c"
+cat >"$fixture/docs/THREADING.md" <<'EOF'
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
+|---|---|---|---|---|
+| `foo.c:one` | value | `atomic_load_explicit` | relaxed | test |
+EOF
+expect_failure 'audit citations do not cover the exact atomic-site inventory' \
+    run_checker_rows 1
 
 # #1320: a prose citation naming a file that does not exist must be REPORTED,
 # not abort the checker. On bash 3.2 -- which the macOS CI runners ship, and

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -663,10 +663,12 @@ if not is_windows
   # neither covered nor explicitly exempted with a reason.
   test('gate_skip_exit_codes',
        find_program(meson.project_source_root() / 'scripts/ci/test-gate-skip-exit-codes.sh'),
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
   test('log_abi_header_not_public',
        find_program(meson.project_source_root() / 'scripts/check_log_header_not_public.sh'),
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 
   # Issue #1302: the two claims are registered separately.  A provenance skip
   # (stripped or non-debug build, or a BSD nm with no --line-numbers) must not
@@ -675,27 +677,32 @@ if not is_windows
   test('log_abi_no_testhook_in_libwirelog',
        find_program(meson.project_source_root() / 'scripts/ci/check-no-testhook-in-libwirelog.sh'),
        args: ['--check=leak', meson.project_build_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
   test('log_abi_testhook_provenance',
        find_program(meson.project_source_root() / 'scripts/ci/check-no-testhook-in-libwirelog.sh'),
        args: ['--check=provenance', meson.project_build_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
   # Its awk predicate was unsatisfiable, so the provenance claim above had never
   # once been evaluated; this drives both checks from stubbed nm output.
   test('testhook_gate_selftest',
        find_program(meson.project_source_root() / 'scripts/ci/test-check-no-testhook.sh'),
        args: [meson.project_build_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
   test('wirelog_easy_abi_opts_symbol',
        find_program(meson.project_source_root() / 'scripts/ci/check-wl-easy-opts-symbol.sh'),
        args: [meson.project_build_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
   # Issue #717 / #703: wirelog/wirelog-advanced.h must not leak any
   # internal header (session.h, backend.h, exec_plan*.h, intern.h,
   # session_facts.h, wirelog-internal.h) into the installed surface.
   test('advanced_abi_header',
        find_program(meson.project_source_root() / 'scripts/ci/check-advanced-header.sh'),
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #688 / #704: meson.build version, the generated wirelog-version.h,
@@ -784,6 +791,25 @@ test('changelog_format', py3,
 # the same handle so platforms without bash (e.g. some Windows
 # runners) silently skip both gates instead of failing
 # inconsistently.
+#
+# Issue #1462: every shell-script gate in suite 'abi' carries an explicit
+# timeout, here and in the `if not is_windows` block above.  Without one they
+# inherit meson's 30s default, which had become an unowned performance budget
+# rather than a hang detector: these gates are process-spawn bound, Windows
+# process creation costs far more than Linux, and threading_doc timed out at
+# 30.09s on the Windows msvc runner while downstream_matrix_contract sat at
+# 27.24s in the same job.  A timeout is a hang detector, so these are set well
+# clear of the worst measured runtime and are deliberately useless for
+# detecting performance drift.  Nothing measures shell-gate wall time today;
+# that gap is tracked in #1462 and is not what this kwarg is for.
+#
+# Every shell gate in the suite carries a timeout, but not all carry the same
+# one: log_abi_compile_erasure keeps 180 because it rebuilds libwirelog, and
+# doop_validation keeps the 90 chosen under #1410.  The rule is that the value
+# is explicit and justified, not that it is uniform.  Gates that never run on
+# Windows are included anyway, so a reviewer checks the rule once instead of
+# re-deriving per-gate platform exposure -- which is how the 30s default
+# became invisible in the first place.
 sh = find_program('bash', required: false)
 
 # Issue #772: release-template gate.  Asserts that the GitHub Releases
@@ -807,7 +833,8 @@ if sh.found()
 
   test('release_template', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-release-template.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1288: the gate above exited 0 on all four of its skip paths, so meson
@@ -819,7 +846,8 @@ if sh.found()
   test('release_template_selftest', sh,
        args: [meson.project_source_root() /
               'scripts/ci/test-check-release-template.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1312: make-tarball.sh read the project version through a pipe whose
@@ -830,7 +858,8 @@ endif
 if sh.found()
   test('version_extraction', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-version-extraction.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1290: the release job attested the archive and downloaded the bundle
@@ -842,7 +871,8 @@ endif
 if sh.found()
   test('attestation_download', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-attestation-download.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1287: cosign matches --certificate-identity-regexp unanchored, and the
@@ -854,7 +884,8 @@ endif
 if sh.found()
   test('identity_pattern', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-identity-pattern.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #747 B18: RC changelog selftest for changelog-freeze checker.
@@ -863,7 +894,8 @@ endif
 if sh.found()
   test('changelog_rc_selftest', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-check-changelog-rc.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1295: make-tarball.sh and verify-release.sh had no coverage at all.
@@ -880,7 +912,8 @@ endif
 if sh.found()
   test('release_roundtrip', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-release-roundtrip.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #734/#1173: docs/THREADING.md atomics audit rows must resolve to
@@ -889,10 +922,12 @@ endif
 if sh.found()
   test('threading_doc', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-threading-doc.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
   test('threading_doc_selftest', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-threading-doc.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #715: release dependency wraps must be reproducible.  Git wraps
@@ -901,7 +936,8 @@ endif
 if sh.found()
   test('wrap_revisions', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-wrap-revisions.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1343: the two wrap-reading gates must agree on what a section header
@@ -913,7 +949,8 @@ if sh.found()
   test('wrap_section_syntax', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-wrap-section-syntax.sh',
               meson.project_source_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #737: forbid new unanchored "Phase NX" labels in wirelog/ source.
@@ -924,7 +961,8 @@ endif
 if sh.found()
   test('phase_labels', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-phase-labels.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #742: every `Status: Future` entry in docs/SEMANTICS.md must
@@ -934,7 +972,8 @@ endif
 if sh.found()
   test('semantics_future', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-semantics-future.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #952 (follow-up to #950): the DOOP .facts catalogue is written down
@@ -947,7 +986,8 @@ if sh.found()
   test('doop_catalogue', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-doop-catalogue.sh',
               meson.project_source_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1163: the GA downstream matrix must contain exactly six pinned
@@ -956,7 +996,8 @@ if sh.found()
   test('downstream_matrix_contract', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-downstream-matrix.sh',
               meson.project_source_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1303: the WIRELOG_*_REQUIRED escalation. Half of this asserts gate
@@ -968,7 +1009,8 @@ if sh.found()
   test('required_gates', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-required-gates.sh',
               meson.project_source_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #750: the release workflow's signing and publication steps and the
@@ -980,7 +1022,8 @@ if sh.found()
   test('release_signing_contract', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-release-signing.sh',
               meson.project_source_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #913: keep the weighted/semiring design proposal explicit about its
@@ -1011,13 +1054,15 @@ if sh.found()
   test('abi_symbols', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-abi-symbols.sh',
               meson.project_build_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 if host_machine.system() == 'linux' and sh.found()
   test('abi_symbols_locale', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-abi-symbols-locale.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1291: sbom/snapshot.txt is a committed artifact, so its order must not
@@ -1077,7 +1122,8 @@ if sh.found()
   test('abi_manifest', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-abi-manifest.sh',
               meson.project_build_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #744: SBOM snapshot gate.  Diffs the detected dependency list
@@ -1121,7 +1167,8 @@ endif
 if host_machine.system() == 'linux' and sh.found()
   test('doop_manifest', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-doop-manifest.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1161: the W=8 perf gate consumes the schema 2 downstream DOOP row
@@ -1132,7 +1179,8 @@ if host_machine.system() == 'linux' and sh.found()
   test('doop_perf_gate_oracle', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-doop-perf-gate-oracle.sh',
               meson.project_source_root()],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1410: calibration repetition progress, bounded process-group cleanup,
@@ -1151,7 +1199,8 @@ endif
 if host_machine.system() == 'linux' and sh.found()
   test('manifest_collation', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-manifest-collation.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 # Issue #1100: clang-tidy ratchet (suite 'tidy').  No CI job has run
@@ -1964,7 +2013,8 @@ test('crdt_correctness_full', test_crdt_perf_gate_exe,
 if host_machine.system() == 'linux' and sh.found()
   test('check_perf_gate_execution', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-check-perf-gate-execution.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 endif
 
 test('perf_nightly_doop_contract', py3,


### PR DESCRIPTION
Fixes #1462.

## Summary

`main`'s `Build / windows-latest / msvc` job is red. It is not a compile error:

```
243/329 abi - wirelog:threading_doc   TIMEOUT   30.09s   exit status 1
```

Reproduced locally through meson on a Windows host, matching CI byte for byte:

```
2/2 abi - wirelog:threading_doc       TIMEOUT   30.18s   exit status 1
```

The gate still passes on content at HEAD -- `check-threading-doc: OK; 91 audit
rows cover the exact atomic-site inventory`. It simply does not finish inside
meson's default timeout.

## Cause

`tests/meson.build` registered `threading_doc` with no `timeout:`, so it
inherited meson's 30s default. `scripts/ci/check-threading-doc.sh` verified the
audit by iterating 91 rows in a shell loop that spawned nine processes per row
-- about 820 in all. Process creation is cheap on Linux and expensive on
Windows, so the gate ran at 21.84 / 21.89 / 22.09s on the three passing CI runs
before the break, against 6.58s on macOS. That is 73% of budget, and the loop's
cost grows with the audit inventory.

The bisect points at 76192fa, but that commit is innocent. It moved 140 lines
between `wirelog/columnar/kfusion.c` and `wirelog/columnar/arrangement.c` and
added 91 lines to `tests/test_worker_session.c`; the audit row count is 91 at
all four bisect points and `docs/THREADING.md` is byte-identical across them.
The gate is contention-sensitive against a fixed budget, so the attribution is
an artifact of a coin flip. Measured on Windows, the old script cost ~15s solo
and ~30.7s at 8-way concurrency -- crossing the default almost exactly.

Two consequences worth stating plainly. First, this was going to break on some
commit. Second, the same job has no `continue-on-error` in `ci-pr.yml` (only in
`ci-main.yml`), so it is **blocking on every pull request**.

## Changes

**`53fe3e9` -- give every abi shell gate an explicit timeout.** 31 registrations
in `tests/meson.build`, following the existing precedent on
`bash_construct_ratchet_selftest`. No previously-set value changes:
`log_abi_compile_erasure` keeps 180 and `doop_validation` keeps the 90 chosen
under #1410. Gates behind `if not is_windows` are included for rule uniformity
even though they have no Windows exposure, so a reviewer checks the rule once
instead of re-deriving per-gate platform exposure.

This was not only about `threading_doc`. `downstream_matrix_contract` was at
27.24s in the same failing job, and in one reviewer's validation run on this
branch it hit **30.98s** -- it would have timed out on the very next suite
execution without this commit.

**`30904a6` -- resolve threading audit anchors in a single awk pass.** One awk
pass over the inventory and the row list replaces the per-row loop. The four
per-row checks keep their order and their exact diagnostic text and still stop
at the first offending row. awk supplies its own associative arrays, so no
bash 4 `declare -A` is needed and the bash 3.2 floor is unchanged.
`resolve_reference_source` and the prose-citation loop -- where the #1320
diagnostic and both `set -u` empty-array guards live -- are untouched.

Three characterization fixtures are added to `scripts/ci/test-threading-doc.sh`.
Two are duplicate rows that also fail an earlier check, and they pin the
duplicate check's position, which **nothing previously did**: the existing
duplicate fixture passes wherever that check sits, so a reordered implementation
satisfied the old suite. The third covers the inventory-coverage diagnostic the
suite never exercised. All three pass against the pre-change checker.

## Evidence

| | before | after |
|---|---|---|
| `check-threading-doc.sh` standalone | 15.5s | **2.8s** |
| `threading_doc` under meson | 19.09s | **4.86s** |
| `threading_doc_selftest` | 7.33s | **6.39s** (with 3 more fixtures) |
| `meson test --suite abi` | -- | 46 tests, 35 OK, 11 SKIP, **0 FAIL** |

`$audit` is **byte-identical** to the pre-change checker on the real repository:
91 lines, 9895 bytes, `cmp` clean. Independently reproduced.

Equivalence was checked across ten differential cases -- duplicate + invalid op,
duplicate + wrong valid op, clean duplicate, absent anchor, empty inventory with
0 and 1 rows, non-empty inventory with 0 rows, partial coverage, `#N` anchor
pair, `#N` wrong op -- all producing identical stdout, stderr and exit code. 43
of the 91 real anchors carry a `#N` suffix.

The check order was swept across all permutations of the four branches: the two
new fixtures catch every misplacement of the duplicate check, where the old
suite caught none.

## Known gaps, deliberately not closed here

- **The order is not fully pinned.** The invalid-operation versus
  does-not-resolve pair remains unpinned. This is cosmetic: all four branches
  `exit 1` and the accumulate step runs only after all four pass, so the verdict
  is order-invariant -- a row broken in both ways reports one of two equally true
  messages either way. Closing it would mean asserting a message for an input the
  row extractor cannot produce.
- **Nothing enforces the timeout rule.** It lives only in a comment, in a
  5,914-line file with 344 `test()` registrations, so the next shell gate added
  silently inherits 30s. `scripts/ci/check-bash-constructs.py` already classifies
  "intro test whose `cmd` resolves to a source-tree `.sh`", so a meta-gate is a
  few lines -- but it is new enforcement machinery with its own failure modes and
  does not belong on the critical path of an outage fix.
- **Nothing measures shell-gate wall time.** An explicit timeout deliberately
  will not detect drift, and no perf gate covers it. Recorded rather than papered
  over.
- **The checker relies on awk stripping the CR** from the helper's CRLF output on
  Windows. Pre-existing -- the old code depended on the same behaviour via
  command substitution -- and the byte-identical `$audit` shows the rewrite adds
  no new exposure.

All four are carried forward in #1464, which stays open after this PR closes #1462.

## Validation

```
meson test -C build --suite abi          46 tests, 35 OK, 11 SKIP, 0 FAIL
bash scripts/ci/check-threading-doc.sh   OK; 91 audit rows
bash scripts/ci/test-threading-doc.sh    test-threading-doc: OK
bash -n on both scripts                  clean
git diff --check                         clean
```

The selftest also passes under the CI interpreter (`C:\Program Files\Git\bin\bash.exe`).

Not executed here: the bash 3.2 and macOS paths are argued and reviewed, not
run, and `scripts/ci/check-bash-constructs.py` hard-skips on win32 -- its
`references()` and `violations()` were driven directly instead and return
results identical to the pre-change baseline. CI's Linux and macOS legs exercise
all of it first, as they do the seven `if not is_windows` registrations, which
meson does not evaluate on a Windows configure (those were confirmed by parsing
`tests/meson.build` with meson's own AST parser).
