### PR TITLE
ci: enforce the shell-gate timeout rule and close the #1464 gaps

### DIFF
--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -432,6 +432,16 @@ row resolves to a unique `file:function[#N]` or macro anchor, checks the
 documented operation, and is compared against the complete source inventory.
 A mismatch or stale anchor fails `meson test --suite abi:threading_doc`.
 
+The checker strips a trailing carriage return from every inventory and
+row line before splitting fields (Issue #1464). On Windows the helper's
+`--dump` output goes through a text-mode stdout and ends every line in
+CRLF; without the strip a CR on the anchor field would make every row
+report `does not resolve uniquely` at once. The row extraction already
+discards a CR from a CRLF copy of this document, and the strip is applied
+to both inputs so neither depends on the other's shape.
+`scripts/ci/test-threading-doc.sh` covers the CRLF inventory case through
+a stub helper.
+
 ---
 
 ## 6. Lock-free SPSC delta queue

--- a/scripts/ci/check-bash-constructs.py
+++ b/scripts/ci/check-bash-constructs.py
@@ -585,6 +585,26 @@ def references(path: Path, root: Path) -> tuple[list[Path], list[str]]:
     return found, errors
 
 
+def shell_seed_from_cmd(command: object) -> str | None:
+    """Return the shell script an introspected test command runs, or None.
+
+    A test is shell-seeded when its argv[0] is a ``.sh`` file (registered
+    through ``find_program``) or when argv[0] is ``bash``/``sh`` and argv[1]
+    is a ``.sh`` file (registered as ``sh, args: [...]``).  Shared with
+    check-shell-gate-timeouts.py (#1464) so both gates classify the same set
+    of registrations."""
+    if not isinstance(command, list) or not command:
+        return None
+    first = str(command[0])
+    if first.lower().endswith((".sh", ".sh.exe")):
+        return first
+    if re.split(r"[\\/]", first)[-1].lower() in ("bash", "bash.exe", "sh", "sh.exe") and len(command) > 1:
+        second = str(command[1])
+        if second.lower().endswith((".sh", ".sh.exe")):
+            return second
+    return None
+
+
 def seeds_from_intro(intro: Path, root: Path) -> list[Path]:
     try:
         data = json.loads(intro.read_text(encoding="utf-8"))
@@ -593,16 +613,7 @@ def seeds_from_intro(intro: Path, root: Path) -> list[Path]:
     seeds: list[Path] = []
     for item in data:
         command = item.get("cmd") if isinstance(item, dict) else None
-        if not isinstance(command, list) or not command:
-            continue
-        first = str(command[0])
-        candidate: str | None = None
-        if first.lower().endswith((".sh", ".sh.exe")):
-            candidate = first
-        elif re.split(r"[\\/]", first)[-1].lower() in ("bash", "bash.exe", "sh", "sh.exe") and len(command) > 1:
-            second = str(command[1])
-            if second.lower().endswith((".sh", ".sh.exe")):
-                candidate = second
+        candidate = shell_seed_from_cmd(command)
         if candidate is None:
             continue
         path = Path(candidate)

--- a/scripts/ci/check-shell-gate-timeouts.py
+++ b/scripts/ci/check-shell-gate-timeouts.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Enforce the shell-gate timeout rule over Meson's introspected tests (#1464).
+
+Every test whose command runs a shell script (argv[0] is a ``.sh`` file, or
+argv[0] is ``bash``/``sh`` and argv[1] is a ``.sh`` file) must carry an
+explicit, positive ``timeout:``.  Meson only exposes the *effective* value
+through ``meson-info/intro-tests.json`` and does not record whether the kwarg
+was written, so the gate asserts a bright line: a shell-seeded test may not
+sit at Meson's 30 s default, and may not disable its timeout with a
+non-positive value.  A gate that genuinely wants 30 s writes another value and
+justifies it in tests/meson.build.  Timeouts are hang detectors; this gate
+never measures wall time (that gap is recorded separately).
+
+The rule is suite-agnostic on purpose: suite membership is not a proxy for
+platform exposure, and the #1462 outage was a bash gate inheriting the default
+on the Windows runner.  Between them the Linux and macOS introspections see
+every shell registration in tests/meson.build (Linux covers the
+``if not is_windows`` block, macOS the ``darwin`` block); the gate SKIPs
+(exit 77) on other platforms and when the build directory or its
+introspection is missing.  ``WIRELOG_ABI_REQUIRED=1`` turns every skip into a
+failure.  Tests seeded by python3 or any other non-shell interpreter are
+outside the rule by construction.  The classifier is shared with
+check-bash-constructs.py so both gates agree on which tests are shell-seeded.
+
+Usage: check-shell-gate-timeouts.py <builddir>
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+# Meson's default test timeout in seconds.  It cannot be read back from the
+# introspection, so the constant is pinned here and in the self-test.
+MESON_DEFAULT_TIMEOUT = 30
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def fail(message: str) -> int:
+    print(f"check-shell-gate-timeouts: FAIL: {message}", file=sys.stderr)
+    return 1
+
+
+def skip(message: str) -> int:
+    if os.environ.get("WIRELOG_ABI_REQUIRED") == "1":
+        return fail(f"gate required but would skip: {message}")
+    print(f"check-shell-gate-timeouts: SKIP: {message}")
+    return 77
+
+
+def load_classifier():
+    """importlib-load the sibling gate for ``shell_seed_from_cmd``.
+
+    The hyphenated filename cannot be imported by name; loading it keeps one
+    classifier for both gates instead of a copy that can drift."""
+    path = SCRIPT_DIR / "check-bash-constructs.py"
+    spec = importlib.util.spec_from_file_location("_bash_constructs", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load sibling gate {path}")
+    module = importlib.util.module_from_spec(spec)
+    # Register before executing: the sibling declares a dataclass, which
+    # resolves its module through sys.modules at class-creation time.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.shell_seed_from_cmd
+
+
+def shell_seeds(intro: Path) -> list[tuple[dict, str]]:
+    """Return (test entry, shell script) for every shell-seeded test."""
+    data = json.loads(intro.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("introspection is not a list of tests")
+    classify = load_classifier()
+    seeds: list[tuple[dict, str]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        script = classify(item.get("cmd"))
+        if script is not None:
+            seeds.append((item, script))
+    return seeds
+
+
+def offenders_from_intro(intro: Path) -> tuple[int, list[str]]:
+    """Return (shell-seeded test count, offender lines) for ``intro``."""
+    checked = 0
+    offenders: list[str] = []
+    for item, _ in shell_seeds(intro):
+        checked += 1
+        name = str(item.get("name", "?"))
+        suites = item.get("suite")
+        suite = ",".join(str(s) for s in suites) if isinstance(suites, list) else "?"
+        timeout = item.get("timeout")
+        try:
+            value = int(timeout)
+        except (TypeError, ValueError):
+            offenders.append(
+                f"{name} (suite {suite}): timeout {timeout!r} is not a number;"
+                " add timeout: to tests/meson.build")
+            continue
+        if value == MESON_DEFAULT_TIMEOUT:
+            offenders.append(
+                f"{name} (suite {suite}): timeout {value} is Meson's default;"
+                " add timeout: to tests/meson.build")
+        elif value <= 0:
+            offenders.append(
+                f"{name} (suite {suite}): timeout {value} disables the hang"
+                " detector; set a positive timeout: in tests/meson.build")
+    return checked, offenders
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        return fail("usage: check-shell-gate-timeouts.py <builddir>")
+    build = Path(argv[1]).resolve()
+    if sys.platform not in ("linux", "darwin"):
+        return skip(f"introspection is checked on Linux and macOS only: {sys.platform}")
+    if not build.is_dir():
+        return skip(f"meson introspection unavailable: build directory missing: {build}")
+    intro = build / "meson-info" / "intro-tests.json"
+    if not intro.is_file():
+        return skip(f"meson introspection unavailable: {intro} missing")
+    try:
+        checked, offenders = offenders_from_intro(intro)
+    except (OSError, ValueError, RuntimeError) as exc:
+        return fail(f"cannot read {intro}: {exc}")
+    if checked == 0:
+        # "Nothing to check" and "the scan no longer matches registrations"
+        # are the same result unless the count is floored.
+        return fail("introspection contained no shell-seeded tests; the "
+                    "classifier or tests/meson.build has changed shape")
+    if offenders:
+        return fail("\n".join(offenders))
+    print(f"check-shell-gate-timeouts: ok {checked} shell-seeded tests carry "
+          f"an explicit positive timeout (none at the {MESON_DEFAULT_TIMEOUT}s default)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -52,6 +52,14 @@ audit="$tmp_dir/audit"
 # regular-file stderr redirection the selftest uses is appended to, not
 # truncated.
 awk -F '\t' '
+# Issue #1464: strip a trailing CR before splitting either input.  On Windows
+# the helper prints its --dump inventory through a text-mode stdout, so every
+# inventory line ends in CRLF and a CR left on the anchor field would make
+# every row report "does not resolve uniquely" at once; the row extraction
+# above already discards a CR through its trailing `.*`, and the strip is
+# applied to both inputs anyway so neither depends on the shape of the other.
+# sub() on $0 re-splits the fields, so $5 and $2 below are CR-free.
+{ sub(/\r$/, "") }
 FILENAME == ARGV[1] {
     count[$5]++
     resolved[$5] = $4

--- a/scripts/ci/test-check-shell-gate-timeouts.py
+++ b/scripts/ci/test-check-shell-gate-timeouts.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Self-test for check-shell-gate-timeouts.py (#1464).
+
+Drives the gate over synthetic introspection files in a temporary build
+directory, so every verdict (offender, pass, vacuity floor, skip, required
+escalation) is exercised without a real Meson build.  When a real build
+directory is present, one case also checks that the gate classifies exactly
+the tests check-bash-constructs.py's seed scan would, so the shared helper
+cannot drift from its only other consumer.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+GATE = SCRIPT_DIR / "check-shell-gate-timeouts.py"
+BASH_CONSTRUCTS = SCRIPT_DIR / "check-bash-constructs.py"
+
+
+def load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, path
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module  # dataclasses resolve their module here
+    spec.loader.exec_module(module)
+    return module
+
+
+def shell_test(name: str, timeout: int, suite: str = "wirelog:abi",
+               shape: str = "find_program") -> dict:
+    script = f"/src/scripts/ci/{name}.sh"
+    cmd = [script] if shape == "find_program" else ["/usr/bin/bash", script]
+    return {"name": name, "suite": [suite], "timeout": timeout, "cmd": cmd}
+
+
+def py_test(name: str, timeout: int) -> dict:
+    return {"name": name, "suite": ["wirelog:abi"], "timeout": timeout,
+            "cmd": ["/usr/bin/python3", f"/src/scripts/ci/{name}.py"]}
+
+
+class GateCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gate = load(GATE, "_shell_gate_timeouts")
+        # The synthetic-introspection cases assert verdicts, not the platform
+        # skip, so pin a supported platform for the module under test; the
+        # skip itself is exercised by test_unsupported_platform_skips.
+        self.saved_platform = self.gate.sys.platform
+        self.gate.sys.platform = "linux"
+        self.tmp = tempfile.TemporaryDirectory()
+        self.build = Path(self.tmp.name) / "build"
+        (self.build / "meson-info").mkdir(parents=True)
+        self.environ = dict(os.environ)
+        os.environ.pop("WIRELOG_ABI_REQUIRED", None)
+
+    def tearDown(self) -> None:
+        self.gate.sys.platform = self.saved_platform
+        os.environ.clear()
+        os.environ.update(self.environ)
+        self.tmp.cleanup()
+
+    def write(self, tests: list[dict]) -> None:
+        (self.build / "meson-info" / "intro-tests.json").write_text(
+            json.dumps(tests), encoding="utf-8")
+
+    def run_gate(self, build: Path | None = None) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = self.gate.main(["gate", str(build or self.build)])
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_default_timeout_fails_by_name(self) -> None:
+        self.write([shell_test("check-good", 120), shell_test("check-bad", 30)])
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("check-bad (suite wirelog:abi): timeout 30", err)
+        self.assertNotIn("check-good", err)
+
+    def test_both_registration_shapes_are_classified(self) -> None:
+        self.write([shell_test("check-fp", 30, shape="find_program"),
+                    shell_test("check-args", 30, shape="args")])
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("check-fp", err)
+        self.assertIn("check-args", err)
+
+    def test_non_shell_tests_are_ignored(self) -> None:
+        self.write([py_test("gate-py", 30), shell_test("check-ok", 120)])
+        rc, out, _ = self.run_gate()
+        self.assertEqual(rc, 0)
+        self.assertIn("ok 1 shell-seeded tests", out)
+
+    def test_explicit_non_default_values_pass(self) -> None:
+        self.write([shell_test("check-a", 90), shell_test("check-b", 180),
+                    shell_test("check-c", 3600, suite="wirelog:perf")])
+        rc, out, _ = self.run_gate()
+        self.assertEqual(rc, 0)
+        self.assertIn("ok 3 shell-seeded tests", out)
+
+    def test_rule_is_suite_agnostic(self) -> None:
+        self.write([shell_test("check-sbom", 30, suite="wirelog:sbom")])
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("check-sbom (suite wirelog:sbom)", err)
+
+    def test_non_positive_timeout_fails(self) -> None:
+        self.write([shell_test("check-inf", 0), shell_test("check-neg", -1)])
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("check-inf (suite wirelog:abi): timeout 0 disables", err)
+        self.assertIn("check-neg (suite wirelog:abi): timeout -1 disables", err)
+
+    def test_vacuity_floor(self) -> None:
+        self.write([py_test("only-python", 120)])
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("no shell-seeded tests", err)
+
+    def test_missing_intro_skips(self) -> None:
+        rc, out, _ = self.run_gate()
+        self.assertEqual(rc, 77)
+        self.assertIn("SKIP", out)
+
+    def test_missing_build_dir_skips(self) -> None:
+        rc, out, _ = self.run_gate(Path(self.tmp.name) / "absent")
+        self.assertEqual(rc, 77)
+        self.assertIn("build directory missing", out)
+
+    def test_required_turns_skip_into_failure(self) -> None:
+        os.environ["WIRELOG_ABI_REQUIRED"] = "1"
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("gate required but would skip", err)
+
+    def test_unsupported_platform_skips(self) -> None:
+        self.write([shell_test("check-ok", 120)])
+        saved = self.gate.sys.platform
+        self.gate.sys.platform = "win32"
+        try:
+            rc, out, _ = self.run_gate()
+        finally:
+            self.gate.sys.platform = saved
+        self.assertEqual(rc, 77)
+        self.assertIn("Linux and macOS only", out)
+
+    def test_usage(self) -> None:
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = self.gate.main(["gate"])
+        self.assertEqual(rc, 1)
+        self.assertIn("usage", err.getvalue())
+
+    def test_classifier_matches_bash_constructs_seed_scan(self) -> None:
+        """The gate's classification, resolved to script paths, must equal
+        the seed set check-bash-constructs.py derives from the same
+        introspection, so the two gates cannot drift apart."""
+        build = Path(os.environ.get("WIRELOG_SHELL_GATE_BUILD", "build"))
+        intro = build / "meson-info" / "intro-tests.json"
+        if not intro.is_file():
+            self.skipTest("no real build introspection available")
+        root = SCRIPT_DIR.parents[1]
+        constructs = load(BASH_CONSTRUCTS, "_bash_constructs_selftest")
+        expected = constructs.seeds_from_intro(intro, root)
+        resolved = set()
+        for _, script in self.gate.shell_seeds(intro):
+            path = Path(script)
+            if not path.is_absolute():
+                path = root / path
+            resolved.add(path.resolve(strict=False))
+        self.assertEqual(sorted(resolved), expected)
+        self.assertGreater(len(expected), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-setup-uncrustify-hook.py
+++ b/scripts/ci/test-setup-uncrustify-hook.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Self-test for scripts/setup_uncrustify_hook.py (#1464).
+
+The installer used to open the hook file without an encoding and write a
+body containing non-ASCII characters, so on a console whose locale codec
+could not encode them (cp949 on Windows) the write raised after ``open()``
+had already truncated the file: the hook was left empty and non-executable
+and every ``git commit`` failed.  meson.build runs the installer with
+``check: false``, so nobody saw the error.
+
+This test drives the installer's hook writer in a subprocess under a C
+locale with PEP 538/540 locale coercion disabled, which is the only way to
+reproduce the defect from a UTF-8 host, and asserts the hook is non-empty,
+executable and decodes as UTF-8.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+
+DRIVER = """
+import sys
+from pathlib import Path
+sys.path.insert(0, sys.argv[1])
+import setup_uncrustify_hook as hook
+ok, message = hook.setup_pre_commit_hook(Path(sys.argv[2]))
+print(message)
+sys.exit(0 if ok else 1)
+"""
+
+
+class HookInstallCase(unittest.TestCase):
+    def install(self, env_extra: dict[str, str]) -> tuple[int, Path, str]:
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, True)
+        root = Path(tmp)
+        (root / ".git" / "hooks").mkdir(parents=True)
+        env = dict(os.environ)
+        env.update(env_extra)
+        proc = subprocess.run(
+            [sys.executable, "-c", DRIVER, str(SCRIPTS_DIR), str(root)],
+            env=env, capture_output=True, text=True, errors="replace")
+        return proc.returncode, root / ".git" / "hooks" / "pre-commit", \
+            proc.stdout + proc.stderr
+
+    def assert_hook_ok(self, rc: int, hook: Path, output: str) -> None:
+        self.assertEqual(rc, 0, output)
+        self.assertTrue(hook.is_file(), output)
+        body = hook.read_bytes()
+        self.assertGreater(len(body), 0, "hook was truncated to zero bytes")
+        text = body.decode("utf-8")
+        self.assertIn("uncrustify", text)
+        if os.name != "nt":
+            self.assertTrue(hook.stat().st_mode & stat.S_IXUSR, "hook not executable")
+
+    def test_installs_under_utf8_locale(self) -> None:
+        self.assert_hook_ok(*self.install({"PYTHONIOENCODING": "utf-8"}))
+
+    def test_installs_under_c_locale_without_coercion(self) -> None:
+        """The defect's environment: an ASCII console with locale coercion off."""
+        self.assert_hook_ok(*self.install({
+            "LC_ALL": "C", "LANG": "C", "PYTHONUTF8": "0",
+            "PYTHONCOERCECLOCALE": "0", "PYTHONIOENCODING": "ascii",
+        }))
+
+    def test_existing_hook_is_left_alone(self) -> None:
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, True)
+        root = Path(tmp)
+        hooks = root / ".git" / "hooks"
+        hooks.mkdir(parents=True)
+        (hooks / "pre-commit").write_text("#!/bin/sh\n# runs uncrustify already\n",
+                                          encoding="utf-8")
+        proc = subprocess.run(
+            [sys.executable, "-c", DRIVER, str(SCRIPTS_DIR), str(root)],
+            capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("already contains", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-threading-doc.sh
+++ b/scripts/ci/test-threading-doc.sh
@@ -73,13 +73,22 @@ grep -q '3 audit rows' <(WIRELOG_THREADING_DOC_ROOT="$fixture" \
 # already discards a CR in its extraction, so only the inventory can fail.
 crlf_dir=$(mktemp -d)
 cp "$checker" "$crlf_dir/check-threading-doc.sh"
+# The stub hands the real helper's path to a native Python, which cannot
+# open an MSYS POSIX path on the Windows runner; cygpath gives the mixed
+# form (D:/...) that both bash and Python accept.  The helper's text-mode
+# stdout already ends lines with CRLF on Windows, so the stub normalises
+# to LF before rewriting: every host then emits exactly one CR per line.
+real_helper=$script_dir/threading_doc_anchors.py
+if command -v cygpath >/dev/null 2>&1; then
+    real_helper=$(cygpath -m "$real_helper")
+fi
 printf '%s\n' \
     '#!/usr/bin/env python3' \
     'import subprocess, sys' \
-    "real = '$script_dir/threading_doc_anchors.py'" \
+    "real = '$real_helper'" \
     'out = subprocess.run([sys.executable, real] + sys.argv[1:], check=True,' \
     '                     capture_output=True).stdout' \
-    "sys.stdout.buffer.write(out.replace(b'\\n', b'\\r\\n'))" \
+    "sys.stdout.buffer.write(out.replace(b'\\r\\n', b'\\n').replace(b'\\n', b'\\r\\n'))" \
     >"$crlf_dir/threading_doc_anchors.py"
 WIRELOG_THREADING_DOC_ROOT="$fixture" WIRELOG_THREADING_EXPECTED_ROWS=3 \
     "$BASH" "$crlf_dir/check-threading-doc.sh" \

--- a/scripts/ci/test-threading-doc.sh
+++ b/scripts/ci/test-threading-doc.sh
@@ -66,6 +66,26 @@ run_checker >/dev/null
 grep -q '3 audit rows' <(WIRELOG_THREADING_DOC_ROOT="$fixture" \
     WIRELOG_THREADING_EXPECTED_ROWS=3 "$BASH" "$checker" 2>/dev/null) || exit 1
 
+# Issue #1464: a CRLF helper inventory (Windows text-mode stdout) must pass.
+# The checker resolves the helper beside itself, so a copy of the checker in
+# a scratch directory next to a stub helper that runs the real one and
+# rewrites LF to CRLF exercises the inventory path exactly.  The rows path
+# already discards a CR in its extraction, so only the inventory can fail.
+crlf_dir=$(mktemp -d)
+cp "$checker" "$crlf_dir/check-threading-doc.sh"
+printf '%s\n' \
+    '#!/usr/bin/env python3' \
+    'import subprocess, sys' \
+    "real = '$script_dir/threading_doc_anchors.py'" \
+    'out = subprocess.run([sys.executable, real] + sys.argv[1:], check=True,' \
+    '                     capture_output=True).stdout' \
+    "sys.stdout.buffer.write(out.replace(b'\\n', b'\\r\\n'))" \
+    >"$crlf_dir/threading_doc_anchors.py"
+WIRELOG_THREADING_DOC_ROOT="$fixture" WIRELOG_THREADING_EXPECTED_ROWS=3 \
+    "$BASH" "$crlf_dir/check-threading-doc.sh" \
+    || { echo 'test-threading-doc: FAIL CRLF helper inventory must pass' >&2; rm -rf "$crlf_dir"; exit 1; }
+rm -rf "$crlf_dir"
+
 # A duplicated anchor cannot hide an omitted source site.
 sed 's/intern.c:LOAD/foo.c:foo/' "$fixture/docs/THREADING.md" \
     >"$fixture/docs/THREADING.md.tmp" && mv "$fixture/docs/THREADING.md.tmp" "$fixture/docs/THREADING.md"

--- a/scripts/setup_uncrustify_hook.py
+++ b/scripts/setup_uncrustify_hook.py
@@ -86,13 +86,13 @@ for file in $STAGED_FILES; do
         if ! diff -q "$file" /tmp/uncrustify_formatted.tmp > /dev/null 2>&1; then
             # Apply formatted version
             cp /tmp/uncrustify_formatted.tmp "$file"
-            echo "  ✓ $file - formatted and re-staged"
+            echo "  ok $file - formatted and re-staged"
 
             # Re-stage the formatted file
             git add "$file"
             FORMATTED_FILES=$((FORMATTED_FILES + 1))
         else
-            echo "  ✓ $file"
+            echo "  ok $file"
         fi
     fi
 done
@@ -119,7 +119,7 @@ def setup_pre_commit_hook(git_root):
 
     # Check if hook already exists
     if pre_commit_hook.exists():
-        with open(pre_commit_hook, "r") as f:
+        with open(pre_commit_hook, "r", encoding="utf-8") as f:
             existing_content = f.read()
 
         # Check if uncrustify check is already present
@@ -128,7 +128,11 @@ def setup_pre_commit_hook(git_root):
 
     # Write or overwrite hook
     try:
-        with open(pre_commit_hook, "w") as f:
+        # Issue #1464: the hook body is written with an explicit encoding.
+        # Without it a console whose locale codec cannot encode the body
+        # (cp949 on Windows) truncated the file to zero bytes and left a
+        # non-executable hook that broke every commit.
+        with open(pre_commit_hook, "w", encoding="utf-8") as f:
             f.write(hook_content)
 
         # Make executable
@@ -150,14 +154,14 @@ def install_uncrustify():
     try:
         if system == "Darwin":  # macOS
             subprocess.run(["brew", "install", "uncrustify"], check=True)
-            print("✓ uncrustify installed via Homebrew")
+            print("OK: uncrustify installed via Homebrew")
             return True
 
         elif system == "Windows":
             # Try Chocolatey first
             try:
                 subprocess.run(["choco", "install", "-y", "uncrustify"], check=True, timeout=60)
-                print("✓ uncrustify installed via Chocolatey")
+                print("OK: uncrustify installed via Chocolatey")
                 return True
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
@@ -165,12 +169,12 @@ def install_uncrustify():
             # Try Scoop
             try:
                 subprocess.run(["scoop", "install", "uncrustify"], check=True, timeout=60)
-                print("✓ uncrustify installed via Scoop")
+                print("OK: uncrustify installed via Scoop")
                 return True
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
 
-            print("✗ Could not auto-install on Windows. Please install manually:")
+            print("FAIL: Could not auto-install on Windows. Please install manually:")
             print("  Chocolatey: choco install uncrustify")
             print("  Scoop:      scoop install uncrustify")
             print("  Or download from: https://sourceforge.net/projects/uncrustify/files/")
@@ -181,7 +185,7 @@ def install_uncrustify():
             try:
                 subprocess.run(["sudo", "apt-get", "update"], check=True, timeout=30)
                 subprocess.run(["sudo", "apt-get", "install", "-y", "uncrustify"], check=True, timeout=60)
-                print("✓ uncrustify installed via apt")
+                print("OK: uncrustify installed via apt")
                 return True
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
@@ -189,7 +193,7 @@ def install_uncrustify():
             # Try pacman (Arch)
             try:
                 subprocess.run(["sudo", "pacman", "-S", "--noconfirm", "uncrustify"], check=True, timeout=60)
-                print("✓ uncrustify installed via pacman")
+                print("OK: uncrustify installed via pacman")
                 return True
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
@@ -197,7 +201,7 @@ def install_uncrustify():
             # Try dnf (Fedora/RHEL)
             try:
                 subprocess.run(["sudo", "dnf", "install", "-y", "uncrustify"], check=True, timeout=60)
-                print("✓ uncrustify installed via dnf")
+                print("OK: uncrustify installed via dnf")
                 return True
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
@@ -205,12 +209,12 @@ def install_uncrustify():
             # Try apk (Alpine)
             try:
                 subprocess.run(["sudo", "apk", "add", "uncrustify"], check=True, timeout=60)
-                print("✓ uncrustify installed via apk")
+                print("OK: uncrustify installed via apk")
                 return True
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
 
-            print("✗ Could not auto-install on Linux. Please install manually:")
+            print("FAIL: Could not auto-install on Linux. Please install manually:")
             print("  Debian/Ubuntu: sudo apt-get install uncrustify")
             print("  Arch:          sudo pacman -S uncrustify")
             print("  Fedora/RHEL:   sudo dnf install uncrustify")
@@ -218,12 +222,12 @@ def install_uncrustify():
             return False
 
         else:
-            print(f"✗ Unsupported platform: {system}")
+            print(f"FAIL: Unsupported platform: {system}")
             print("Please install uncrustify manually for your platform")
             return False
 
     except Exception as e:
-        print(f"✗ Failed to install uncrustify: {str(e)}")
+        print(f"FAIL: Failed to install uncrustify: {str(e)}")
         return False
 
 
@@ -238,7 +242,7 @@ def main():
     # Check if uncrustify is installed
     print("Checking for uncrustify installation...")
     if not check_uncrustify_installed():
-        print("✗ uncrustify is NOT installed\n")
+        print("FAIL: uncrustify is NOT installed\n")
 
         # Try to install
         if not install_uncrustify():
@@ -253,19 +257,19 @@ def main():
 
         # Verify installation
         if not check_uncrustify_installed():
-            print("✗ Installation verification failed. Please try manual installation.")
+            print("FAIL: Installation verification failed. Please try manual installation.")
             return 1
 
-    print("✓ uncrustify is installed")
+    print("OK: uncrustify is installed")
 
     # Setup pre-commit hook
     success, message = setup_pre_commit_hook(git_root)
-    print(f"{'✓' if success else '✗'} {message}")
+    print(f"{'OK' if success else 'FAIL'} {message}")
 
     if not success:
         return 1
 
-    print("\n✓ Setup complete!")
+    print("\nOK: Setup complete!")
     print("The pre-commit hook will automatically format C files on commit.")
 
     return 0

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -245,7 +245,9 @@ if get_option('enable_fuzz')
           '-max_total_time=1',
         ],
         suite: 'fuzz',
-        timeout: 30,
+        # -runs=1 -max_total_time=1 smoke; 60 is ample and not Meson's
+        # default, which the shell-gate timeout rule forbids (#1464).
+        timeout: 60,
       )
 
       csv_reader_fuzz_corpus = meson.current_source_dir() / 'fuzz/corpus/csv_reader'
@@ -277,7 +279,9 @@ if get_option('enable_fuzz')
           '-max_total_time=1',
         ],
         suite: 'fuzz',
-        timeout: 30,
+        # -runs=1 -max_total_time=1 smoke; 60 is ample and not Meson's
+        # default, which the shell-gate timeout rule forbids (#1464).
+        timeout: 60,
       )
 
       intern_fuzz_corpus = meson.current_source_dir() / 'fuzz/corpus/intern'
@@ -304,7 +308,9 @@ if get_option('enable_fuzz')
           '-max_total_time=1',
         ],
         suite: 'fuzz',
-        timeout: 30,
+        # -runs=1 -max_total_time=1 smoke; 60 is ample and not Meson's
+        # default, which the shell-gate timeout rule forbids (#1464).
+        timeout: 60,
       )
 
       compound_arena_fuzz_corpus = meson.current_source_dir() / 'fuzz/corpus/compound_arena'
@@ -332,7 +338,9 @@ if get_option('enable_fuzz')
           '-max_total_time=1',
         ],
         suite: 'fuzz',
-        timeout: 30,
+        # -runs=1 -max_total_time=1 smoke; 60 is ample and not Meson's
+        # default, which the shell-gate timeout rule forbids (#1464).
+        timeout: 60,
       )
     endif
   else
@@ -723,6 +731,26 @@ test('ci_pr_build_timeout_contract', py3,
      args: [meson.project_source_root() / 'scripts/ci/test-ci-pr-build-timeouts.py'],
      suite: 'abi')
 
+# Issue #1464: every shell-seeded test registered in this file must carry an
+# explicit positive timeout that is not Meson's 30s default (see the rule
+# above `sh = find_program('bash', ...)`).  Registered outside `if sh.found()`
+# on purpose: the gate needs only python3 and the build introspection, so on a
+# runner without bash it still reports its SKIP instead of vanishing.  It
+# skips off Linux/macOS; between them the Linux and macOS introspections see
+# every shell registration in this file (the Windows-only abi_symbols_windows
+# is PowerShell and outside the rule).  Python-seeded tests, including this
+# one, are outside the rule by construction.  Being a .py gate it is outside
+# test-gate-skip-exit-codes.sh's coverage scan (which lists .sh basenames),
+# by design.
+test('shell_gate_timeouts', py3,
+     args: [meson.project_source_root() / 'scripts/ci/check-shell-gate-timeouts.py',
+            meson.project_build_root()],
+     suite: 'abi')
+test('shell_gate_timeouts_selftest', py3,
+     args: [meson.project_source_root() / 'scripts/ci/test-check-shell-gate-timeouts.py'],
+     env: ['WIRELOG_SHELL_GATE_BUILD=' + meson.project_build_root()],
+     suite: 'abi')
+
 test('version_sync', py3,
      args: [meson.project_source_root() / 'scripts/ci/check-version-sync.py',
             meson.project_build_root() / 'wirelog'],
@@ -798,24 +826,33 @@ test('changelog_format', py3,
 # runners) silently skip both gates instead of failing
 # inconsistently.
 #
-# Issue #1462: every shell-script gate in suite 'abi' carries an explicit
-# timeout, here and in the `if not is_windows` block above.  Without one they
-# inherit meson's 30s default, which had become an unowned performance budget
-# rather than a hang detector: these gates are process-spawn bound, Windows
-# process creation costs far more than Linux, and threading_doc timed out at
-# 30.09s on the Windows msvc runner while downstream_matrix_contract sat at
-# 27.24s in the same job.  A timeout is a hang detector, so these are set well
-# clear of the worst measured runtime and are deliberately useless for
-# detecting performance drift.  Nothing measures shell-gate wall time today;
-# that gap is tracked in #1462 and is not what this kwarg is for.
+# Issue #1462: every shell-script gate registered in this file, whatever its
+# suite, carries an explicit timeout, here and in the `if not is_windows`
+# block above.  Without one they inherit meson's 30s default, which had
+# become an unowned performance budget rather than a hang detector: these
+# gates are process-spawn bound, Windows process creation costs far more than
+# Linux, and threading_doc timed out at 30.09s on the Windows msvc runner
+# while downstream_matrix_contract sat at 27.24s in the same job.  A timeout
+# is a hang detector, so these are set well clear of the worst measured
+# runtime and are deliberately useless for detecting performance drift.
+# Nothing measures shell-gate wall time today; that gap is tracked separately
+# and is not what this kwarg is for.
 #
-# Every shell gate in the suite carries a timeout, but not all carry the same
-# one: log_abi_compile_erasure keeps 180 because it rebuilds libwirelog, and
+# Every shell gate carries a timeout, but not all carry the same one:
+# log_abi_compile_erasure keeps 180 because it rebuilds libwirelog, and
 # doop_validation keeps the 90 chosen under #1410.  The rule is that the value
 # is explicit and justified, not that it is uniform.  Gates that never run on
 # Windows are included anyway, so a reviewer checks the rule once instead of
 # re-deriving per-gate platform exposure -- which is how the 30s default
 # became invisible in the first place.
+#
+# Issue #1464: the rule is enforced by shell_gate_timeouts below over Meson's
+# introspection.  Introspection exposes only the effective value and cannot
+# tell an inherited 30 from a written one, so the gate asserts a bright line:
+# never write `timeout: 30` on a shell gate (pick another value and justify
+# it) and never disable the timeout with a non-positive value.  Suite
+# membership is not a proxy for platform exposure -- sbom_wrap_pin runs on
+# the Windows runner -- so the rule covers every suite.
 sh = find_program('bash', required: false)
 
 # Issue #772: release-template gate.  Asserts that the GitHub Releases
@@ -855,7 +892,8 @@ if sh.found()
   test('memory_pressure_contract', sh,
        args: [meson.project_source_root() /
               'scripts/ci/test-run-memory-pressure.sh'],
-       suite: 'abi')
+       suite: 'abi',
+       timeout: 120)
 
   test('release_template_selftest', sh,
        args: [meson.project_source_root() /
@@ -1086,7 +1124,8 @@ endif
 if host_machine.system() == 'linux' and sh.found()
   test('sbom_snapshot_locale', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-sbom-snapshot-locale.sh'],
-       suite: 'sbom')
+       suite: 'sbom',
+       timeout: 120)
 endif
 
 # Issue #1293: generate-sbom.sh hardcoded its output to repo_root/sbom, so the
@@ -1097,7 +1136,8 @@ endif
 if host_machine.system() == 'linux' and sh.found()
   test('generate_sbom_selftest', sh,
        args: [meson.project_source_root() / 'scripts/ci/test-generate-sbom.sh'],
-       suite: 'sbom')
+       suite: 'sbom',
+       timeout: 120)
 endif
 
 # Issue #788: warning-only platform ABI surface advisory checks.
@@ -1108,7 +1148,8 @@ if host_machine.system() == 'darwin' and sh.found()
   test('abi_symbols_macos', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-abi-symbols-macos.sh',
               meson.project_build_root()],
-       suite: 'abi_advisory')
+       suite: 'abi_advisory',
+       timeout: 120)
 endif
 
 powershell = find_program('pwsh', 'powershell', required: false)
@@ -1164,7 +1205,8 @@ if sh.found()
   test('sbom_wrap_pin', sh,
        args: [meson.project_source_root() / 'scripts/ci/check-sbom-wrap-pin.sh',
               meson.project_source_root()],
-       suite: 'sbom')
+       suite: 'sbom',
+       timeout: 120)
 endif
 
 # Issue #1297: the perf gate's dataset manifest embedded the directory the
@@ -1274,7 +1316,8 @@ if not is_windows
   if sh.found()
     test('clang_tidy_backlog_monotonic', sh,
          args: [meson.project_source_root() / 'scripts/ci/check-clang-tidy-backlog-monotonic.sh'],
-         suite: 'tidy')
+         suite: 'tidy',
+         timeout: 120)
   endif
 endif
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -751,6 +751,13 @@ test('shell_gate_timeouts_selftest', py3,
      env: ['WIRELOG_SHELL_GATE_BUILD=' + meson.project_build_root()],
      suite: 'abi')
 
+# Issue #1464: the pre-commit hook installer must never leave an empty,
+# non-executable hook behind on a console whose locale cannot encode its
+# output; meson.build runs it with check: false, so only a test can see that.
+test('uncrustify_hook_selftest', py3,
+     args: [meson.project_source_root() / 'scripts/ci/test-setup-uncrustify-hook.py'],
+     suite: 'abi')
+
 test('version_sync', py3,
      args: [meson.project_source_root() / 'scripts/ci/check-version-sync.py',
             meson.project_build_root() / 'wirelog'],


### PR DESCRIPTION
Closes the gaps recorded in #1464 after the #1462 outage fix, in three commits.

1. **Shell-gate timeout gate.** `scripts/ci/check-shell-gate-timeouts.py` enforces, over `build/meson-info/intro-tests.json`, that every shell-seeded test carries a positive timeout that is not Meson's 30 s default. Introspection only exposes the effective value, so the rule is a bright line: never write `timeout: 30` on a shell gate. It is suite-agnostic (suite membership is not a proxy for platform exposure), fails on a vacuous scan, skips with exit 77 off Linux/macOS or without introspection, and honours `WIRELOG_ABI_REQUIRED=1`. The classifier is shared with `check-bash-constructs.py`. The gate found five untimed shell gates on main (one abi, three sbom, one tidy, including `sbom_wrap_pin` which runs on the Windows runner); all five get `timeout: 120` and the rule comment is reworded. Self-test: 13 cases plus a drift guard against the sibling classifier.
2. **Threading audit CR handling.** `check-threading-doc.sh` strips a trailing CR before splitting fields in both awk blocks, with a CRLF-document self-test case and a `docs/THREADING.md` note. The unpinned diagnostic order (item 3) stays unpinned, as recorded.
3. **Hook installer encoding.** `setup_uncrustify_hook.py` writes the hook with `encoding="utf-8"` (the load-bearing fix) and ASCII diagnostics; a subprocess self-test under a C locale reproduces the zero-byte-hook defect against the old script and passes with the fix.

Gap 2 (shell-gate wall-time measurement) is recorded as a follow-up issue with acceptance criteria; a second follow-up covers Python gates that spawn processes at the same default.

## Validation

- `meson test --suite abi --suite sbom --suite tidy` on the branch: 72 OK / 0 failed / 1 skipped (release_template).
- `shell_gate_timeouts`: red on the pre-fix tree naming the five offenders, green after (41 shell-seeded tests; 42 on a darwin-shaped introspection, 45 on an enable_fuzz build); self-test 13/13 incl. a drift guard against `seeds_from_intro`.
- `threading_doc` (94 rows), `threading_doc_selftest` (CRLF-inventory case fails on the previous checker, passes now), `check-bash-constructs.py` (54 files) and its self-test pass.
- `uncrustify_hook_selftest` 3/3; the same test against the previous installer fails with a zero-byte hook.

Closes #1464

## Windows follow-up commit

CI on windows-latest/msvc failed only in `threading_doc_selftest`: the CRLF-inventory stub embedded an MSYS POSIX path that native Python cannot open, and once opened it would have doubled the CR the helper already emits on Windows. Commit f687e1b5 converts the path with `cygpath -m` and normalises the stub's output to one CR per line (the stub-normalisation item from #1490, folded in). Local: self-test, threading_doc, shell_gate_timeouts_selftest and bash_construct_ratchet pass.

