### PR TITLE
fix(#1438): validate cache consumers by relation generations

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2536,6 +2536,24 @@ test_arrangement_cache_reuse_exe = executable(
 
 test('arrangement_cache_reuse', test_arrangement_cache_reuse_exe)
 
+# Generation-token consumer regressions (Issue #1438)
+test_generation_cache_exe = executable(
+  'test_generation_cache',
+  files('test_generation_cache.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('generation_cache', test_generation_cache_exe)
+
 # ============================================================================
 # Arrangement LRU Eviction Tests (Issue #216)
 # ============================================================================

--- a/tests/test_arrangement_cache_reuse.c
+++ b/tests/test_arrangement_cache_reuse.c
@@ -26,6 +26,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/session_facts.h"
 #include "../wirelog/wirelog.h"
+#include "../wirelog/columnar/internal.h"
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -42,29 +43,29 @@ static int pass_count = 0;
 static int fail_count = 0;
 
 #define TEST(name)                                      \
-    do {                                                \
-        test_count++;                                   \
-        printf("TEST %d: %s ... ", test_count, (name)); \
-    } while (0)
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
 
 #define PASS()            \
-    do {                  \
-        pass_count++;     \
-        printf("PASS\n"); \
-    } while (0)
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
 
 #define FAIL(msg)                    \
-    do {                             \
-        fail_count++;                \
-        printf("FAIL: %s\n", (msg)); \
-        return;                      \
-    } while (0)
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+            return;                      \
+        } while (0)
 
 #define ASSERT(cond, msg) \
-    do {                  \
-        if (!(cond))      \
+        do {                  \
+            if (!(cond))      \
             FAIL(msg);    \
-    } while (0)
+        } while (0)
 
 /* ----------------------------------------------------------------
  * Helpers
@@ -83,7 +84,7 @@ noop_cb(const char *r, const int64_t *row, uint32_t nc, void *u)
  * Caller owns *out_sess, *out_plan, *out_prog and must free them. */
 static int
 make_session(const char *src, wl_session_t **out_sess, wl_plan_t **out_plan,
-             wirelog_program_t **out_prog)
+    wirelog_program_t **out_prog)
 {
     wirelog_error_t err;
     wirelog_program_t *prog = wirelog_parse_string(src, &err);
@@ -135,6 +136,50 @@ free_session(wl_session_t *sess, wl_plan_t *plan, wirelog_program_t *prog)
     wirelog_program_free(prog);
 }
 
+static void
+test_same_nrows_mutation_rebuilds_arrangement(void)
+{
+    TEST("Same-nrows mutation invalidates arrangement snapshot");
+    const char *src = ".decl valueFlow(z: int32, x: int32)\n"
+        "valueFlow(10, 1). valueFlow(20, 2).\n"
+        "valueFlow(30, 3). valueFlow(40, 4).\n";
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    ASSERT(make_session(src, &sess, &plan, &prog) == 0,
+        "session creation failed");
+    uint32_t key_cols[1] = { 0 };
+    col_arrangement_t *arr
+        = col_session_get_arrangement(sess, "valueFlow", key_cols, 1);
+    ASSERT(arr != NULL, "initial arrangement must build");
+
+    col_rel_t *rel = NULL;
+    wl_col_session_t *internal = COL_SESSION(sess);
+    for (uint32_t i = 0; i < internal->nrels; i++) {
+        if (internal->rels[i] && internal->rels[i]->name
+            && strcmp(internal->rels[i]->name, "valueFlow") == 0) {
+            rel = internal->rels[i];
+            break;
+        }
+    }
+    ASSERT(rel != NULL, "source relation must be found");
+    int64_t changed = 99;
+    ASSERT(col_rel_set(rel, 0, 0, changed) == 0,
+        "same-nrows mutation must succeed");
+
+    col_arrangement_t *rebuilt
+        = col_session_get_arrangement(sess, "valueFlow", key_cols, 1);
+    ASSERT(rebuilt == arr, "registry entry remains stable");
+    int64_t key[1] = { 99 };
+    ASSERT(col_arrangement_find_first_typed(rebuilt, rel, key) != UINT32_MAX,
+        "rebuilt arrangement contains changed key");
+    key[0] = 10;
+    ASSERT(col_arrangement_find_first_typed(rebuilt, rel, key) == UINT32_MAX,
+        "rebuilt arrangement drops old key");
+    free_session(sess, plan, prog);
+    PASS();
+}
+
 /* ================================================================
  * Test 1: First get_arrangement call builds the index
  *
@@ -149,16 +194,16 @@ test_first_call_builds_index(void)
 
     /* valueFlow-like: 2 columns (z, x); 4 base facts */
     const char *src = ".decl valueFlow(z: int32, x: int32)\n"
-                      "valueFlow(10, 1). valueFlow(20, 2).\n"
-                      "valueFlow(30, 3). valueFlow(40, 4).\n"
-                      ".decl sink(z: int32, x: int32)\n"
-                      "sink(z, x) :- valueFlow(z, x).\n";
+        "valueFlow(10, 1). valueFlow(20, 2).\n"
+        "valueFlow(30, 3). valueFlow(40, 4).\n"
+        ".decl sink(z: int32, x: int32)\n"
+        "sink(z, x) :- valueFlow(z, x).\n";
 
     wl_session_t *sess = NULL;
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
     ASSERT(make_session(src, &sess, &plan, &prog) == 0,
-           "session creation failed");
+        "session creation failed");
 
     /* Request arrangement on col 0 (z key) */
     uint32_t key_cols[1] = { 0 };
@@ -167,7 +212,7 @@ test_first_call_builds_index(void)
 
     ASSERT(arr != NULL, "arrangement must be non-NULL for existing relation");
     ASSERT(arr->indexed_rows > 0,
-           "first call must build index (indexed_rows > 0)");
+        "first call must build index (indexed_rows > 0)");
     ASSERT(arr->indexed_rows == 4, "indexed_rows must equal fact count (4)");
 
     free_session(sess, plan, prog);
@@ -187,16 +232,16 @@ test_second_call_same_pointer(void)
     TEST("Second get_arrangement call: same pointer (cache hit)");
 
     const char *src = ".decl valueFlow(z: int32, x: int32)\n"
-                      "valueFlow(10, 1). valueFlow(20, 2).\n"
-                      "valueFlow(30, 3). valueFlow(40, 4).\n"
-                      ".decl sink(z: int32, x: int32)\n"
-                      "sink(z, x) :- valueFlow(z, x).\n";
+        "valueFlow(10, 1). valueFlow(20, 2).\n"
+        "valueFlow(30, 3). valueFlow(40, 4).\n"
+        ".decl sink(z: int32, x: int32)\n"
+        "sink(z, x) :- valueFlow(z, x).\n";
 
     wl_session_t *sess = NULL;
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
     ASSERT(make_session(src, &sess, &plan, &prog) == 0,
-           "session creation failed");
+        "session creation failed");
 
     uint32_t key_cols[1] = { 0 };
 
@@ -211,7 +256,7 @@ test_second_call_same_pointer(void)
     ASSERT(arr_r9 != NULL, "R9 arrangement must be non-NULL");
 
     ASSERT(arr_r6 == arr_r9,
-           "R6 and R9 must receive same arrangement pointer (cache hit)");
+        "R6 and R9 must receive same arrangement pointer (cache hit)");
 
     free_session(sess, plan, prog);
     PASS();
@@ -230,17 +275,17 @@ test_no_rebuild_between_rules(void)
     TEST("No rebuild between rules: indexed_rows unchanged on 2nd/3rd call");
 
     const char *src = ".decl valueFlow(z: int32, x: int32)\n"
-                      "valueFlow(10, 1). valueFlow(20, 2).\n"
-                      "valueFlow(30, 3). valueFlow(40, 4).\n"
-                      "valueFlow(50, 5).\n"
-                      ".decl sink(z: int32, x: int32)\n"
-                      "sink(z, x) :- valueFlow(z, x).\n";
+        "valueFlow(10, 1). valueFlow(20, 2).\n"
+        "valueFlow(30, 3). valueFlow(40, 4).\n"
+        "valueFlow(50, 5).\n"
+        ".decl sink(z: int32, x: int32)\n"
+        "sink(z, x) :- valueFlow(z, x).\n";
 
     wl_session_t *sess = NULL;
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
     ASSERT(make_session(src, &sess, &plan, &prog) == 0,
-           "session creation failed");
+        "session creation failed");
 
     uint32_t key_cols[1] = { 0 };
 
@@ -256,14 +301,14 @@ test_no_rebuild_between_rules(void)
         = col_session_get_arrangement(sess, "valueFlow", key_cols, 1);
     ASSERT(arr2 == arr, "must return same pointer");
     ASSERT(arr->indexed_rows == rows_after_r6,
-           "indexed_rows must be unchanged after second access (no rebuild)");
+        "indexed_rows must be unchanged after second access (no rebuild)");
 
     /* R10: third access */
     col_arrangement_t *arr3
         = col_session_get_arrangement(sess, "valueFlow", key_cols, 1);
     ASSERT(arr3 == arr, "third access must return same pointer");
     ASSERT(arr->indexed_rows == rows_after_r6,
-           "indexed_rows must be unchanged after third access");
+        "indexed_rows must be unchanged after third access");
 
     free_session(sess, plan, prog);
     PASS();
@@ -281,16 +326,16 @@ test_different_keycols_separate_entries(void)
     TEST("Different key_cols: separate cache entries (distinct pointers)");
 
     const char *src = ".decl valueFlow(z: int32, x: int32)\n"
-                      "valueFlow(10, 1). valueFlow(20, 2).\n"
-                      "valueFlow(30, 3).\n"
-                      ".decl sink(z: int32, x: int32)\n"
-                      "sink(z, x) :- valueFlow(z, x).\n";
+        "valueFlow(10, 1). valueFlow(20, 2).\n"
+        "valueFlow(30, 3).\n"
+        ".decl sink(z: int32, x: int32)\n"
+        "sink(z, x) :- valueFlow(z, x).\n";
 
     wl_session_t *sess = NULL;
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
     ASSERT(make_session(src, &sess, &plan, &prog) == 0,
-           "session creation failed");
+        "session creation failed");
 
     /* Arrangement keyed on col 0 (z) */
     uint32_t key_col0[1] = { 0 };
@@ -305,7 +350,7 @@ test_different_keycols_separate_entries(void)
     ASSERT(arr_x != NULL, "arrangement on col 1 must be non-NULL");
 
     ASSERT(arr_z != arr_x,
-           "different key_cols must produce distinct cache entries");
+        "different key_cols must produce distinct cache entries");
 
     /* Both must be fully indexed */
     ASSERT(arr_z->indexed_rows == 3, "col-0 arrangement must index all 3 rows");
@@ -336,29 +381,29 @@ test_invalidation_resets_indexed_rows(void)
     TEST("Invalidation: indexed_rows reset to 0 immediately");
 
     const char *src = ".decl valueFlow(z: int32, x: int32)\n"
-                      "valueFlow(10, 1). valueFlow(20, 2).\n"
-                      "valueFlow(30, 3). valueFlow(40, 4).\n"
-                      ".decl sink(z: int32, x: int32)\n"
-                      "sink(z, x) :- valueFlow(z, x).\n";
+        "valueFlow(10, 1). valueFlow(20, 2).\n"
+        "valueFlow(30, 3). valueFlow(40, 4).\n"
+        ".decl sink(z: int32, x: int32)\n"
+        "sink(z, x) :- valueFlow(z, x).\n";
 
     wl_session_t *sess = NULL;
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
     ASSERT(make_session(src, &sess, &plan, &prog) == 0,
-           "session creation failed");
+        "session creation failed");
 
     uint32_t key_cols[1] = { 0 };
     col_arrangement_t *arr
         = col_session_get_arrangement(sess, "valueFlow", key_cols, 1);
     ASSERT(arr != NULL, "arrangement must be non-NULL");
     ASSERT(arr->indexed_rows == 4,
-           "indexed_rows must be 4 before invalidation");
+        "indexed_rows must be 4 before invalidation");
 
     /* Simulate iteration boundary: invalidate */
     col_session_invalidate_arrangements(sess, "valueFlow");
 
     ASSERT(arr->indexed_rows == 0,
-           "indexed_rows must be 0 immediately after invalidation");
+        "indexed_rows must be 0 immediately after invalidation");
 
     free_session(sess, plan, prog);
     PASS();
@@ -377,16 +422,16 @@ test_rebuild_after_invalidation(void)
     TEST("Rebuild after invalidation: indexed_rows restored to N");
 
     const char *src = ".decl valueFlow(z: int32, x: int32)\n"
-                      "valueFlow(10, 1). valueFlow(20, 2).\n"
-                      "valueFlow(30, 3). valueFlow(40, 4).\n"
-                      ".decl sink(z: int32, x: int32)\n"
-                      "sink(z, x) :- valueFlow(z, x).\n";
+        "valueFlow(10, 1). valueFlow(20, 2).\n"
+        "valueFlow(30, 3). valueFlow(40, 4).\n"
+        ".decl sink(z: int32, x: int32)\n"
+        "sink(z, x) :- valueFlow(z, x).\n";
 
     wl_session_t *sess = NULL;
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
     ASSERT(make_session(src, &sess, &plan, &prog) == 0,
-           "session creation failed");
+        "session creation failed");
 
     uint32_t key_cols[1] = { 0 };
 
@@ -395,7 +440,7 @@ test_rebuild_after_invalidation(void)
         = col_session_get_arrangement(sess, "valueFlow", key_cols, 1);
     ASSERT(arr != NULL, "arrangement must be non-NULL");
     ASSERT(arr->indexed_rows == 4,
-           "indexed_rows must be 4 before invalidation");
+        "indexed_rows must be 4 before invalidation");
 
     /* Invalidate (iteration boundary) */
     col_session_invalidate_arrangements(sess, "valueFlow");
@@ -406,7 +451,7 @@ test_rebuild_after_invalidation(void)
         = col_session_get_arrangement(sess, "valueFlow", key_cols, 1);
     ASSERT(arr2 != NULL, "arrangement must be non-NULL after rebuild");
     ASSERT(arr2->indexed_rows == 4,
-           "indexed_rows must be restored to 4 after rebuild");
+        "indexed_rows must be restored to 4 after rebuild");
 
     free_session(sess, plan, prog);
     PASS();
@@ -423,19 +468,19 @@ test_invalidation_scope(void)
     TEST("Invalidation scope: only named relation is reset");
 
     const char *src = ".decl valueFlow(z: int32, x: int32)\n"
-                      "valueFlow(10, 1). valueFlow(20, 2).\n"
-                      ".decl edge(a: int32, b: int32)\n"
-                      "edge(1, 2). edge(2, 3). edge(3, 4).\n"
-                      ".decl sink(z: int32, x: int32)\n"
-                      "sink(z, x) :- valueFlow(z, x).\n"
-                      ".decl reach(a: int32, b: int32)\n"
-                      "reach(a, b) :- edge(a, b).\n";
+        "valueFlow(10, 1). valueFlow(20, 2).\n"
+        ".decl edge(a: int32, b: int32)\n"
+        "edge(1, 2). edge(2, 3). edge(3, 4).\n"
+        ".decl sink(z: int32, x: int32)\n"
+        "sink(z, x) :- valueFlow(z, x).\n"
+        ".decl reach(a: int32, b: int32)\n"
+        "reach(a, b) :- edge(a, b).\n";
 
     wl_session_t *sess = NULL;
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
     ASSERT(make_session(src, &sess, &plan, &prog) == 0,
-           "session creation failed");
+        "session creation failed");
 
     uint32_t key_cols[1] = { 0 };
 
@@ -453,9 +498,9 @@ test_invalidation_scope(void)
     col_session_invalidate_arrangements(sess, "valueFlow");
 
     ASSERT(arr_vf->indexed_rows == 0,
-           "valueFlow indexed_rows must be 0 after invalidation");
+        "valueFlow indexed_rows must be 0 after invalidation");
     ASSERT(arr_edge->indexed_rows == 3,
-           "edge indexed_rows must be unchanged (not invalidated)");
+        "edge indexed_rows must be unchanged (not invalidated)");
 
     free_session(sess, plan, prog);
     PASS();
@@ -480,17 +525,17 @@ test_valueflow_z_key_cache_reuse(void)
     /* valueFlow with 6 facts, 2 columns (z, x).
      * Three rules (R6, R9, R10) all join on col 0 = z. */
     const char *src = ".decl valueFlow(z: int32, x: int32)\n"
-                      "valueFlow(10, 1). valueFlow(20, 2).\n"
-                      "valueFlow(30, 3). valueFlow(40, 4).\n"
-                      "valueFlow(50, 5). valueFlow(60, 6).\n"
-                      ".decl result(z: int32, x: int32)\n"
-                      "result(z, x) :- valueFlow(z, x).\n";
+        "valueFlow(10, 1). valueFlow(20, 2).\n"
+        "valueFlow(30, 3). valueFlow(40, 4).\n"
+        "valueFlow(50, 5). valueFlow(60, 6).\n"
+        ".decl result(z: int32, x: int32)\n"
+        "result(z, x) :- valueFlow(z, x).\n";
 
     wl_session_t *sess = NULL;
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
     ASSERT(make_session(src, &sess, &plan, &prog) == 0,
-           "session creation failed");
+        "session creation failed");
 
     uint32_t key_col_z[1] = { 0 }; /* col 0 = z */
 
@@ -507,14 +552,14 @@ test_valueflow_z_key_cache_reuse(void)
     ASSERT(arr_r9 != NULL, "R9: arrangement must be non-NULL");
     ASSERT(arr_r9 == arr_r6, "R9: must receive same pointer as R6 (cache hit)");
     ASSERT(arr_r9->indexed_rows == rows_at_r6,
-           "R9: indexed_rows must be unchanged (no rebuild between R6 and R9)");
+        "R9: indexed_rows must be unchanged (no rebuild between R6 and R9)");
 
     /* R10 accesses same arrangement */
     col_arrangement_t *arr_r10
         = col_session_get_arrangement(sess, "valueFlow", key_col_z, 1);
     ASSERT(arr_r10 != NULL, "R10: arrangement must be non-NULL");
     ASSERT(arr_r10 == arr_r6,
-           "R10: must receive same pointer as R6 (cache hit)");
+        "R10: must receive same pointer as R6 (cache hit)");
     ASSERT(
         arr_r10->indexed_rows == rows_at_r6,
         "R10: indexed_rows must be unchanged (no rebuild between R9 and R10)");
@@ -522,15 +567,15 @@ test_valueflow_z_key_cache_reuse(void)
     /* Verify that invalidation (iteration boundary) is what resets it */
     col_session_invalidate_arrangements(sess, "valueFlow");
     ASSERT(arr_r6->indexed_rows == 0,
-           "indexed_rows must be 0 after iteration boundary invalidation");
+        "indexed_rows must be 0 after iteration boundary invalidation");
 
     /* After iteration boundary: next rule access rebuilds */
     col_arrangement_t *arr_next_iter
         = col_session_get_arrangement(sess, "valueFlow", key_col_z, 1);
     ASSERT(arr_next_iter != NULL,
-           "post-invalidation get_arrangement must return non-NULL");
+        "post-invalidation get_arrangement must return non-NULL");
     ASSERT(arr_next_iter->indexed_rows == 6,
-           "post-invalidation: index must be fully rebuilt (indexed_rows = 6)");
+        "post-invalidation: index must be fully rebuilt (indexed_rows = 6)");
 
     free_session(sess, plan, prog);
     PASS();
@@ -553,6 +598,7 @@ main(void)
     test_rebuild_after_invalidation();
     test_invalidation_scope();
     test_valueflow_z_key_cache_reuse();
+    test_same_nrows_mutation_rebuilds_arrangement();
 
     printf("\nResults: %d/%d passed", pass_count, test_count);
     if (fail_count > 0)

--- a/tests/test_generation_cache.c
+++ b/tests/test_generation_cache.c
@@ -1,0 +1,326 @@
+/*
+ * Direct generation-token regression coverage for cache consumers (#1438).
+ */
+
+#include "wirelog/columnar/columnar_nanoarrow.h"
+#include "wirelog/columnar/internal.h"
+#include "wirelog/exec_plan_gen.h"
+#include "wirelog/passes/fusion.h"
+#include "wirelog/passes/jpp.h"
+#include "wirelog/passes/sip.h"
+#include "wirelog/session.h"
+#include "wirelog/session_facts.h"
+#include "wirelog/wirelog.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures;
+
+#define CHECK(condition, message) \
+        do { \
+            if (!(condition)) { \
+                fprintf(stderr, "FAIL: %s\n", (message)); \
+                failures++; \
+                goto cleanup; \
+            } \
+        } while (0)
+
+static void
+noop_cb(const char *relation, const int64_t *row, uint32_t ncols, void *data)
+{
+    (void)relation;
+    (void)row;
+    (void)ncols;
+    (void)data;
+}
+
+static col_rel_t *
+find_relation(wl_session_t *session, const char *name)
+{
+    wl_col_session_t *cs = COL_SESSION(session);
+    for (uint32_t i = 0; i < cs->nrels; i++) {
+        if (cs->rels[i] && cs->rels[i]->name
+            && strcmp(cs->rels[i]->name, name) == 0)
+            return cs->rels[i];
+    }
+    return NULL;
+}
+
+static int
+make_session(wl_session_t **session_out, wl_plan_t **plan_out,
+    wirelog_program_t **program_out)
+{
+    /* Keep the mutation at row 100 so a prefix-only content check cannot
+     * accidentally validate the cache. */
+    size_t cap = 4096;
+    char *source = (char *)malloc(cap);
+    if (!source)
+        return -1;
+    size_t used = (size_t)snprintf(source, cap,
+            ".decl edge(a: int32, b: int32)\n");
+    for (int i = 0; i <= 100; i++) {
+        int n = snprintf(source + used, cap - used, "edge(%d, %d).\n", i, i);
+        if (n < 0 || (size_t)n >= cap - used) {
+            free(source);
+            return -1;
+        }
+        used += (size_t)n;
+    }
+
+    wirelog_error_t error = WIRELOG_OK;
+    wirelog_program_t *program = wirelog_parse_string(source, &error);
+    free(source);
+    if (!program)
+        return -1;
+    wl_fusion_apply(program, NULL);
+    wl_jpp_apply(program, NULL);
+    wl_sip_apply(program, NULL);
+
+    wl_plan_t *plan = NULL;
+    if (wl_plan_from_program(program, &plan) != 0) {
+        wirelog_program_free(program);
+        return -1;
+    }
+    wl_session_t *session = NULL;
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &session) != 0
+        || wl_session_load_facts(session, program) != 0
+        || wl_session_snapshot(session, noop_cb, NULL) != 0) {
+        if (session)
+            wl_session_destroy(session);
+        wl_plan_free(plan);
+        wirelog_program_free(program);
+        return -1;
+    }
+    *session_out = session;
+    *plan_out = plan;
+    *program_out = program;
+    return 0;
+}
+
+static void
+destroy_session(wl_session_t *session, wl_plan_t *plan,
+    wirelog_program_t *program)
+{
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    wirelog_program_free(program);
+}
+
+static wl_plan_expr_buffer_t
+make_b_gt_100(void)
+{
+    /* VAR("col1") CONST_INT(100) CMP_GT. */
+    static const uint8_t expression[] = {
+        WL_PLAN_EXPR_VAR, 4, 0, 'c', 'o', 'l', '1',
+        WL_PLAN_EXPR_CONST_INT,
+        100, 0, 0, 0, 0, 0, 0, 0,
+        WL_PLAN_EXPR_CMP_GT
+    };
+    wl_plan_expr_buffer_t result;
+    result.data = (uint8_t *)malloc(sizeof(expression));
+    result.size = sizeof(expression);
+    if (result.data)
+        memcpy(result.data, expression, sizeof(expression));
+    return result;
+}
+
+static int
+index_diff_arrangement(col_diff_arrangement_t *arr, const col_rel_t *rel,
+    const uint32_t *key_cols, uint32_t key_count)
+{
+    if (col_diff_arrangement_ensure_ht_capacity(arr, rel->nrows) != 0)
+        return -1;
+    for (uint32_t row = 0; row < rel->nrows; row++) {
+        uint32_t hash = 2166136261u;
+        for (uint32_t key = 0; key < key_count; key++)
+            hash = wl_columnar_hash_value(hash, rel, key_cols[key],
+                    rel->columns[key_cols[key]][row]);
+        uint32_t bucket = hash & (arr->nbuckets - 1);
+        arr->ht_next[row] = arr->ht_head[bucket];
+        arr->ht_head[bucket] = row + 1;
+    }
+    arr->indexed_rows = rel->nrows;
+    arr->current_nrows = rel->nrows;
+    return 0;
+}
+
+static int
+diff_contains_key(const col_diff_arrangement_t *arr, const col_rel_t *rel,
+    uint32_t key_col, int64_t value)
+{
+    uint32_t hash = wl_columnar_hash_value(2166136261u, rel, key_col,
+            value);
+    uint32_t cursor = arr->ht_head[hash & (arr->nbuckets - 1)];
+    while (cursor != 0) {
+        uint32_t row = cursor - 1;
+        if (row < rel->nrows && rel->columns[key_col][row] == value)
+            return 1;
+        cursor = arr->ht_next[row];
+    }
+    return 0;
+}
+
+static void
+free_arrangement_clones(col_arr_entry_t *entries, uint32_t count)
+{
+    for (uint32_t i = 0; i < count; i++) {
+        arr_free_contents(&entries[i].arr);
+        free(entries[i].key_cols);
+        free(entries[i].rel_name);
+    }
+    free(entries);
+}
+
+static void
+free_diff_clones(col_diff_arr_entry_t *entries, uint32_t count)
+{
+    for (uint32_t i = 0; i < count; i++) {
+        col_diff_arrangement_destroy(entries[i].diff_arr);
+        free(entries[i].key_cols);
+        free(entries[i].rel_name);
+    }
+    free(entries);
+}
+
+static int
+test_generation_consumers(void)
+{
+    wl_session_t *session = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *program = NULL;
+    col_rel_t *rel = NULL;
+    wl_plan_expr_buffer_t filter = { 0 };
+    col_arr_entry_t *arr_clone = NULL;
+    uint32_t arr_clone_cap = 0;
+    col_diff_arr_entry_t *diff_clone = NULL;
+    uint32_t diff_clone_cap = 0;
+    int result = 0;
+    CHECK(make_session(&session, &plan, &program) == 0,
+        "session creation failed");
+    rel = find_relation(session, "edge");
+    CHECK(rel != NULL && rel->nrows == 101, "source relation missing");
+
+    wl_col_session_t *cs = COL_SESSION(session);
+    filter = make_b_gt_100();
+    CHECK(filter.data != NULL, "filter allocation failed");
+    uint64_t filter_hash = wl_columnar_filter_fnv1a_hash(filter.data,
+            filter.size);
+    uint32_t key_col = 0;
+
+    col_rel_t *filtered = wl_columnar_filter_apply_right_filter_cached(
+        cs, &filter, "edge", rel);
+    CHECK(filtered != NULL && filtered->nrows == 0,
+        "initial filtered cache result must be empty");
+
+    /* Mutation is at row 100, outside the first 100 rows, and nrows stays 101. */
+    CHECK(col_rel_set(rel, 100, 1, 101) == 0,
+        "same-nrows source mutation failed");
+    filtered = wl_columnar_filter_apply_right_filter_cached(
+        cs, &filter, "edge", rel);
+    CHECK(filtered != NULL && filtered->nrows == 1,
+        "filtered cache did not rebuild after same-nrows mutation");
+    CHECK(filtered->columns[0][0] == 100 && filtered->columns[1][0] == 101,
+        "filtered cache did not expose the new row");
+
+    col_arrangement_t *filtered_arr = col_session_get_filt_arrangement(cs,
+            "edge", filter_hash, filtered, &key_col, 1);
+    CHECK(filtered_arr != NULL, "filtered arrangement creation failed");
+    int64_t key = 100;
+    CHECK(col_arrangement_find_first_typed(filtered_arr, filtered, &key)
+        != UINT32_MAX,
+        "filtered arrangement missed initial filtered key");
+
+    CHECK(col_rel_set(rel, 100, 0, 202) == 0,
+        "second same-nrows source mutation failed");
+    filtered = wl_columnar_filter_apply_right_filter_cached(
+        cs, &filter, "edge", rel);
+    CHECK(filtered != NULL && filtered->nrows == 1
+        && filtered->columns[0][0] == 202,
+        "filtered cache did not regenerate after key mutation");
+    filtered_arr = col_session_get_filt_arrangement(cs, "edge", filter_hash,
+            filtered, &key_col, 1);
+    CHECK(filtered_arr != NULL, "filtered arrangement rebuild failed");
+    key = 202;
+    CHECK(col_arrangement_find_first_typed(filtered_arr, filtered, &key)
+        != UINT32_MAX,
+        "filtered arrangement missed new key");
+    key = 100;
+    CHECK(col_arrangement_find_first_typed(filtered_arr, filtered, &key)
+        == UINT32_MAX,
+        "filtered arrangement retained stale key");
+
+    col_sorted_arr_t *sorted = col_session_get_sorted_arrangement(cs, "edge",
+            1);
+    CHECK(sorted != NULL && sorted->nrows == 101,
+        "sorted arrangement creation failed");
+    CHECK(col_rel_set(rel, 0, 1, 1000) == 0,
+        "sorted same-nrows mutation failed");
+    sorted = col_session_get_sorted_arrangement(cs, "edge", 1);
+    CHECK(sorted != NULL && sorted->sorted[1] == 1
+        && sorted->sorted[(size_t)(sorted->nrows - 1) * sorted->ncols + 1]
+        == 1000,
+        "sorted arrangement did not rebuild order");
+
+    col_diff_arrangement_t *diff = col_session_get_diff_arrangement(cs,
+            "edge", rel, &key_col, 1);
+    CHECK(diff != NULL, "differential arrangement creation failed");
+    CHECK(index_diff_arrangement(diff, rel, &key_col, 1) == 0,
+        "differential arrangement initial index failed");
+    CHECK(diff->indexed_rows == rel->nrows,
+        "initial differential index incomplete");
+    CHECK(col_rel_set(rel, 100, 0, 303) == 0,
+        "differential same-nrows mutation failed");
+    diff = col_session_get_diff_arrangement(cs, "edge", rel, &key_col, 1);
+    CHECK(diff != NULL && diff->indexed_rows == 0,
+        "differential arrangement did not discard stale index");
+    CHECK(index_diff_arrangement(diff, rel, &key_col, 1) == 0,
+        "differential arrangement rebuild failed");
+    CHECK(diff_contains_key(diff, rel, 0, 303),
+        "differential arrangement missed new probe key");
+    CHECK(!diff_contains_key(diff, rel, 0, 202),
+        "differential arrangement retained stale bucket");
+
+    col_arrangement_t *primary = col_session_get_arrangement(session, "edge",
+            &key_col, 1);
+    CHECK(primary != NULL && primary->indexed_rows == rel->nrows,
+        "primary arrangement creation failed");
+    CHECK(col_arr_entries_clone(cs->arr_entries, cs->arr_count,
+        &arr_clone, &arr_clone_cap, NULL) == 0 && arr_clone_cap > 0,
+        "primary arrangement worker clone failed");
+    CHECK(arr_clone[0].source_snapshot.relation_identity == 0
+        && arr_clone[0].arr.indexed_rows == 0,
+        "worker clone reused coordinator primary snapshot");
+
+    CHECK(col_diff_arr_entries_clone(cs->diff_arr_entries, cs->diff_arr_count,
+        &diff_clone, &diff_clone_cap) == 0 && diff_clone_cap > 0,
+        "differential arrangement worker clone failed");
+    CHECK(diff_clone[0].diff_arr->source_snapshot.relation_identity == 0
+        && diff_clone[0].diff_arr->indexed_rows == 0,
+        "worker clone reused coordinator differential snapshot");
+    arr_clone[0].arr.indexed_rows = 7;
+    diff_clone[0].diff_arr->indexed_rows = 7;
+    CHECK(cs->arr_entries[0].arr.indexed_rows != 7
+        && cs->diff_arr_entries[0].diff_arr->indexed_rows != 7,
+        "worker cache mutation leaked into coordinator");
+
+    result = 1;
+
+cleanup:
+    free_arrangement_clones(arr_clone, arr_clone_cap);
+    free_diff_clones(diff_clone, diff_clone_cap);
+    free(filter.data);
+    if (session)
+        destroy_session(session, plan, program);
+    return result;
+}
+
+int
+main(void)
+{
+    printf("generation cache consumer regressions\n");
+    (void)test_generation_consumers();
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/test_mat_cache_lifetime.c
+++ b/tests/test_mat_cache_lifetime.c
@@ -248,6 +248,58 @@ test_copy_survives_cache_eviction(void)
     col_rel_destroy(right);
 }
 
+static void
+test_snapshot_invalidates_same_shape_and_poisoned_generations(void)
+{
+    tests_run++;
+    col_mat_cache_t cache = { 0 };
+    col_rel_t *left = make_relation(6000);
+    col_rel_t *right = make_relation(6001);
+    col_rel_t *result = make_relation(6002);
+    ASSERT_TRUE(left && right && result, "snapshot relations allocated");
+    ASSERT_TRUE(col_mat_cache_insert(&cache, left, right, result) == 0,
+        "snapshot cache insert succeeds");
+    ASSERT_TRUE(col_mat_cache_lookup(&cache, left, right) == result,
+        "matching snapshot is a hit");
+
+    /* Keep nrows and the first row shape unchanged while changing the view. */
+    ASSERT_TRUE(col_rel_set(left, 0, 0, 6999) == 0,
+        "same-shape mutation succeeds");
+    ASSERT_TRUE(col_mat_cache_lookup(&cache, left, right) == NULL,
+        "same-nrows mutation is a miss");
+
+    /* A poisoned generation is never evidence of freshness. */
+    left->view_generation = WL_COLUMNAR_REL_GENERATION_INVALID;
+    ASSERT_TRUE(col_mat_cache_lookup(&cache, left, right) == NULL,
+        "invalid generation is always a miss");
+
+    /* Mutating beyond the legacy 100-row hash prefix is still stale. */
+    col_mat_cache_t long_cache = { 0 };
+    col_rel_t *long_left = col_rel_new_auto("long-left", 1);
+    col_rel_t *long_right = make_relation(7001);
+    col_rel_t *long_result = make_relation(7002);
+    ASSERT_TRUE(long_left && long_right && long_result,
+        "long snapshot relations allocated");
+    for (int64_t i = 0; i < 101; i++)
+        ASSERT_TRUE(col_rel_append_row(long_left, &i) == 0,
+            "long relation row append succeeds");
+    ASSERT_TRUE(col_mat_cache_insert(&long_cache, long_left, long_right,
+        long_result) == 0, "long snapshot cache insert succeeds");
+    ASSERT_TRUE(col_mat_cache_lookup(&long_cache, long_left, long_right)
+        == long_result, "long snapshot initially hits");
+    ASSERT_TRUE(col_rel_set(long_left, 100, 0, 7999) == 0,
+        "outside-prefix mutation succeeds");
+    ASSERT_TRUE(col_mat_cache_lookup(&long_cache, long_left, long_right)
+        == NULL, "outside-prefix mutation is a miss");
+    col_mat_cache_clear(&long_cache);
+    col_rel_destroy(long_left);
+    col_rel_destroy(long_right);
+
+    col_mat_cache_clear(&cache);
+    col_rel_destroy(left);
+    col_rel_destroy(right);
+}
+
 int
 main(void)
 {
@@ -256,6 +308,7 @@ main(void)
     test_lru_preserves_pinned_entry();
     test_all_pinned_insert_retains_callers_ownership();
     test_copy_survives_cache_eviction();
+    test_snapshot_invalidates_same_shape_and_poisoned_generations();
     printf("materialization-cache lifetime: %d tests, %d failures\n",
         tests_run, tests_failed);
     return tests_failed == 0 ? 0 : 1;

--- a/tests/test_mat_cache_lifetime.c
+++ b/tests/test_mat_cache_lifetime.c
@@ -291,11 +291,15 @@ test_snapshot_invalidates_same_shape_and_poisoned_generations(void)
         "outside-prefix mutation succeeds");
     ASSERT_TRUE(col_mat_cache_lookup(&long_cache, long_left, long_right)
         == NULL, "outside-prefix mutation is a miss");
+    col_mat_cache_release_pins(&long_cache);
     col_mat_cache_clear(&long_cache);
+    ASSERT_TRUE(long_cache.count == 0, "long snapshot cache is released");
     col_rel_destroy(long_left);
     col_rel_destroy(long_right);
 
+    col_mat_cache_release_pins(&cache);
     col_mat_cache_clear(&cache);
+    ASSERT_TRUE(cache.count == 0, "snapshot cache is released");
     col_rel_destroy(left);
     col_rel_destroy(right);
 }

--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -624,7 +624,11 @@ test_arrangement_clone_ownership(void)
         && dst->arr.key_cols == dst->key_cols
         && dst->arr.key_cols != src->arr.key_cols
         && dst->arr.key_count == src->arr.key_count
-        && dst->arr.indexed_rows == src->arr.indexed_rows
+        /* Issue #1438: a clone is a cold entry -- the buckets are copied
+        * but the freshness token and indexed_rows are reset so the first
+        * lookup rebuilds against the worker's own partition relation. */
+        && dst->arr.indexed_rows == 0
+        && dst->source_snapshot.relation_identity == 0
         && dst->arr.content_hash == src->arr.content_hash
         && dst->arr.nbuckets == src->arr.nbuckets
         && dst->arr.ht_cap == src->arr.ht_cap

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -367,6 +367,13 @@ col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst,
     dst->arr.nbuckets = src->arr.nbuckets;
     dst->arr.ht_cap = src->arr.ht_cap;
     dst->arr.generation = src->arr.generation;
+    /* A worker's relation is a partition with its own identity, and the
+     * differential join walks [indexed_rows, nrows) of its arrangement
+     * directly.  The clone therefore arrives cold: the freshness token is
+     * zeroed so the first lookup rebuilds against the worker's relation
+     * instead of trusting the coordinator's index (Issue #1438). */
+    dst->source_snapshot = (col_relation_snapshot_t){ 0, 0, 0 };
+    dst->arr.indexed_rows = 0;
     col_arr_attach_memory_governor(&dst->arr, memory_governor);
     if (dst->arr.memory_governor && src->mem_bytes > 0) {
         wl_columnar_memory_governor_t *governor
@@ -827,8 +834,10 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
         if (!match)
             continue;
 
-        /* Found: update if stale. */
-        if (e->arr.indexed_rows == 0) {
+        /* A token mismatch invalidates the complete index. */
+        bool snapshot_match = wl_columnar_relation_snapshot_equal(
+            e->source_snapshot, wl_columnar_relation_snapshot(rel));
+        if (!snapshot_match || e->arr.indexed_rows == 0) {
             /* Deduct stale bytes before rebuild; restore on failure. */
             cs->arr_total_bytes -= e->mem_bytes;
             if (arr_build_full(&e->arr, rel) != 0) {
@@ -841,6 +850,7 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
                 return NULL;
             }
             cs->arr_total_bytes += e->mem_bytes;
+            e->source_snapshot = wl_columnar_relation_snapshot(rel);
         } else if (e->arr.indexed_rows < rel->nrows) {
             uint32_t old = e->arr.indexed_rows;
             cs->arr_total_bytes -= e->mem_bytes;
@@ -854,6 +864,7 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
                 return NULL;
             }
             cs->arr_total_bytes += e->mem_bytes;
+            e->source_snapshot = wl_columnar_relation_snapshot(rel);
         }
         /* Bump LRU clock on every access. */
         e->lru_clock = ++cs->arr_clock;
@@ -944,6 +955,7 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
             cs->arr_count--;
         return NULL;
     }
+    e->source_snapshot = wl_columnar_relation_snapshot(rel);
     if (!arr_memory_bytes(&e->arr, &e->mem_bytes)) {
         arr_free_contents(&e->arr);
         col_arr_detach_memory_governor(&e->arr);
@@ -1190,14 +1202,18 @@ col_session_get_delta_arrangement(wl_col_session_t *cs, const char *rel_name,
         }
         if (!match)
             continue;
-        /* Found: rebuild if stale (delta changed size). */
-        if (e->arr.indexed_rows != delta_rel->nrows) {
+        /* A changed source token requires a complete rebuild even when the
+         * row count is unchanged. */
+        bool snapshot_match = wl_columnar_relation_snapshot_equal(
+            e->source_snapshot, wl_columnar_relation_snapshot(delta_rel));
+        if (!snapshot_match || e->arr.indexed_rows != delta_rel->nrows) {
             if (delta_rel->nrows > 0) {
                 if (arr_build_full(&e->arr, delta_rel) != 0)
                     return NULL;
             } else {
                 arr_free_contents(&e->arr);
             }
+            e->source_snapshot = wl_columnar_relation_snapshot(delta_rel);
         }
         return &e->arr;
     }
@@ -1245,6 +1261,7 @@ col_session_get_delta_arrangement(wl_col_session_t *cs, const char *rel_name,
         memset(e, 0, sizeof(*e));
         return NULL;
     }
+    e->source_snapshot = wl_columnar_relation_snapshot(delta_rel);
     return &e->arr;
 }
 
@@ -1309,14 +1326,16 @@ col_session_get_filt_arrangement(wl_col_session_t *cs, const char *rel_name,
         }
         if (!match)
             continue;
-        /* Found: rebuild if stale (filtered_rel grew since last build). */
-        if (e->arr.indexed_rows != filtered_rel->nrows) {
+        bool snapshot_match = wl_columnar_relation_snapshot_equal(
+            e->source_snapshot, wl_columnar_relation_snapshot(filtered_rel));
+        if (!snapshot_match || e->arr.indexed_rows != filtered_rel->nrows) {
             if (filtered_rel->nrows > 0) {
                 if (arr_build_full(&e->arr, filtered_rel) != 0)
                     return NULL;
             } else {
                 arr_free_contents(&e->arr);
             }
+            e->source_snapshot = wl_columnar_relation_snapshot(filtered_rel);
         }
         return &e->arr;
     }
@@ -1365,6 +1384,7 @@ col_session_get_filt_arrangement(wl_col_session_t *cs, const char *rel_name,
         memset(e, 0, sizeof(*e));
         return NULL;
     }
+    e->source_snapshot = wl_columnar_relation_snapshot(filtered_rel);
     return &e->arr;
 }
 
@@ -1440,8 +1460,10 @@ sarr_build(col_sorted_arr_t *sarr, const col_rel_t *rel, uint32_t key_col)
     sarr->key_col = key_col;
     sarr->indexed_rows = 0;
 
-    if (rel->nrows == 0)
+    if (rel->nrows == 0) {
+        sarr->source_snapshot = wl_columnar_relation_snapshot(rel);
         return 0;
+    }
 
     size_t bytes = (size_t)rel->nrows * rel->ncols * sizeof(int64_t);
     sarr->sorted = (int64_t *)malloc(bytes);
@@ -1466,6 +1488,7 @@ sarr_build(col_sorted_arr_t *sarr, const col_rel_t *rel, uint32_t key_col)
     }
     sarr->nrows = rel->nrows;
     sarr->indexed_rows = rel->nrows;
+    sarr->source_snapshot = wl_columnar_relation_snapshot(rel);
     return 0;
 }
 
@@ -1497,8 +1520,11 @@ col_session_get_sorted_arrangement(wl_col_session_t *cs, const char *rel_name,
             continue;
         if (strcmp(e->rel_name, rel_name) != 0)
             continue;
-        /* Found: rebuild if stale. */
-        if (e->sarr.indexed_rows != rel->nrows) {
+        /* indexed_rows is only a progress marker; freshness is the source
+         * snapshot. */
+        if (!wl_columnar_relation_snapshot_equal(e->sarr.source_snapshot,
+            wl_columnar_relation_snapshot(rel))
+            || e->sarr.indexed_rows != rel->nrows) {
             if (sarr_build(&e->sarr, rel, key_col) != 0)
                 return NULL;
         }
@@ -1566,16 +1592,21 @@ col_session_free_sorted_arrangements(wl_col_session_t *cs)
  * col_session_get_diff_arrangement:
  *
  * Return (or lazily create) a differential arrangement for `rel_name`
- * keyed on `key_cols[0..key_count)`. The arrangement persists across
- * iterations within an epoch, enabling incremental hash index reuse.
+ * keyed on `key_cols[0..key_count)`.  The arrangement persists across
+ * iterations within an epoch and the caller indexes only rows beyond
+ * `indexed_rows`, but only while its freshness token still matches
+ * `source_rel`: on a relation identity or generation mismatch the hash
+ * chains and progress counters are cleared and the token is poisoned, so
+ * the caller re-indexes from row 0 (Issue #1438).
  *
  * Returns NULL on allocation failure.
  */
 col_diff_arrangement_t *
 col_session_get_diff_arrangement(wl_col_session_t *cs, const char *rel_name,
+    const col_rel_t *source_rel,
     const uint32_t *key_cols, uint32_t key_count)
 {
-    if (!cs || !rel_name || key_count == 0)
+    if (!cs || !rel_name || !source_rel || key_count == 0)
         return NULL;
 
     /* Search existing entries. */
@@ -1592,8 +1623,22 @@ col_session_get_diff_arrangement(wl_col_session_t *cs, const char *rel_name,
                 break;
             }
         }
-        if (match)
+        if (match) {
+            col_diff_arrangement_t *arr = e->diff_arr;
+            if (!wl_columnar_relation_snapshot_equal(
+                    arr->source_snapshot,
+                    wl_columnar_relation_snapshot(source_rel))) {
+                memset(arr->ht_head, 0,
+                    (size_t)arr->nbuckets * sizeof(*arr->ht_head));
+                memset(arr->ht_next, 0,
+                    (size_t)arr->ht_cap * sizeof(*arr->ht_next));
+                arr->base_nrows = 0;
+                arr->current_nrows = 0;
+                arr->indexed_rows = 0;
+                arr->source_snapshot = (col_relation_snapshot_t){ 0, 0, 0 };
+            }
             return e->diff_arr;
+        }
     }
 
     /* Not found: grow registry and create new entry. */
@@ -1630,6 +1675,7 @@ col_session_get_diff_arrangement(wl_col_session_t *cs, const char *rel_name,
         memset(e, 0, sizeof(*e));
         return NULL;
     }
+    e->diff_arr->source_snapshot = (col_relation_snapshot_t){ 0, 0, 0 };
     col_diff_arrangement_attach_ledger(e->diff_arr, &cs->mem_ledger);
     cs->diff_arr_count++;
     return e->diff_arr;
@@ -1697,6 +1743,11 @@ col_diff_arr_entry_clone(const col_diff_arr_entry_t *src,
             memset(dst, 0, sizeof(*dst));
             return ENOMEM;
         }
+        dst->diff_arr->source_snapshot
+            = (col_relation_snapshot_t){ 0, 0, 0 };
+        dst->diff_arr->indexed_rows = 0;
+        dst->diff_arr->base_nrows = 0;
+        dst->diff_arr->current_nrows = 0;
     }
 
     return 0;

--- a/wirelog/columnar/cache.c
+++ b/wirelog/columnar/cache.c
@@ -300,6 +300,12 @@ col_mat_cache_lookup(col_mat_cache_t *cache, const col_rel_t *left,
     for (uint32_t i = 0; i < cache->count; i++) {
         if (cache->entries[i].left_hash == lh
             && cache->entries[i].right_hash == rh
+            && wl_columnar_relation_snapshot_equal(
+                cache->entries[i].left_snapshot,
+                wl_columnar_relation_snapshot(left))
+            && wl_columnar_relation_snapshot_equal(
+                cache->entries[i].right_snapshot,
+                wl_columnar_relation_snapshot(right))
             && cache->entries[i].result != NULL
             && !cache->entries[i].eviction_deferred) {
             col_mat_entry_t *entry = &cache->entries[i];
@@ -332,6 +338,10 @@ col_mat_cache_lookup_pin(col_mat_cache_t *cache, const col_rel_t *left,
     for (uint32_t i = 0; i < cache->count; i++) {
         col_mat_entry_t *entry = &cache->entries[i];
         if (entry->left_hash == lh && entry->right_hash == rh
+            && wl_columnar_relation_snapshot_equal(entry->left_snapshot,
+            wl_columnar_relation_snapshot(left))
+            && wl_columnar_relation_snapshot_equal(entry->right_snapshot,
+            wl_columnar_relation_snapshot(right))
             && entry->result != NULL && !entry->eviction_deferred) {
             entry->lru_clock = ++cache->clock;
             cache->hits++;
@@ -409,6 +419,8 @@ col_mat_cache_insert_pin(col_mat_cache_t *cache, const col_rel_t *left,
     col_mat_entry_t *e = &cache->entries[cache->count++];
     e->left_hash = col_mat_cache_key_content(left);
     e->right_hash = col_mat_cache_key_content(right);
+    e->left_snapshot = wl_columnar_relation_snapshot(left);
+    e->right_snapshot = wl_columnar_relation_snapshot(right);
     e->result = result;
     e->mem_bytes = result_bytes;
     e->lru_clock = ++cache->clock;

--- a/wirelog/columnar/diff_arrangement.c
+++ b/wirelog/columnar/diff_arrangement.c
@@ -78,6 +78,7 @@ col_diff_arrangement_create(const uint32_t *key_cols, uint32_t key_count,
     arr->worker_id = worker_id;
     arr->nbuckets = DIFF_ARRANGEMENT_INITIAL_BUCKETS;
     arr->ht_cap = DIFF_ARRANGEMENT_INITIAL_BUCKETS;
+    arr->source_snapshot = (col_relation_snapshot_t){ 0, 0, 0 };
     arr->ledger = NULL;
 
     arr->ht_head = calloc(arr->ht_cap, sizeof(uint32_t));
@@ -162,6 +163,7 @@ col_diff_arrangement_deep_copy(const col_diff_arrangement_t *arr)
     copy->worker_id = arr->worker_id;
     copy->nbuckets = arr->nbuckets;
     copy->ht_cap = arr->ht_cap;
+    copy->source_snapshot = arr->source_snapshot;
     /* The copy belongs to whoever asked for it (a worker session); the
     * caller attaches the right ledger.  Never inherit the source's. */
     copy->ledger = NULL;

--- a/wirelog/columnar/diff_arrangement.h
+++ b/wirelog/columnar/diff_arrangement.h
@@ -18,6 +18,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+typedef struct col_relation_snapshot {
+    uint64_t relation_identity;
+    uint64_t view_generation;
+    uint64_t storage_generation;
+} col_relation_snapshot_t;
+
 /**
  * col_diff_arrangement - Delta-aware hash table for incremental indexing.
  *
@@ -44,6 +50,7 @@ typedef struct col_diff_arrangement {
     uint32_t *ht_next;
     uint32_t nbuckets;
     uint32_t ht_cap;
+    col_relation_snapshot_t source_snapshot;
     /* Issue #1380: when non-NULL, the struct, key_cols, ht_head and ht_next
     * bytes are charged to WL_MEM_SUBSYS_ARRANGEMENT on this ledger.  NULL
     * until col_diff_arrangement_attach_ledger(); deep copies start NULL. */

--- a/wirelog/columnar/filter.c
+++ b/wirelog/columnar/filter.c
@@ -970,8 +970,12 @@ wl_columnar_filter_apply_right_filter_cached(wl_col_session_t *sess,
             || memcmp(sess->filt_cache[i].filter_data, fexpr->data,
             fexpr->size) != 0)
             continue;
-        /* Cache hit */
-        if (sess->filt_cache[i].source_nrows == rel->nrows)
+        /* Cache hit: the freshness token is the contract (Issue #1438);
+         * the row count is kept as a cheap second guard. */
+        if (wl_columnar_relation_snapshot_equal(
+                sess->filt_cache[i].source_snapshot,
+                wl_columnar_relation_snapshot(rel))
+            && sess->filt_cache[i].source_nrows == rel->nrows)
             return sess->filt_cache[i].filtered; /* still valid */
         /* Source grew — rebuild in-place */
         if (sess->filt_cache[i].filtered)
@@ -986,6 +990,8 @@ wl_columnar_filter_apply_right_filter_cached(wl_col_session_t *sess,
             return NULL;
         }
         sess->filt_cache[i].source_nrows = rel->nrows;
+        sess->filt_cache[i].source_snapshot
+            = wl_columnar_relation_snapshot(rel);
         return sess->filt_cache[i].filtered;
     }
 
@@ -1016,6 +1022,8 @@ wl_columnar_filter_apply_right_filter_cached(wl_col_session_t *sess,
     sess->filt_cache[idx].filter_size = fexpr->size;
     sess->filt_cache[idx].filter_hash = fhash;
     sess->filt_cache[idx].source_nrows = 0; /* will be set after fill */
+    sess->filt_cache[idx].source_snapshot = (col_relation_snapshot_t){ 0, 0,
+                                                                       0 };
     sess->filt_cache[idx].filtered = col_rel_new_like("$rfilter_cache", rel);
     if (!sess->filt_cache[idx].filtered) {
         free(sess->filt_cache[idx].filter_data);
@@ -1034,5 +1042,7 @@ wl_columnar_filter_apply_right_filter_cached(wl_col_session_t *sess,
         return NULL;
     }
     sess->filt_cache[idx].source_nrows = rel->nrows;
+    sess->filt_cache[idx].source_snapshot
+        = wl_columnar_relation_snapshot(rel);
     return out;
 }

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -503,11 +503,42 @@ _Static_assert(offsetof(col_rel_t, relation_identity) >
     "relation generation fields must remain outside the legacy prefix");
 #endif /* C11 _Static_assert */
 
+#define WL_COLUMNAR_REL_GENERATION_INVALID UINT64_MAX
+
+static inline col_relation_snapshot_t
+wl_columnar_relation_snapshot(const col_rel_t *rel)
+{
+    col_relation_snapshot_t snapshot = { 0, 0, 0 };
+    if (rel) {
+        snapshot.relation_identity = rel->relation_identity;
+        snapshot.view_generation = rel->view_generation;
+        snapshot.storage_generation = rel->storage_generation;
+    }
+    return snapshot;
+}
+
+static inline bool
+wl_columnar_relation_snapshot_valid(col_relation_snapshot_t snapshot)
+{
+    return snapshot.relation_identity != 0
+           && snapshot.view_generation != WL_COLUMNAR_REL_GENERATION_INVALID
+           && snapshot.storage_generation != WL_COLUMNAR_REL_GENERATION_INVALID;
+}
+
+static inline bool
+wl_columnar_relation_snapshot_equal(col_relation_snapshot_t left,
+    col_relation_snapshot_t right)
+{
+    return wl_columnar_relation_snapshot_valid(left)
+           && wl_columnar_relation_snapshot_valid(right)
+           && left.relation_identity == right.relation_identity
+           && left.view_generation == right.view_generation
+           && left.storage_generation == right.storage_generation;
+}
+
 /* Generation counters are intentionally checked rather than wrapping.  A
  * saturated counter is invalid for cache equality; the next cache unit will
  * use wl_columnar_relation_generation_valid() before accepting a hit. */
-#define WL_COLUMNAR_REL_GENERATION_INVALID UINT64_MAX
-
 static inline bool
 wl_columnar_relation_generation_valid(uint64_t generation)
 {
@@ -1087,6 +1118,8 @@ typedef struct {
     uint64_t generation;
     bool owner_alive;
     bool owns_result;
+    col_relation_snapshot_t left_snapshot;
+    col_relation_snapshot_t right_snapshot;
 } col_mat_entry_t;
 
 typedef struct {
@@ -1152,6 +1185,7 @@ typedef struct {
     uint32_t pin_count;    /* active internal reader leases */
     bool rebuild_deferred; /* invalidation waits for readers */
     bool evict_deferred;   /* reclaim was requested while pinned */
+    col_relation_snapshot_t source_snapshot;
 } col_arr_entry_t;
 
 /* Non-public lease for a primary arrangement borrowed by an operator. */
@@ -1179,6 +1213,7 @@ typedef struct {
      * currently charged for sorted[]; 0 when ledger is NULL. */
     wl_mem_ledger_t *ledger;
     uint64_t ledger_bytes;
+    col_relation_snapshot_t source_snapshot;
 } col_sorted_arr_t;
 
 /*
@@ -1302,6 +1337,7 @@ typedef struct col_filt_cache_entry {
     uint8_t *filter_data;    /* owned copy of filter expression bytes */
     uint32_t filter_size;    /* byte length of filter_data */
     uint32_t source_nrows;   /* nrows of source rel when entry was built */
+    col_relation_snapshot_t source_snapshot;
     col_rel_t *filtered;     /* owned: the filtered relation */
 } col_filt_cache_entry_t;
 
@@ -1318,6 +1354,7 @@ typedef struct col_filt_arr_entry {
     uint32_t *key_cols;    /* owned: right-side key column indices */
     uint32_t key_count;
     col_arrangement_t arr; /* owned: hash index over filtered relation */
+    col_relation_snapshot_t source_snapshot;
 } col_filt_arr_entry_t;
 
 /*
@@ -2217,6 +2254,7 @@ col_session_free_filt_arrangements(wl_col_session_t *cs);
 /* Differential arrangement registry (Issue #263) */
 col_diff_arrangement_t *
 col_session_get_diff_arrangement(wl_col_session_t *cs, const char *rel_name,
+    const col_rel_t *source_rel,
     const uint32_t *key_cols, uint32_t key_count);
 void
 col_session_free_diff_arrangements(wl_col_session_t *cs);

--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -2154,8 +2154,8 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
     col_diff_arrangement_t *darr = NULL;
     if (kc > 0 && op->right_relation && !used_right_delta
         && op->right_filter_expr.size == 0)
-        darr = col_session_get_diff_arrangement(sess, op->right_relation, rk,
-                kc);
+        darr = col_session_get_diff_arrangement(sess, op->right_relation,
+                right, rk, kc);
 
     if (darr
         && col_diff_arrangement_ensure_ht_capacity(darr, right->nrows) != 0)
@@ -2172,6 +2172,7 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
         }
         darr->indexed_rows = right->nrows;
         darr->current_nrows = right->nrows;
+        darr->source_snapshot = wl_columnar_relation_snapshot(right);
 
         uint32_t min_left = col_join_parallel_min_left_rows();
         if (min_left == 0)


### PR DESCRIPTION
Re-lands 68cd283c (PR #1443) on current main. The original merged only into a stacked base branch that was later rewritten, so its code never reached `main`.

## What changes

- Every cache consumer (filter cache, materialization cache, primary/filtered/sorted/delta arrangements, differential arrangement) captures a `col_relation_snapshot_t` freshness token (`relation_identity`, `view_generation`, `storage_generation` from #1441) at build time and compares the full token on lookup. A mismatch rebuilds. Row-count or pointer equality is no longer sufficient for a hit.
- `col_session_get_diff_arrangement` takes the source relation so the differential arrangement is validated the same way.
- Materialization cache entries are keyed on relation identity as well as the content prefix hash: distinct relation objects with identical content no longer share an entry (the prefix hash covers only 100 rows).
- `col_arr_entry_clone` zeroes the clone's token and `indexed_rows`, so a TDD worker's clone arrives cold and rebuilds against the worker's own relation on first access. Worker relations carry their own identity, so the coordinator's index can never be a valid hit for them.

## Differences from 68cd283c

- The `kfusion.c` clone hunk is dropped: main no longer has that clone (76192fa1 moved the clone helpers into `arrangement.c`). `tests/test_worker_session.c` case [9] asserts the cold-clone contract instead.
- `filter.c` keeps the `source_nrows == rel->nrows` guard AND-ed with the token.
- `tests/test_arrangement_cache_reuse.c` carries an uncrustify reflow because the version on main fails `uncrustify --check`.

## Cost note

Cold clones cost one discarded hashtable memcpy plus one full arrangement build per cloned primary arrangement per worker on first access, on the worker-init path. The engine loop already invalidated every grown relation per sub-pass (#275), so append-driven full rebuilds are not a regression. `--suite perf` skipped locally (no performance governor); please read it from CI. Follow-up issues for seeding worker tokens from shared views, deferring rebuilds under a pin, and pruning dead incremental paths are filed separately.

## Validation

- `meson test -C build`: 352 OK, 0 failed, 13 skipped (perf and stress-release gates only). clang-tidy ratchet, threading doc, ABI suites green.
- ASan/UBSan: generation_cache, arrangement_cache_reuse, mat_cache_lifetime, worker_session, arrangement, delta_arrangement, diff_join, relation_generations, session, k_fusion_memory clean.
- TSan (`-Dthreads=posix`): diff_join, tdd_decision_stats, tdd_multiworker, worker_session, e2e_kfusion_k4_inline, e2e_tsan_inline_kfusion, 0 warnings.
- `.text` delta vs main in the CI configuration: +1815 B (budget 5120).

Closes #1438
