### PR TITLE
fix: defer primary arrangement rebuilds while pinned

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -579,9 +579,15 @@ exactly once, including on allocation and join-error paths.
 |---|---|---|
 | LRU eviction | skip and defer reclamation | reclaim normally |
 | relation invalidation | mark rebuild deferred; keep the old index readable | invalidate immediately |
-| final lease release | apply deferred invalidation | no action |
+| stale generation, row growth, or pending invalidation on lookup | defer rebuild and return unavailable; preserve hash buffers and chains | rebuild before returning |
+| final lease release | apply deferred invalidation, without rebuilding; next lookup rebuilds lazily | no action |
 
 This is an internal coordinator/worker-session contract, not a public API or a
-general concurrent-reader mechanism. Filtered, differential, sorted and
+general concurrent-reader mechanism. Release all leases before session teardown.
+The lease protects index buffers and entry identity, not source column values,
+row positions or compound storage: a reader must not probe an old index against
+a mutated source. Source-reader protection is tracked in #1485; generation
+checks on subsequent lookups are not a substitute for that protection.
+Filtered, differential, sorted and
 materialization-cache lifetimes, plus relation-generation validation, remain
 tracked separately in issue #1435.

--- a/tests/test_arrangement_lru_eviction.c
+++ b/tests/test_arrangement_lru_eviction.c
@@ -403,6 +403,156 @@ test_pinned_invalidation(void)
     PASS();
 }
 
+/* No probe is performed against changed source columns until all old leases
+ * end. These cases test index storage, not source-reader isolation. */
+static void
+test_pinned_rebuild(unsigned scenario)
+{
+    const char *names[] = {
+        "same-count mutation", "append within capacity", "append with growth",
+        "synthetic incremental append", "synthetic incremental growth",
+        "explicit invalidation", "empty index", "deferred eviction",
+    };
+    TEST(names[scenario]);
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+        "edge(10, 1). edge(20, 2). edge(30, 3).\n"
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n";
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    col_arrangement_pin_t first = { 0 }, second = { 0 }, denied = { 0 };
+    uint64_t *heads = NULL;
+    uint32_t *chains = NULL;
+    const char *failure = NULL;
+#define PIN_CHECK(condition, message) do { \
+            if (!(condition)) { failure = message; goto cleanup; } \
+} while (0)
+    PIN_CHECK(make_session(src, &sess, &plan, &prog) == 0, "session setup");
+    wl_col_session_t *cs = COL_SESSION(sess);
+    col_rel_t *rel = session_find_rel(cs, "edge");
+    uint32_t key[1] = { 0 };
+    PIN_CHECK(rel != NULL, "source relation missing");
+    if (scenario == 6) {
+        rel->nrows = 0;
+        wl_columnar_relation_touch_view(rel);
+    }
+    PIN_CHECK(col_session_pin_arrangement(sess, "edge", key, 1, &first) == 0,
+        "first pin");
+    /* Empty indexes always need a build, so a nested acquisition may defer. */
+    if (scenario != 6)
+        PIN_CHECK(col_session_pin_arrangement(sess, "edge", key, 1,
+            &second) == 0,
+            "fresh nested pin");
+    col_arr_entry_t *entry = first.entry;
+    col_arrangement_t *arr = first.arr;
+    if (scenario == 0 || scenario == 7)
+        PIN_CHECK(col_rel_set(rel, 0, 0, 11) == 0, "same-count mutation");
+    if (scenario >= 1 && scenario <= 4) {
+        unsigned count = (scenario == 2 || scenario == 4) ? 40 : 1;
+        for (unsigned i = 0; i < count; i++) {
+            int64_t row[2] = { 100 + i, 1000 + i };
+            PIN_CHECK(col_rel_append_row(rel, row) == 0, "source append");
+        }
+        if (scenario >= 3) {
+            /* Defensive incremental branch: real appends change the token. */
+            entry->source_snapshot = wl_columnar_relation_snapshot(rel);
+        }
+    }
+    if (scenario == 5)
+        col_session_invalidate_arrangements(sess, "edge");
+    if (scenario == 7) {
+        uint32_t alternate[1] = { 1 };
+        cs->arr_cache_limit_bytes = 0;
+        cs->arr_cap = cs->arr_count;
+        PIN_CHECK(col_session_get_arrangement(sess, "edge", alternate, 1)
+            == NULL && entry->evict_deferred,
+            "pressure must defer eviction and registry growth");
+    }
+    /* Capture after source allocation; only arrangement accounting is fixed. */
+    col_arrangement_t saved = *arr;
+    col_relation_snapshot_t snapshot = entry->source_snapshot;
+    size_t bytes = entry->mem_bytes, total = cs->arr_total_bytes;
+    heads = malloc(arr->nbuckets * sizeof(*heads));
+    chains = malloc((arr->indexed_rows + 1u) * sizeof(*chains));
+    PIN_CHECK(heads && chains, "snapshot allocation");
+    memcpy(heads, arr->ht_head, arr->nbuckets * sizeof(*heads));
+    if (arr->indexed_rows)
+        memcpy(chains, arr->ht_next, arr->indexed_rows * sizeof(*chains));
+    PIN_CHECK(col_session_get_arrangement(sess, "edge", key, 1) == NULL,
+        "lookup rebuilt or returned a stale pinned index");
+    PIN_CHECK(col_session_pin_arrangement(sess, "edge", key, 1, &denied) != 0
+        && !denied.active, "stale acquisition must remain inactive");
+    PIN_CHECK(entry->pin_count == (scenario == 6 ? 1u : 2u)
+        && entry->rebuild_deferred, "deferred lease count");
+    PIN_CHECK(arr->ht_head == saved.ht_head && arr->ht_next == saved.ht_next
+        && arr->nbuckets == saved.nbuckets && arr->ht_cap == saved.ht_cap
+        && arr->generation == saved.generation
+        && arr->indexed_rows == saved.indexed_rows
+        && entry->mem_bytes == bytes && cs->arr_total_bytes == total
+        && arr->reservation.bytes == saved.reservation.bytes
+        && wl_columnar_relation_snapshot_equal(entry->source_snapshot, snapshot)
+        && memcmp(heads, arr->ht_head, arr->nbuckets * sizeof(*heads)) == 0
+        && (!arr->indexed_rows || memcmp(chains, arr->ht_next,
+        arr->indexed_rows * sizeof(*chains)) == 0),
+        "denied lookup changed index storage, token or accounting");
+    col_arrangement_pin_release(&second);
+    PIN_CHECK(entry->pin_count == 1 && entry->rebuild_deferred
+        && arr->indexed_rows == saved.indexed_rows,
+        "nonfinal release invalidated the index");
+    col_arrangement_pin_release(&first);
+    PIN_CHECK(entry->pin_count == 0 && !entry->rebuild_deferred
+        && arr->indexed_rows == 0
+        && (scenario == 7 ? entry->mem_bytes == 0
+            : arr->generation == saved.generation),
+        "final release must invalidate without rebuilding");
+    arr = col_session_get_arrangement(sess, "edge", key, 1);
+    PIN_CHECK(arr && arr->indexed_rows == rel->nrows
+        && wl_columnar_relation_snapshot_equal(entry->source_snapshot,
+        wl_columnar_relation_snapshot(rel)), "lazy rebuild freshness");
+    for (uint32_t i = 0; i < rel->nrows; i++) {
+        int64_t row[2] = { rel->columns[0][i], rel->columns[1][i] };
+        uint32_t found = col_arrangement_find_first(arr, rel->columns, 2, row);
+        PIN_CHECK(found == i, "rebuilt key mismatch");
+        unsigned matches = 0, visited = 0;
+        while (found != UINT32_MAX && visited++ < rel->nrows) {
+            PIN_CHECK(found < rel->nrows, "rebuilt chain out of bounds");
+            if (rel->columns[0][found] == row[0])
+                matches++;
+            found = col_arrangement_find_next(arr, found);
+        }
+        PIN_CHECK(found == UINT32_MAX && matches == 1,
+            "rebuilt key multiplicity or cycle mismatch");
+    }
+    if (scenario == 0 || scenario == 7) {
+        int64_t old[2] = { 10, 1 };
+        PIN_CHECK(col_arrangement_find_first(arr, rel->columns, 2, old)
+            == UINT32_MAX, "removed key still indexed");
+    }
+    size_t sum = 0;
+    for (uint32_t i = 0; i < cs->arr_count; i++)
+        sum += cs->arr_entries[i].mem_bytes;
+    PIN_CHECK(sum == cs->arr_total_bytes, "rebuild accounting sum");
+    if (scenario != 6) {
+        uint32_t generation = arr->generation;
+        PIN_CHECK(col_session_get_arrangement(sess, "edge", key, 1) == arr
+            && arr->generation == generation,
+            "fresh lookup rebuilt unnecessarily");
+    }
+cleanup:
+    col_arrangement_pin_release(&denied);
+    col_arrangement_pin_release(&second);
+    col_arrangement_pin_release(&first);
+    free(heads);
+    free(chains);
+    if (sess)
+        free_session(sess, plan, prog);
+    if (failure)
+        FAIL(failure);
+    PASS();
+#undef PIN_CHECK
+}
+
 /* ================================================================
  * main
  * ================================================================ */
@@ -416,6 +566,8 @@ main(void)
     test_tombstone_rebuild();
     test_total_bytes_accounting();
     test_pinned_invalidation();
+    for (unsigned scenario = 0; scenario < 8; scenario++)
+        test_pinned_rebuild(scenario);
 
     printf("\n%d/%d tests passed", pass_count, test_count);
     if (fail_count > 0)

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -837,6 +837,14 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
         /* A token mismatch invalidates the complete index. */
         bool snapshot_match = wl_columnar_relation_snapshot_equal(
             e->source_snapshot, wl_columnar_relation_snapshot(rel));
+        /* Even a same-capacity rebuild rewrites bucket generations/chains.
+         * Keep every index mutation behind the last reader's release. */
+        if (e->pin_count > 0
+            && (!snapshot_match || e->arr.indexed_rows == 0
+            || e->arr.indexed_rows < rel->nrows || e->rebuild_deferred)) {
+            e->rebuild_deferred = true;
+            return NULL;
+        }
         if (!snapshot_match || e->arr.indexed_rows == 0) {
             /* Deduct stale bytes before rebuild; restore on failure. */
             cs->arr_total_bytes -= e->mem_bytes;
@@ -886,7 +894,8 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
     uint32_t slot = cs->arr_count; /* default: append */
     for (uint32_t i = 0; i < cs->arr_count; i++) {
         if (cs->arr_entries[i].arr.indexed_rows == 0
-            && cs->arr_entries[i].mem_bytes == 0) {
+            && cs->arr_entries[i].mem_bytes == 0
+            && cs->arr_entries[i].pin_count == 0) {
             slot = i;
             break;
         }

--- a/wirelog/columnar/columnar_nanoarrow.h
+++ b/wirelog/columnar/columnar_nanoarrow.h
@@ -270,10 +270,14 @@ typedef struct {
  * col_session_get_arrangement:
  *
  * Return (or lazily create) an arrangement for `rel_name` keyed on
- * `key_cols[0..key_count)`.  If the arrangement exists but is stale
- * (rel->nrows > indexed_rows), it is updated incrementally before return.
+ * `key_cols[0..key_count)`. Stale source generations require a full rebuild;
+ * a matching generation with additional rows uses an incremental update.
+ * If an active lease prevents either operation, mark rebuilding deferred
+ * and return NULL. Final lease release invalidates the index; the next
+ * lookup rebuilds lazily. A lease protects index storage, not source columns.
  *
- * Returns NULL on allocation failure or if the relation is not found.
+ * Returns NULL on allocation failure, invalid input, a missing relation,
+ * or when an active lease prevents returning a fresh index.
  *
  * @param sess       A wl_session_t* backed by the columnar backend.
  * @param rel_name   Relation to index.

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1830,6 +1830,10 @@ col_rel_set_column_types(col_rel_t *r,
 uint32_t
 col_arrangement_find_first_typed(const col_arrangement_t *arr,
     const col_rel_t *rel, const int64_t *key_row);
+/* Acquire only a fresh index. Stale pinned entries defer rebuild and reject
+ * new leases. Protects index storage, not source mutation or destruction;
+ * release every lease before session teardown. Final release invalidates
+ * deferred indexes; rebuilding is lazy on the next lookup. */
 int
 col_session_pin_arrangement(wl_session_t *sess, const char *rel_name,
     const uint32_t *key_cols, uint32_t key_count,


### PR DESCRIPTION
## Summary

Addresses the pinned primary-arrangement rebuild hazard recorded in #1435. Does not close #1435 or #1384: other cached-view and source-reader lifetime work remains.

Before either full rebuild or incremental indexing, refuse to mutate an entry with active pins when its source snapshot is stale, row count requires work, or invalidation is already deferred. Return unavailable instead of exposing a stale index to a new caller. Preserve buffer contents, dimensions, bucket generation, source snapshot and accounting until the final lease releases. Also exclude pinned entries from tombstone-slot reuse.

Final release retains existing lazy semantics: invalidate now, rebuild on the next lookup; deferred eviction still runs only after the last lease. Fresh nested leases remain supported.

This protects index storage and identity, not mutation/destruction of the probed source columns. Architect/Critic review filed #1485 as a child of #1384 for source-version reader protection; #1483 consumes that interface for compaction but retains its other borrower obligations.

## Validation

- `meson test -C build --print-errorlogs` on final candidate: 352 passed, 0 failed, 14 conditional skips. Includes all four clang-tidy checks. Arrangement regression executable: 13/13 passed in normal and ASan/UBSan builds.

- Existing arrangement LRU test passed in normal and ASan/UBSan builds before changes.
- Seven new regression cases failed against the original code: same-count mutation, within-capacity and growing append, both synthetic matching-token incremental paths, explicit invalidation and empty index.
- Added deferred-eviction coverage, two-lease/nonfinal-release checks, failed acquisition cleanup, hash-content/metadata/accounting checks and exact rebuilt key/multiplicity checks. Tests do not probe a stale index against mutated source columns.
- Normal focused tests: 8/8 passed before adding the final eviction case; final full-suite evidence below covers that case too.
- ASan/UBSan focused tests: 8/8 passed on the final candidate, including generation_cache, diff_join, arrangement_incr_invalidation, arrangement, arrangement_cache_reuse, join_arrangement, arrangement_lru_eviction and worker_session.
- CI Uncrustify 0.78.1: all four changed C/header files passed.
- `.text`: 269477 bytes vs baseline 273644, delta -4167; size gate passed without changing baseline.

No shared-state synchronization was added; these tests do not establish concurrent source-mutation safety. Cross-platform CI remains required.

## Independent gates

Reviewer Godel, Architect Pasteur and Critic Socrates approved tree `81118dfab81f8c649ec2720ab5b119240f38f814`, diff SHA-256 `a2f61ef0aca9010325f69be912a72e0a53884f21e1c1ce6cdd646f9fbb453ffb`. Commit `f410a8d34fb94062afa05ff19df131f483b93608` matches the approved tree after hooks. Latest main fetched and rebase performed before push; base `fce2642c`. No merge performed.
