### PR TITLE
fix(#1435): defer pinned arrangement rebuild on token mismatch

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -582,7 +582,14 @@ exactly once, including on allocation and join-error paths.
 |---|---|---|
 | LRU eviction | skip and defer reclamation | reclaim normally |
 | relation invalidation | mark rebuild deferred; keep the old index readable | invalidate immediately |
+| token mismatch or growth while leased | defer rebuild; return unavailable (callers fall back to ephemeral) | rebuild in place |
 | final lease release | apply deferred invalidation | no action |
+
+A deferred rebuild is applied at the last release, which clears the index,
+and executed on the next lookup after that release; a lookup that finds a
+leased, stale entry returns nothing rather than reallocating the hash-table
+buffers under the reader (Issue #1435). A pinned, token-fresh, empty index is
+still handed out, since an empty relation legitimately has nothing indexed.
 
 This is an internal coordinator/worker-session contract, not a public API or a
 general concurrent-reader mechanism. Filtered, differential, sorted and

--- a/tests/test_arrangement_lru_eviction.c
+++ b/tests/test_arrangement_lru_eviction.c
@@ -404,6 +404,159 @@ test_pinned_invalidation(void)
 }
 
 /* ================================================================
+ * Test 6: token mismatch under a lease defers the rebuild (#1435)
+ * ================================================================ */
+static void
+test_pinned_rebuild_deferred(void)
+{
+    TEST("pinned arrangement is never rebuilt in place on a stale token");
+
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+        "edge(10, 1). edge(20, 2). edge(30, 3).\n"
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n";
+
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    ASSERT(make_session(src, &sess, &plan, &prog) == 0,
+        "session creation failed");
+
+    wl_col_session_t *cs = COL_SESSION(sess);
+    col_rel_t *edge = session_find_rel(cs, "edge");
+    uint32_t key_cols[1] = { 0 };
+    col_arrangement_pin_t pin;
+    col_arrangement_pin_t second;
+    ASSERT(edge != NULL && edge->nrows == 3, "edge must hold three rows");
+    ASSERT(col_session_pin_arrangement(sess, "edge", key_cols, 1, &pin) == 0,
+        "arrangement pin must succeed");
+    col_arr_entry_t *entry = pin.entry;
+    const uint64_t *head_before = entry->arr.ht_head;
+    const uint32_t *next_before = entry->arr.ht_next;
+    uint32_t generation_before = entry->arr.generation;
+    uint32_t nbuckets_before = entry->arr.nbuckets;
+    uint32_t ht_cap_before = entry->arr.ht_cap;
+    size_t mem_bytes_before = entry->mem_bytes;
+    size_t total_before = cs->arr_total_bytes;
+    uint64_t clock_before = entry->lru_clock;
+    ASSERT(entry->arr.indexed_rows == 3, "index must cover the three rows");
+
+    /* Same-row-count mutation: key 20 becomes 40.  The token no longer
+     * matches, but the reader holds a lease, so the index must stay
+     * exactly as it is and the lookup must report it unavailable. */
+    ASSERT(col_rel_set(edge, 1, 0, 40) == 0, "in-place set failed");
+    ASSERT(col_session_get_arrangement(sess, "edge", key_cols, 1) == NULL,
+        "stale leased entry must be reported unavailable");
+    ASSERT(entry->rebuild_deferred && entry->pin_count == 1,
+        "rebuild must be deferred while pinned");
+    ASSERT(entry->arr.ht_head == head_before &&
+        entry->arr.ht_next == next_before
+        && entry->arr.generation == generation_before
+        && entry->arr.nbuckets == nbuckets_before
+        && entry->arr.ht_cap == ht_cap_before
+        && entry->arr.indexed_rows == 3
+        && entry->mem_bytes == mem_bytes_before
+        && cs->arr_total_bytes == total_before
+        && entry->lru_clock == clock_before,
+        "deferral must leave buffers, accounting and clock untouched");
+    ASSERT(col_session_pin_arrangement(sess, "edge", key_cols, 1, &second)
+        == EBUSY && entry->pin_count == 1 && !second.active,
+        "a second lease on a stale entry must report EBUSY");
+
+    /* Growth without a token change cannot happen through the relation
+     * API on main (an append publishes a new view generation), so the
+     * incremental clause is exercised white-box: refresh the token after
+     * an append to simulate a consumer that refreshed it without
+     * rebuilding.  indexed_rows < nrows must defer just like a mismatch. */
+    int64_t row[2] = { 50, 5 };
+    ASSERT(col_rel_append_row(edge, row) == 0, "append failed");
+    entry->rebuild_deferred = false;
+    entry->source_snapshot = wl_columnar_relation_snapshot(edge);
+    ASSERT(col_session_get_arrangement(sess, "edge", key_cols, 1) == NULL
+        && entry->rebuild_deferred && entry->arr.indexed_rows == 3
+        && entry->arr.ht_head == head_before,
+        "growth under a lease must defer the incremental update");
+
+    col_arrangement_pin_release(&pin);
+    ASSERT(!pin.active && entry->pin_count == 0
+        && entry->arr.indexed_rows == 0,
+        "last release must apply the deferred invalidation");
+    col_arrangement_t *arr = col_session_get_arrangement(sess, "edge",
+            key_cols, 1);
+    ASSERT(arr != NULL && arr->indexed_rows == 4,
+        "next lookup after release must rebuild over four rows");
+    int64_t probe_new[2] = { 40, 0 };
+    int64_t probe_old[2] = { 20, 0 };
+    ASSERT(col_arrangement_find_first_typed(arr, edge, probe_new)
+        != UINT32_MAX,
+        "rebuilt index must find the new key");
+    ASSERT(col_arrangement_find_first_typed(arr, edge, probe_old)
+        == UINT32_MAX,
+        "rebuilt index must not find the replaced key");
+
+    free_session(sess, plan, prog);
+    PASS();
+}
+
+/* ================================================================
+ * Test 7: a pinned, token-fresh, empty index is still handed out
+ * ================================================================ */
+static void
+test_pinned_empty_index_available(void)
+{
+    TEST("pinned empty arrangement stays available to a second lease");
+
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+        ".decl seed(x: int32, y: int32)\n"
+        "seed(1, 2).\n"
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- seed(x, z), edge(z, y).\n";
+
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    ASSERT(make_session(src, &sess, &plan, &prog) == 0,
+        "session creation failed");
+
+    wl_col_session_t *cs = COL_SESSION(sess);
+    col_rel_t *edge = session_find_rel(cs, "edge");
+    uint32_t key_cols[1] = { 0 };
+    col_arrangement_pin_t first;
+    col_arrangement_pin_t second;
+    ASSERT(edge != NULL && edge->nrows == 0, "edge must be empty");
+    /* A session relation gets its column layout at the first insert; give
+     * the empty relation its schema so the lookup validates the key column
+     * and indexes zero rows, which is the shape a bounded join sees for an
+     * empty right relation. */
+    ASSERT(col_rel_set_schema(edge, 2, NULL) == 0, "schema failed");
+    ASSERT(col_session_pin_arrangement(sess, "edge", key_cols, 1, &first) == 0
+        && first.entry->arr.indexed_rows == 0,
+        "an empty relation must still get a lease");
+    const uint64_t *empty_head = first.entry->arr.ht_head;
+    uint32_t empty_buckets = first.entry->arr.nbuckets;
+    size_t empty_mem = first.entry->mem_bytes;
+    ASSERT(col_session_get_arrangement(sess, "edge", key_cols, 1)
+        == first.arr && !first.entry->rebuild_deferred,
+        "a pinned, fresh, empty index must be returned, not deferred");
+    /* The empty index is handed out through the same-size rebuild path
+     * today; it must never reallocate the buffers under the lease. */
+    ASSERT(first.entry->arr.ht_head == empty_head
+        && first.entry->arr.nbuckets == empty_buckets
+        && first.entry->mem_bytes == empty_mem,
+        "looking up a pinned empty index must not touch its buffers");
+    ASSERT(col_session_pin_arrangement(sess, "edge", key_cols, 1, &second)
+        == 0 && first.entry->pin_count == 2,
+        "a second lease on a fresh empty index must succeed");
+    col_arrangement_pin_release(&second);
+    col_arrangement_pin_release(&first);
+    ASSERT(first.entry == NULL && cs->arr_count > 0,
+        "both leases must be released");
+
+    free_session(sess, plan, prog);
+    PASS();
+}
+
+/* ================================================================
  * main
  * ================================================================ */
 int
@@ -416,6 +569,8 @@ main(void)
     test_tombstone_rebuild();
     test_total_bytes_accounting();
     test_pinned_invalidation();
+    test_pinned_rebuild_deferred();
+    test_pinned_empty_index_available();
 
     printf("\n%d/%d tests passed", pass_count, test_count);
     if (fail_count > 0)

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -837,6 +837,21 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
         /* A token mismatch invalidates the complete index. */
         bool snapshot_match = wl_columnar_relation_snapshot_equal(
             e->source_snapshot, wl_columnar_relation_snapshot(rel));
+        /* A leased entry is never rebuilt or grown in place (Issue #1435):
+         * arr_build_full and arr_update_incremental may reallocate ht_head
+         * and ht_next under a reader.  Defer exactly as invalidation does
+         * and report the index unavailable; every production caller then
+         * falls back to an ephemeral hash table, and the last release
+         * clears the index so the next lookup rebuilds it.  A pinned,
+         * token-fresh, empty index is fine to hand out: an empty relation
+         * legitimately has nothing indexed.  The clock is not bumped
+         * because the caller received nothing. */
+        if (e->pin_count > 0
+            && (!snapshot_match || e->rebuild_deferred
+            || e->arr.indexed_rows < rel->nrows)) {
+            e->rebuild_deferred = true;
+            return NULL;
+        }
         if (!snapshot_match || e->arr.indexed_rows == 0) {
             /* Deduct stale bytes before rebuild; restore on failure. */
             cs->arr_total_bytes -= e->mem_bytes;
@@ -982,8 +997,22 @@ col_session_pin_arrangement(wl_session_t *sess, const char *rel_name,
         return EINVAL;
     memset(pin, 0, sizeof(*pin));
     arr = col_session_get_arrangement(sess, rel_name, key_cols, key_count);
-    if (!arr)
+    if (!arr) {
+        /* Distinguish a leased, stale entry (Issue #1435) from a build or
+         * admission failure: the former is a transient EBUSY that a caller
+         * may satisfy with an ephemeral arrangement. */
+        wl_col_session_t *cs = COL_SESSION(sess);
+        for (uint32_t i = 0; i < cs->arr_count; i++) {
+            const col_arr_entry_t *e = &cs->arr_entries[i];
+            if (e->pin_count > 0 && e->rebuild_deferred
+                && e->key_count == key_count
+                && strcmp(e->rel_name, rel_name) == 0
+                && memcmp(e->key_cols, key_cols,
+                (size_t)key_count * sizeof(*key_cols)) == 0)
+                return EBUSY;
+        }
         return ENOMEM;
+    }
     entry = col_arr_entry_for_arr(COL_SESSION(sess), arr);
     if (!entry)
         return EINVAL;

--- a/wirelog/columnar/columnar_nanoarrow.h
+++ b/wirelog/columnar/columnar_nanoarrow.h
@@ -273,7 +273,10 @@ typedef struct {
  * `key_cols[0..key_count)`.  If the arrangement exists but is stale
  * (rel->nrows > indexed_rows), it is updated incrementally before return.
  *
- * Returns NULL on allocation failure or if the relation is not found.
+ * Returns NULL on allocation failure, if the relation is not found, or when
+ * the entry is leased by a reader and stale: the rebuild is then deferred
+ * until the last release and the caller must use an ephemeral arrangement
+ * (Issue #1435).
  *
  * @param sess       A wl_session_t* backed by the columnar backend.
  * @param rel_name   Relation to index.

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1830,6 +1830,12 @@ col_rel_set_column_types(col_rel_t *r,
 uint32_t
 col_arrangement_find_first_typed(const col_arrangement_t *arr,
     const col_rel_t *rel, const int64_t *key_row);
+/* Take a reader lease on the (rel_name, key_cols) primary arrangement,
+ * building it first when needed.  Returns 0 with *pin active; EBUSY when
+ * the entry is leased by another reader and stale, so it cannot be rebuilt
+ * until that lease is released (use an ephemeral arrangement; Issue #1435);
+ * ENOMEM when the index cannot be built or admitted.  No production caller
+ * distinguishes EBUSY from ENOMEM today; both fall back. */
 int
 col_session_pin_arrangement(wl_session_t *sess, const char *rel_name,
     const uint32_t *key_cols, uint32_t key_count,


### PR DESCRIPTION
First of the remaining #1435 units: primary arrangement rebuilds are now deferred while a reader holds the lease.

## What changes

- `col_session_get_arrangement`: a registry hit whose entry is leased (`pin_count > 0`) and stale (freshness token mismatch, rebuild already deferred, or index covering fewer rows than the relation) marks the rebuild deferred and returns NULL before touching buffers, accounting or the LRU clock. The unpinned path is unchanged. A pinned, token-fresh, empty index is still returned, since an empty relation legitimately has nothing indexed and the bounded join producer of #1446 takes a second lease on exactly that entry.
- `col_session_pin_arrangement` reports `EBUSY` for a leased, stale entry (documented on the prototype); every production caller already falls back to an ephemeral hash table on any failure.
- `docs/MEMORY.md` section 10: new lease-table row; the deferred rebuild is applied at the last release and executed on the next lookup after it.
- Tests (`tests/test_arrangement_lru_eviction.c`): same-row-count in-place mutation under a lease leaves hash-table pointers, generation, bucket count, accounting and clock untouched and reports the index unavailable; a second lease reports `EBUSY`; the growth clause is exercised white-box; the rebuild after release indexes the new key and drops the old; an empty relation stays available to a second lease.

## Why

The invalidation path already deferred through `rebuild_deferred` and honored it on the last release; the freshness-token path from #1438 bypassed that protocol and could reallocate `ht_head`/`ht_next` under a reader. Unreachable in production today because the keyed join never mutates its right relation inside its lease window; the #1446 producer holds a lease across batches and suspended readers would not be so lucky.

## Scope

Primary arrangements only. The filtered-relation cache still has no lease and is destroyed in place on a stale token; that unit and wiring the keyed join to it follow separately, so #1435 stays open.

## Validation

- Focused: arrangement_lru_eviction (7/7 incl. the two new cases), arrangement_cache_reuse, generation_cache, join_arrangement, worker_session, arrangement, diff_join.
- Full `meson test` on the rebased tree: 354 OK / 0 failed / 13 skipped (perf and stress-release gates); clang-tidy ratchet, threading doc (94 rows) and ABI gates green.
- ASan/UBSan with leak detection: clean on the focused set plus tdd_recursive, mat_cache_lifetime, cache_reclaimer.
- `.text` +122 B vs main in the CI configuration; gate passes.

Refs #1435
