### PR TITLE
fix: release filtered joins on early exits

### DIFF
--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -1036,6 +1036,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
     if (!lk || !rk) {
         free(lk);
         free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return ENOMEM;
@@ -1068,6 +1070,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
     if (!out) {
         free(lk);
         free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return ENOMEM;
@@ -1076,6 +1080,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
         free(lk);
         free(rk);
         col_rel_destroy(out);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return ENOMEM;
@@ -1098,6 +1104,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
         && !sess->coordinator) {
         free(lk);
         free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return eval_stack_push(stack, out, true);
@@ -1108,6 +1116,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
         col_rel_destroy(out);
         free(lk);
         free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return ENOMEM;
@@ -1155,6 +1165,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
             col_rel_destroy(out);
             free(lk);
             free(rk);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
             if (left_e.owned)
                 col_rel_destroy(left);
             return ENOMEM;
@@ -1292,6 +1304,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
                 col_rel_destroy(out);
                 free(lk);
                 free(rk);
+                if (right_filtered)
+                    col_rel_destroy(right_filtered);
                 if (left_e.owned)
                     col_rel_destroy(left);
                 return ENOMEM;
@@ -1323,6 +1337,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
                 col_rel_destroy(out);
                 free(lk);
                 free(rk);
+                if (right_filtered)
+                    col_rel_destroy(right_filtered);
                 if (left_e.owned)
                     col_rel_destroy(left);
                 return ENOMEM;
@@ -2082,6 +2098,8 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
     if (!lk || !rk) {
         free(lk);
         free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return ENOMEM;
@@ -2098,6 +2116,8 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
     if (!col_join_key_types_compatible(left, lk, right, rk, kc)) {
         free(lk);
         free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return EINVAL;
@@ -2113,6 +2133,8 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
     if (!out) {
         free(lk);
         free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return ENOMEM;
@@ -2121,6 +2143,8 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
         free(lk);
         free(rk);
         col_rel_destroy(out);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return ENOMEM;
@@ -2132,6 +2156,8 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
         WL_MEM_SUBSYS_RELATION, 80)) {
         free(lk);
         free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return eval_stack_push(stack, out, true);
@@ -2142,6 +2168,8 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
         col_rel_destroy(out);
         free(lk);
         free(rk);
+        if (right_filtered)
+            col_rel_destroy(right_filtered);
         if (left_e.owned)
             col_rel_destroy(left);
         return ENOMEM;
@@ -2391,6 +2419,8 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
             col_rel_destroy(out);
             free(lk);
             free(rk);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
             if (left_e.owned)
                 col_rel_destroy(left);
             return ENOMEM;


### PR DESCRIPTION
## Summary
- release owned `right_filtered` relations on every early exit after filtering in both keyed join operators
- preserve cached-filter ownership and all antijoin/semijoin behavior

Closes #1505

## Validation
- normal `diff_join` and `tdd_recursive`: passed
- ASan/UBSan `diff_join` and `tdd_recursive`: passed
- full normal Meson: 354 passed, 13 skipped, 0 failed
