### PR TITLE
feat: report bounded join fallback diagnostics

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -389,7 +389,8 @@ workloads:
 | `1` | At `col_session_destroy()` print the coordinator summary: one header line with `rss_peak`, the ledger table, and one aggregate line for TDD workers. |
 | `2` | Additionally print the full ledger of every TDD worker when it is torn down (after every TDD stratum, so this is verbose). |
 
-Example (`W=8`, the 100-edge closure fixture, level 2, one worker shown):
+Example (`W=8`, the 100-edge closure fixture, level 2, one worker shown;
+`WIRELOG_JOIN_BATCH_BYTES` is enabled):
 
 ```
 [wirelog mem] scope=coordinator workers=8 rss_peak=9.0MB
@@ -403,6 +404,7 @@ Example (`W=8`, the 100-edge closure fixture, level 2, one worker shown):
   STORED       current=100.6KB    peak=248.6KB    cap=4.7GB
   TEMPORARY    current=0B         peak=80.0KB     cap=4.7GB
 [wirelog mem] tdd_workers reports=8 peak_max=12.5MB peak_sum=98.8MB
+[wirelog mem] join_batch fallback_count=0 last_reason=none rows_per_batch=128
 [wirelog mem] scope=worker id=0 workers=8
 [wirelog mem] budget=10.5GB current=12.3MB peak=12.5MB
   RELATION     current=0B         peak=128.0KB    cap=5.2GB
@@ -414,6 +416,26 @@ Example (`W=8`, the 100-edge closure fixture, level 2, one worker shown):
 largest single worker peak and `peak_sum` the sum of all worker peaks (an
 upper bound on their concurrent footprint, since the same worker slot is
 recreated per stratum).
+
+When `WIRELOG_JOIN_BATCH_BYTES` is enabled, the coordinator report appends a
+session-local bounded-join line:
+
+```text
+[wirelog mem] join_batch fallback_count=N last_reason=NAME rows_per_batch=N
+```
+
+`fallback_count` counts bounded-mode shapes that fell back to the one-shot
+join. `last_reason` is the final recorded reason (`none` when the count is
+zero); the vocabulary is the stable names returned by the bounded-join
+eligibility contract, such as `cross-join`, `delta-right`, `filtered-right`,
+`no-arrangement`, and `row-too-large`. `rows_per_batch` is the batch size
+chosen by the most recently successful producer in that session, or zero when
+the most recent bounded attempt made no producer decision. It is not an
+aggregate across joins and is diagnostic only. The line is omitted when
+`WIRELOG_JOIN_BATCH_BYTES` is unset, invalid, or zero, preserving the report
+when bounded joins are disabled. With `WL_MEM_REPORT=2`, the same fields are
+printed for each worker session; worker values are not folded into the
+coordinator line.
 
 The report is not async-signal-safe and goes to `stderr` unconditionally;
 it does not use `WL_LOG`.

--- a/tests/test_mem_report_contract.py
+++ b/tests/test_mem_report_contract.py
@@ -2,15 +2,19 @@
 """Check that WL_MEM_REPORT is diagnostic-only and byte fields are stable."""
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 
 
-def run(binary, enabled):
+def run(binary, enabled, batch_bytes=None):
     env = os.environ.copy()
     env.pop("WL_MEM_REPORT", None)
+    env.pop("WIRELOG_JOIN_BATCH_BYTES", None)
     if enabled:
         env["WL_MEM_REPORT"] = "1"
+    if batch_bytes is not None:
+        env["WIRELOG_JOIN_BATCH_BYTES"] = str(batch_bytes)
     return subprocess.run([binary], capture_output=True, text=True,
                           env=env, timeout=300, check=False)
 
@@ -23,6 +27,7 @@ def main():
         binary = str(Path(name))
         off = run(binary, False)
         on = run(binary, True)
+        on_batch = run(binary, True, 4096)
         if off.returncode != on.returncode or off.stdout != on.stdout:
             raise AssertionError(f"WL_MEM_REPORT changed result output: {binary}")
         if "[wirelog mem]" in off.stderr:
@@ -32,6 +37,16 @@ def main():
         for field in ("budget_bytes=", "current_bytes=", "peak_bytes="):
             if field not in on.stderr:
                 raise AssertionError(f"missing {field}: {binary}")
+        if "join_batch " in on.stderr:
+            raise AssertionError(f"disabled join report leaked into output: {binary}")
+        if on_batch.returncode != on.returncode or on_batch.stdout != on.stdout:
+            raise AssertionError(f"join report changed result output: {binary}")
+        join_lines = [line for line in on_batch.stderr.splitlines()
+                      if line.startswith("[wirelog mem] join_batch ")]
+        if not join_lines or any(not re.search(
+                r"fallback_count=\d+ last_reason=\S+ rows_per_batch=\d+$",
+                line) for line in join_lines):
+            raise AssertionError(f"invalid bounded join report: {binary}")
     return 0
 
 

--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -1002,6 +1002,46 @@ test_join_output_limit_scaling(void)
 }
 
 static int
+test_worker_join_batch_diagnostics_are_local(void)
+{
+    TEST("worker bounded-join diagnostics do not inherit coordinator state");
+
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *coord = make_coordinator(&plan, &prog);
+    if (!coord) {
+        FAIL("coordinator creation");
+        return 1;
+    }
+    coord->join_batch_bytes = 4096;
+    coord->join_batch_strict = true;
+    coord->join_batch_fallback_count = 7;
+    coord->join_batch_last_reason = 6;
+    coord->join_batch_warned_reasons = 0x40;
+    coord->join_batch_last_rows_per_batch = 128;
+
+    wl_col_session_t worker;
+    memset(&worker, 0, sizeof(worker));
+    int rc = col_worker_session_create(coord, 0, NULL, 0, &worker);
+    int ok = rc == 0
+        && worker.join_batch_bytes == coord->join_batch_bytes
+        && worker.join_batch_strict == coord->join_batch_strict
+        && worker.join_batch_fallback_count == 0
+        && worker.join_batch_last_reason == 0
+        && worker.join_batch_warned_reasons == 0
+        && worker.join_batch_last_rows_per_batch == 0;
+    if (rc == 0)
+        col_worker_session_destroy(&worker);
+    cleanup_coordinator(coord, plan, prog);
+    if (!ok) {
+        FAIL("worker inherited coordinator bounded-join diagnostics");
+        return 1;
+    }
+    PASS();
+    return 0;
+}
+
+static int
 test_hash_table_independent(void)
 {
     TEST("worker hash table is independent (lazy rebuild)");
@@ -1605,6 +1645,7 @@ main(void)
     test_session_add_rel_reuses_removed_slot();
     test_session_add_rel_invalidates_filter_cache();
     test_join_output_limit_scaling();
+    test_worker_join_batch_diagnostics_are_local();
     test_rdf_graph_column_propagates_to_col_rel();
     test_rdf_no_graph_column_defaults_to_false();
     test_rdf_graph_metadata_auto_created_when_any_graph_column();

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1604,6 +1604,9 @@ typedef struct wl_col_session_t {
     uint32_t join_batch_fallback_count;
     uint8_t join_batch_last_reason;
     uint8_t join_batch_warned_reasons; /* one WL_LOG warning per reason */
+    /* Rows selected by the most recently successful bounded producer in this
+     * session. Zero means the latest bounded attempt made no decision. */
+    uint32_t join_batch_last_rows_per_batch;
     /* Issue #959: high-water mark of a single join's output, per session.
      * Workers are separate sessions, so each carries its own -- which is the
      * number needed to decide whether dividing the row cap by W is right:

--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -1049,6 +1049,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
     col_join_batch_eligibility_t batch_elig = col_join_batch_eligibility(sess,
             kc, used_right_delta, op->right_filter_expr.size != 0);
     bool bounded = batch_elig == COL_JOIN_BATCH_ELIGIBLE;
+    if (sess->join_batch_bytes > 0)
+        sess->join_batch_last_rows_per_batch = 0;
     if (sess->join_batch_bytes > 0 && !bounded) {
         if (sess->join_batch_strict) {
             free(lk);
@@ -1359,6 +1361,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
             } else if (create_rc != 0) {
                 join_rc = create_rc;
             } else {
+                sess->join_batch_last_rows_per_batch =
+                    col_join_batch_rows_per_batch(cont);
                 join_rc = col_join_batch_run_to_relation(cont, sess, out);
                 wl_columnar_continuation_destroy(cont);
                 if (join_rc != 0)

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -10,6 +10,7 @@
 
 #include "columnar/compound_side.h"
 #include "columnar/internal.h"
+#include "columnar/join_batch.h"
 #include "wirelog/util/log.h"
 
 #include "../wirelog-internal.h"
@@ -973,6 +974,26 @@ mem_report_bytes(uint64_t bytes, char *buf, size_t len)
     return buf;
 }
 
+/* Bounded-join diagnostics are session-local rather than ledger fields.
+ * Keep them in an appended line so existing WL_MEM_REPORT consumers retain
+ * their ordering and byte-valued fields. */
+static void
+col_session_mem_report_join_batch(const wl_col_session_t *sess)
+{
+    const char *reason = "none";
+
+    if (!sess || sess->join_batch_bytes == 0)
+        return;
+    if (sess->join_batch_fallback_count > 0)
+        reason = col_join_batch_eligibility_name(
+            (col_join_batch_eligibility_t)sess->join_batch_last_reason);
+    fprintf(stderr,
+        "[wirelog mem] join_batch fallback_count=%u last_reason=%s "
+        "rows_per_batch=%u\n",
+        sess->join_batch_fallback_count, reason,
+        sess->join_batch_last_rows_per_batch);
+}
+
 /*
  * col_compute_worker_cap: RAM-aware worker cap formula (Issue #409).
  * See declaration in internal.h for full rationale and examples.
@@ -1586,6 +1607,7 @@ col_session_destroy(wl_session_t *session)
             (unsigned long long)sess->mem_worker_reports,
             mem_report_bytes(sess->mem_worker_peak_max, b2, sizeof(b2)),
             mem_report_bytes(sess->mem_worker_peak_sum, b3, sizeof(b3)));
+        col_session_mem_report_join_batch(sess);
     }
 
     /* Issue #959: report the join-output high-water mark before teardown.
@@ -1762,6 +1784,13 @@ col_worker_session_create(wl_col_session_t *coordinator,
     wl_columnar_memory_governor_ref_retain(out_worker->memory_governor);
     out_worker->extension_expr_status = 0;
     out_worker->callback_session_key = coordinator->callback_session_key;
+    /* Diagnostic counters describe this worker's session, not the
+     * coordinator that was copied above.  Keep the batch configuration but
+     * start worker-local observations from an empty state. */
+    out_worker->join_batch_fallback_count = 0;
+    out_worker->join_batch_last_reason = 0;
+    out_worker->join_batch_warned_reasons = 0;
+    out_worker->join_batch_last_rows_per_batch = 0;
     out_worker->delta_events = NULL;
     out_worker->delta_event_count = 0;
     out_worker->delta_event_capacity = 0;
@@ -1971,6 +2000,7 @@ col_worker_session_destroy(wl_col_session_t *worker)
         fprintf(stderr, "[wirelog mem] scope=worker id=%u workers=%u\n",
             worker->worker_id, worker->num_workers);
         wl_mem_ledger_report(&worker->mem_ledger);
+        col_session_mem_report_join_batch(worker);
     }
 
     /* Free mat_cache entries (all worker-owned since zeroed at create) */


### PR DESCRIPTION
## Summary
- expose bounded keyed-join fallback count, reason, and last producer batch size in `WL_MEM_REPORT`
- preserve existing report output when `WIRELOG_JOIN_BATCH_BYTES` is unset, invalid, or zero
- isolate worker diagnostics and document the append-only report contract

## Validation
- focused normal: 5/5 passed
- focused ASan/UBSan: 5/5 passed
- full normal Meson: 355 passed, 13 skipped, 0 failed
- release `.text` gate: delta -4747 bytes (threshold +5120)

## Dependency
Stacked on PR #1503 (`issue-1476-append-all-admission`), which is stacked on PR #1474 for #1446. Retarget to `main` after the parent PRs merge.

Closes #1478
