### PR TITLE
refactor: share admitted append-all growth

### DIFF
--- a/tests/test_memory_admission_relation.c
+++ b/tests/test_memory_admission_relation.c
@@ -533,6 +533,102 @@ test_arena_append_all_admission_boundary(void)
         wl_columnar_memory_governor_ref_release(ref);
 }
 
+static col_rel_t *
+make_full_heap_relation(const char *name, int64_t value, bool timestamps)
+{
+    col_rel_t *relation = col_rel_new_auto(name, 1);
+    if (!relation)
+        return NULL;
+    for (uint32_t i = 0; i < COL_REL_INIT_CAP; i++) {
+        if (col_rel_append_row(relation, &value) != 0)
+            goto fail;
+    }
+    if (timestamps && col_rel_enable_timestamps(relation) != 0)
+        goto fail;
+    return relation;
+
+fail:
+    col_rel_destroy(relation);
+    return NULL;
+}
+
+static void
+test_heap_append_all_admission_boundary(void)
+{
+    const uint64_t exact_bytes = (uint64_t)(COL_REL_INIT_CAP * 2u)
+        * (sizeof(int64_t) + sizeof(col_delta_timestamp_t));
+    wl_columnar_memory_resolution_t resolution;
+    wl_columnar_memory_governor_ref_t *ref;
+    col_rel_t *dst;
+    col_rel_t *src;
+    int64_t value = 61;
+
+    make_resolution(&resolution, exact_bytes);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    dst = ref ? make_full_heap_relation("heap-append-exact", value, true)
+              : NULL;
+    src = col_rel_new_auto("heap-append-source", 1);
+    CHECK(dst && src, "heap append_all exact-fit setup");
+    if (dst && src) {
+        uint64_t old_storage = dst->storage_generation;
+        CHECK(col_rel_enable_timestamps(src) == 0
+            && col_rel_append_row(src, &value) == 0,
+            "heap append_all timestamp source");
+        src->timestamps[0].iteration = 77;
+        CHECK(col_rel_attach_memory_governor(dst, ref) == 0,
+            "heap append_all exact-fit governor");
+        CHECK(col_rel_append_all(dst, src, NULL) == 0,
+            "heap append_all exact-fit admission");
+        CHECK(dst->capacity == COL_REL_INIT_CAP * 2u
+            && dst->nrows == COL_REL_INIT_CAP + 1u
+            && dst->timestamps[COL_REL_INIT_CAP].iteration == 77,
+            "heap append_all exact-fit state");
+        CHECK(dst->storage_generation == old_storage + 1u,
+            "heap append_all advanced storage generation once");
+        CHECK(dst->retained_reserved_bytes == exact_bytes
+            && wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == exact_bytes,
+            "heap append_all exact-fit reservation");
+    }
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+
+    make_resolution(&resolution, exact_bytes - 1u);
+    ref = wl_columnar_memory_governor_ref_create(&resolution);
+    dst = ref ? make_full_heap_relation("heap-append-denied", value, true)
+              : NULL;
+    src = col_rel_new_auto("heap-append-denied-source", 1);
+    CHECK(dst && src, "heap append_all denial setup");
+    if (dst && src) {
+        int64_t *old_columns = dst->columns[0];
+        col_delta_timestamp_t *old_timestamps = dst->timestamps;
+        uint32_t old_capacity = dst->capacity;
+        uint32_t old_rows = dst->nrows;
+        uint64_t old_storage = dst->storage_generation;
+        CHECK(col_rel_enable_timestamps(src) == 0
+            && col_rel_append_row(src, &value) == 0,
+            "heap append_all denial timestamp source");
+        CHECK(col_rel_attach_memory_governor(dst, ref) == 0,
+            "heap append_all denial governor");
+        CHECK(col_rel_append_all(dst, src, NULL) == ENOMEM,
+            "heap append_all one-byte denial");
+        CHECK(dst->columns[0] == old_columns
+            && dst->timestamps == old_timestamps
+            && dst->capacity == old_capacity && dst->nrows == old_rows
+            && dst->storage_generation == old_storage,
+            "heap append_all denial changed state");
+        CHECK(wl_columnar_memory_reserved(
+                wl_columnar_memory_governor_ref_get(ref)) == 0,
+            "heap append_all denial left reservation");
+    }
+    col_rel_destroy(src);
+    col_rel_destroy(dst);
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+}
+
 static void
 test_cow_capacity_denial_preserves_state(void)
 {
@@ -618,6 +714,7 @@ main(void)
     test_unmanaged_arena_append_all_preserves_ownership();
     test_unmanaged_arena_append_all_reconciles_timestamps();
     test_arena_append_all_admission_boundary();
+    test_heap_append_all_admission_boundary();
     test_cow_capacity_denial_preserves_state();
     test_cow_ledger_reconcile_is_exact_once();
     if (failures != 0)

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1868,42 +1868,12 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
             transitioned = true;
             alias_release_pending = true;
         } else {
-            /* Heap-owned growth: admit (retained relations), prepare, commit,
-             * publish -- see col_rel_append_row. */
-            wl_columnar_memory_reservation_t pending;
-            int pending_rc = 0;
-            uint64_t new_bytes = 0;
-            bool admitted = dst->memory_governor != NULL;
-            if (admitted) {
-                pending_rc = col_rel_reserve_retained(dst, new_cap, &pending);
-                if (pending_rc < 0)
-                    goto allocation_failure;
-                if (!col_rel_retained_bytes(dst->ncols, new_cap,
-                    dst->timestamps != NULL, &new_bytes)) {
-                    col_rel_reservation_rollback(&pending);
-                    goto allocation_failure;
-                }
-            }
-            int64_t **new_cols = NULL;
-            col_delta_timestamp_t *new_ts = NULL;
-            int prepare_rc = col_rel_prepare_resize(dst, new_cap,
-                    &new_cols, &new_ts);
-            if (prepare_rc != 0) {
-                if (admitted)
-                    col_rel_reservation_rollback(&pending);
-                rc = prepare_rc;
-                goto cleanup;
-            }
-            if (admitted && pending_rc > 0
-                && col_rel_publish_retained_reservation(dst, &pending,
-                new_bytes) != 0) {
-                col_rel_reservation_rollback(&pending);
-                col_columns_free(new_cols, dst->ncols);
-                free(new_ts);
-                goto allocation_failure;
-            }
-            col_rel_publish_resize(dst, new_cols, new_ts, new_cap);
-            transitioned = false;
+            /* Heap-owned growth uses the same admission transaction as
+             * append_row.  The helper reconciles the ledger and advances
+             * storage generation exactly once. */
+            if (col_rel_reserve_capacity_admitted(dst, new_cap, NULL) != 0)
+                goto fail_prepared;
+            transitioned = true;
         }
         if (!transitioned) {
             col_rel_ledger_reconcile(dst, ledger_before);

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1871,8 +1871,9 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
             /* Heap-owned growth uses the same admission transaction as
              * append_row.  The helper reconciles the ledger and advances
              * storage generation exactly once. */
-            if (col_rel_reserve_capacity_admitted(dst, new_cap, NULL) != 0)
-                goto fail_prepared;
+            rc = col_rel_reserve_capacity_admitted(dst, new_cap, NULL);
+            if (rc != 0)
+                goto cleanup;
             transitioned = true;
         }
         if (!transitioned) {
@@ -1941,8 +1942,6 @@ invalid:
 overflow:
     rc = EOVERFLOW;
     goto cleanup;
-allocation_failure:
-    rc = ENOMEM;
 cleanup:
     free(prepared_types);
     if (prepared_schema_ok)


### PR DESCRIPTION
## Summary

Closes #1476.

Route heap-owned `col_rel_append_all` growth through the same admitted-capacity transaction used by `col_rel_append_row`. Preserve unmanaged-arena and shared/arena promotion behavior. Add timestamp-aware exact-fit and one-byte-denial regression coverage, including unchanged destination state and reservation cleanup on denial.

PR #1474, which introduced the shared helper, is now merged into `main`; this PR is rebased directly onto current `main` and contains only the append-all migration and its tests.

## Validation

- `meson test -C build memory_admission_relation relation_append compaction csv_streaming --print-errorlogs` — 4/4 passed
- `meson test -C build-asan memory_admission_relation relation_append compaction csv_streaming --print-errorlogs` — 4/4 passed
- `git diff --cached --check` — passed
- commit hook uncrustify — passed
