### PR TITLE
feat(#1431): admit the program-owned intern table under the memory governor

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -255,7 +255,8 @@ propagate failure and must not report a truncated successful result.
 
 | Allocation class | Owner and lifetime | #1418 status | Failure contract |
 | --- | --- | --- | --- |
-| Parser AST, interned names, and parse diagnostics | `wirelog_program_t`, released by `wirelog_program_free()` | Excluded; parse context is created before a managed session | Return `NULL` with `WIRELOG_ERR_PARSE` or `WIRELOG_ERR_MEMORY`; no partial program is published |
+| Parser AST and parse diagnostics | `wirelog_program_t`, released by `wirelog_program_free()` | Excluded; parse context is created before a managed session | Return `NULL` with `WIRELOG_ERR_PARSE` or `WIRELOG_ERR_MEMORY`; no partial program is published |
+| Interned strings (`wl_intern_t`: hash slots, id segments, string copies) | `wirelog_program_t`; the reservation is retained until `wirelog_program_free()` | Covered from the first managed session (#1431): session creation attaches the program's table to that session's governor and admits the bytes it already holds transactionally, so session creation fails with `ENOMEM`/`EOVERFLOW` (public `WIRELOG_ERR_MEMORY`) when they exceed the budget; that governor owns the table for the program's lifetime regardless of later sessions' budgets, and session destruction never releases it. Each unique `wl_intern_put()` reserves the string copy plus any new id segment or doubled slot array before allocating, with the old footprint still held; duplicates are uncharged | `wl_intern_put()` returns `-1` and leaves every existing id, `wl_intern_reverse()` result and the reservation unchanged. Residual: string builtins and non-pre-interned literals evaluated under an enforcing budget carry that `-1` as a string id instead of failing the step (follow-up) |
 | IR/program relation metadata | `wirelog_program_t`, released with the program | Excluded; same owner as parser output | Return `NULL` with the existing parse/IR error; callers retain no partially initialized program |
 | Optimized execution plan | `wirelog_executor_t`, released by `wirelog_executor_free()` | Excluded; plan construction precedes result collection | Return `NULL` with `WIRELOG_ERR_INVALID_IR`, `WIRELOG_ERR_MEMORY`, or the existing executor error |
 | Executor/session wrapper and columnar session storage | `wirelog_executor_t` and its session | Covered by #1413/#1369 session admission, not charged again here | Session creation fails with the existing public memory error and releases all reservations |
@@ -372,9 +373,11 @@ workloads:
   teardown.  Branch arenas and pools are redirected to the parent (ARENA),
   but join outputs, arrangements and caches created inside a parallel
   branch (K ≥ 4) charge the throwaway copy.  #1375 retires this path.
-- Parser and IR, the execution plan, the intern table, nanoarrow schemas,
-  the compound-term arena, exchange buffers, thread stacks (8 MB per TDD
-  worker by default) and the work queue.
+- Parser and IR, the execution plan, nanoarrow schemas, the compound-term
+  arena, exchange buffers, thread stacks (8 MB per TDD worker by default)
+  and the work queue.  The intern table is program-owned but charged to
+  the first managed session's governor (#1431, see the #1418 matrix); its
+  bytes appear in that governor's reserved total, not in the session ledger.
 
 ## 3. Reading the report: `WL_MEM_REPORT`
 

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -194,7 +194,7 @@ On non-MSVC builds the same macros expand to
 
 ### 4.4 MSVC shim in `intern.c`
 
-`wirelog/intern.c:63-88` provides the same shape of shim for the
+`wirelog/intern.c:67-92` provides the same shape of shim for the
 `uint32_t` published-entry counter of the shared symbol table
 (Issue #958):
 
@@ -217,7 +217,7 @@ orders named above.
   `atomic_bool`, `atomic_uint_fast64_t` as MSVC-compatible aliases.
 - `wirelog/util/lockfree_queue.c:31,48` defines `wl_atomic_u32` per
   branch.
-- `wirelog/intern.c:74,80` defines `wl_intern_atomic_u32` per branch.
+- `wirelog/intern.c:78,84` defines `wl_intern_atomic_u32` per branch.
 
 These exist so struct fields can be declared portably; the audit in
 §5 below covers only call sites, not type-declaration sites.
@@ -411,7 +411,7 @@ named in the justification.
 | Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
 | `intern.c:WL_INTERN_LOAD_ACQUIRE` | `intern->count` | `atomic_load_explicit` | `acquire` | `WL_INTERN_LOAD_ACQUIRE`, used by `wl_intern_reverse`/`wl_intern_count`. Pairs with the release store below: an id below the observed count names a fully written entry, and the segment holding it is allocated and never moves |
-| `intern.c:WL_INTERN_LOAD_RELAXED` | `intern->count` | `atomic_load_explicit` | `relaxed` | `WL_INTERN_LOAD_RELAXED`, used by `wl_intern_put`, `intern_resize` and `wl_intern_free`. The writer holds `intern->lock` (or, in `free`, has exclusive access), so no edge is needed |
+| `intern.c:WL_INTERN_LOAD_RELAXED` | `intern->count` | `atomic_load_explicit` | `relaxed` | `WL_INTERN_LOAD_RELAXED`, used by `wl_intern_put`, `intern_resize_prepare`, `intern_retained_bytes_locked` and `wl_intern_free`. Every caller holds `intern->lock` (`wl_intern_free` takes it to release the governor reservation, Issue #1431), so no edge is needed |
 | `intern.c:WL_INTERN_STORE_RELEASE` | `intern->count` | `atomic_store_explicit` | `release` | `WL_INTERN_STORE_RELEASE`, used by `wl_intern_put` after the string and its segment pointer are written. Publishing the count first would let a lock-free reader dereference an unwritten slot |
 
 ### 5.11 Total

--- a/tests/bench_incremental_frontier.c
+++ b/tests/bench_incremental_frontier.c
@@ -33,6 +33,7 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 static uint64_t
 now_ns(void)
@@ -61,9 +62,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 
@@ -83,9 +86,9 @@ main(void)
     printf("\n=== Phase 4 Frontier Persistence Performance Benchmark ===\n\n");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      ".decl path(x: int32, y: int32)\n"
-                      "path(x, y) :- edge(x, y).\n"
-                      "path(x, z) :- path(x, y), edge(y, z).\n";
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n"
+        "path(x, z) :- path(x, y), edge(y, z).\n";
 
     wl_plan_t *plan = build_plan(src);
     if (!plan) {
@@ -213,9 +216,9 @@ main(void)
     /* Results */
     printf("RESULTS:\n");
     printf("  Baseline (full eval):      %.2f ms\n",
-           (double)full_time_ns / 1000000.0);
+        (double)full_time_ns / 1000000.0);
     printf("  Incremental (batched):     %.2f ms\n",
-           (double)incr_time_ns / 1000000.0);
+        (double)incr_time_ns / 1000000.0);
 
     double speedup = (double)full_time_ns / (double)incr_time_ns;
     printf("  Speedup:                   %.2fx\n\n", speedup);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -40,6 +40,7 @@ optimizer_src = files(
 # Meson deduplicates against targets that already list thread_src.
 intern_src = [
   files('../wirelog/intern.c'),
+  files('../wirelog/columnar/memory_governor.c'),
   wirelog_thread_src,
 ]
 
@@ -282,9 +283,8 @@ if get_option('enable_fuzz')
       intern_fuzz_corpus = meson.current_source_dir() / 'fuzz/corpus/intern'
       intern_fuzz = executable(
         'intern_fuzz',
-        files('fuzz/intern_fuzz.c',
-          '../wirelog/intern.c'),
-        wirelog_thread_src,
+        files('fuzz/intern_fuzz.c'),
+        intern_src,
         include_directories: [wirelog_inc, wirelog_src_inc],
         c_args: ['-fsanitize=fuzzer'],
         link_args: ['-fsanitize=fuzzer'],
@@ -1338,6 +1338,17 @@ test_intern_exe = executable(
 )
 
 test('intern', test_intern_exe)
+
+test_memory_admission_intern_exe = executable(
+  'test_memory_admission_intern',
+  files('test_memory_admission_intern.c'),
+  intern_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
+)
+
+test('memory_admission_intern', test_memory_admission_intern_exe,
+     suite: 'unit')
 
 # Issue #1381: execute the memory-ledger arithmetic contract.  This remains
 # accounting-only; reservation/admission is owned by the #1368/#1369 units.

--- a/tests/plan_fixture.h
+++ b/tests/plan_fixture.h
@@ -1,0 +1,80 @@
+/* plan_fixture.h - keep parsed programs alive for the plans built from them
+ *
+ * Copyright (C) CleverPlant
+ * Licensed under LGPL-3.0
+ *
+ * wl_plan_t and every session created from it borrow the program's intern
+ * table (see the borrow note in exec_plan_gen.c and the executor contract in
+ * wirelog.h).  Test helpers used to free the program right after
+ * wl_plan_from_program(); that was latent while nothing touched the intern
+ * through the plan, and became a use-after-free once session creation
+ * attaches the memory governor to plan->intern (Issue #1431).
+ *
+ * Usage inside a build_plan() helper:
+ *
+ *     int rc = wl_plan_from_program(prog, &plan);
+ *     if (rc != 0) {
+ *         wirelog_program_free(prog);
+ *         return NULL;
+ *     }
+ *     plan_fixture_hold(prog);
+ *     return plan;
+ *
+ * plan_fixture_hold() registers plan_fixture_release() with atexit() on first
+ * use, so every exit path of the test binary frees the held programs after
+ * main() returns and after every session and plan has been destroyed.
+ * plan_fixture_release() may also be called explicitly; it is idempotent.
+ *
+ * Header-only, no dependencies beyond wirelog.h.
+ */
+#ifndef WIRELOG_TESTS_PLAN_FIXTURE_H
+#define WIRELOG_TESTS_PLAN_FIXTURE_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../wirelog/wirelog.h"
+
+static wirelog_program_t **plan_fixture_programs;
+static size_t plan_fixture_count;
+static size_t plan_fixture_capacity;
+static int plan_fixture_atexit_registered;
+
+static void
+plan_fixture_release(void)
+{
+    while (plan_fixture_count > 0)
+        wirelog_program_free(plan_fixture_programs[--plan_fixture_count]);
+    free(plan_fixture_programs);
+    plan_fixture_programs = NULL;
+    plan_fixture_capacity = 0;
+}
+
+/* Take ownership of @prog until process exit.  Never fails silently: an
+ * allocation failure while growing the table aborts the test binary, because
+ * freeing the program here would recreate the dangling borrow. */
+static void
+plan_fixture_hold(wirelog_program_t *prog)
+{
+    if (!prog)
+        return;
+    if (plan_fixture_count == plan_fixture_capacity) {
+        size_t new_capacity = plan_fixture_capacity ? plan_fixture_capacity *
+            2 : 16;
+        wirelog_program_t **grown = realloc(plan_fixture_programs,
+                new_capacity * sizeof(*grown));
+        if (!grown) {
+            fprintf(stderr, "plan_fixture_hold: out of memory\n");
+            abort();
+        }
+        plan_fixture_programs = grown;
+        plan_fixture_capacity = new_capacity;
+    }
+    plan_fixture_programs[plan_fixture_count++] = prog;
+    if (!plan_fixture_atexit_registered) {
+        plan_fixture_atexit_registered = 1;
+        atexit(plan_fixture_release);
+    }
+}
+
+#endif /* WIRELOG_TESTS_PLAN_FIXTURE_H */

--- a/tests/test_affected_strata_rewrites.c
+++ b/tests/test_affected_strata_rewrites.c
@@ -47,6 +47,7 @@
 #include "../wirelog/wirelog.h"
 
 #include "test_tmpdir.h"
+#include "plan_fixture.h"
 
 /* ======================================================================== */
 /* TEST HARNESS MACROS                                                       */
@@ -176,8 +177,12 @@ build_plan(const char *src, bool optimize)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    return (rc == 0) ? plan : NULL;
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        return NULL;
+    }
+    plan_fixture_hold(prog);
+    return plan;
 }
 
 /*

--- a/tests/test_compaction.c
+++ b/tests/test_compaction.c
@@ -23,6 +23,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -84,9 +85,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_constant_filter_pushdown.c
+++ b/tests/test_constant_filter_pushdown.c
@@ -12,6 +12,7 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -48,9 +49,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_csv_streaming.c
+++ b/tests/test_csv_streaming.c
@@ -179,9 +179,97 @@ test_admission_release(void)
     return clean ? 0 : 1;
 }
 
+/* Issue #1431: a program-owned intern table attached to an exhausted
+ * governor denies the first unique string a CSV load tries to intern.  The
+ * load must report an error, the ids interned before the load must still
+ * resolve, and neither governor may keep a stale reservation. */
+static int
+test_intern_denial_keeps_prior_ids(void)
+{
+    char path[512];
+    if (write_fixture(path, sizeof(path), "wirelog_csv_streaming_intern.csv",
+        "1,alpha\n2,beta\n") != 0)
+        return 1;
+
+    wirelog_column_type_t types[] = {
+        WIRELOG_TYPE_INT64, WIRELOG_TYPE_STRING,
+    };
+    wl_columnar_memory_resolution_t generous = {
+        .budget_bytes = 1u << 20,
+            .headroom_bytes = 0,
+            .usable_bytes = 1u << 20,
+            .mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING,
+            .source = WL_COLUMNAR_MEMORY_SOURCE_ENV,
+            .status = WL_COLUMNAR_MEMORY_OK,
+    };
+    wl_columnar_memory_resolution_t exact = generous;
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *probe
+        = wl_columnar_memory_governor_ref_create(&generous);
+    wl_columnar_memory_governor_ref_t *csv_ref
+        = wl_columnar_memory_governor_ref_create(&generous);
+    wl_columnar_memory_governor_ref_t *tight = NULL;
+    stream_observer_t obs = {0};
+    uint64_t footprint = 0;
+    int rc = -1;
+    int clean = 0;
+
+    if (!intern || !probe || !csv_ref)
+        goto out;
+    /* "alpha" is interned before the load; measure the table's footprint
+     * through a probe governor, then re-attach it to a governor whose budget
+     * is exactly that footprint so any growth is denied. */
+    if (wl_intern_put(intern, "alpha") != 0
+        || wl_intern_attach_memory_governor(intern, probe) != 0)
+        goto out;
+    footprint = wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(probe));
+    if (footprint == 0 || wl_intern_detach_memory_governor(intern, probe) != 0)
+        goto out;
+    exact.budget_bytes = footprint;
+    exact.usable_bytes = footprint;
+    tight = wl_columnar_memory_governor_ref_create(&exact);
+    if (!tight || wl_intern_attach_memory_governor(intern, tight) != 0)
+        goto out;
+
+    rc = wl_csv_read_file_via_ctx_stream_admitted(path, ',', types, 2, 2,
+            observe_rows, &obs, intern_cb, intern,
+            wl_columnar_memory_governor_ref_get(csv_ref));
+    clean = rc != 0
+        && wl_intern_count(intern) == 1u
+        && wl_intern_get(intern, "alpha") == 0
+        && strcmp(wl_intern_reverse(intern, 0), "alpha") == 0
+        && wl_intern_get(intern, "beta") == -1
+        && wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(tight)) == footprint
+        && wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(csv_ref)) == 0;
+    if (!clean)
+        fprintf(stderr, "intern denial: rc=%d count=%u reserved=%llu/%llu\n",
+            rc, (unsigned)wl_intern_count(intern),
+            (unsigned long long)wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(tight)),
+            (unsigned long long)footprint);
+out:
+    if (intern)
+        wl_intern_free(intern);
+    if (tight)
+        clean = clean && wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(tight)) == 0;
+    if (tight)
+        wl_columnar_memory_governor_ref_release(tight);
+    if (csv_ref)
+        wl_columnar_memory_governor_ref_release(csv_ref);
+    if (probe)
+        wl_columnar_memory_governor_ref_release(probe);
+    remove(path);
+    return clean ? 0 : 1;
+}
+
 int
 main(void)
 {
     return test_batches_and_strings() || test_callback_failure()
-           || test_admission_denial() || test_admission_release();
+           || test_admission_denial() || test_admission_release()
+           || test_intern_denial_keeps_prior_ids();
 }

--- a/tests/test_delta_callback.c
+++ b/tests/test_delta_callback.c
@@ -22,6 +22,7 @@
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog-extension.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -80,9 +81,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 
@@ -406,7 +409,7 @@ test_no_partial_delta_on_error(void)
         FAIL("could not generate failure plan");
         return 1;
     }
-    wirelog_program_free(program);
+    plan_fixture_hold(program);
     wl_session_t *session = NULL;
     if (wl_session_create_with_snapshot(wl_backend_columnar(), plan, 1,
         snapshot, &session) != 0

--- a/tests/test_delta_retraction.c
+++ b/tests/test_delta_retraction.c
@@ -22,6 +22,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -69,9 +70,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_doop_multiworker.c
+++ b/tests/test_doop_multiworker.c
@@ -28,6 +28,7 @@
 #include "../wirelog/passes/fusion.h"
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -143,9 +144,11 @@ run_multi_idb_chain(int chain_len, uint32_t num_workers)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return -1;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *session = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, num_workers, &session);
@@ -272,9 +275,11 @@ run_doop_synthetic(uint32_t num_workers)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return -1;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *sess = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, num_workers, &sess);

--- a/tests/test_fpga_backend.c
+++ b/tests/test_fpga_backend.c
@@ -18,6 +18,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -156,9 +157,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_gc_epoch_boundary.c
+++ b/tests/test_gc_epoch_boundary.c
@@ -27,6 +27,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -84,9 +85,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_incremental_insertion.c
+++ b/tests/test_incremental_insertion.c
@@ -24,28 +24,29 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 /* ======================================================================== */
 /* TEST HARNESS MACROS                                                       */
 /* ======================================================================== */
 
 #define TEST(name)                       \
-    do {                                 \
-        printf("  [TEST] %-60s ", name); \
-        fflush(stdout);                  \
-    } while (0)
+        do {                                 \
+            printf("  [TEST] %-60s ", name); \
+            fflush(stdout);                  \
+        } while (0)
 
 #define PASS              \
-    do {                  \
-        printf("PASS\n"); \
-        tests_passed++;   \
-    } while (0)
+        do {                  \
+            printf("PASS\n"); \
+            tests_passed++;   \
+        } while (0)
 
 #define FAIL(msg)                  \
-    do {                           \
-        printf("FAIL: %s\n", msg); \
-        tests_failed++;            \
-    } while (0)
+        do {                           \
+            printf("FAIL: %s\n", msg); \
+            tests_failed++;            \
+        } while (0)
 
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -74,9 +75,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 
@@ -112,9 +115,9 @@ test_frontier_preserved_after_incremental_insert(void)
     TEST("frontier_preserved_after_incremental_insert");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      ".decl path(x: int32, y: int32)\n"
-                      "path(x, y) :- edge(x, y).\n"
-                      "path(x, z) :- path(x, y), edge(y, z).\n";
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n"
+        "path(x, z) :- path(x, y), edge(y, z).\n";
 
     wl_plan_t *plan = build_plan(src);
     if (!plan) {
@@ -179,7 +182,7 @@ test_frontier_preserved_after_incremental_insert(void)
     if (rc != 0) {
         char msg[64];
         snprintf(msg, sizeof(msg), "col_session_insert_incremental returned %d",
-                 rc);
+            rc);
         wl_session_destroy(sess);
         wl_plan_free(plan);
         FAIL(msg);
@@ -200,9 +203,9 @@ test_frontier_preserved_after_incremental_insert(void)
         || f_after.outer_epoch != f_before.outer_epoch) {
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "frontier changed: before=(%u,%u) after=(%u,%u)",
-                 f_before.iteration, f_before.outer_epoch, f_after.iteration,
-                 f_after.outer_epoch);
+            "frontier changed: before=(%u,%u) after=(%u,%u)",
+            f_before.iteration, f_before.outer_epoch, f_after.iteration,
+            f_after.outer_epoch);
         wl_session_destroy(sess);
         wl_plan_free(plan);
         FAIL(msg);
@@ -233,9 +236,9 @@ test_incremental_insert_enables_affected_stratum_detection(void)
     TEST("incremental_insert_enables_affected_stratum_detection");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      ".decl path(x: int32, y: int32)\n"
-                      "path(x, y) :- edge(x, y).\n"
-                      "path(x, z) :- path(x, y), edge(y, z).\n";
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n"
+        "path(x, z) :- path(x, y), edge(y, z).\n";
 
     wl_plan_t *plan = build_plan(src);
     if (!plan) {
@@ -275,7 +278,7 @@ test_incremental_insert_enables_affected_stratum_detection(void)
     if (rc != 0) {
         char msg[64];
         snprintf(msg, sizeof(msg), "col_session_insert_incremental returned %d",
-                 rc);
+            rc);
         wl_session_destroy(sess);
         wl_plan_free(plan);
         FAIL(msg);
@@ -313,9 +316,9 @@ test_multiple_incremental_inserts_preserve_frontier(void)
     TEST("multiple_incremental_inserts_preserve_cumulative_frontier");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      ".decl path(x: int32, y: int32)\n"
-                      "path(x, y) :- edge(x, y).\n"
-                      "path(x, z) :- path(x, y), edge(y, z).\n";
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n"
+        "path(x, z) :- path(x, y), edge(y, z).\n";
 
     wl_plan_t *plan = build_plan(src);
     if (!plan) {
@@ -454,9 +457,9 @@ test_empty_incremental_insert_safe_frontier_unchanged(void)
     TEST("empty_incremental_insert_safe_frontier_unchanged");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      ".decl path(x: int32, y: int32)\n"
-                      "path(x, y) :- edge(x, y).\n"
-                      "path(x, z) :- path(x, y), edge(y, z).\n";
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n"
+        "path(x, z) :- path(x, y), edge(y, z).\n";
 
     wl_plan_t *plan = build_plan(src);
     if (!plan) {
@@ -531,10 +534,10 @@ test_empty_incremental_insert_safe_frontier_unchanged(void)
         || f_after.outer_epoch != f_before.outer_epoch) {
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "frontier changed after empty insert: before=(%u,%u) "
-                 "after=(%u,%u)",
-                 f_before.iteration, f_before.outer_epoch, f_after.iteration,
-                 f_after.outer_epoch);
+            "frontier changed after empty insert: before=(%u,%u) "
+            "after=(%u,%u)",
+            f_before.iteration, f_before.outer_epoch, f_after.iteration,
+            f_after.outer_epoch);
         wl_session_destroy(sess);
         wl_plan_free(plan);
         FAIL(msg);
@@ -562,7 +565,7 @@ main(void)
     test_empty_incremental_insert_safe_frontier_unchanged();
 
     printf("\n=== Results: %d/%d passed ===\n", tests_passed,
-           tests_passed + tests_failed);
+        tests_passed + tests_failed);
 
     return tests_failed > 0 ? 1 : 0;
 }

--- a/tests/test_join_limit.c
+++ b/tests/test_join_limit.c
@@ -25,6 +25,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -87,9 +88,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_max_workers.c
+++ b/tests/test_max_workers.c
@@ -22,6 +22,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -84,9 +85,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_mem_instrumentation.c
+++ b/tests/test_mem_instrumentation.c
@@ -38,6 +38,7 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -177,9 +178,11 @@ run_chain(uint32_t workers, run_result_t *out)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *sess = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, workers, &sess);

--- a/tests/test_memory_admission_intern.c
+++ b/tests/test_memory_admission_intern.c
@@ -1,0 +1,480 @@
+/* Program-owned intern-table admission tests for issue #1431. */
+
+#include "../wirelog/columnar/memory_governor.h"
+#include "../wirelog/intern.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+static wl_columnar_memory_governor_ref_t *
+test_governor(uint64_t usable_bytes)
+{
+    wl_columnar_memory_resolution_t resolution = {
+        .budget_bytes = usable_bytes,
+        .headroom_bytes = 0,
+        .usable_bytes = usable_bytes,
+        .mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING,
+        .source = WL_COLUMNAR_MEMORY_SOURCE_ENV,
+        .status = WL_COLUMNAR_MEMORY_OK,
+    };
+    return wl_columnar_memory_governor_ref_create(&resolution);
+}
+
+static int
+test_attach_and_release(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref = test_governor(256);
+    wl_columnar_memory_governor_t *governor;
+    int rc;
+
+    if (!intern || !ref)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    rc = wl_intern_attach_memory_governor(intern, ref);
+    if (rc != 0 || wl_columnar_memory_reserved(governor) != 256) {
+        wl_intern_free(intern);
+        wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_intern_free(intern);
+    if (wl_columnar_memory_reserved(governor) != 0) {
+        wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    return 0;
+}
+
+static int
+test_denied_growth_preserves_table(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref = test_governor(256);
+    wl_columnar_memory_governor_t *governor;
+    int64_t id;
+
+    if (!intern || !ref)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    if (wl_intern_attach_memory_governor(intern, ref) != 0)
+        return 1;
+    id = wl_intern_put(intern, "new-symbol");
+    if (id != -1 || wl_intern_count(intern) != 0
+        || wl_intern_get(intern, "new-symbol") != -1
+        || wl_columnar_memory_reserved(governor) != 256) {
+        wl_intern_free(intern);
+        wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_intern_free(intern);
+    wl_columnar_memory_governor_ref_release(ref);
+    return 0;
+}
+
+static int
+test_duplicate_is_uncharged(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref = test_governor(4096);
+    wl_columnar_memory_governor_t *governor;
+    uint64_t before;
+    int64_t first;
+    int64_t duplicate;
+
+    if (!intern || !ref)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    if (wl_intern_attach_memory_governor(intern, ref) != 0)
+        return 1;
+    first = wl_intern_put(intern, "same-symbol");
+    before = wl_columnar_memory_reserved(governor);
+    duplicate = wl_intern_put(intern, "same-symbol");
+    if (first < 0 || duplicate != first
+        || wl_columnar_memory_reserved(governor) != before) {
+        wl_intern_free(intern);
+        wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_intern_free(intern);
+    wl_columnar_memory_governor_ref_release(ref);
+    return 0;
+}
+
+static int
+test_conflicting_governor_is_rejected(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *first = test_governor(4096);
+    wl_columnar_memory_governor_ref_t *second = test_governor(4096);
+    int rc;
+
+    if (!intern || !first || !second)
+        return 1;
+    if (wl_intern_attach_memory_governor(intern, first) != 0)
+        return 1;
+    rc = wl_intern_attach_memory_governor(intern, second);
+    wl_intern_free(intern);
+    wl_columnar_memory_governor_ref_release(first);
+    wl_columnar_memory_governor_ref_release(second);
+    return rc == EBUSY ? 0 : 1;
+}
+
+static int
+test_same_governor_is_idempotent_and_detachable(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref = test_governor(4096);
+    wl_columnar_memory_governor_t *governor;
+    int rc;
+
+    if (!intern || !ref)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    if (wl_intern_attach_memory_governor(intern, ref) != 0)
+        return 1;
+    rc = wl_intern_attach_memory_governor(intern, ref);
+    if (rc != EALREADY || wl_columnar_memory_reserved(governor) == 0)
+        return 1;
+    if (wl_intern_detach_memory_governor(intern, ref) != 0
+        || wl_columnar_memory_reserved(governor) != 0) {
+        wl_intern_free(intern);
+        wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_intern_free(intern);
+    wl_columnar_memory_governor_ref_release(ref);
+    return 0;
+}
+
+/* Sizes derived from the layout rather than written as literals: the slot
+ * array is opaque to this test, so its element size is read back from the
+ * reservation an empty table publishes on attach (64 slots, no segment). */
+#define INTERN_TEST_INITIAL_SLOTS 64u
+#define INTERN_TEST_SEG0_ENTRIES 64u
+
+static uint64_t
+slot_bytes_for(uint32_t slots)
+{
+    static uint64_t per_slot;
+    if (per_slot == 0) {
+        wl_intern_t *probe = wl_intern_create();
+        wl_columnar_memory_governor_ref_t *ref = test_governor(UINT64_MAX / 4);
+        if (probe && ref
+            && wl_intern_attach_memory_governor(probe, ref) == 0)
+            per_slot = wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref))
+                / INTERN_TEST_INITIAL_SLOTS;
+        if (probe)
+            wl_intern_free(probe);
+        if (ref)
+            wl_columnar_memory_governor_ref_release(ref);
+    }
+    return per_slot * slots;
+}
+
+static uint64_t
+segment_bytes_for(uint32_t seg)
+{
+    return (uint64_t)(INTERN_TEST_SEG0_ENTRIES << seg) * sizeof(char *);
+}
+
+/* Put "sym-<i>" for i in [0, n) and return the bytes their copies retain. */
+static uint64_t
+fill_symbols(wl_intern_t *intern, uint32_t n, uint64_t *sum_out)
+{
+    uint64_t sum = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        char buf[32];
+        int len = snprintf(buf, sizeof(buf), "sym-%u", i);
+        if (len < 0 || wl_intern_put(intern, buf) != (int64_t)i)
+            return 1;
+        sum += (uint64_t)len + 1u;
+    }
+    *sum_out = sum;
+    return 0;
+}
+
+/* Every id below @n still names its "sym-<i>" and resolves back to it. */
+static int
+symbols_intact(const wl_intern_t *intern, uint32_t n)
+{
+    for (uint32_t i = 0; i < n; i++) {
+        char buf[32];
+        const char *back = wl_intern_reverse(intern, (int64_t)i);
+        snprintf(buf, sizeof(buf), "sym-%u", i);
+        if (!back || strcmp(back, buf) != 0
+            || wl_intern_get(intern, buf) != (int64_t)i)
+            return 0;
+    }
+    return 1;
+}
+
+static int
+test_unique_put_charges_exact_bytes(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref = test_governor(1u << 20);
+    wl_columnar_memory_governor_t *governor;
+    const char *sym = "unique-symbol";
+    uint64_t expect;
+    int ok;
+
+    if (!intern || !ref)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    if (wl_intern_attach_memory_governor(intern, ref) != 0)
+        return 1;
+    expect = slot_bytes_for(INTERN_TEST_INITIAL_SLOTS)
+        + segment_bytes_for(0) + strlen(sym) + 1u;
+    ok = wl_intern_put(intern, sym) == 0
+        && wl_columnar_memory_reserved(governor) == expect;
+    wl_intern_free(intern);
+    ok = ok && wl_columnar_memory_reserved(governor) == 0;
+    wl_columnar_memory_governor_ref_release(ref);
+    return ok ? 0 : 1;
+}
+
+/* Grow a table of @prefill symbols by one more put under a budget of
+ * exactly old + new (admits) and old + new - 1 (denies).  @old_slots and
+ * @new_slots describe the slot array before and after the put, @new_seg is
+ * the segment the put opens or UINT32_MAX. */
+static int
+exact_fit_case(uint32_t prefill, uint32_t old_slots, uint32_t new_slots,
+    uint32_t new_seg, const char *name)
+{
+    for (int deny = 0; deny < 2; deny++) {
+        wl_intern_t *intern = wl_intern_create();
+        wl_columnar_memory_governor_ref_t *ref;
+        wl_columnar_memory_governor_t *governor;
+        uint64_t sum = 0;
+        uint64_t old_bytes;
+        uint64_t new_bytes;
+        int64_t id;
+        int ok;
+
+        if (!intern || fill_symbols(intern, prefill, &sum) != 0)
+            return 1;
+        old_bytes = slot_bytes_for(old_slots) + sum;
+        for (uint32_t seg = 0; (INTERN_TEST_SEG0_ENTRIES << seg) <= prefill
+            || seg == 0; seg++) {
+            if (prefill > 0 || seg == 0)
+                old_bytes += segment_bytes_for(seg);
+            if (prefill == 0)
+                break;
+            if ((INTERN_TEST_SEG0_ENTRIES <<
+                (seg + 1)) - INTERN_TEST_SEG0_ENTRIES
+                >= prefill)
+                break;
+        }
+        if (prefill == 0)
+            old_bytes -= segment_bytes_for(0);
+        new_bytes = old_bytes - slot_bytes_for(old_slots)
+            + slot_bytes_for(new_slots) + strlen(name) + 1u
+            + (new_seg == UINT32_MAX ? 0 : segment_bytes_for(new_seg));
+        ref = test_governor(old_bytes + new_bytes - (uint64_t)deny);
+        if (!ref)
+            return 1;
+        governor = wl_columnar_memory_governor_ref_get(ref);
+        if (wl_intern_attach_memory_governor(intern, ref) != 0
+            || wl_columnar_memory_reserved(governor) != old_bytes) {
+            fprintf(stderr, "exact fit %s: attach reserved %llu, want %llu\n",
+                name, (unsigned long long)wl_columnar_memory_reserved(governor),
+                (unsigned long long)old_bytes);
+            return 1;
+        }
+        id = wl_intern_put(intern, name);
+        if (deny)
+            ok = id == -1 && symbols_intact(intern, prefill)
+                && wl_intern_count(intern) == prefill
+                && wl_intern_get(intern, name) == -1
+                && wl_columnar_memory_reserved(governor) == old_bytes;
+        else
+            ok = id == (int64_t)prefill && symbols_intact(intern, prefill)
+                && wl_intern_count(intern) == prefill + 1u
+                && wl_intern_get(intern, name) == (int64_t)prefill
+                && wl_columnar_memory_reserved(governor) == new_bytes;
+        if (!ok)
+            fprintf(stderr,
+                "exact fit %s (%s): id %lld reserved %llu want %llu\n",
+                name, deny ? "deny" : "admit", (long long)id,
+                (unsigned long long)wl_columnar_memory_reserved(governor),
+                (unsigned long long)(deny ? old_bytes : new_bytes));
+        wl_intern_free(intern);
+        ok = ok && wl_columnar_memory_reserved(governor) == 0;
+        wl_columnar_memory_governor_ref_release(ref);
+        if (!ok)
+            return 1;
+    }
+    return 0;
+}
+
+static int
+test_exact_fit_string(void)
+{
+    /* One symbol present: the put adds only its copy. */
+    return exact_fit_case(1u, INTERN_TEST_INITIAL_SLOTS,
+               INTERN_TEST_INITIAL_SLOTS, UINT32_MAX, "second-symbol");
+}
+
+static int
+test_exact_fit_segment(void)
+{
+    /* Ids 0..63 fill segment 0 (the 49th put already doubled the slots);
+     * id 64 opens segment 1. */
+    return exact_fit_case(64u, 2u * INTERN_TEST_INITIAL_SLOTS,
+               2u * INTERN_TEST_INITIAL_SLOTS, 1u, "opens-segment-one");
+}
+
+static int
+test_exact_fit_hash_resize(void)
+{
+    /* 48 symbols sit at the 3/4 load factor of 64 slots; the 49th put
+     * doubles the slot array and frees the old one. */
+    return exact_fit_case(48u, INTERN_TEST_INITIAL_SLOTS,
+               2u * INTERN_TEST_INITIAL_SLOTS, UINT32_MAX, "forces-resize");
+}
+
+static int
+test_three_resizes_exact_footprint(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref = test_governor(1u << 20);
+    wl_columnar_memory_governor_ref_t *again = test_governor(1u << 20);
+    wl_columnar_memory_governor_t *governor;
+    uint64_t sum = 0;
+    uint64_t expect;
+    uint64_t running;
+    int ok;
+
+    if (!intern || !ref || !again)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    if (wl_intern_attach_memory_governor(intern, ref) != 0)
+        return 1;
+    /* 200 unique symbols: the slot array doubles at the 49th, 97th and
+     * 193rd put (64 -> 128 -> 256 -> 512), segment 1 opens at id 64 and
+     * segment 2 at id 192, so the 193rd put both resizes and opens a
+     * segment in one reservation. */
+    if (fill_symbols(intern, 200u, &sum) != 0)
+        return 1;
+    expect = slot_bytes_for(8u * INTERN_TEST_INITIAL_SLOTS)
+        + segment_bytes_for(0) + segment_bytes_for(1) + segment_bytes_for(2)
+        + sum;
+    running = wl_columnar_memory_reserved(governor);
+    ok = running == expect && symbols_intact(intern, 200u)
+        && wl_intern_count(intern) == 200u;
+    if (!ok)
+        fprintf(stderr, "three resizes: reserved %llu, want %llu\n",
+            (unsigned long long)running, (unsigned long long)expect);
+    /* Detach and re-attach: the rescan must reproduce the running total. */
+    ok = ok && wl_intern_detach_memory_governor(intern, ref) == 0
+        && wl_columnar_memory_reserved(governor) == 0
+        && wl_intern_attach_memory_governor(intern, again) == 0
+        && wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(again)) == running;
+    wl_intern_free(intern);
+    ok = ok && wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(again)) == 0;
+    wl_columnar_memory_governor_ref_release(ref);
+    wl_columnar_memory_governor_ref_release(again);
+    return ok ? 0 : 1;
+}
+
+static int
+test_denied_growth_on_populated_table(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref;
+    wl_columnar_memory_governor_t *governor;
+    uint64_t sum = 0;
+    uint64_t old_bytes;
+    int ok;
+
+    if (!intern || fill_symbols(intern, 10u, &sum) != 0)
+        return 1;
+    old_bytes = slot_bytes_for(INTERN_TEST_INITIAL_SLOTS)
+        + segment_bytes_for(0) + sum;
+    /* A budget of exactly the current footprint admits the attach and
+     * denies every growth. */
+    ref = test_governor(old_bytes);
+    if (!ref)
+        return 1;
+    governor = wl_columnar_memory_governor_ref_get(ref);
+    ok = wl_intern_attach_memory_governor(intern, ref) == 0
+        && wl_columnar_memory_reserved(governor) == old_bytes
+        && wl_intern_put(intern, "sym-3") == 3 /* duplicate: uncharged */
+        && wl_intern_put(intern, "one-too-many") == -1
+        && wl_intern_get(intern, "one-too-many") == -1
+        && symbols_intact(intern, 10u) && wl_intern_count(intern) == 10u
+        && wl_columnar_memory_reserved(governor) == old_bytes;
+    wl_intern_free(intern);
+    ok = ok && wl_columnar_memory_reserved(governor) == 0;
+    wl_columnar_memory_governor_ref_release(ref);
+    return ok ? 0 : 1;
+}
+
+/* Attach admits the bytes the table already holds transactionally: a
+ * budget one byte short of the footprint is refused with ENOMEM, no
+ * governor is retained and the table is untouched. */
+static int
+test_attach_denied_when_existing_bytes_exceed_budget(void)
+{
+    wl_intern_t *intern = wl_intern_create();
+    wl_columnar_memory_governor_ref_t *ref;
+    wl_columnar_memory_governor_ref_t *fits;
+    uint64_t sum = 0;
+    uint64_t old_bytes;
+    int ok;
+
+    if (!intern || fill_symbols(intern, 10u, &sum) != 0)
+        return 1;
+    old_bytes = slot_bytes_for(INTERN_TEST_INITIAL_SLOTS)
+        + segment_bytes_for(0) + sum;
+    ref = test_governor(old_bytes - 1u);
+    fits = test_governor(old_bytes);
+    if (!ref || !fits)
+        return 1;
+    ok = wl_intern_attach_memory_governor(intern, ref) == ENOMEM
+        && wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(ref)) == 0
+        && symbols_intact(intern, 10u) && wl_intern_count(intern) == 10u
+        /* The refused governor left no ownership behind: a fitting one
+         * attaches normally afterwards. */
+        && wl_intern_attach_memory_governor(intern, fits) == 0
+        && wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(fits)) == old_bytes;
+    wl_intern_free(intern);
+    ok = ok && wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(fits)) == 0;
+    wl_columnar_memory_governor_ref_release(ref);
+    wl_columnar_memory_governor_ref_release(fits);
+    return ok ? 0 : 1;
+}
+
+int
+main(void)
+{
+    int failures = 0;
+    failures += test_attach_and_release();
+    failures += test_denied_growth_preserves_table();
+    failures += test_duplicate_is_uncharged();
+    failures += test_conflicting_governor_is_rejected();
+    failures += test_same_governor_is_idempotent_and_detachable();
+    failures += test_unique_put_charges_exact_bytes();
+    failures += test_exact_fit_string();
+    failures += test_exact_fit_segment();
+    failures += test_exact_fit_hash_resize();
+    failures += test_three_resizes_exact_footprint();
+    failures += test_denied_growth_on_populated_table();
+    failures += test_attach_denied_when_existing_bytes_exceed_budget();
+    if (failures != 0) {
+        fprintf(stderr, "memory admission intern tests failed: %d\n",
+            failures);
+        return 1;
+    }
+    puts("memory admission intern tests passed");
+    return 0;
+}

--- a/tests/test_option2_cse.c
+++ b/tests/test_option2_cse.c
@@ -18,6 +18,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/session_facts.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -34,30 +35,30 @@ static int pass_count = 0;
 static int fail_count = 0;
 
 #define TEST(name)                                      \
-    do {                                                \
-        test_count++;                                   \
-        printf("TEST %d: %s ... ", test_count, (name)); \
-    } while (0)
+        do {                                                \
+            test_count++;                                   \
+            printf("TEST %d: %s ... ", test_count, (name)); \
+        } while (0)
 
 #define PASS()            \
-    do {                  \
-        pass_count++;     \
-        printf("PASS\n"); \
-    } while (0)
+        do {                  \
+            pass_count++;     \
+            printf("PASS\n"); \
+        } while (0)
 
 #define FAIL(msg)                    \
-    do {                             \
-        fail_count++;                \
-        printf("FAIL: %s\n", (msg)); \
-    } while (0)
+        do {                             \
+            fail_count++;                \
+            printf("FAIL: %s\n", (msg)); \
+        } while (0)
 
 #define ASSERT(cond, msg) \
-    do {                  \
-        if (!(cond)) {    \
-            FAIL(msg);    \
-            return;       \
-        }                 \
-    } while (0)
+        do {                  \
+            if (!(cond)) {    \
+                FAIL(msg);    \
+                return;       \
+            }                 \
+        } while (0)
 
 /* ========================================================================
  * K-FUSION mode detection
@@ -95,7 +96,11 @@ make_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
+    if (!plan) {
+        wirelog_program_free(prog);
+        return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 
@@ -151,7 +156,7 @@ struct count_ctx {
 
 static void
 count_cb(const char *relation, const int64_t *row, uint32_t ncols,
-         void *user_data)
+    void *user_data)
 {
     struct count_ctx *ctx = (struct count_ctx *)user_data;
     ctx->count++;
@@ -217,10 +222,10 @@ test_2atom_no_expansion(void)
     TEST("2-atom rule (TC) is not expanded");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      "edge(1, 2). edge(2, 3).\n"
-                      ".decl tc(x: int32, y: int32)\n"
-                      "tc(x, y) :- edge(x, y).\n"
-                      "tc(x, z) :- tc(x, y), edge(y, z).\n";
+        "edge(1, 2). edge(2, 3).\n"
+        ".decl tc(x: int32, y: int32)\n"
+        "tc(x, y) :- edge(x, y).\n"
+        "tc(x, z) :- tc(x, y), edge(y, z).\n";
 
     wl_plan_t *plan = make_plan(src);
     ASSERT(plan != NULL, "plan generation failed");
@@ -241,14 +246,14 @@ test_3atom_expansion(void)
     TEST("3-atom recursive rule produces K=3 copies");
 
     const char *src = ".decl a(x: int32, y: int32)\n"
-                      ".decl b(x: int32, y: int32)\n"
-                      ".decl c(x: int32, y: int32)\n"
-                      ".decl r(x: int32, w: int32)\n"
-                      "a(1, 2). b(2, 3). c(3, 4).\n"
-                      "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
-                      "a(x, y) :- r(x, y).\n"
-                      "b(x, y) :- r(x, y).\n"
-                      "c(x, y) :- r(x, y).\n";
+        ".decl b(x: int32, y: int32)\n"
+        ".decl c(x: int32, y: int32)\n"
+        ".decl r(x: int32, w: int32)\n"
+        "a(1, 2). b(2, 3). c(3, 4).\n"
+        "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
+        "a(x, y) :- r(x, y).\n"
+        "b(x, y) :- r(x, y).\n"
+        "c(x, y) :- r(x, y).\n";
 
     wl_plan_t *plan = make_plan(src);
     ASSERT(plan != NULL, "plan generation failed");
@@ -259,7 +264,7 @@ test_3atom_expansion(void)
     if (using_k_fusion()) {
         uint32_t k_fusions = count_ops(r, WL_PLAN_OP_K_FUSION);
         ASSERT(k_fusions >= 1,
-               "expected K_FUSION operator with ENABLE_K_FUSION=1");
+            "expected K_FUSION operator with ENABLE_K_FUSION=1");
     } else {
         uint32_t force_delta = count_delta_mode(r, WL_DELTA_FORCE_DELTA);
         ASSERT(force_delta == 3, "expected 3 FORCE_DELTA ops for 3-atom rule");
@@ -281,14 +286,14 @@ test_3atom_materialization_hints(void)
     TEST("3-atom rule has materialization hints on first K-2 joins");
 
     const char *src = ".decl a(x: int32, y: int32)\n"
-                      ".decl b(x: int32, y: int32)\n"
-                      ".decl c(x: int32, y: int32)\n"
-                      ".decl r(x: int32, w: int32)\n"
-                      "a(1, 2). b(2, 3). c(3, 4).\n"
-                      "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
-                      "a(x, y) :- r(x, y).\n"
-                      "b(x, y) :- r(x, y).\n"
-                      "c(x, y) :- r(x, y).\n";
+        ".decl b(x: int32, y: int32)\n"
+        ".decl c(x: int32, y: int32)\n"
+        ".decl r(x: int32, w: int32)\n"
+        "a(1, 2). b(2, 3). c(3, 4).\n"
+        "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
+        "a(x, y) :- r(x, y).\n"
+        "b(x, y) :- r(x, y).\n"
+        "c(x, y) :- r(x, y).\n";
 
     wl_plan_t *plan = make_plan(src);
     ASSERT(plan != NULL, "plan generation failed");
@@ -300,13 +305,13 @@ test_3atom_materialization_hints(void)
         /* K_FUSION encapsulates all copies; materialization hints are internal */
         uint32_t k_fusions = count_ops(r, WL_PLAN_OP_K_FUSION);
         ASSERT(k_fusions >= 1,
-               "expected K_FUSION operator with ENABLE_K_FUSION=1");
+            "expected K_FUSION operator with ENABLE_K_FUSION=1");
     } else {
         /* K=3: first K-2=1 JOIN position is materialized per copy.
          * 3 copies × 1 materialized JOIN = 3 total. */
         uint32_t mat = count_materialized(r);
         ASSERT(mat == 3,
-               "expected 3 materialized hints (1 per copy × 3 copies)");
+            "expected 3 materialized hints (1 per copy × 3 copies)");
     }
 
     wl_plan_free(plan);
@@ -319,14 +324,14 @@ test_3atom_force_full(void)
     TEST("3-atom rule has correct FORCE_FULL count");
 
     const char *src = ".decl a(x: int32, y: int32)\n"
-                      ".decl b(x: int32, y: int32)\n"
-                      ".decl c(x: int32, y: int32)\n"
-                      ".decl r(x: int32, w: int32)\n"
-                      "a(1, 2). b(2, 3). c(3, 4).\n"
-                      "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
-                      "a(x, y) :- r(x, y).\n"
-                      "b(x, y) :- r(x, y).\n"
-                      "c(x, y) :- r(x, y).\n";
+        ".decl b(x: int32, y: int32)\n"
+        ".decl c(x: int32, y: int32)\n"
+        ".decl r(x: int32, w: int32)\n"
+        "a(1, 2). b(2, 3). c(3, 4).\n"
+        "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
+        "a(x, y) :- r(x, y).\n"
+        "b(x, y) :- r(x, y).\n"
+        "c(x, y) :- r(x, y).\n";
 
     wl_plan_t *plan = make_plan(src);
     ASSERT(plan != NULL, "plan generation failed");
@@ -338,12 +343,12 @@ test_3atom_force_full(void)
         /* K_FUSION encapsulates all copies; FORCE_FULL is internal */
         uint32_t k_fusions = count_ops(r, WL_PLAN_OP_K_FUSION);
         ASSERT(k_fusions >= 1,
-               "expected K_FUSION operator with ENABLE_K_FUSION=1");
+            "expected K_FUSION operator with ENABLE_K_FUSION=1");
     } else {
         /* Each copy: 1 FORCE_DELTA + 2 FORCE_FULL = K*(K-1) = 6 FORCE_FULL */
         uint32_t force_full = count_delta_mode(r, WL_DELTA_FORCE_FULL);
         ASSERT(force_full == 6,
-               "expected 6 FORCE_FULL ops (2 per copy × 3 copies)");
+            "expected 6 FORCE_FULL ops (2 per copy × 3 copies)");
     }
 
     wl_plan_free(plan);
@@ -356,11 +361,11 @@ test_nonrecursive_no_rewrite(void)
     TEST("non-recursive stratum is not rewritten");
 
     const char *src = ".decl a(x: int32, y: int32)\n"
-                      ".decl b(x: int32, y: int32)\n"
-                      ".decl c(x: int32, y: int32)\n"
-                      ".decl r(x: int32, w: int32)\n"
-                      "a(1, 2). b(2, 3). c(3, 4).\n"
-                      "r(x, w) :- a(x, y), b(y, z), c(z, w).\n";
+        ".decl b(x: int32, y: int32)\n"
+        ".decl c(x: int32, y: int32)\n"
+        ".decl r(x: int32, w: int32)\n"
+        "a(1, 2). b(2, 3). c(3, 4).\n"
+        "r(x, w) :- a(x, y), b(y, z), c(z, w).\n";
 
     wl_plan_t *plan = make_plan(src);
     ASSERT(plan != NULL, "plan generation failed");
@@ -381,14 +386,14 @@ test_delta_and_full_invariant(void)
     TEST("K=3 expansion: FORCE_DELTA + FORCE_FULL = K*K");
 
     const char *src = ".decl a(x: int32, y: int32)\n"
-                      ".decl b(x: int32, y: int32)\n"
-                      ".decl c(x: int32, y: int32)\n"
-                      ".decl r(x: int32, w: int32)\n"
-                      "a(1, 2). b(2, 3). c(3, 4).\n"
-                      "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
-                      "a(x, y) :- r(x, y).\n"
-                      "b(x, y) :- r(x, y).\n"
-                      "c(x, y) :- r(x, y).\n";
+        ".decl b(x: int32, y: int32)\n"
+        ".decl c(x: int32, y: int32)\n"
+        ".decl r(x: int32, w: int32)\n"
+        "a(1, 2). b(2, 3). c(3, 4).\n"
+        "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
+        "a(x, y) :- r(x, y).\n"
+        "b(x, y) :- r(x, y).\n"
+        "c(x, y) :- r(x, y).\n";
 
     wl_plan_t *plan = make_plan(src);
     ASSERT(plan != NULL, "plan generation failed");
@@ -400,7 +405,7 @@ test_delta_and_full_invariant(void)
         /* K_FUSION encapsulates all copies; fd/ff counts are internal */
         uint32_t k_fusions = count_ops(r, WL_PLAN_OP_K_FUSION);
         ASSERT(k_fusions >= 1,
-               "expected K_FUSION operator with ENABLE_K_FUSION=1");
+            "expected K_FUSION operator with ENABLE_K_FUSION=1");
     } else {
         /* For K copies, each copy has K IDB positions:
          * 1 FORCE_DELTA + (K-1) FORCE_FULL = K per copy.
@@ -410,7 +415,7 @@ test_delta_and_full_invariant(void)
         uint32_t ff = count_delta_mode(r, WL_DELTA_FORCE_FULL);
         char msg[128];
         snprintf(msg, sizeof(msg), "expected fd+ff=9 (K*K), got fd=%u ff=%u",
-                 fd, ff);
+            fd, ff);
         ASSERT(fd + ff == 9, msg);
     }
 
@@ -424,14 +429,14 @@ test_expanded_plan_free(void)
     TEST("wl_plan_free handles expanded plan without crash");
 
     const char *src = ".decl a(x: int32, y: int32)\n"
-                      ".decl b(x: int32, y: int32)\n"
-                      ".decl c(x: int32, y: int32)\n"
-                      ".decl r(x: int32, w: int32)\n"
-                      "a(1, 2). b(2, 3). c(3, 4).\n"
-                      "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
-                      "a(x, y) :- r(x, y).\n"
-                      "b(x, y) :- r(x, y).\n"
-                      "c(x, y) :- r(x, y).\n";
+        ".decl b(x: int32, y: int32)\n"
+        ".decl c(x: int32, y: int32)\n"
+        ".decl r(x: int32, w: int32)\n"
+        "a(1, 2). b(2, 3). c(3, 4).\n"
+        "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
+        "a(x, y) :- r(x, y).\n"
+        "b(x, y) :- r(x, y).\n"
+        "c(x, y) :- r(x, y).\n";
 
     wl_plan_t *plan = make_plan(src);
     ASSERT(plan != NULL, "plan generation failed");
@@ -450,10 +455,10 @@ test_expanded_plan_free(void)
  * ======================================================================== */
 
 static const char *k2_src = ".decl a(x: int32, y: int32)\n"
-                            ".decl b(x: int32, y: int32)\n"
-                            "a(1, 2). b(2, 3).\n"
-                            "a(x, z) :- a(x, y), b(y, z).\n"
-                            "b(x, y) :- a(x, y).\n";
+    ".decl b(x: int32, y: int32)\n"
+    "a(1, 2). b(2, 3).\n"
+    "a(x, z) :- a(x, y), b(y, z).\n"
+    "b(x, y) :- a(x, y).\n";
 
 static void
 test_2atom_k2_expansion(void)
@@ -469,13 +474,13 @@ test_2atom_k2_expansion(void)
     if (using_k_fusion()) {
         uint32_t k_fusions = count_ops(a, WL_PLAN_OP_K_FUSION);
         ASSERT(k_fusions >= 1,
-               "expected K_FUSION operator with ENABLE_K_FUSION=1");
+            "expected K_FUSION operator with ENABLE_K_FUSION=1");
     } else {
         uint32_t force_delta = count_delta_mode(a, WL_DELTA_FORCE_DELTA);
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "expected >= 2 FORCE_DELTA ops for K=2 rule, got %u",
-                 force_delta);
+            "expected >= 2 FORCE_DELTA ops for K=2 rule, got %u",
+            force_delta);
         ASSERT(force_delta >= 2, msg);
     }
 
@@ -498,15 +503,15 @@ test_2atom_k2_force_full(void)
         /* K_FUSION encapsulates all copies; FORCE_FULL is internal */
         uint32_t k_fusions = count_ops(a, WL_PLAN_OP_K_FUSION);
         ASSERT(k_fusions >= 1,
-               "expected K_FUSION operator with ENABLE_K_FUSION=1");
+            "expected K_FUSION operator with ENABLE_K_FUSION=1");
     } else {
         /* K=2: each copy has 1 FORCE_DELTA + 1 FORCE_FULL.
          * 2 copies => 2 FORCE_FULL total. */
         uint32_t force_full = count_delta_mode(a, WL_DELTA_FORCE_FULL);
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "expected >= 2 FORCE_FULL ops for K=2 rule, got %u",
-                 force_full);
+            "expected >= 2 FORCE_FULL ops for K=2 rule, got %u",
+            force_full);
         ASSERT(force_full >= 2, msg);
     }
 
@@ -529,18 +534,18 @@ test_2atom_k2_concat_consolidate(void)
         /* K_FUSION replaces CONCAT+CONSOLIDATE structure */
         uint32_t k_fusions = count_ops(a, WL_PLAN_OP_K_FUSION);
         ASSERT(k_fusions >= 1,
-               "expected K_FUSION operator with ENABLE_K_FUSION=1");
+            "expected K_FUSION operator with ENABLE_K_FUSION=1");
     } else {
         uint32_t concats = count_ops(a, WL_PLAN_OP_CONCAT);
         char msg_concat[128];
         snprintf(msg_concat, sizeof(msg_concat),
-                 "expected >= 2 CONCAT ops for K=2 rule, got %u", concats);
+            "expected >= 2 CONCAT ops for K=2 rule, got %u", concats);
         ASSERT(concats >= 2, msg_concat);
 
         uint32_t consols = count_ops(a, WL_PLAN_OP_CONSOLIDATE);
         char msg_consol[128];
         snprintf(msg_consol, sizeof(msg_consol),
-                 "expected >= 1 CONSOLIDATE op for K=2 rule, got %u", consols);
+            "expected >= 1 CONSOLIDATE op for K=2 rule, got %u", consols);
         ASSERT(consols >= 1, msg_consol);
     }
 
@@ -563,13 +568,13 @@ test_2atom_k2_invariant(void)
         /* K_FUSION encapsulates all copies; fd/ff counts are internal */
         uint32_t k_fusions = count_ops(a, WL_PLAN_OP_K_FUSION);
         ASSERT(k_fusions >= 1,
-               "expected K_FUSION operator with ENABLE_K_FUSION=1");
+            "expected K_FUSION operator with ENABLE_K_FUSION=1");
     } else {
         uint32_t fd = count_delta_mode(a, WL_DELTA_FORCE_DELTA);
         uint32_t ff = count_delta_mode(a, WL_DELTA_FORCE_FULL);
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "expected fd+ff=4 (K*K for K=2), got fd=%u ff=%u", fd, ff);
+            "expected fd+ff=4 (K*K for K=2), got fd=%u ff=%u", fd, ff);
         ASSERT(fd + ff == 4, msg);
     }
 
@@ -592,13 +597,13 @@ test_2atom_k2_no_materialization(void)
         /* K_FUSION encapsulates all copies; materialization is internal */
         uint32_t k_fusions = count_ops(a, WL_PLAN_OP_K_FUSION);
         ASSERT(k_fusions >= 1,
-               "expected K_FUSION operator with ENABLE_K_FUSION=1");
+            "expected K_FUSION operator with ENABLE_K_FUSION=1");
     } else {
         /* K=2: K-2 = 0 intermediate joins to materialize per copy. */
         uint32_t mat = count_materialized(a);
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "expected 0 materialized hints for K=2 rule, got %u", mat);
+            "expected 0 materialized hints for K=2 rule, got %u", mat);
         ASSERT(mat == 0, msg);
     }
 
@@ -614,10 +619,10 @@ test_k1_k3_unaffected(void)
     /* K=1: single-IDB-atom rule (transitive closure with EDB join).
      * The body has only 1 IDB atom (tc) so it should NOT be expanded. */
     const char *tc_src = ".decl edge(x: int32, y: int32)\n"
-                         "edge(1, 2). edge(2, 3).\n"
-                         ".decl tc(x: int32, y: int32)\n"
-                         "tc(x, y) :- edge(x, y).\n"
-                         "tc(x, z) :- tc(x, y), edge(y, z).\n";
+        "edge(1, 2). edge(2, 3).\n"
+        ".decl tc(x: int32, y: int32)\n"
+        "tc(x, y) :- edge(x, y).\n"
+        "tc(x, z) :- tc(x, y), edge(y, z).\n";
 
     wl_plan_t *plan_tc = make_plan(tc_src);
     ASSERT(plan_tc != NULL, "TC plan generation failed");
@@ -628,21 +633,21 @@ test_k1_k3_unaffected(void)
     uint32_t fd_k1 = count_delta_mode(tc, WL_DELTA_FORCE_DELTA);
     char msg_k1[128];
     snprintf(msg_k1, sizeof(msg_k1),
-             "K=1 TC should have 0 FORCE_DELTA ops, got %u", fd_k1);
+        "K=1 TC should have 0 FORCE_DELTA ops, got %u", fd_k1);
     ASSERT(fd_k1 == 0, msg_k1);
 
     wl_plan_free(plan_tc);
 
     /* K=3: 3-atom recursive rule should still produce exactly 3 copies. */
     const char *cspa_src = ".decl a(x: int32, y: int32)\n"
-                           ".decl b(x: int32, y: int32)\n"
-                           ".decl c(x: int32, y: int32)\n"
-                           ".decl r(x: int32, w: int32)\n"
-                           "a(1, 2). b(2, 3). c(3, 4).\n"
-                           "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
-                           "a(x, y) :- r(x, y).\n"
-                           "b(x, y) :- r(x, y).\n"
-                           "c(x, y) :- r(x, y).\n";
+        ".decl b(x: int32, y: int32)\n"
+        ".decl c(x: int32, y: int32)\n"
+        ".decl r(x: int32, w: int32)\n"
+        "a(1, 2). b(2, 3). c(3, 4).\n"
+        "r(x, w) :- a(x, y), b(y, z), c(z, w).\n"
+        "a(x, y) :- r(x, y).\n"
+        "b(x, y) :- r(x, y).\n"
+        "c(x, y) :- r(x, y).\n";
 
     wl_plan_t *plan_cspa = make_plan(cspa_src);
     ASSERT(plan_cspa != NULL, "CSPA plan generation failed");
@@ -654,14 +659,14 @@ test_k1_k3_unaffected(void)
         uint32_t k_fusions = count_ops(r, WL_PLAN_OP_K_FUSION);
         char msg_k3[128];
         snprintf(msg_k3, sizeof(msg_k3),
-                 "K=3 rule should have K_FUSION operator, got %u k_fusions",
-                 k_fusions);
+            "K=3 rule should have K_FUSION operator, got %u k_fusions",
+            k_fusions);
         ASSERT(k_fusions >= 1, msg_k3);
     } else {
         uint32_t fd_k3 = count_delta_mode(r, WL_DELTA_FORCE_DELTA);
         char msg_k3[128];
         snprintf(msg_k3, sizeof(msg_k3),
-                 "K=3 rule should have 3 FORCE_DELTA ops, got %u", fd_k3);
+            "K=3 rule should have 3 FORCE_DELTA ops, got %u", fd_k3);
         ASSERT(fd_k3 == 3, msg_k3);
     }
 
@@ -679,10 +684,10 @@ test_integ_two_way_join_regression(void)
     TEST("integ: 2-way TC unaffected by delta expansion (regression guard)");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      "edge(1, 2). edge(2, 3). edge(3, 4).\n"
-                      ".decl tc(x: int32, y: int32)\n"
-                      "tc(x, y) :- edge(x, y).\n"
-                      "tc(x, z) :- tc(x, y), edge(y, z).\n";
+        "edge(1, 2). edge(2, 3). edge(3, 4).\n"
+        ".decl tc(x: int32, y: int32)\n"
+        "tc(x, y) :- edge(x, y).\n"
+        "tc(x, z) :- tc(x, y), edge(y, z).\n";
 
     int64_t count = run_program(src, 1);
     ASSERT(count >= 0, "TC evaluation failed");
@@ -700,9 +705,9 @@ test_integ_three_way_join_correctness(void)
     TEST("integ: 3-way join (3-hop path) correctness");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      "edge(1, 2). edge(2, 3). edge(3, 4).\n"
-                      ".decl path3(x: int32, z: int32)\n"
-                      "path3(x, z) :- edge(x, y), edge(y, w), edge(w, z).\n";
+        "edge(1, 2). edge(2, 3). edge(3, 4).\n"
+        ".decl path3(x: int32, z: int32)\n"
+        "path3(x, z) :- edge(x, y), edge(y, w), edge(w, z).\n";
 
     int64_t count = run_program(src, 1);
     ASSERT(count >= 0, "program evaluation failed");
@@ -720,19 +725,19 @@ test_integ_cspa_memory_alias(void)
     TEST("integ: CSPA memoryAlias 3-atom recursive rule correctness");
 
     const char *src = ".decl pointsTo(ptr: int32, cell: int32)\n"
-                      "pointsTo(1, 10). pointsTo(2, 10). pointsTo(3, 20). "
-                      "pointsTo(4, 20).\n"
-                      ".decl memoryAlias(x: int32, y: int32)\n"
-                      "memoryAlias(x, y) :- pointsTo(x, a), pointsTo(y, a).\n"
-                      "memoryAlias(x, z) :- pointsTo(x, a), memoryAlias(a, b), "
-                      "pointsTo(z, b).\n";
+        "pointsTo(1, 10). pointsTo(2, 10). pointsTo(3, 20). "
+        "pointsTo(4, 20).\n"
+        ".decl memoryAlias(x: int32, y: int32)\n"
+        "memoryAlias(x, y) :- pointsTo(x, a), pointsTo(y, a).\n"
+        "memoryAlias(x, z) :- pointsTo(x, a), memoryAlias(a, b), "
+        "pointsTo(z, b).\n";
 
     int64_t count = run_program(src, 1);
     ASSERT(count >= 0, "CSPA evaluation failed");
 
     char msg[128];
     snprintf(msg, sizeof(msg), "expected 8 memoryAlias facts, got %" PRId64,
-             count);
+        count);
     ASSERT(count == 8, msg);
 
     PASS();
@@ -772,6 +777,6 @@ main(void)
     test_integ_cspa_memory_alias();
 
     printf("\n%d tests: %d passed, %d failed\n", test_count, pass_count,
-           fail_count);
+        fail_count);
     return fail_count > 0 ? 1 : 0;
 }

--- a/tests/test_queue_transport.c
+++ b/tests/test_queue_transport.c
@@ -18,6 +18,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/util/lockfree_queue.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -93,9 +94,11 @@ run_tc_chain20(uint32_t num_workers)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return -1;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *session = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, num_workers, &session);
@@ -149,9 +152,11 @@ run_tc_single_edge(uint32_t num_workers)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return -1;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *session = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, num_workers, &session);
@@ -203,9 +208,11 @@ run_tc_no_facts(uint32_t num_workers)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return -1;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *session = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, num_workers, &session);

--- a/tests/test_rotation_strategy.c
+++ b/tests/test_rotation_strategy.c
@@ -34,6 +34,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -112,9 +113,11 @@ build_minimal_plan(void)
     wl_sip_apply(prog, NULL);
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_rule_level_frontier.c
+++ b/tests/test_rule_level_frontier.c
@@ -32,28 +32,29 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 /* ======================================================================== */
 /* TEST HARNESS MACROS                                                       */
 /* ======================================================================== */
 
 #define TEST(name)                       \
-    do {                                 \
-        printf("  [TEST] %-62s ", name); \
-        fflush(stdout);                  \
-    } while (0)
+        do {                                 \
+            printf("  [TEST] %-62s ", name); \
+            fflush(stdout);                  \
+        } while (0)
 
 #define PASS              \
-    do {                  \
-        printf("PASS\n"); \
-        tests_passed++;   \
-    } while (0)
+        do {                  \
+            printf("PASS\n"); \
+            tests_passed++;   \
+        } while (0)
 
 #define FAIL(msg)                  \
-    do {                           \
-        printf("FAIL: %s\n", msg); \
-        tests_failed++;            \
-    } while (0)
+        do {                           \
+            printf("FAIL: %s\n", msg); \
+            tests_failed++;            \
+        } while (0)
 
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -81,7 +82,7 @@ make_var_op(const char *rel_name)
  */
 static void
 init_relation(wl_plan_relation_t *pr, const char *rel_name, const char *dep_rel,
-              wl_plan_op_t *op_storage)
+    wl_plan_op_t *op_storage)
 {
     op_storage[0] = make_var_op(dep_rel);
     pr->name = rel_name;
@@ -111,9 +112,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 
@@ -136,7 +139,7 @@ find_recursive_stratum(const wl_plan_t *plan)
 
 static void
 count_cb(const char *relation, const int64_t *row, uint32_t ncols,
-         void *user_data)
+    void *user_data)
 {
     int64_t *count = (int64_t *)user_data;
     (*count)++;
@@ -195,14 +198,14 @@ test_direct_rule_dependency_affects_single_rule(void)
     if (mask_edge != (uint64_t)0x1) {
         char buf[80];
         snprintf(buf, sizeof(buf), "edge: expected 0x1, got 0x%" PRIx64,
-                 mask_edge);
+            mask_edge);
         FAIL(buf);
         return;
     }
     if (mask_node != (uint64_t)0x2) {
         char buf[80];
         snprintf(buf, sizeof(buf), "node: expected 0x2, got 0x%" PRIx64,
-                 mask_node);
+            mask_node);
         FAIL(buf);
         return;
     }
@@ -273,7 +276,7 @@ test_transitive_rule_dependency_marks_chain(void)
     } else {
         char buf[80];
         snprintf(buf, sizeof(buf), "expected 0x%" PRIx64 ", got 0x%" PRIx64,
-                 expected, mask);
+            expected, mask);
         FAIL(buf);
     }
 }
@@ -297,9 +300,9 @@ test_unaffected_stratum_frontier_preserved_after_insert(void)
     TEST("unaffected stratum frontier preserved after incremental insert");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      ".decl path(x: int32, y: int32)\n"
-                      "path(x, y) :- edge(x, y).\n"
-                      "path(x, z) :- path(x, y), edge(y, z).\n";
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n"
+        "path(x, z) :- path(x, y), edge(y, z).\n";
 
     wl_plan_t *plan = build_plan(src);
     if (!plan) {
@@ -363,7 +366,7 @@ test_unaffected_stratum_frontier_preserved_after_insert(void)
     if (rc != 0) {
         char msg[64];
         snprintf(msg, sizeof(msg), "col_session_insert_incremental returned %d",
-                 rc);
+            rc);
         wl_session_destroy(sess);
         wl_plan_free(plan);
         FAIL(msg);
@@ -383,9 +386,9 @@ test_unaffected_stratum_frontier_preserved_after_insert(void)
         || f_after.outer_epoch != f_before.outer_epoch) {
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "frontier changed by insert: before=(%u,%u) after=(%u,%u)",
-                 f_before.iteration, f_before.outer_epoch, f_after.iteration,
-                 f_after.outer_epoch);
+            "frontier changed by insert: before=(%u,%u) after=(%u,%u)",
+            f_before.iteration, f_before.outer_epoch, f_after.iteration,
+            f_after.outer_epoch);
         wl_session_destroy(sess);
         wl_plan_free(plan);
         FAIL(msg);
@@ -420,12 +423,12 @@ static void
 test_output_correctness_incremental_matches_baseline(void)
 {
     TEST("output correctness: incremental matches full-reset baseline (6 "
-         "paths)");
+        "paths)");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      ".decl path(x: int32, y: int32)\n"
-                      "path(x, y) :- edge(x, y).\n"
-                      "path(x, z) :- path(x, y), edge(y, z).\n";
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n"
+        "path(x, z) :- path(x, y), edge(y, z).\n";
 
     /* ---- Baseline session: insert all edges at once ---- */
     wl_plan_t *plan_base = build_plan(src);
@@ -506,7 +509,7 @@ test_output_correctness_incremental_matches_baseline(void)
     if (rc != 0) {
         char msg[64];
         snprintf(msg, sizeof(msg), "col_session_insert_incremental returned %d",
-                 rc);
+            rc);
         wl_session_destroy(sess_inc);
         wl_plan_free(plan_inc);
         FAIL(msg);
@@ -534,8 +537,8 @@ test_output_correctness_incremental_matches_baseline(void)
     if (incremental_count != baseline_count) {
         char msg[128];
         snprintf(msg, sizeof(msg),
-                 "count mismatch: baseline=%" PRId64 " incremental=%" PRId64,
-                 baseline_count, incremental_count);
+            "count mismatch: baseline=%" PRId64 " incremental=%" PRId64,
+            baseline_count, incremental_count);
         FAIL(msg);
         return;
     }
@@ -642,7 +645,7 @@ test_null_insertion_returns_zero_mask(void)
     } else {
         char buf[80];
         snprintf(buf, sizeof(buf), "expected 0,0 got 0x%" PRIx64 ",0x%" PRIx64,
-                 m1, m2);
+            m1, m2);
         FAIL(buf);
     }
 }
@@ -708,7 +711,7 @@ test_global_rule_indices_across_strata(void)
     } else {
         char buf[80];
         snprintf(buf, sizeof(buf), "expected 0x%" PRIx64 ", got 0x%" PRIx64,
-                 expected, mask);
+            expected, mask);
         FAIL(buf);
     }
 }
@@ -729,9 +732,9 @@ test_multiple_incremental_inserts_preserve_frontier(void)
     TEST("multiple incremental inserts: frontier preserved across all cycles");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
-                      ".decl path(x: int32, y: int32)\n"
-                      "path(x, y) :- edge(x, y).\n"
-                      "path(x, z) :- path(x, y), edge(y, z).\n";
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n"
+        "path(x, z) :- path(x, y), edge(y, z).\n";
 
     wl_plan_t *plan = build_plan(src);
     if (!plan) {
@@ -847,7 +850,7 @@ int
 main(void)
 {
     printf("\n=== Rule-Level Frontier Integration Tests (Phase 4, US-4-006) "
-           "===\n\n");
+        "===\n\n");
 
     test_direct_rule_dependency_affects_single_rule();
     test_transitive_rule_dependency_marks_chain();
@@ -859,7 +862,7 @@ main(void)
     test_multiple_incremental_inserts_preserve_frontier();
 
     printf("\n=== Results: %d/%d passed ===\n\n", tests_passed,
-           tests_passed + tests_failed);
+        tests_passed + tests_failed);
 
     return tests_failed > 0 ? 1 : 0;
 }

--- a/tests/test_safe_worker_scaling.c
+++ b/tests/test_safe_worker_scaling.c
@@ -25,6 +25,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <limits.h>
 #include <stdint.h>
@@ -111,9 +112,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -343,6 +343,93 @@ build_plan(const char *src)
 /* Tests                                                                    */
 /* ======================================================================== */
 
+/* Issue #1431: the program's intern table is charged to the governor of the
+ * first session created from its plan, a second session from the same plan
+ * tolerates that the table is already owned (EBUSY), destroying either
+ * session leaves the program-owned reservation in place, and only
+ * wirelog_program_free() releases it. */
+static void
+test_intern_reservation_program_lifetime(void)
+{
+    TEST("session: intern reservation is program-owned and survives destroy");
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(
+        "edge(1, 2).\n"
+        "path(x, y) :- edge(x, y).\n", &err);
+    wl_plan_t *plan = NULL;
+    wl_session_t *first = NULL;
+    wl_session_t *second = NULL;
+    wl_columnar_memory_governor_ref_t *owner = NULL;
+    uint64_t with_first;
+    uint64_t retained;
+
+    if (!prog || wl_plan_from_program(prog, &plan) != 0 || !plan) {
+        if (prog)
+            wirelog_program_free(prog);
+        FAIL("plan generation failed");
+        return;
+    }
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &first) != 0
+        || !first) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("first session create failed");
+        return;
+    }
+    owner = COL_SESSION(first)->memory_governor;
+    wl_columnar_memory_governor_ref_retain(owner);
+    with_first = wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(owner));
+
+    /* The second session gets its own governor; the intern stays with the
+     * first one and is neither re-charged nor stolen. */
+    if (wl_session_create(wl_backend_columnar(), plan, 1, &second) != 0
+        || !second
+        || COL_SESSION(second)->memory_governor == owner
+        || wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(owner)) != with_first) {
+        if (second)
+            wl_session_destroy(second);
+        wl_session_destroy(first);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        wl_columnar_memory_governor_ref_release(owner);
+        FAIL("second session did not tolerate the owned intern table");
+        return;
+    }
+    wl_session_destroy(second);
+    if (wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(owner)) != with_first) {
+        wl_session_destroy(first);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        wl_columnar_memory_governor_ref_release(owner);
+        FAIL("destroying the second session changed the owner's reservation");
+        return;
+    }
+    wl_session_destroy(first);
+    retained = wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(owner));
+    wl_plan_free(plan);
+    if (retained == 0 || retained > with_first
+        || wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(owner)) != retained) {
+        wirelog_program_free(prog);
+        wl_columnar_memory_governor_ref_release(owner);
+        FAIL("session destroy released or kept the wrong intern bytes");
+        return;
+    }
+    wirelog_program_free(prog);
+    if (wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(owner)) != 0) {
+        wl_columnar_memory_governor_ref_release(owner);
+        FAIL("wirelog_program_free did not release the intern reservation");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(owner);
+    PASS();
+}
+
 /*
  * Test: create a session and destroy it without crash.
  */
@@ -1226,6 +1313,7 @@ main(void)
 
     test_session_hash_overflow_rejected();
     test_retained_relation_admission();
+    test_intern_reservation_program_lifetime();
     test_session_create_destroy();
     test_session_create_destroy_columnar();
     test_session_create_with_options();

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -20,6 +20,7 @@
 #include "../wirelog/columnar/memory_governor.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <errno.h>
@@ -330,9 +331,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_session_compound_arena_lifecycle.c
+++ b/tests/test_session_compound_arena_lifecycle.c
@@ -25,6 +25,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -82,9 +83,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_side_compound_delta.c
+++ b/tests/test_side_compound_delta.c
@@ -15,6 +15,7 @@
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog-types.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -63,9 +64,11 @@ build_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
     return plan;
 }
 

--- a/tests/test_tdd_decision_stats.c
+++ b/tests/test_tdd_decision_stats.c
@@ -14,6 +14,7 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdint.h>
 #include <errno.h>
@@ -129,9 +130,11 @@ run_snapshot_frames(void)
     wl_sip_apply(prog, NULL);
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return 1;
+    }
+    plan_fixture_hold(prog);
     if (plan->stratum_count != 3) {
         wl_plan_free(plan);
         return 1;
@@ -207,9 +210,11 @@ run_audit_boundary(int mode)
     wl_sip_apply(prog, NULL);
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return 1;
+    }
+    plan_fixture_hold(prog);
     wl_session_t *sess = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, 8, &sess);
     if (rc != 0) {
@@ -307,9 +312,11 @@ run_bdx_mode(decision_stats_t *stats, int use_step)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return 1;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *sess = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, 8, &sess);
@@ -375,9 +382,11 @@ run_bdx_repeated_snapshot(decision_stats_t *first, decision_stats_t *second,
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return 1;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *sess = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, 8, &sess);
@@ -443,9 +452,11 @@ run_remove_invalidates_stable_snapshot(decision_stats_t *after_remove,
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return 1;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *sess = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, 8, &sess);

--- a/tests/test_tdd_multiworker.c
+++ b/tests/test_tdd_multiworker.c
@@ -22,6 +22,7 @@
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog.h"
 #include "columnar/internal.h"
+#include "plan_fixture.h"
 
 #include <errno.h>
 #include <inttypes.h>
@@ -240,9 +241,11 @@ run_tc_chain20(uint32_t num_workers)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return -1;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *session = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, num_workers, &session);

--- a/tests/test_tdd_single_key_owner.c
+++ b/tests/test_tdd_single_key_owner.c
@@ -14,6 +14,7 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -80,9 +81,11 @@ make_session(uint32_t workers, wl_plan_t **plan_out)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0 || !plan)
+    if (rc != 0 || !plan) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    plan_fixture_hold(prog);
 
     wl_session_t *sess = NULL;
     rc = wl_session_create(wl_backend_columnar(), plan, workers, &sess);

--- a/tests/test_workers_as_cap.c
+++ b/tests/test_workers_as_cap.c
@@ -12,6 +12,7 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 
@@ -35,8 +36,12 @@ build_plan(void)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    return rc == 0 ? plan : NULL;
+    if (rc != 0) {
+        wirelog_program_free(prog);
+        return NULL;
+    }
+    plan_fixture_hold(prog);
+    return plan;
 }
 
 static int

--- a/wirelog/api_facade.c
+++ b/wirelog/api_facade.c
@@ -22,6 +22,7 @@
 #include "session_facts.h"
 #include "wirelog-config.h"
 
+#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -670,10 +671,15 @@ wirelog_executor_create(wirelog_program_t *program, wirelog_error_t *error)
         set_error(error, WIRELOG_ERR_INVALID_IR);
         return NULL;
     }
-    if (wl_session_create(wl_backend_columnar(), executor->plan, 1,
-        &executor->session) != 0) {
+    int session_rc = wl_session_create(wl_backend_columnar(), executor->plan,
+            1, &executor->session);
+    if (session_rc != 0) {
         wirelog_executor_free(executor);
-        set_error(error, WIRELOG_ERR_EXEC);
+        /* ENOMEM is an allocation failure; EOVERFLOW is the memory governor
+         * refusing to admit the program's intern table (#1431).  Both are
+         * memory verdicts under the docs/MEMORY.md contract. */
+        set_error(error, (session_rc == ENOMEM || session_rc == EOVERFLOW)
+            ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_EXEC);
         return NULL;
     }
     if (wl_session_load_facts(executor->session, program) != 0

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1021,6 +1021,7 @@ col_session_create_internal(const wl_plan_t *plan, uint32_t num_workers,
     wl_columnar_memory_resolution_t memory_resolution;
     wl_columnar_memory_sources_t memory_sources;
     wl_columnar_memory_governor_ref_t *memory_governor;
+    bool intern_attached_here = false;
     const char *memory_budget = getenv("WIRELOG_MEMORY_BUDGET");
 
     if (!plan || !out)
@@ -1096,6 +1097,24 @@ col_session_create_internal(const wl_plan_t *plan, uint32_t num_workers,
 
     sess->plan = plan;
     sess->intern = plan->intern;
+    if (sess->intern) {
+        int intern_rc = wl_intern_attach_memory_governor(
+            sess->intern, sess->memory_governor);
+        /* A program-owned table may already be attached to the governor of
+        * an earlier session.  Its reservation must remain with the program;
+        * this session continues with its own governor for session-owned
+        * storage and must not rebind or double-charge the intern table. */
+        intern_attached_here = intern_rc == 0;
+        if (intern_rc != 0 && intern_rc != EALREADY && intern_rc != EBUSY) {
+            /* Attach failed before taking ownership, so there is nothing
+             * to detach: the table is either unattached or owned by an
+             * earlier session's governor. */
+            wl_columnar_memory_governor_ref_release(
+                sess->memory_governor);
+            free(sess);
+            return intern_rc;
+        }
+    }
     sess->num_workers = num_workers > 0 ? num_workers : 1;
     WL_LOG(WL_LOG_SEC_SESSION, WL_LOG_INFO, "session created num_workers=%u",
         sess->num_workers);
@@ -1160,6 +1179,9 @@ col_session_create_internal(const wl_plan_t *plan, uint32_t num_workers,
                     "(set WIRELOG_MAX_WORKERS to override, max %u)\n",
                     sess->num_workers, effective_cap,
                     WL_MAX_WORKERS_HARD_LIMIT);
+                if (intern_attached_here)
+                    (void)wl_intern_detach_memory_governor(
+                        sess->intern, sess->memory_governor);
                 wl_columnar_memory_governor_ref_release(
                     sess->memory_governor);
                 free(sess);
@@ -1227,6 +1249,9 @@ col_session_create_internal(const wl_plan_t *plan, uint32_t num_workers,
     sess->pending_input_change = true;
     sess->rels = (col_rel_t **)calloc(sess->rel_cap, sizeof(col_rel_t *));
     if (!sess->rels) {
+        if (intern_attached_here)
+            (void)wl_intern_detach_memory_governor(
+                sess->intern, sess->memory_governor);
         wl_columnar_memory_governor_ref_release(sess->memory_governor);
         free(sess);
         return ENOMEM;
@@ -1493,6 +1518,9 @@ oom:
     delta_pool_destroy(sess->delta_pool); /* NULL-safe */
     wl_arena_free(sess->eval_arena);      /* NULL-safe; releases admission */
     (void)wl_compound_arena_free_checked(sess->compound_arena);
+    if (intern_attached_here)
+        (void)wl_intern_detach_memory_governor(
+            sess->intern, sess->memory_governor);
     wl_columnar_memory_governor_ref_release(sess->memory_governor);
     free(sess);
     return ENOMEM;

--- a/wirelog/intern.c
+++ b/wirelog/intern.c
@@ -52,9 +52,12 @@
 
 #include "intern.h"
 
+#include "columnar/memory_governor.h"
+
 #include "thread.h"
 
 #include <stdint.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -146,7 +149,77 @@ struct wl_intern {
 
     /* Writers only.  Readers (reverse/count) never take it. */
     mutex_t lock;
+
+    /* Interned strings are program-owned and may outlive any session. */
+    wl_columnar_memory_governor_ref_t *memory_governor;
+    wl_columnar_memory_reservation_t reservation;
+    uint64_t reserved_bytes;
 };
+
+static inline uint32_t intern_seg_size(uint32_t seg);
+static inline char *intern_string_at(const wl_intern_t *intern,
+    uint32_t id);
+
+static uint64_t
+intern_retained_bytes_locked(const wl_intern_t *intern)
+{
+    uint64_t total = (uint64_t)intern->slot_capacity
+        * sizeof(wl_intern_slot_t);
+    uint32_t count = WL_INTERN_LOAD_RELAXED(&intern->count);
+
+    for (uint32_t seg = 0; seg < INTERN_MAX_SEGMENTS; seg++) {
+        if (intern->segments[seg]) {
+            uint64_t bytes = (uint64_t)intern_seg_size(seg)
+                * sizeof(char *);
+            if (UINT64_MAX - total < bytes)
+                return UINT64_MAX;
+            total += bytes;
+        }
+    }
+    for (uint32_t i = 0; i < count; i++) {
+        const char *str = intern_string_at(intern, i);
+        size_t len = strlen(str);
+        if (len == SIZE_MAX)
+            return UINT64_MAX;
+        len++;
+        if ((uint64_t)len > UINT64_MAX - total)
+            return UINT64_MAX;
+        total += (uint64_t)len;
+    }
+    return total;
+}
+
+static int
+intern_publish_reservation(wl_intern_t *intern,
+    wl_columnar_memory_reservation_t *pending, uint64_t bytes)
+{
+    wl_columnar_memory_reservation_t previous;
+    if (!intern || !pending || !intern->memory_governor)
+        return EINVAL;
+    if (!wl_columnar_memory_commit(pending, intern))
+        return ENOMEM;
+    wl_columnar_memory_reservation_init(&previous);
+    if (intern->reserved_bytes > 0
+        && !wl_columnar_memory_reservation_move(
+            &previous, &intern->reservation)) {
+        (void)wl_columnar_memory_release(pending);
+        return ENOMEM;
+    }
+    if (!wl_columnar_memory_reservation_move(
+            &intern->reservation, pending)) {
+        if (intern->reserved_bytes > 0) {
+            wl_columnar_memory_reservation_init(&intern->reservation);
+            (void)wl_columnar_memory_reservation_move(
+                &intern->reservation, &previous);
+        }
+        (void)wl_columnar_memory_release(pending);
+        return ENOMEM;
+    }
+    if (intern->reserved_bytes > 0)
+        (void)wl_columnar_memory_release(&previous);
+    intern->reserved_bytes = bytes;
+    return 0;
+}
 
 /* ======================================================================== */
 /* FNV-1a Hash                                                              */
@@ -220,26 +293,6 @@ intern_string_at(const wl_intern_t *intern, uint32_t id)
     return intern->segments[seg][id - intern_seg_base(seg)];
 }
 
-/* Make sure the segment holding @id exists.  Caller holds @lock. */
-static int
-intern_seg_ensure(wl_intern_t *intern, uint32_t id)
-{
-    uint32_t seg = intern_seg_of(id);
-
-    if (seg >= INTERN_MAX_SEGMENTS)
-        return -1;
-    if (intern->segments[seg])
-        return 0;
-
-    char **block = (char **)calloc((size_t)intern_seg_size(seg),
-            sizeof(char *));
-    if (!block)
-        return -1;
-
-    intern->segments[seg] = block;
-    return 0;
-}
-
 /* ======================================================================== */
 /* Internal Helpers                                                         */
 /* ======================================================================== */
@@ -252,14 +305,19 @@ intern_seg_ensure(wl_intern_t *intern, uint32_t id)
  * be freed here.
  */
 static int
-intern_resize(wl_intern_t *intern)
+intern_resize_prepare(const wl_intern_t *intern,
+    wl_intern_slot_t **out_slots, uint32_t *out_capacity)
 {
-    uint32_t count = WL_INTERN_LOAD_RELAXED(&intern->count);
+    uint32_t count;
+    wl_intern_slot_t *new_slots;
+    uint32_t new_cap;
 
-    if (intern->slot_capacity > UINT32_MAX / 2U)
+    if (!intern || !out_slots || !out_capacity
+        || intern->slot_capacity > UINT32_MAX / 2U)
         return -1;
-    uint32_t new_cap = intern->slot_capacity * 2U;
-    wl_intern_slot_t *new_slots
+    count = WL_INTERN_LOAD_RELAXED(&intern->count);
+    new_cap = intern->slot_capacity * 2U;
+    new_slots
         = (wl_intern_slot_t *)malloc((size_t)new_cap
             * sizeof(wl_intern_slot_t));
     if (!new_slots)
@@ -275,9 +333,8 @@ intern_resize(wl_intern_t *intern)
         new_slots[h].string_id = i;
     }
 
-    free(intern->slots);
-    intern->slots = new_slots;
-    intern->slot_capacity = new_cap;
+    *out_slots = new_slots;
+    *out_capacity = new_cap;
     return 0;
 }
 
@@ -322,6 +379,8 @@ wl_intern_create(void)
         return NULL;
     }
 
+    wl_columnar_memory_reservation_init(&intern->reservation);
+
     WL_INTERN_STORE_RELEASE(&intern->count, 0u);
 
     intern->slot_capacity = INTERN_INITIAL_CAP;
@@ -339,13 +398,95 @@ wl_intern_create(void)
     return intern;
 }
 
+int
+wl_intern_attach_memory_governor(
+    wl_intern_t *intern,
+    wl_columnar_memory_governor_ref_t *governor_ref)
+{
+    wl_columnar_memory_reservation_t pending;
+    wl_columnar_memory_admission_status_t status;
+    wl_columnar_memory_governor_t *governor;
+    uint64_t bytes;
+
+    if (!intern || !governor_ref)
+        return EINVAL;
+
+    mutex_lock(&intern->lock);
+    if (intern->memory_governor) {
+        int rc = intern->memory_governor == governor_ref ? EALREADY : EBUSY;
+        mutex_unlock(&intern->lock);
+        return rc;
+    }
+
+    governor = wl_columnar_memory_governor_ref_get(governor_ref);
+    bytes = intern_retained_bytes_locked(intern);
+    if (!governor || bytes == UINT64_MAX) {
+        mutex_unlock(&intern->lock);
+        return ENOMEM;
+    }
+    wl_columnar_memory_reservation_init(&pending);
+    status = wl_columnar_memory_reserve_checked(governor, bytes, &pending);
+    if (status != WL_COLUMNAR_MEMORY_ADMISSION_OK
+        && status != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY) {
+        mutex_unlock(&intern->lock);
+        return status == WL_COLUMNAR_MEMORY_ADMISSION_DENIED
+            ? ENOMEM : EOVERFLOW;
+    }
+    if (!wl_columnar_memory_commit(&pending, intern)) {
+        (void)wl_columnar_memory_release(&pending);
+        mutex_unlock(&intern->lock);
+        return ENOMEM;
+    }
+    wl_columnar_memory_governor_ref_retain(governor_ref);
+    intern->memory_governor = governor_ref;
+    (void)wl_columnar_memory_reservation_move(
+        &intern->reservation, &pending);
+    intern->reserved_bytes = bytes;
+    mutex_unlock(&intern->lock);
+    return 0;
+}
+
+int
+wl_intern_detach_memory_governor(
+    wl_intern_t *intern,
+    wl_columnar_memory_governor_ref_t *governor_ref)
+{
+    if (!intern || !governor_ref)
+        return EINVAL;
+    mutex_lock(&intern->lock);
+    if (!intern->memory_governor) {
+        mutex_unlock(&intern->lock);
+        return 0;
+    }
+    if (intern->memory_governor != governor_ref) {
+        mutex_unlock(&intern->lock);
+        return EBUSY;
+    }
+    if (intern->reserved_bytes > 0)
+        (void)wl_columnar_memory_release(&intern->reservation);
+    intern->reserved_bytes = 0;
+    intern->memory_governor = NULL;
+    wl_columnar_memory_governor_ref_release(governor_ref);
+    mutex_unlock(&intern->lock);
+    return 0;
+}
+
 void
 wl_intern_free(wl_intern_t *intern)
 {
     if (!intern)
         return;
 
-    uint32_t count = WL_INTERN_LOAD_RELAXED(&intern->count);
+    uint32_t count;
+
+    mutex_lock(&intern->lock);
+    count = WL_INTERN_LOAD_RELAXED(&intern->count);
+    if (intern->reserved_bytes > 0)
+        (void)wl_columnar_memory_release(&intern->reservation);
+    intern->reserved_bytes = 0;
+    wl_columnar_memory_governor_ref_release(intern->memory_governor);
+    intern->memory_governor = NULL;
+    mutex_unlock(&intern->lock);
     for (uint32_t i = 0; i < count; i++)
         free(intern_string_at(intern, i));
 
@@ -360,71 +501,150 @@ wl_intern_free(wl_intern_t *intern)
 int64_t
 wl_intern_put(wl_intern_t *intern, const char *str)
 {
+    wl_columnar_memory_reservation_t pending;
+    bool pending_valid = false;
+    char *copy;
+    char **new_segment = NULL;
+    wl_intern_slot_t *new_slots = NULL;
+    uint32_t h = 0;
+    uint32_t new_id;
+    uint32_t seg;
+    uint32_t new_cap;
+    bool needs_segment;
+    bool needs_resize;
+    uint64_t retained_after = 0;
+    size_t slen;
+    size_t copy_bytes;
+    int64_t existing;
+
     if (!intern || !str)
         return -1;
 
     /* Prepare the owned copy before taking the writer lock.  strlen/malloc/
      * memcpy are independent of the table and used to make every worker wait
      * behind the lock while doing allocation and copying (#961).  A duplicate
-     * discovered below simply releases this speculative copy. */
-    size_t slen = strlen(str);
-    char *copy = (char *)malloc(slen + 1);
+     * discovered below simply releases this speculative copy; its bytes are
+     * never charged to the governor (Issue #1431).  Segment and slot arrays
+     * are still allocated under the lock: they grow geometrically, so their
+     * cost is amortized over 64 * 2^k and 2x puts respectively. */
+    slen = strlen(str);
+    if (slen == SIZE_MAX)
+        return -1;
+    copy_bytes = slen + 1;
+    copy = (char *)malloc(copy_bytes);
     if (!copy)
         return -1;
-    memcpy(copy, str, slen + 1);
+    memcpy(copy, str, copy_bytes);
 
     mutex_lock(&intern->lock);
-
-    /* Check if already interned */
-    uint32_t h = 0;
-    int64_t existing = intern_lookup_locked(intern, str, &h);
+    existing = intern_lookup_locked(intern, str, &h);
     if (existing >= 0) {
-        free(copy);
         mutex_unlock(&intern->lock);
+        free(copy);
         return existing;
     }
+    new_id = WL_INTERN_LOAD_RELAXED(&intern->count);
+    if (new_id >= INTERN_MAX_STRINGS)
+        goto fail;
+    seg = intern_seg_of(new_id);
+    needs_segment = intern->segments[seg] == NULL;
+    needs_resize = (uint64_t)(new_id + 1U) * INTERN_LOAD_FACTOR_DEN
+        > (uint64_t)intern->slot_capacity * INTERN_LOAD_FACTOR_NUM;
+    if (needs_resize && intern->slot_capacity > UINT32_MAX / 2U)
+        goto fail;
+    new_cap = needs_resize ? intern->slot_capacity * 2U
+                           : intern->slot_capacity;
 
-    /* New string: make room for it in the segmented storage. */
-    uint32_t new_id = WL_INTERN_LOAD_RELAXED(&intern->count);
-    if (new_id >= INTERN_MAX_STRINGS
-        || intern_seg_ensure(intern, new_id) != 0) {
-        free(copy);
-        mutex_unlock(&intern->lock);
-        return -1;
+    if (intern->memory_governor) {
+        /* Retained footprint after this put: every byte the table holds now
+         * except the slot array a resize frees, plus the copy, a fresh
+         * segment when @new_id opens one, and the doubled slot array.
+         * intern->reserved_bytes is exact (attach scans, every publish
+         * stores the new total), so no rescan is needed here.  Growth is
+         * reserved while the old footprint is still held, so exact fit
+         * means old + new <= budget, the same convention as relation.c. */
+        uint64_t old_bytes = intern->reserved_bytes;
+        uint64_t freed_slot_bytes = 0;
+        uint64_t segment_bytes = 0;
+        uint64_t slot_bytes = 0;
+        wl_columnar_memory_admission_status_t status;
+
+        if (needs_resize
+            && (!wl_columnar_memory_size_mul(intern->slot_capacity,
+            sizeof(wl_intern_slot_t), &freed_slot_bytes)
+            || !wl_columnar_memory_size_mul(new_cap,
+            sizeof(wl_intern_slot_t), &slot_bytes)))
+            goto fail;
+        if (needs_segment
+            && !wl_columnar_memory_size_mul(intern_seg_size(seg),
+            sizeof(char *), &segment_bytes))
+            goto fail;
+        if (freed_slot_bytes > old_bytes)
+            goto fail;
+        retained_after = old_bytes - freed_slot_bytes;
+        if (!wl_columnar_memory_size_add(retained_after, copy_bytes,
+            &retained_after)
+            || !wl_columnar_memory_size_add(retained_after, segment_bytes,
+            &retained_after)
+            || !wl_columnar_memory_size_add(retained_after, slot_bytes,
+            &retained_after))
+            goto fail;
+        wl_columnar_memory_reservation_init(&pending);
+        status = wl_columnar_memory_reserve_growth(
+            wl_columnar_memory_governor_ref_get(intern->memory_governor),
+            old_bytes, retained_after, &pending);
+        if (status != WL_COLUMNAR_MEMORY_ADMISSION_OK
+            && status != WL_COLUMNAR_MEMORY_ADMISSION_ADVISORY)
+            goto fail;
+        pending_valid = true;
     }
 
-    /* Resize hash table before insertion if the new entry would exceed the load factor. */
-    if ((uint64_t)(new_id + 1U) * INTERN_LOAD_FACTOR_DEN
-        > (uint64_t)intern->slot_capacity * INTERN_LOAD_FACTOR_NUM) {
-        if (intern_resize(intern) != 0) {
-            free(copy);
-            mutex_unlock(&intern->lock);
-            return -1;
-        }
-        uint32_t mask = intern->slot_capacity - 1U;
-        h = fnv1a(str) & mask;
+    if (needs_segment) {
+        new_segment = (char **)calloc((size_t)intern_seg_size(seg),
+                sizeof(char *));
+        if (!new_segment)
+            goto fail;
+    }
+    if (needs_resize
+        && intern_resize_prepare(intern, &new_slots, &new_cap) != 0)
+        goto fail;
+    if (pending_valid
+        && intern_publish_reservation(intern, &pending, retained_after) != 0)
+        goto fail;
+
+    /* Nothing below can fail: the reservation now belongs to the table. */
+    if (new_slots) {
+        free(intern->slots);
+        intern->slots = new_slots;
+        intern->slot_capacity = new_cap;
+    }
+    if (needs_resize) {
+        h = fnv1a(str) & (intern->slot_capacity - 1U);
         while (intern->slots[h].string_id != SLOT_EMPTY)
-            h = (h + 1U) & mask;
+            h = (h + 1U) & (intern->slot_capacity - 1U);
     }
-
-    uint32_t seg = intern_seg_of(new_id);
+    if (new_segment)
+        intern->segments[seg] = new_segment;
     intern->segments[seg][new_id - intern_seg_base(seg)] = copy;
+    intern->slots[h].string_id = new_id;
 
     /* Release store: any reader that acquire-loads a count greater than
      * new_id also sees the segment pointer and the string above.  The
      * entry must be complete before the count is published, never the
-     * other way round. */
-    /* Release is sufficient only because EVERY store to count happens
-     * under intern->lock: another writer's segment and slot writes are
-     * ordered before its unlock, which is ordered before our lock and
-     * therefore before this store.  An unlocked count store would break
-     * the transitivity a lock-free reverse() depends on. */
+     * other way round.  Release is sufficient only because EVERY store to
+     * count happens under intern->lock. */
     WL_INTERN_STORE_RELEASE(&intern->count, new_id + 1U);
-
-    intern->slots[h].string_id = new_id;
-
     mutex_unlock(&intern->lock);
     return (int64_t)new_id;
+
+fail:
+    free(copy);
+    free((void *)new_segment);
+    free(new_slots);
+    if (pending_valid)
+        (void)wl_columnar_memory_rollback(&pending);
+    mutex_unlock(&intern->lock);
+    return -1;
 }
 
 int64_t

--- a/wirelog/intern.h
+++ b/wirelog/intern.h
@@ -34,6 +34,21 @@
 #include <stdint.h>
 
 typedef struct wl_intern wl_intern_t;
+typedef struct wl_columnar_memory_governor_ref
+    wl_columnar_memory_governor_ref_t;
+
+/* Attach program-owned intern storage to a retained governor.  Existing
+ * bytes are admitted transactionally; EBUSY means another governor already
+ * owns the table and the caller must continue using that owner. */
+int
+wl_intern_attach_memory_governor(
+    wl_intern_t *intern,
+    wl_columnar_memory_governor_ref_t *governor);
+
+int
+wl_intern_detach_memory_governor(
+    wl_intern_t *intern,
+    wl_columnar_memory_governor_ref_t *governor);
 
 /**
  * wl_intern_create:

--- a/wirelog/wirelog-easy.c
+++ b/wirelog/wirelog-easy.c
@@ -120,7 +120,10 @@ ensure_plan_built(wirelog_easy_session_t *s, uint32_t num_workers)
             &session);
     if (rc != 0 || !session) {
         wl_plan_free(plan);
-        return (rc == ENOMEM) ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_EXEC;
+        /* ENOMEM is an allocation failure; EOVERFLOW is the memory
+         * governor refusing to admit the program's intern table (#1431). */
+        return (rc == ENOMEM || rc == EOVERFLOW)
+            ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_EXEC;
     }
 
     /* Issue #718: seed inline `.dl` facts into the freshly built session


### PR DESCRIPTION
Re-lands #1445's intern admission (7d681c4f) on current main. The original merged only into a stacked base branch that was later rewritten, so its code never reached `main`. Two commits:

1. `test: honor program lifetime in plan fixtures` (tests only). `wl_plan_t` and sessions borrow the program's intern table, but 25 test/bench helpers freed the program right after `wl_plan_from_program()`. That was latent on main and becomes a use-after-free once session creation attaches the governor to the table. New header-only `tests/plan_fixture.h` holds programs until process exit (atexit-registered release). Four files carry an uncrustify reflow because they were not formatter-clean on main and the lint gate formats every changed file.
2. `feat(#1431): admit the program-owned intern table under the memory governor`.

## Contract

- Session creation attaches `plan->intern` to the session's governor. Existing bytes are admitted transactionally; if they do not fit, creation fails with `ENOMEM`/`EOVERFLOW`, mapped to `WIRELOG_ERR_MEMORY` by `wirelog_easy_open` and `wirelog_executor_create` (the latter previously returned the blanket `WIRELOG_ERR_EXEC` for that path).
- The first managed session's governor owns the table for the program's lifetime. Later sessions from the same plan get `EBUSY`, tolerated, and use their own governor for session-owned storage. Session destruction never releases the reservation; `wl_intern_free()` from `wirelog_program_free()` releases it once.
- `wl_intern_put()` reserves growth before allocating: string copy plus a new id segment or doubled slot array (minus the freed old array), on top of the exact running total the table keeps. Growth is reserved with the old footprint still held (exact fit means old + new <= budget, the relation.c convention). Denial returns -1 and leaves ids, `wl_intern_reverse()` and the reservation untouched. Duplicates are never charged; the speculative copy stays outside the writer lock (#961).

## Differences from 7d681c4f

Exact resize accounting (the original rescanned every string per put and would over-count permanently once that scan was dropped); #961 copy-outside-the-lock restored; overflow guards via `wl_columnar_memory_size_add/mul`; dead detach removed from the attach-failed path; `intern_fuzz` and the admission test link `intern_src`; clang-tidy findings in `intern.c` fixed; `docs/MEMORY.md` matrix row and `docs/THREADING.md` intern rows updated.

## Residual and follow-ups

String builtins and literals not pre-interned by the plan generator carry a denied put's -1 as a string id under an enforcing budget (documented in `docs/MEMORY.md`). Follow-up issues are filed for that, for rebinding an orphaned intern governor, a CI guard for the program-lifetime pattern, an intern microbenchmark, and driving session-create denial through the public API (the budget floor of 256 MiB keeps that out of unit-test reach; the verdict is covered at attach level).

## Validation

- Unit A alone: focused 29/29; full suite under ASan/UBSan with leak detection 349 OK / 0 failed.
- Units A+B: `meson test` 352 OK / 0 failed / 13 skipped (perf and stress-release gates), clang-tidy ratchet, threading doc, ABI gates green; full ASan/UBSan suite 350 OK / 0 failed; TSan (`-Dthreads=posix`) clean on intern_parallel_determinism, memory_admission_intern, session, worker_borrow_w2_tsan, tdd_multiworker; `.text` delta vs main in the CI configuration +1383 B (budget 5120).

Closes #1431
