### PR TITLE
feat: add inactive source access gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **Added the allocation-free source access contract** (#1492). The internal
+  gate supports concurrent readers, an exclusive nonrecursive writer,
+  address-bound tokens, deterministic contention errors, and reader-count
+  overflow handling without allocating.
+
 - **Arrangement registry stays scannable after a failed tombstone reuse**
   (#1515). The name and key allocations for a new `(relation, key columns)`
   entry now precede any change to the reused slot, and a first build denied

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -228,7 +228,7 @@ These exist so struct fields can be declared portably; the audit in
 
 Every `atomic_*` call site in `wirelog/` production sources. Counted
 mechanically by `scripts/ci/check-threading-doc.sh`; row count must
-match the script's count (currently **96**).
+match the script's count (currently **110**).
 
 Format: `file:function[#N]` | field | operation | order | justification.
 
@@ -392,7 +392,21 @@ and direct non-atomic payload reads require external synchronization.
 | `memory_governor.c:wl_columnar_memory_reservation_move#6` | `source->owner_bits` | `atomic_store_explicit` | `relaxed` | Clear the source owner after ownership has moved |
 | `memory_governor.c:wl_columnar_memory_reservation_move#7` | `source->state` | `atomic_store_explicit` | `release` | Publish the empty source state after clearing its ownership |
 
-### 5.9 `wirelog/arena/compound_arena.c` — mutation gate (5 rows)
+### 5.9 `wirelog/columnar/arrangement.c` — reservation relocation (5 rows)
+
+Arrangement registry entries embed non-copyable memory reservations. These
+loads validate the reservation state before moving or publishing a token;
+the relocation paths preserve identity and transfer ownership explicitly.
+
+| Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
+|---|---|---|---|---|
+| `arrangement.c:arr_publish_reservation` | `arr->reservation.state` | `atomic_load_explicit` | `acquire` | Observe the prior reservation state before moving or releasing it |
+| `arrangement.c:arr_entry_relocate` | `src->arr.reservation.state` | `atomic_load_explicit` | `acquire` | Validate the source token before relocating the registry entry |
+| `arrangement.c:arr_entry_relocate#2` | `dst->arr.reservation.state` | `atomic_load_explicit` | `acquire` | Revalidate the moved token before transferring its owner |
+| `arrangement.c:filt_arr_entry_relocate` | `src->arr.reservation.state` | `atomic_load_explicit` | `acquire` | Validate the filtered source token before relocation |
+| `arrangement.c:filt_arr_entry_relocate#2` | `dst->arr.reservation.state` | `atomic_load_explicit` | `acquire` | Revalidate the moved filtered token before owner transfer |
+
+### 5.10 `wirelog/arena/compound_arena.c` — mutation gate (5 rows)
 
 | Anchor (`file:function[#N]`) | Field | Op | Order | Justification |
 |---|---|---|---|---|
@@ -405,7 +419,7 @@ and direct non-atomic payload reads require external synchronization.
 On MSVC the helper load/store use interlocked intrinsics because the shared
 `wl_atomic_u64` compatibility type cannot use C11 atomic operations directly.
 
-### 5.10 `wirelog/intern.c` — shared symbol table (3 rows)
+### 5.11 `wirelog/intern.c` — shared symbol table (3 rows)
 
 The intern table is shared, unsynchronized, by every parallel worker
 (Issue #958). Writers (`wl_intern_put`, `wl_intern_get`) serialize on
@@ -421,12 +435,12 @@ named in the justification.
 | `intern.c:WL_INTERN_LOAD_RELAXED` | `intern->count` | `atomic_load_explicit` | `relaxed` | `WL_INTERN_LOAD_RELAXED`, used by `wl_intern_put`, `intern_resize_prepare`, `intern_retained_bytes_locked` and `wl_intern_free`. Every caller holds `intern->lock` (`wl_intern_free` takes it to release the governor reservation, Issue #1431), so no edge is needed |
 | `intern.c:WL_INTERN_STORE_RELEASE` | `intern->count` | `atomic_store_explicit` | `release` | `WL_INTERN_STORE_RELEASE`, used by `wl_intern_put` after the string and its segment pointer are written. Publishing the count first would let a lock-free reader dereference an unwritten slot |
 
-### 5.11 Existing inventory total
+### 5.12 Existing inventory total
 
-21 + 4 + 2 + 3 + 19 + 1 + 1 + 1 + 3 + 36 + 5 = **96 atomic call sites**
+21 + 4 + 5 + 19 + 1 + 1 + 1 + 37 + 5 + 5 + 3 = **102 atomic call sites**
 before the inactive source-access contract below.
 
-### 5.12 `wirelog/columnar/source_access.h` — inactive source gate (8 rows)
+### 5.13 `wirelog/columnar/source_access.h` — inactive source gate (8 rows)
 
 This header-only gate is a testable internal contract and is not linked into
 the production library. Its state is zero-initialized; reader and writer
@@ -447,7 +461,7 @@ gate and token state unchanged.
 | `source_access.h:wl_columnar_source_access_writer_release` | `gate->state` | `atomic_load_explicit` | acquire | Validate the writer state before terminal publication |
 | `source_access.h:wl_columnar_source_access_writer_release#2` | `gate->state` | `atomic_compare_exchange_weak_explicit` | release/relaxed | Publish writer payload completion and retry spurious failure |
 
-21 + 4 + 2 + 3 + 19 + 1 + 1 + 1 + 3 + 36 + 5 + 8 = **104 atomic call sites**.
+21 + 4 + 5 + 19 + 1 + 1 + 1 + 37 + 5 + 5 + 3 + 8 = **110 atomic call sites**.
 
 The `#N` suffix counts all atomic sites in a symbol, regardless of operation;
 the first site remains unsuffixed. `scripts/ci/check-threading-doc.sh` uses

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -421,9 +421,33 @@ named in the justification.
 | `intern.c:WL_INTERN_LOAD_RELAXED` | `intern->count` | `atomic_load_explicit` | `relaxed` | `WL_INTERN_LOAD_RELAXED`, used by `wl_intern_put`, `intern_resize_prepare`, `intern_retained_bytes_locked` and `wl_intern_free`. Every caller holds `intern->lock` (`wl_intern_free` takes it to release the governor reservation, Issue #1431), so no edge is needed |
 | `intern.c:WL_INTERN_STORE_RELEASE` | `intern->count` | `atomic_store_explicit` | `release` | `WL_INTERN_STORE_RELEASE`, used by `wl_intern_put` after the string and its segment pointer are written. Publishing the count first would let a lock-free reader dereference an unwritten slot |
 
-### 5.11 Total
+### 5.11 Existing inventory total
 
-21 + 4 + 2 + 3 + 19 + 1 + 1 + 1 + 3 + 36 + 5 = **96 atomic call sites**.
+21 + 4 + 2 + 3 + 19 + 1 + 1 + 1 + 3 + 36 + 5 = **96 atomic call sites**
+before the inactive source-access contract below.
+
+### 5.12 `wirelog/columnar/source_access.h` — inactive source gate (8 rows)
+
+This header-only gate is a testable internal contract and is not linked into
+the production library. Its state is zero-initialized; reader and writer
+tokens are caller-owned, address-bound and thread-confined. Acquire operations
+use acquire semantics before consuming protected state; release operations use
+release semantics after protected payload publication. The containing owner
+must outlive all active tokens. `EBUSY`, `EINVAL` and `EOVERFLOW` leave the
+gate and token state unchanged.
+
+| Anchor (file:function[#N]) | Field | Op | Order | Justification |
+|---|---|---|---|---|
+| `source_access.h:wl_columnar_source_access_gate_init` | `gate->state` | `atomic_store_explicit` | relaxed | Establish inactive zero state before publication |
+| `source_access.h:wl_columnar_source_access_reader_acquire` | `gate->state` | `atomic_load_explicit` | acquire | Observe writer release before admitting a reader |
+| `source_access.h:wl_columnar_source_access_reader_acquire#2` | `gate->state` | `atomic_compare_exchange_weak_explicit` | acquire/relaxed | Linearize reader admission without overflowing the writer sentinel |
+| `source_access.h:wl_columnar_source_access_reader_release` | `gate->state` | `atomic_load_explicit` | acquire | Observe the active gate before releasing this reader |
+| `source_access.h:wl_columnar_source_access_reader_release#2` | `gate->state` | `atomic_compare_exchange_weak_explicit` | release/relaxed | Publish reader payload completion and decrement atomically |
+| `source_access.h:wl_columnar_source_access_writer_acquire` | `gate->state` | `atomic_compare_exchange_weak_explicit` | acquire/relaxed | Linearize exclusive writer admission and retry spurious failure |
+| `source_access.h:wl_columnar_source_access_writer_release` | `gate->state` | `atomic_load_explicit` | acquire | Validate the writer state before terminal publication |
+| `source_access.h:wl_columnar_source_access_writer_release#2` | `gate->state` | `atomic_compare_exchange_weak_explicit` | release/relaxed | Publish writer payload completion and retry spurious failure |
+
+21 + 4 + 2 + 3 + 19 + 1 + 1 + 1 + 3 + 36 + 5 + 8 = **104 atomic call sites**.
 
 The `#N` suffix counts all atomic sites in a symbol, regardless of operation;
 the first site remains unsuffixed. `scripts/ci/check-threading-doc.sh` uses

--- a/scripts/ci/check-source-access-contract.sh
+++ b/scripts/ci/check-source-access-contract.sh
@@ -5,7 +5,7 @@ root="${WIRELOG_SOURCE_ACCESS_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 header="$root/wirelog/columnar/source_access.h"
 [ -f "$header" ] || { echo "source-access: missing header" >&2; exit 1; }
 
-if rg -n 'malloc|calloc|realloc|free\s*\(' "$header"; then
+if grep -n -E 'malloc|calloc|realloc|free[[:space:]]*\(' "$header"; then
     echo "source-access: allocation call in gate" >&2
     exit 1
 fi
@@ -15,13 +15,13 @@ for symbol in \
     wl_columnar_source_access_reader_release \
     wl_columnar_source_access_writer_acquire \
     wl_columnar_source_access_writer_release; do
-    rg -q "$symbol" "$header" || {
+    grep -E -q "^[[:space:]]*${symbol}[[:space:]]*\\(" "$header" || {
         echo "source-access: missing $symbol" >&2
         exit 1
     }
 done
 
-if rg -n 'wirelog/columnar/source_access\.h|source_access\.h' \
+if grep -n -F -e 'wirelog/columnar/source_access.h' -e 'source_access.h' \
     "$root/meson.build" "$root/wirelog/meson.build"; then
     echo "source-access: gate must not enter production source lists" >&2
     exit 1

--- a/scripts/ci/check-source-access-contract.sh
+++ b/scripts/ci/check-source-access-contract.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="${WIRELOG_SOURCE_ACCESS_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+header="$root/wirelog/columnar/source_access.h"
+[ -f "$header" ] || { echo "source-access: missing header" >&2; exit 1; }
+
+if rg -n 'malloc|calloc|realloc|free\s*\(' "$header"; then
+    echo "source-access: allocation call in gate" >&2
+    exit 1
+fi
+
+for symbol in \
+    wl_columnar_source_access_reader_acquire \
+    wl_columnar_source_access_reader_release \
+    wl_columnar_source_access_writer_acquire \
+    wl_columnar_source_access_writer_release; do
+    rg -q "$symbol" "$header" || {
+        echo "source-access: missing $symbol" >&2
+        exit 1
+    }
+done
+
+if rg -n 'wirelog/columnar/source_access\.h|source_access\.h' \
+    "$root/meson.build" "$root/wirelog/meson.build"; then
+    echo "source-access: gate must not enter production source lists" >&2
+    exit 1
+fi
+
+echo "source-access: allocation-free, test-only contract OK"

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -19,7 +19,7 @@ fi
 rows="$tmp_dir/rows"
 sed -nE 's/^\| `([^`]+:[A-Za-z_][A-Za-z0-9_]*(#[0-9]+)?)` \| [^|]* \| `([^`]*)` \|.*/\1\t\3/p' "$doc" >"$rows"
 row_count=$(wc -l <"$rows")
-expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-104}"
+expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-105}"
 [ "$row_count" -eq "$expected_rows" ] || {
     echo "check-threading-doc: FAIL: expected $expected_rows audit rows, found $row_count" >&2
     exit 1

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -19,7 +19,7 @@ fi
 rows="$tmp_dir/rows"
 sed -nE 's/^\| `([^`]+:[A-Za-z_][A-Za-z0-9_]*(#[0-9]+)?)` \| [^|]* \| `([^`]*)` \|.*/\1\t\3/p' "$doc" >"$rows"
 row_count=$(wc -l <"$rows")
-expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-97}"
+expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-104}"
 [ "$row_count" -eq "$expected_rows" ] || {
     echo "check-threading-doc: FAIL: expected $expected_rows audit rows, found $row_count" >&2
     exit 1

--- a/scripts/ci/check-threading-doc.sh
+++ b/scripts/ci/check-threading-doc.sh
@@ -19,7 +19,7 @@ fi
 rows="$tmp_dir/rows"
 sed -nE 's/^\| `([^`]+:[A-Za-z_][A-Za-z0-9_]*(#[0-9]+)?)` \| [^|]* \| `([^`]*)` \|.*/\1\t\3/p' "$doc" >"$rows"
 row_count=$(wc -l <"$rows")
-expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-105}"
+expected_rows="${WIRELOG_THREADING_EXPECTED_ROWS:-110}"
 [ "$row_count" -eq "$expected_rows" ] || {
     echo "check-threading-doc: FAIL: expected $expected_rows audit rows, found $row_count" >&2
     exit 1

--- a/scripts/ci/test-gate-skip-exit-codes.sh
+++ b/scripts/ci/test-gate-skip-exit-codes.sh
@@ -85,6 +85,7 @@ check() {
 # `SKIP ...; exit 0` injected into it: EXEMPT passed, COVERED failed by name.
 COVERED="
 check-sbom-wrap-pin.sh
+check-source-access-contract.sh
 check-abi-manifest.sh
 check-abi-symbols.sh
 check-abi-symbols-locale.sh

--- a/scripts/ci/test-source-access-contract.sh
+++ b/scripts/ci/test-source-access-contract.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+project_root=$(cd "$script_dir/../.." && pwd)
+checker="$script_dir/check-source-access-contract.sh"
+tmp_root=$(mktemp -d "${TMPDIR:-/tmp}/wirelog-source-access.XXXXXX")
+trap 'rm -rf "$tmp_root"' EXIT
+
+tool_path="$tmp_root/bin"
+mkdir "$tool_path"
+for utility in bash grep mkdir cp rm; do
+    ln -s "$(command -v "$utility")" "$tool_path/$utility"
+done
+
+make_fixture() {
+    fixture_root=$1
+    mkdir -p "$fixture_root/wirelog/columnar"
+    cp "$project_root/wirelog/columnar/source_access.h" \
+       "$fixture_root/wirelog/columnar/source_access.h"
+    : > "$fixture_root/meson.build"
+    : > "$fixture_root/wirelog/meson.build"
+}
+
+run_checker() {
+    PATH="$tool_path" WIRELOG_SOURCE_ACCESS_ROOT=$1 "$checker"
+}
+
+valid_root="$tmp_root/valid"
+make_fixture "$valid_root"
+run_checker "$valid_root"
+
+missing_header_root="$tmp_root/missing-header"
+mkdir -p "$missing_header_root/wirelog/columnar"
+: > "$missing_header_root/meson.build"
+: > "$missing_header_root/wirelog/meson.build"
+if missing_header_output=$(run_checker "$missing_header_root" 2>&1); then
+    echo "source-access self-test: missing-header fixture unexpectedly passed" >&2
+    exit 1
+fi
+case "$missing_header_output" in
+    *'source-access: missing header'*) ;;
+    *)
+        echo "source-access self-test: missing-header diagnostic not found" >&2
+        exit 1
+        ;;
+esac
+
+allocation_root="$tmp_root/allocation"
+make_fixture "$allocation_root"
+printf '%s\n' 'void free (void *pointer);' >> \
+    "$allocation_root/wirelog/columnar/source_access.h"
+if run_checker "$allocation_root"; then
+    echo "source-access self-test: allocation fixture unexpectedly passed" >&2
+    exit 1
+fi
+
+comment_root="$tmp_root/comment-only"
+make_fixture "$comment_root"
+sed -i.bak \
+    '/^[[:space:]]*wl_columnar_source_access_writer_release[[:space:]]*([[:space:]]*$/d' \
+    "$comment_root/wirelog/columnar/source_access.h"
+rm "$comment_root/wirelog/columnar/source_access.h.bak"
+printf '%s\n' \
+    '/* wl_columnar_source_access_writer_release */' >> \
+    "$comment_root/wirelog/columnar/source_access.h"
+if run_checker "$comment_root"; then
+    echo "source-access self-test: comment-only fixture unexpectedly passed" >&2
+    exit 1
+fi
+
+production_root="$tmp_root/production"
+make_fixture "$production_root"
+printf '%s\n' 'wirelog/columnar/source_access.h' > \
+    "$production_root/wirelog/meson.build"
+if run_checker "$production_root"; then
+    echo "source-access self-test: production-list fixture unexpectedly passed" >&2
+    exit 1
+fi
+
+echo "source-access self-test: OK"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -83,6 +83,10 @@ if source_access_shell.found()
        args: [meson.project_source_root() /
               'scripts/ci/check-source-access-contract.sh'],
        suite: 'abi', timeout: 60)
+  test('source_access_contract_selftest', source_access_shell,
+       args: [meson.project_source_root() /
+              'scripts/ci/test-source-access-contract.sh'],
+       suite: 'abi', timeout: 60)
 endif
 
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -79,11 +79,10 @@ test('source_access', source_access_exe, suite: ['unit', 'tsan'], timeout: 60)
 
 source_access_shell = find_program('bash', required: false)
 if source_access_shell.found()
-  source_access_contract = find_program(
-    join_paths(meson.project_source_root(),
-      'scripts/ci/check-source-access-contract.sh'))
   test('source_access_contract', source_access_shell,
-       args: [source_access_contract], suite: 'abi', timeout: 60)
+       args: [meson.project_source_root() /
+              'scripts/ci/check-source-access-contract.sh'],
+       suite: 'abi', timeout: 60)
 endif
 
 # ============================================================================

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -68,6 +68,24 @@ io_src = files(
 # to subdir builds via the parent scope.
 thread_src = wirelog_thread_src
 
+source_access_exe = executable(
+  'test_source_access',
+  files('test_source_access.c'),
+  thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [threads_dep],
+)
+test('source_access', source_access_exe, suite: ['unit', 'tsan'], timeout: 60)
+
+source_access_shell = find_program('bash', required: false)
+if source_access_shell.found()
+  source_access_contract = find_program(
+    join_paths(meson.project_source_root(),
+      'scripts/ci/check-source-access-contract.sh'))
+  test('source_access_contract', source_access_shell,
+       args: [source_access_contract], suite: 'abi', timeout: 60)
+endif
+
 # ============================================================================
 # Test Executables
 # ============================================================================

--- a/tests/test_source_access.c
+++ b/tests/test_source_access.c
@@ -1,0 +1,261 @@
+/* Focused contract tests for the inactive source access gate (#1492). */
+
+#include "../wirelog/columnar/source_access.h"
+#include "wirelog/thread.h"
+
+#include <stdio.h>
+
+static int failures;
+
+#define CHECK(condition, message) do { \
+            if (!(condition)) { printf("FAIL: %s\n", message); failures++; \
+                                return; } \
+} while (0)
+
+static void
+test_lifecycle(void)
+{
+    wl_columnar_source_access_gate_t gate = { 0 };
+    wl_columnar_source_access_reader_t reader = { 0 }, second = { 0 }, copy;
+    wl_columnar_source_access_writer_t writer = { 0 };
+    wl_columnar_source_access_gate_init(&gate);
+    CHECK(wl_columnar_source_access_reader_acquire(&gate, &reader) == 0,
+        "reader acquire");
+    copy = reader;
+    CHECK(wl_columnar_source_access_reader_release(&copy) == EINVAL,
+        "copied reader release rejected");
+    CHECK(atomic_load_explicit(&gate.state, memory_order_relaxed) == 1
+        && reader.owner == &gate, "failed copy release changed state");
+    CHECK(wl_columnar_source_access_reader_acquire(&gate, &second) == 0,
+        "second reader acquire");
+    CHECK(atomic_load_explicit(&gate.state, memory_order_relaxed) == 2,
+        "multiple readers share the gate");
+    CHECK(wl_columnar_source_access_writer_acquire(&gate, &writer) == EBUSY,
+        "writer blocked by reader");
+    CHECK(wl_columnar_source_access_reader_release(&second) == 0,
+        "second reader release");
+    CHECK(atomic_load_explicit(&gate.state, memory_order_relaxed) == 1,
+        "one reader remains after second release");
+    CHECK(wl_columnar_source_access_reader_release(&reader) == 0,
+        "reader release");
+    CHECK(wl_columnar_source_access_writer_acquire(&gate, &writer) == 0,
+        "writer acquire");
+    CHECK(wl_columnar_source_access_reader_acquire(&gate, &reader) == EBUSY,
+        "reader blocked by writer");
+    CHECK(wl_columnar_source_access_writer_acquire(&gate, &writer) == EINVAL,
+        "writer token reuse rejected");
+    CHECK(wl_columnar_source_access_writer_release(&writer) == 0,
+        "writer release");
+}
+
+struct cross_thread_arg {
+    wl_columnar_source_access_reader_t *reader;
+    int result;
+};
+
+static void *
+cross_thread_release(void *opaque)
+{
+    struct cross_thread_arg *arg = opaque;
+    arg->result = wl_columnar_source_access_reader_release(arg->reader);
+    return NULL;
+}
+
+static void
+test_invalid_and_cross_thread(void)
+{
+    wl_columnar_source_access_gate_t gate = { 0 };
+    wl_columnar_source_access_reader_t reader = { 0 }, copy;
+    struct cross_thread_arg arg = { &reader, 0 };
+    thread_t thread;
+    wl_columnar_source_access_gate_init(&gate);
+    CHECK(wl_columnar_source_access_reader_acquire(NULL, &reader) == EINVAL,
+        "null gate rejected");
+    CHECK(wl_columnar_source_access_reader_acquire(&gate, NULL) == EINVAL,
+        "null token rejected");
+    CHECK(wl_columnar_source_access_reader_acquire(&gate, &reader) == 0,
+        "reader acquire");
+    copy = reader;
+    CHECK(wl_columnar_source_access_reader_release(&copy) == EINVAL,
+        "copy rejected");
+    CHECK(thread_create(&thread, cross_thread_release, &arg) == 0,
+        "cross-thread setup");
+    CHECK(thread_join(&thread) == 0 && arg.result == EINVAL,
+        "cross-thread release rejected");
+    CHECK(reader.owner == &gate
+        && atomic_load_explicit(&gate.state, memory_order_relaxed) == 1,
+        "cross-thread failure preserved state");
+    CHECK(wl_columnar_source_access_reader_release(&reader) == 0,
+        "owning thread release");
+    CHECK(wl_columnar_source_access_reader_release(&reader) == EINVAL,
+        "duplicate release rejected");
+}
+
+static void
+test_reader_overflow(void)
+{
+    wl_columnar_source_access_gate_t gate = { 0 };
+    wl_columnar_source_access_reader_t reader = { 0 };
+    wl_columnar_source_access_gate_init(&gate);
+    atomic_store_explicit(&gate.state,
+        WL_COLUMNAR_SOURCE_ACCESS_WRITER - 1u, memory_order_relaxed);
+    CHECK(wl_columnar_source_access_reader_acquire(&gate, &reader)
+        == EOVERFLOW, "reader overflow rejected");
+    CHECK(atomic_load_explicit(&gate.state, memory_order_relaxed)
+        == WL_COLUMNAR_SOURCE_ACCESS_WRITER - 1u && reader.owner == NULL,
+        "overflow preserved state");
+    atomic_store_explicit(&gate.state, WL_COLUMNAR_SOURCE_ACCESS_WRITER,
+        memory_order_relaxed);
+    CHECK(wl_columnar_source_access_reader_acquire(&gate, &reader) == EBUSY,
+        "writer sentinel remains exclusive");
+}
+
+struct stress_arg {
+    wl_columnar_source_access_gate_t *gate;
+    unsigned iterations;
+    unsigned successes;
+};
+
+static void *
+reader_stress(void *opaque)
+{
+    struct stress_arg *arg = opaque;
+    for (unsigned i = 0; i < arg->iterations; i++) {
+        wl_columnar_source_access_reader_t token = { 0 };
+        int rc = wl_columnar_source_access_reader_acquire(arg->gate, &token);
+        if (rc == 0) {
+            arg->successes++;
+            if (wl_columnar_source_access_reader_release(&token) != 0)
+                return (void *)1;
+        } else if (rc != EBUSY && rc != EOVERFLOW)
+            return (void *)1;
+    }
+    return NULL;
+}
+
+static void
+test_concurrent_readers(void)
+{
+    enum { THREADS = 4 };
+    wl_columnar_source_access_gate_t gate = { 0 };
+    struct stress_arg args[THREADS];
+    thread_t threads[THREADS];
+    wl_columnar_source_access_gate_init(&gate);
+    for (unsigned i = 0; i < THREADS; i++) {
+        args[i] = (struct stress_arg){ &gate, 1000, 0 };
+        CHECK(thread_create(&threads[i], reader_stress, &args[i]) == 0,
+            "reader stress create");
+    }
+    for (unsigned i = 0; i < THREADS; i++)
+        CHECK(thread_join(&threads[i]) == 0, "reader stress join");
+    unsigned total = 0;
+    for (unsigned i = 0; i < THREADS; i++)
+        total += args[i].successes;
+    CHECK(total > 0 && atomic_load_explicit(&gate.state, memory_order_relaxed)
+        == 0, "reader stress balanced");
+}
+
+struct publication_arg {
+    wl_columnar_source_access_gate_t *gate;
+    atomic_int *payload;
+    unsigned iterations;
+    atomic_int failed;
+    atomic_uint_fast64_t writer_active;
+    atomic_uint_fast64_t writer_successes;
+    atomic_uint_fast64_t reader_successes;
+};
+
+static void *
+publication_writer(void *opaque)
+{
+    struct publication_arg *arg = opaque;
+    wl_columnar_source_access_writer_t token = { 0 };
+    for (unsigned i = 0; i < arg->iterations; i++) {
+        int rc = wl_columnar_source_access_writer_acquire(arg->gate, &token);
+        if (rc == 0) {
+            atomic_store_explicit(&arg->writer_active, 1,
+                memory_order_relaxed);
+            atomic_store_explicit(arg->payload, (int)(i & 1u),
+                memory_order_relaxed);
+            atomic_fetch_add_explicit(&arg->writer_successes, 1,
+                memory_order_relaxed);
+            atomic_store_explicit(&arg->writer_active, 0,
+                memory_order_relaxed);
+            if (wl_columnar_source_access_writer_release(&token) != 0) {
+                atomic_store_explicit(&arg->failed, 1, memory_order_relaxed);
+                return NULL;
+            }
+        } else if (rc != EBUSY) {
+            atomic_store_explicit(&arg->failed, 1, memory_order_relaxed);
+            return NULL;
+        }
+    }
+    return NULL;
+}
+
+static void *
+publication_reader(void *opaque)
+{
+    struct publication_arg *arg = opaque;
+    for (unsigned i = 0; i < arg->iterations; i++) {
+        wl_columnar_source_access_reader_t token = { 0 };
+        int rc = wl_columnar_source_access_reader_acquire(arg->gate, &token);
+        if (rc == 0) {
+            if (atomic_load_explicit(&arg->writer_active,
+                memory_order_relaxed) != 0) {
+                atomic_store_explicit(&arg->failed, 1, memory_order_relaxed);
+                return NULL;
+            }
+            int value = atomic_load_explicit(arg->payload,
+                    memory_order_relaxed);
+            atomic_fetch_add_explicit(&arg->reader_successes, 1,
+                memory_order_relaxed);
+            if ((value != 0 && value != 1)
+                || wl_columnar_source_access_reader_release(&token) != 0) {
+                atomic_store_explicit(&arg->failed, 1, memory_order_relaxed);
+                return NULL;
+            }
+        } else if (rc != EBUSY) {
+            atomic_store_explicit(&arg->failed, 1, memory_order_relaxed);
+            return NULL;
+        }
+    }
+    return NULL;
+}
+
+static void
+test_writer_publication(void)
+{
+    wl_columnar_source_access_gate_t gate = { 0 };
+    atomic_int payload = 0;
+    struct publication_arg arg = { &gate, &payload, 1 };
+    thread_t writer, reader;
+    wl_columnar_source_access_gate_init(&gate);
+    atomic_store_explicit(&arg.failed, 0, memory_order_relaxed);
+    atomic_store_explicit(&arg.writer_active, 0, memory_order_relaxed);
+    atomic_store_explicit(&arg.writer_successes, 0, memory_order_relaxed);
+    atomic_store_explicit(&arg.reader_successes, 0, memory_order_relaxed);
+    CHECK(thread_create(&writer, publication_writer, &arg) == 0,
+        "writer publication create");
+    CHECK(thread_create(&reader, publication_reader, &arg) == 0,
+        "reader publication create");
+    CHECK(thread_join(&writer) == 0 && thread_join(&reader) == 0
+        && atomic_load_explicit(&arg.failed, memory_order_relaxed) == 0
+        && atomic_load_explicit(&arg.writer_successes, memory_order_relaxed) > 0
+        && atomic_load_explicit(&arg.reader_successes, memory_order_relaxed) > 0
+        && atomic_load_explicit(&gate.state, memory_order_relaxed) == 0,
+        "writer publication ordering and balance");
+}
+
+int
+main(void)
+{
+    printf("Source access gate tests (#1492)\n");
+    test_lifecycle();
+    test_invalid_and_cross_thread();
+    test_reader_overflow();
+    test_concurrent_readers();
+    test_writer_publication();
+    printf("%s\n", failures == 0 ? "PASS" : "FAIL");
+    return failures == 0 ? 0 : 1;
+}

--- a/wirelog/columnar/source_access.h
+++ b/wirelog/columnar/source_access.h
@@ -1,0 +1,201 @@
+/*
+ * columnar/source_access.h - allocation-free source reader/writer gate
+ *
+ * Internal, inactive until the source-lifetime integration units enable it.
+ */
+
+#ifndef WL_COLUMNAR_SOURCE_ACCESS_H
+#define WL_COLUMNAR_SOURCE_ACCESS_H
+
+#include "columnar/mem_ledger.h"
+#include "wirelog/thread.h"
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#define WL_COLUMNAR_SOURCE_ACCESS_WRITER UINT64_MAX
+
+typedef struct wl_columnar_source_access_gate {
+    wl_atomic_u64 state;
+} wl_columnar_source_access_gate_t;
+
+typedef struct wl_columnar_source_access_reader {
+    wl_columnar_source_access_gate_t *owner;
+    uintptr_t identity;
+#if defined(WL_HAVE_C11_THREADS)
+    thrd_t owner_thread;
+#elif defined(_WIN32) || defined(_WIN64)
+    DWORD owner_thread;
+#else
+    pthread_t owner_thread;
+#endif
+    bool thread_valid;
+} wl_columnar_source_access_reader_t;
+
+typedef struct wl_columnar_source_access_writer {
+    wl_columnar_source_access_gate_t *owner;
+    uintptr_t identity;
+#if defined(WL_HAVE_C11_THREADS)
+    thrd_t owner_thread;
+#elif defined(_WIN32) || defined(_WIN64)
+    DWORD owner_thread;
+#else
+    pthread_t owner_thread;
+#endif
+    bool thread_valid;
+} wl_columnar_source_access_writer_t;
+
+static inline void
+wl_columnar_source_access_gate_init(wl_columnar_source_access_gate_t *gate)
+{
+    if (gate)
+        atomic_store_explicit(&gate->state, 0, memory_order_relaxed);
+}
+
+static inline bool
+wl_columnar_source_access_reader_thread_equal(
+    const wl_columnar_source_access_reader_t *token)
+{
+#if defined(WL_HAVE_C11_THREADS)
+    return token->thread_valid
+           && thrd_equal(token->owner_thread, thrd_current()) != 0;
+#elif defined(_WIN32) || defined(_WIN64)
+    return token->thread_valid
+           && token->owner_thread == GetCurrentThreadId();
+#else
+    return token->thread_valid
+           && pthread_equal(token->owner_thread, pthread_self()) != 0;
+#endif
+}
+
+static inline bool
+wl_columnar_source_access_writer_thread_equal(
+    const wl_columnar_source_access_writer_t *token)
+{
+#if defined(WL_HAVE_C11_THREADS)
+    return token->thread_valid
+           && thrd_equal(token->owner_thread, thrd_current()) != 0;
+#elif defined(_WIN32) || defined(_WIN64)
+    return token->thread_valid
+           && token->owner_thread == GetCurrentThreadId();
+#else
+    return token->thread_valid
+           && pthread_equal(token->owner_thread, pthread_self()) != 0;
+#endif
+}
+
+static inline int
+wl_columnar_source_access_reader_acquire(
+    wl_columnar_source_access_gate_t *gate,
+    wl_columnar_source_access_reader_t *token)
+{
+    uint64_t observed;
+    if (!gate || !token || token->owner || token->identity != 0
+        || token->thread_valid)
+        return EINVAL;
+    observed = atomic_load_explicit(&gate->state, memory_order_acquire);
+    for (;;) {
+        if (observed == WL_COLUMNAR_SOURCE_ACCESS_WRITER)
+            return EBUSY;
+        if (observed == WL_COLUMNAR_SOURCE_ACCESS_WRITER - 1u)
+            return EOVERFLOW;
+        if (atomic_compare_exchange_weak_explicit(&gate->state, &observed,
+            observed + 1u, memory_order_acquire, memory_order_relaxed))
+            break;
+    }
+    token->owner = gate;
+    token->identity = (uintptr_t)token;
+#if defined(WL_HAVE_C11_THREADS)
+    token->owner_thread = thrd_current();
+#elif defined(_WIN32) || defined(_WIN64)
+    token->owner_thread = GetCurrentThreadId();
+#else
+    token->owner_thread = pthread_self();
+#endif
+    token->thread_valid = true;
+    return 0;
+}
+
+static inline int
+wl_columnar_source_access_reader_release(
+    wl_columnar_source_access_reader_t *token)
+{
+    wl_columnar_source_access_gate_t *gate;
+    uint64_t observed;
+    if (!token || token->identity != (uintptr_t)token || !token->owner
+        || !wl_columnar_source_access_reader_thread_equal(token))
+        return EINVAL;
+    gate = token->owner;
+    observed = atomic_load_explicit(&gate->state, memory_order_acquire);
+    for (;;) {
+        if (observed == 0 || observed == WL_COLUMNAR_SOURCE_ACCESS_WRITER)
+            return EINVAL;
+        if (atomic_compare_exchange_weak_explicit(&gate->state, &observed,
+            observed - 1u, memory_order_release, memory_order_relaxed))
+            break;
+    }
+    token->owner = NULL;
+    token->identity = 0;
+    token->thread_valid = false;
+    return 0;
+}
+
+static inline int
+wl_columnar_source_access_writer_acquire(
+    wl_columnar_source_access_gate_t *gate,
+    wl_columnar_source_access_writer_t *token)
+{
+    uint64_t expected;
+    if (!gate || !token || token->owner || token->identity != 0
+        || token->thread_valid)
+        return EINVAL;
+    for (;;) {
+        expected = 0;
+        if (atomic_compare_exchange_weak_explicit(&gate->state, &expected,
+            WL_COLUMNAR_SOURCE_ACCESS_WRITER, memory_order_acquire,
+            memory_order_relaxed))
+            break;
+        if (expected != 0)
+            return EBUSY;
+    }
+    token->owner = gate;
+    token->identity = (uintptr_t)token;
+#if defined(WL_HAVE_C11_THREADS)
+    token->owner_thread = thrd_current();
+#elif defined(_WIN32) || defined(_WIN64)
+    token->owner_thread = GetCurrentThreadId();
+#else
+    token->owner_thread = pthread_self();
+#endif
+    token->thread_valid = true;
+    return 0;
+}
+
+static inline int
+wl_columnar_source_access_writer_release(
+    wl_columnar_source_access_writer_t *token)
+{
+    wl_columnar_source_access_gate_t *gate;
+    uint64_t observed;
+    if (!token || token->identity != (uintptr_t)token || !token->owner
+        || !wl_columnar_source_access_writer_thread_equal(token))
+        return EINVAL;
+    gate = token->owner;
+    observed = atomic_load_explicit(&gate->state, memory_order_acquire);
+    if (observed != WL_COLUMNAR_SOURCE_ACCESS_WRITER)
+        return EINVAL;
+    for (;;) {
+        if (atomic_compare_exchange_weak_explicit(&gate->state, &observed, 0,
+            memory_order_release, memory_order_relaxed))
+            break;
+        if (observed != WL_COLUMNAR_SOURCE_ACCESS_WRITER)
+            return EBUSY;
+    }
+    token->owner = NULL;
+    token->identity = 0;
+    token->thread_valid = false;
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## Summary
- add an allocation-free internal reader/writer source-access gate for #1492
- enforce reader sharing, exclusive nonrecursive writers, token address/thread ownership, overflow handling, and failure-state preservation
- keep the gate inactive and out of production source lists
- add deterministic unit/TSan coverage, a Bash-gated contract check, and the 102-row threading atomic audit

## Validation
- Meson: 355 passed, 0 failed, 14 skipped
- focused source-access, contract, and gate-skip tests: 3/3 passed
- 30 direct source-access repetitions passed
- uncrustify, threading audit, allocation-free contract, diff check, and text-size gate passed
- rebased onto `origin/main` at `b7d420654a793f6e4dee387c7edd00eb24392361`

Closes #1492
