### PR TITLE
feat: serialize committed memory reservation downsizing

### DIFF
--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -228,7 +228,7 @@ These exist so struct fields can be declared portably; the audit in
 
 Every `atomic_*` call site in `wirelog/` production sources. Counted
 mechanically by `scripts/ci/check-threading-doc.sh`; row count must
-match the script's count (currently **94**).
+match the script's count (currently **96**).
 
 Format: `file:function[#N]` | field | operation | order | justification.
 
@@ -341,12 +341,16 @@ and the wasted work is bounded.
 |---|---|---|---|---|
 | `session.c:col_worker_session_create` | per-worker view of `ledger->total_budget` | `atomic_load_explicit` | `relaxed` | Worker session reads coordinator's budget snapshot; advisory, no edge required |
 
-### 5.8 `wirelog/columnar/memory_governor.c` — reservation state (27 rows)
+### 5.8 `wirelog/columnar/memory_governor.c` — reservation state (36 rows)
 
 The governor uses one atomic counter for the shared reservation limit and
 token state transitions. The CAS admission loop is overflow-safe and a token
 reaches released exactly once; owner identity is stored as an atomic pointer
 representation so transfer cannot race a release with a data race.
+Downsize, release, and transfer claim the token before accessing mutable payload;
+contending operations return false when the token is busy. Accounting completes
+before publishing the updated committed or released state. Move, reinitialization,
+and direct non-atomic payload reads require external synchronization.
 
 | Anchor (file:function[#N]) | Field | Op | Order | Justification |
 |---|---|---|---|---|
@@ -365,16 +369,18 @@ representation so transfer cannot race a release with a data race.
 | `memory_governor.c:reserve_internal#6` | `reservation->state` | `atomic_store_explicit` | `release` | Abandon a token that exceeded the usable limit |
 | `memory_governor.c:reserve_internal#7` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `relaxed`/`relaxed` | Atomically admit without exceeding the shared limit |
 | `memory_governor.c:reserve_internal#8` | `reservation->state` | `atomic_store_explicit` | `release` | Publish the fully initialized reserved token |
-| `memory_governor.c:transition_reservation` | `reservation->state` | `atomic_compare_exchange_weak_explicit` | `release`/`acquire` | Retry spurious weak-CAS failures while enforcing a legal state transition |
-| `memory_governor.c:claim_reservation_state` | `reservation->state` | `atomic_compare_exchange_weak_explicit` | `release`/`acquire` | Claim a token or transfer state without relying on an MSVC-only strong-CAS shim |
+| `memory_governor.c:transition_reservation` | `reservation->state` | `atomic_compare_exchange_weak_explicit` | `acq_rel`/`acquire` | Acquire prior payload publication while enforcing a legal state transition and retrying spurious failure |
+| `memory_governor.c:claim_reservation_state` | `reservation->state` | `atomic_compare_exchange_weak_explicit` | `acq_rel`/`acquire` | Acquire exclusive access to token payload before downsize, release, or transfer |
 | `memory_governor.c:wl_columnar_memory_commit` | `reservation->owner_bits` | `atomic_store_explicit` | `release` | Publish committed ownership before the commit state |
 | `memory_governor.c:wl_columnar_memory_commit#2` | `reservation->state` | `atomic_store_explicit` | `release` | Publish the committed state after owner initialization |
 | `memory_governor.c:wl_columnar_memory_transfer` | `reservation->state` | `atomic_load_explicit` | `acquire` | Read the active state before claiming transfer |
 | `memory_governor.c:wl_columnar_memory_transfer#2` | `reservation->owner_bits` | `atomic_store_explicit` | `release` | Publish the new logical owner |
 | `memory_governor.c:wl_columnar_memory_transfer#3` | `reservation->state` | `atomic_store_explicit` | `release` | Restore the active state after owner transfer |
-| `memory_governor.c:finish_reservation` | `reservation->state` | `atomic_load_explicit` | `acquire` | Wait for an in-flight commit or transfer to publish a stable state |
-| `memory_governor.c:finish_reservation#2` | `reserved_bytes` | `atomic_load_explicit` | `relaxed` | Read current total before returning token capacity |
-| `memory_governor.c:finish_reservation#3` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `release`/`relaxed` | Return exactly this token's bytes without underflow |
+| `memory_governor.c:credit_reservation` | `reserved_bytes` | `atomic_load_explicit` | `relaxed` | Read current total while holding the token claim |
+| `memory_governor.c:credit_reservation#2` | `reserved_bytes` | `atomic_compare_exchange_weak_explicit` | `release`/`relaxed` | Return the claimed token's capacity or shrink delta without underflow |
+| `memory_governor.c:wl_columnar_memory_reservation_downsize` | `reservation->state` | `atomic_store_explicit` | `release` | Publish updated bytes after crediting the delta, or restore committed state on failure |
+| `memory_governor.c:finish_reservation` | `reservation->state` | `atomic_load_explicit` | `acquire` | Observe an eligible stable state before claiming release; reject a busy token |
+| `memory_governor.c:finish_reservation#2` | `reservation->state` | `atomic_store_explicit` | `release` | Publish released state only after accounting, or restore the prior state on failure |
 | `memory_governor.c:wl_columnar_memory_reserve_growth` | `reservation->state` | `atomic_load_explicit` | `acquire` | Validate the source token before creating a distinct growth reservation |
 | `memory_governor.c:wl_columnar_memory_reserved` | `reserved_bytes` | `atomic_load_explicit` | `acquire` | Read a coherent observable reservation total |
 | `memory_governor.c:wl_columnar_memory_reservation_move` | `destination->state` | `atomic_load_explicit` | `acquire` | Validate the destination token before moving ownership |
@@ -416,7 +422,7 @@ named in the justification.
 
 ### 5.11 Total
 
-21 + 4 + 2 + 3 + 19 + 1 + 1 + 1 + 3 + 27 + 7 + 5 = **94 atomic call sites**.
+21 + 4 + 2 + 3 + 19 + 1 + 1 + 1 + 3 + 36 + 5 = **96 atomic call sites**.
 
 The `#N` suffix counts all atomic sites in a symbol, regardless of operation;
 the first site remains unsuffixed. `scripts/ci/check-threading-doc.sh` uses

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -19,7 +19,7 @@ fi
 rows="$tmp_dir/rows"
 sed -nE 's/^\| `([^`]+:[A-Za-z_][A-Za-z0-9_]*(#[0-9]+)?)` \| [^|]* \| `([^`]*)` \|.*/\1\t\3/p' "$doc" >"$rows"
 row_count=$(wc -l <"$rows")
-expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-94}"
+expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-96}"
 [ "$row_count" -eq "$expected_rows" ] || {
     echo "check-threading-doc: FAIL: expected $expected_rows audit rows, found $row_count" >&2
     exit 1

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1355,6 +1355,7 @@ test_memory_governor_exe = executable(
     + thread_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [threads_dep],
+  c_args: ['-DWL_COLUMNAR_MEMORY_TEST_HOOKS=1'],
 )
 test('memory_governor', test_memory_governor_exe, suite: 'unit')
 

--- a/tests/test_memory_governor.c
+++ b/tests/test_memory_governor.c
@@ -357,6 +357,280 @@ test_checked_admission(void)
     return 0;
 }
 
+static int
+test_downsize(void)
+{
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_t governor;
+    wl_columnar_memory_reservation_t token, other, copy, moved;
+    int owner;
+    TEST("committed reservation downsizing and invalid states");
+    make_resolution(&resolution, 1000, 900);
+    wl_columnar_memory_governor_init(&governor, &resolution);
+    wl_columnar_memory_reservation_init(&token);
+    wl_columnar_memory_reservation_init(&other);
+    wl_columnar_memory_reservation_init(&moved);
+    if (wl_columnar_memory_reservation_downsize(NULL, 1)
+        || wl_columnar_memory_reservation_downsize(&token, 1)
+        || !wl_columnar_memory_reserve(&governor, 600, &token)
+        || !wl_columnar_memory_reserve(&governor, 100, &other)
+        || wl_columnar_memory_reservation_downsize(&token, 300)
+        || !wl_columnar_memory_commit(&token, &owner)) {
+        FAIL("setup or noncommitted rejection");
+        return 1;
+    }
+    memcpy(&copy, &token, sizeof(copy));
+    if (wl_columnar_memory_reservation_downsize(&copy, 300)
+        || wl_columnar_memory_reservation_downsize(&token, 0)
+        || wl_columnar_memory_reservation_downsize(&token, 601)
+        || !wl_columnar_memory_reservation_downsize(&token, 600)
+        || wl_columnar_memory_reserved(&governor) != 700
+        || !wl_columnar_memory_reservation_downsize(&token, 300)
+        || !wl_columnar_memory_reservation_downsize(&token, 200)
+        || token.bytes != 200
+        || atomic_load_explicit(&token.owner_bits, memory_order_acquire)
+        != (uint64_t)(uintptr_t)&owner
+        || wl_columnar_memory_reserved(&governor) != 300) {
+        FAIL("downsize changed identity/owner or credited wrong amount");
+        return 1;
+    }
+    /* Exercise busy rejection without scheduling assumptions. */
+    atomic_store_explicit(&token.state,
+        WL_COLUMNAR_MEMORY_RESERVATION_DOWNSIZING, memory_order_release);
+    if (wl_columnar_memory_reservation_downsize(&token, 100)
+        || wl_columnar_memory_release(&token)
+        || wl_columnar_memory_transfer(&token, &other)) {
+        FAIL("busy token accepted an operation");
+        return 1;
+    }
+    atomic_store_explicit(&token.state,
+        WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED, memory_order_release);
+    /* Inject corrupt aggregate accounting to verify failure is reversible. */
+    atomic_store_explicit(&governor.reserved_bytes, 1, memory_order_relaxed);
+    if (wl_columnar_memory_reservation_downsize(&token, 100)
+        || wl_columnar_memory_release(&token) || token.bytes != 200
+        || atomic_load_explicit(&token.state, memory_order_acquire)
+        != WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED) {
+        FAIL("accounting failure changed token");
+        return 1;
+    }
+    atomic_store_explicit(&governor.reserved_bytes, 300, memory_order_relaxed);
+    if (!wl_columnar_memory_transfer(&token, &other)
+        || atomic_load_explicit(&token.owner_bits, memory_order_acquire)
+        != (uint64_t)(uintptr_t)&other
+        || !wl_columnar_memory_reservation_move(&moved, &token)
+        || wl_columnar_memory_reservation_downsize(&token, 100)
+        || !wl_columnar_memory_reservation_downsize(&moved, 100)
+        || atomic_load_explicit(&moved.owner_bits, memory_order_acquire)
+        != (uint64_t)(uintptr_t)&other
+        || !wl_columnar_memory_release(&moved)
+        || wl_columnar_memory_reservation_downsize(&moved, 1)
+        || wl_columnar_memory_reserved(&governor) != 100
+        || !wl_columnar_memory_release(&other)
+        || wl_columnar_memory_reserved(&governor) != 0) {
+        FAIL("move or residual release accounting");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static struct {
+    wl_columnar_memory_reservation_t *token;
+    unsigned phase;
+    unsigned hits;
+    bool armed;
+    bool valid;
+} schedule;
+
+void
+wl_columnar_memory_test_hook(wl_columnar_memory_reservation_t *token,
+    unsigned phase)
+{
+    if (!schedule.armed || token != schedule.token || phase != schedule.phase)
+        return;
+    /* One-shot nesting models a competing operation while this call is paused. */
+    schedule.armed = false;
+    schedule.hits++;
+    if (phase == WL_COLUMNAR_MEMORY_TEST_RELEASE_BEFORE_CLAIM) {
+        schedule.valid = wl_columnar_memory_reservation_downsize(token, 200)
+            && wl_columnar_memory_reserved(token->governor) == 1200;
+        return;
+    }
+    uint64_t state = WL_COLUMNAR_MEMORY_RESERVATION_RELEASING;
+    uint64_t total = 1600;
+    if (phase == WL_COLUMNAR_MEMORY_TEST_DOWNSIZE_CLAIMED
+        || phase == WL_COLUMNAR_MEMORY_TEST_DOWNSIZE_CREDITED)
+        state = WL_COLUMNAR_MEMORY_RESERVATION_DOWNSIZING;
+    if (phase == WL_COLUMNAR_MEMORY_TEST_TRANSFER_CLAIMED)
+        state = WL_COLUMNAR_MEMORY_RESERVATION_TRANSFERRING;
+    if (phase == WL_COLUMNAR_MEMORY_TEST_RELEASE_CREDITED)
+        total = 1000;
+    if (phase == WL_COLUMNAR_MEMORY_TEST_DOWNSIZE_CREDITED)
+        total = 1200;
+    schedule.valid = atomic_load_explicit(&token->state, memory_order_acquire)
+        == state && wl_columnar_memory_reserved(token->governor) == total;
+    bool release = wl_columnar_memory_release(token);
+    bool downsize = wl_columnar_memory_reservation_downsize(token, 100);
+    bool transfer = wl_columnar_memory_transfer(token, &schedule);
+    bool reserve = wl_columnar_memory_reserve(token->governor, 50, token);
+    schedule.valid = schedule.valid && !release && !downsize && !transfer
+        && !reserve && wl_columnar_memory_reserved(token->governor) == total
+        && atomic_load_explicit(&token->owner_bits, memory_order_acquire)
+        == (uint64_t)(uintptr_t)token->governor;
+}
+
+static int
+test_downsize_interleavings(void)
+{
+    TEST("controlled claim, credit, and publication interleavings");
+    for (unsigned phase = WL_COLUMNAR_MEMORY_TEST_RELEASE_BEFORE_CLAIM;
+        phase <= WL_COLUMNAR_MEMORY_TEST_DOWNSIZE_CREDITED; phase++) {
+        wl_columnar_memory_resolution_t resolution;
+        wl_columnar_memory_governor_t governor;
+        wl_columnar_memory_reservation_t token, other;
+        make_resolution(&resolution, 5000, 4500);
+        wl_columnar_memory_governor_init(&governor, &resolution);
+        wl_columnar_memory_reservation_init(&token);
+        wl_columnar_memory_reservation_init(&other);
+        if (!wl_columnar_memory_reserve(&governor, 600, &token)
+            || !wl_columnar_memory_reserve(&governor, 1000, &other)
+            || !wl_columnar_memory_commit(&token, &governor)) {
+            FAIL("controlled schedule setup");
+            return 1;
+        }
+        schedule.token = &token;
+        schedule.phase = phase;
+        schedule.hits = 0;
+        schedule.armed = true;
+        schedule.valid = false;
+        bool is_downsize = phase == WL_COLUMNAR_MEMORY_TEST_DOWNSIZE_CLAIMED
+            || phase == WL_COLUMNAR_MEMORY_TEST_DOWNSIZE_CREDITED;
+        bool is_transfer = phase == WL_COLUMNAR_MEMORY_TEST_TRANSFER_CLAIMED;
+        bool ok;
+        if (is_downsize)
+            ok = wl_columnar_memory_reservation_downsize(&token, 200);
+        else if (is_transfer)
+            ok = wl_columnar_memory_transfer(&token, &other);
+        else
+            ok = wl_columnar_memory_release(&token);
+        schedule.armed = false;
+        uint64_t expected = 1000 + (is_downsize ? 200 : is_transfer ? 600 : 0);
+        bool valid = ok && schedule.valid && schedule.hits == 1
+            && wl_columnar_memory_reserved(&governor) == expected
+            && atomic_load_explicit(&token.owner_bits, memory_order_acquire)
+            == (uint64_t)(uintptr_t)(is_transfer
+                ? (void *)&other : (void *)&governor);
+        if (!is_downsize && !is_transfer) {
+            valid = valid && atomic_load_explicit(&token.state,
+                    memory_order_acquire)
+                == WL_COLUMNAR_MEMORY_RESERVATION_RELEASED;
+            valid = wl_columnar_memory_reserve(&governor, 50, &token) && valid;
+        }
+        valid = wl_columnar_memory_release(&token) && valid;
+        valid = valid && wl_columnar_memory_reserved(&governor) == 1000;
+        valid = wl_columnar_memory_release(&other) && valid;
+        if (!valid || wl_columnar_memory_reserved(&governor) != 0) {
+            FAIL("controlled schedule violated accounting or publication");
+            return 1;
+        }
+    }
+    PASS();
+    return 0;
+}
+
+struct downsize_arg {
+    wl_columnar_memory_reservation_t *token;
+    wl_atomic_u64 *start;
+    unsigned op;
+    bool success;
+};
+
+static void *
+downsize_thread(void *ptr)
+{
+    struct downsize_arg *arg = ptr;
+    while (!atomic_load_explicit(arg->start, memory_order_acquire)) {
+    }
+    if (arg->op == 0)
+        arg->success = wl_columnar_memory_reservation_downsize(arg->token, 200);
+    else if (arg->op == 1)
+        arg->success = wl_columnar_memory_release(arg->token);
+    else
+        arg->success = wl_columnar_memory_transfer(arg->token, arg->start);
+    return NULL;
+}
+
+static int
+test_downsize_races(void)
+{
+    TEST(
+        "downsize/release/transfer contention conserves unrelated reservations");
+    for (unsigned round = 0; round < 100; round++) {
+        wl_columnar_memory_resolution_t resolution;
+        wl_columnar_memory_governor_t governor;
+        wl_columnar_memory_reservation_t token, other;
+        wl_atomic_u64 start;
+        thread_t threads[3];
+        struct downsize_arg args[3];
+        unsigned created = 0;
+        make_resolution(&resolution, 1000, 900);
+        wl_columnar_memory_governor_init(&governor, &resolution);
+        wl_columnar_memory_reservation_init(&token);
+        wl_columnar_memory_reservation_init(&other);
+        if (!wl_columnar_memory_reserve(&governor, 600, &token)
+            || !wl_columnar_memory_reserve(&governor, 100, &other)
+            || !wl_columnar_memory_commit(&token, &governor)) {
+            FAIL("race setup");
+            return 1;
+        }
+        atomic_store_explicit(&start, 0, memory_order_relaxed);
+        for (unsigned i = 0; i < 3; i++) {
+            args[i] = (struct downsize_arg){ &token, &start,
+                                             i ==
+                                             0 ? 0 : (round % 4 ==
+                                             3 ? 1 : round % 3), false };
+            if (thread_create(&threads[i], downsize_thread, &args[i]) != 0)
+                break;
+            created++;
+        }
+        atomic_store_explicit(&start, 1, memory_order_release);
+        for (unsigned i = 0; i < created; i++)
+            thread_join(&threads[i]);
+        bool released = atomic_load_explicit(&token.state, memory_order_acquire)
+            == WL_COLUMNAR_MEMORY_RESERVATION_RELEASED;
+        bool downsize_succeeded = false;
+        bool transfer_succeeded = false;
+        unsigned releases = 0;
+        for (unsigned i = 0; i < created; i++) {
+            if (args[i].success && args[i].op == 0)
+                downsize_succeeded = true;
+            if (args[i].success && args[i].op == 1)
+                releases++;
+            if (args[i].success && args[i].op == 2)
+                transfer_succeeded = true;
+        }
+        uint64_t expected = 100 + (released ? 0 : token.bytes);
+        bool valid = wl_columnar_memory_reserved(&governor) == expected
+            && releases == (released ? 1u : 0u)
+            && token.bytes == (downsize_succeeded ? 200u : 600u)
+            && atomic_load_explicit(&token.owner_bits, memory_order_acquire)
+            == (uint64_t)(uintptr_t)(transfer_succeeded
+                ? (void *)&start : (void *)&governor);
+        if (!released)
+            valid = wl_columnar_memory_release(&token) && valid;
+        valid = valid && wl_columnar_memory_reserved(&governor) == 100;
+        valid = wl_columnar_memory_release(&other) && valid;
+        if (created != 3 || !valid
+            || wl_columnar_memory_reserved(&governor) != 0) {
+            FAIL("concurrent lifecycle leaked or double credited capacity");
+            return 1;
+        }
+    }
+    PASS();
+    return 0;
+}
+
 int
 main(void)
 {
@@ -368,6 +642,9 @@ main(void)
     test_reservation_lifecycle();
     test_concurrent_admission();
     test_checked_admission();
+    test_downsize();
+    test_downsize_interleavings();
+    test_downsize_races();
     printf("\nPassed %d/%d; Failed %d\n",
         tests_run - tests_failed, tests_run, tests_failed);
     return tests_failed == 0 ? 0 : 1;

--- a/wirelog/columnar/memory_governor.c
+++ b/wirelog/columnar/memory_governor.c
@@ -23,6 +23,13 @@
 
 #define WL_MEMORY_PATH_MAX 4096
 
+#ifdef WL_COLUMNAR_MEMORY_TEST_HOOKS
+#define WL_MEMORY_TEST_POINT(token, phase) wl_columnar_memory_test_hook(token, \
+            phase)
+#else
+#define WL_MEMORY_TEST_POINT(token, phase) ((void)0)
+#endif
+
 static uint64_t
 headroom_for(uint64_t budget)
 {
@@ -653,7 +660,7 @@ transition_reservation(wl_columnar_memory_reservation_t *reservation,
         return false;
     for (;;) {
         if (atomic_compare_exchange_weak_explicit(&reservation->state,
-            &observed, to, memory_order_release, memory_order_acquire))
+            &observed, to, memory_order_acq_rel, memory_order_acquire))
             return true;
         if (observed != from)
             return false;
@@ -671,7 +678,7 @@ claim_reservation_state(wl_columnar_memory_reservation_t *reservation,
         return false;
     for (;;) {
         if (atomic_compare_exchange_weak_explicit(&reservation->state,
-            &observed, to, memory_order_release, memory_order_acquire))
+            &observed, to, memory_order_acq_rel, memory_order_acquire))
             return true;
         if (observed != from)
             return false;
@@ -709,42 +716,18 @@ wl_columnar_memory_transfer(wl_columnar_memory_reservation_t *reservation,
     if (!claim_reservation_state(reservation, state,
         WL_COLUMNAR_MEMORY_RESERVATION_TRANSFERRING))
         return false;
+    WL_MEMORY_TEST_POINT(reservation, WL_COLUMNAR_MEMORY_TEST_TRANSFER_CLAIMED);
     atomic_store_explicit(&reservation->owner_bits,
         (uint64_t)(uintptr_t)owner, memory_order_release);
     atomic_store_explicit(&reservation->state, state, memory_order_release);
     return true;
 }
 
+/* Called only while the token is exclusively claimed. */
 static bool
-finish_reservation(wl_columnar_memory_reservation_t *reservation,
-    bool rollback)
+credit_reservation(wl_columnar_memory_governor_t *governor, uint64_t bytes)
 {
-    uint64_t expected;
-    wl_columnar_memory_governor_t *governor;
-    uint64_t bytes;
     uint64_t old;
-
-    if (!reservation_identity_valid(reservation))
-        return false;
-    governor = reservation->governor;
-    bytes = reservation->bytes;
-    if (!governor || bytes == 0)
-        return false;
-    if (rollback) {
-        if (!transition_reservation(reservation,
-            WL_COLUMNAR_MEMORY_RESERVATION_RESERVED,
-            WL_COLUMNAR_MEMORY_RESERVATION_RELEASED))
-            return false;
-    } else {
-        expected = atomic_load_explicit(&reservation->state,
-                memory_order_acquire);
-        if (expected != WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
-            && expected != WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED)
-            return false;
-        if (!transition_reservation(reservation, expected,
-            WL_COLUMNAR_MEMORY_RESERVATION_RELEASED))
-            return false;
-    }
     old = atomic_load_explicit(&governor->reserved_bytes, memory_order_relaxed);
     for (;;) {
         uint64_t next;
@@ -760,6 +743,57 @@ finish_reservation(wl_columnar_memory_reservation_t *reservation,
 }
 
 bool
+wl_columnar_memory_reservation_downsize(
+    wl_columnar_memory_reservation_t *reservation, uint64_t bytes)
+{
+    bool ok = false;
+    if (bytes == 0 || !claim_reservation_state(reservation,
+        WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED,
+        WL_COLUMNAR_MEMORY_RESERVATION_DOWNSIZING))
+        return false;
+    WL_MEMORY_TEST_POINT(reservation, WL_COLUMNAR_MEMORY_TEST_DOWNSIZE_CLAIMED);
+    if (reservation->governor && bytes <= reservation->bytes
+        && credit_reservation(reservation->governor,
+        reservation->bytes - bytes)) {
+        reservation->bytes = bytes;
+        ok = true;
+        WL_MEMORY_TEST_POINT(reservation,
+            WL_COLUMNAR_MEMORY_TEST_DOWNSIZE_CREDITED);
+    }
+    atomic_store_explicit(&reservation->state,
+        WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED, memory_order_release);
+    return ok;
+}
+
+static bool
+finish_reservation(wl_columnar_memory_reservation_t *reservation,
+    bool rollback)
+{
+    uint64_t state;
+    bool ok;
+    if (!reservation_identity_valid(reservation))
+        return false;
+    state = atomic_load_explicit(&reservation->state, memory_order_acquire);
+    if (state != WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+        && (rollback || state != WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED))
+        return false;
+    WL_MEMORY_TEST_POINT(reservation,
+        WL_COLUMNAR_MEMORY_TEST_RELEASE_BEFORE_CLAIM);
+    if (!claim_reservation_state(reservation, state,
+        WL_COLUMNAR_MEMORY_RESERVATION_RELEASING))
+        return false;
+    WL_MEMORY_TEST_POINT(reservation, WL_COLUMNAR_MEMORY_TEST_RELEASE_CLAIMED);
+    /* Payload cannot change until accounting is complete and state published. */
+    ok = reservation->governor && reservation->bytes != 0
+        && credit_reservation(reservation->governor, reservation->bytes);
+    WL_MEMORY_TEST_POINT(reservation, WL_COLUMNAR_MEMORY_TEST_RELEASE_CREDITED);
+    atomic_store_explicit(&reservation->state,
+        ok ? WL_COLUMNAR_MEMORY_RESERVATION_RELEASED : state,
+        memory_order_release);
+    return ok;
+}
+
+bool
 wl_columnar_memory_rollback(
     wl_columnar_memory_reservation_t *reservation)
 {
@@ -769,11 +803,7 @@ wl_columnar_memory_rollback(
 bool
 wl_columnar_memory_release(wl_columnar_memory_reservation_t *reservation)
 {
-    if (!reservation_identity_valid(reservation))
-        return false;
-    if (finish_reservation(reservation, false))
-        return true;
-    return finish_reservation(reservation, true);
+    return finish_reservation(reservation, false);
 }
 
 uint64_t

--- a/wirelog/columnar/memory_governor.h
+++ b/wirelog/columnar/memory_governor.h
@@ -102,6 +102,8 @@ typedef enum {
     WL_COLUMNAR_MEMORY_RESERVATION_CLAIMED = 4,
     WL_COLUMNAR_MEMORY_RESERVATION_COMMITTING = 5,
     WL_COLUMNAR_MEMORY_RESERVATION_TRANSFERRING = 6,
+    WL_COLUMNAR_MEMORY_RESERVATION_DOWNSIZING = 7,
+    WL_COLUMNAR_MEMORY_RESERVATION_RELEASING = 8,
 } wl_columnar_memory_reservation_state_t;
 
 typedef enum {
@@ -123,7 +125,24 @@ typedef struct {
     const void *identity;
 } wl_columnar_memory_reservation_t;
 
-/* Initialize a caller-owned token before its first reserve or reuse. */
+#ifdef WL_COLUMNAR_MEMORY_TEST_HOOKS
+/* Only compiled into the direct-source governor test executable. */
+enum {
+    WL_COLUMNAR_MEMORY_TEST_RELEASE_BEFORE_CLAIM = 1,
+    WL_COLUMNAR_MEMORY_TEST_DOWNSIZE_CLAIMED,
+    WL_COLUMNAR_MEMORY_TEST_RELEASE_CLAIMED,
+    WL_COLUMNAR_MEMORY_TEST_TRANSFER_CLAIMED,
+    WL_COLUMNAR_MEMORY_TEST_RELEASE_CREDITED,
+    WL_COLUMNAR_MEMORY_TEST_DOWNSIZE_CREDITED,
+};
+void
+wl_columnar_memory_test_hook(wl_columnar_memory_reservation_t *reservation,
+    unsigned phase);
+#endif
+
+/* Initialize a caller-owned token before its first reserve or reuse.
+ * Initialization and move require exclusive access to both token objects.
+ * Direct reads of non-atomic token payload require external synchronization. */
 void
 wl_columnar_memory_reservation_init(
     wl_columnar_memory_reservation_t *reservation);
@@ -205,6 +224,16 @@ wl_columnar_memory_commit(wl_columnar_memory_reservation_t *reservation,
 bool
 wl_columnar_memory_transfer(wl_columnar_memory_reservation_t *reservation,
     const void *owner);
+
+/* Credit storage already released by the owner of a committed token.
+ * Only positive sizes <= the current size are accepted; equality is a no-op.
+ * Zero requires explicit release after freeing the remaining storage.
+ * Serialized with release/transfer/downsize; busy or invalid tokens return
+ * false without mutation. This does not establish storage-reader safety or
+ * admit overlapping replacement allocations. Owner and identity are retained. */
+bool
+wl_columnar_memory_reservation_downsize(
+    wl_columnar_memory_reservation_t *reservation, uint64_t bytes);
 
 bool
 wl_columnar_memory_rollback(


### PR DESCRIPTION
## Summary

Closes #1482. Prerequisite for #1483; does not close #1371 or claim bounded-memory DOOP completion.

Add an internal committed-reservation downsize operation. Positive reductions credit exactly the removed bytes, equality succeeds without credit, and zero/growth/copy/invalid-state requests are rejected. Zero requires explicit release. Owner and token identity are preserved.

Downsize, release and transfer serialize through claimed token states. Mutable payload is read only after claiming; release publishes RELEASED only after returning capacity. Both claim helpers acquire prior payload publication. Move/reinitialization and direct payload reads require external synchronization. This is an accounting primitive after actual storage release, not allocation admission or reader-safety permission.

Synchronize the threading audit with all 96 atomic sites; preserve exact inventory enforcement.

## Validation

- Rebased onto current main `fce2642c` before final validation.
- `meson test -C build --print-errorlogs`: 352 passed, 0 failed, 14 conditional skips, including all four clang-tidy checks and the threading audit.

- Baseline governor test passed; new tests failed to compile before the new API/states existed (compile-red, not a behavioral runtime-red).
- Lifecycle, invalid-state, accounting-underflow recovery, move, residual release and 100 gated concurrent downsize/release/transfer rounds with an unrelated live reservation. Assert successful transfers and owner preservation explicitly.
- Six deterministic schedules pause at actual claim/credit/publication boundaries using one-shot nested operations; the seam is compiled only into the direct-source governor test target. This verifies observable ordering, while real pthread contention separately exercises cross-thread behavior.
- Mutation sensitivity: stale preclaim size caching and premature RELEASED publication each fail the controlled schedule test (exit 1); eight other tests pass. Mutations existed only in `/tmp` copies, not the worktree.
- ASan/UBSan standalone pthread governor tests: 9/9 passed.
- TSan standalone pthread governor tests: 9/9 passed.
- CI Uncrustify 0.78.1: all three changed C/header files passed.
- `.text`: 269276 bytes vs baseline 273644, delta -4368; size gate passed without changing baseline.

No actual relation compaction or spill implementation in this unit. Full DOOP and cross-platform CI are separate validation scopes.

## Independent gates

Reviewer Descartes initially blocked inadequate deterministic/owner assertions; both were corrected. Final Reviewer, Architect Lagrange and Critic Rawls all approved candidate tree `251a61a47b99b46a3fe2d673488c0a626ec29255`, diff SHA-256 `13aeca344849b8e4e6b0917bdc925bd2a778511ded1ac9a316bdb76a6f3b37e1`. Commit `08971b983275ad8319afef5313fb1c181cfdf2d4` has that exact tree after hooks. No merge performed.
