### PR TITLE
Track columnar relation source ownership

### DIFF
--- a/tests/test_relation_generations.c
+++ b/tests/test_relation_generations.c
@@ -131,6 +131,41 @@ test_storage_only_cow_and_compaction(void)
 }
 
 static void
+test_flattened_storage_ownership(void)
+{
+    col_rel_t *source = new_relation();
+    col_rel_t *alias = new_relation();
+    col_rel_t *flattened = new_relation();
+    int64_t row = 41;
+    CHECK(source && alias && flattened, "storage ownership relations");
+    CHECK(col_rel_append_row(source, &row) == 0, "storage ownership seed");
+    CHECK(col_rel_install_shared_view(alias, source) == 0,
+        "owner to alias publication");
+    CHECK(alias->storage_owner == source
+        && alias->storage_owner_identity == source->relation_identity
+        && source->storage_alias_borrows == 1,
+        "alias records its ultimate owner");
+    CHECK(col_rel_storage_owner_destroy_status(source) == EBUSY,
+        "owner reports active alias borrow");
+
+    CHECK(col_rel_install_shared_view(flattened, alias) == 0,
+        "alias-of-alias publication");
+    CHECK(flattened->storage_owner == source
+        && flattened->storage_owner != alias
+        && source->storage_alias_borrows == 2,
+        "alias-of-alias is flattened to the root");
+
+    CHECK(col_rel_set(flattened, 0, 0, 99) == 0,
+        "flattened alias COW");
+    CHECK(flattened->storage_owner == flattened
+        && source->storage_alias_borrows == 1
+        && col_rel_get(source, 0, 0) == row
+        && col_rel_get(flattened, 0, 0) == 99,
+        "COW releases only the flattened alias borrow");
+    cleanup_relations();
+}
+
+static void
 test_copy_and_shared_semantics(void)
 {
     col_rel_t *src = new_relation();
@@ -1128,6 +1163,7 @@ main(void)
 {
     test_same_row_count_mutation();
     test_storage_only_cow_and_compaction();
+    test_flattened_storage_ownership();
     test_copy_and_shared_semantics();
     test_rollback_fresh_generation();
     test_overflow_boundary();

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -173,10 +173,12 @@ tdd_destroy_delta_slots(col_eval_tdd_worker_ctx_t *ctxs, uint32_t W,
 static void
 tdd_cleanup_workers(wl_col_session_t *coord)
 {
-    for (uint32_t w = 0; w < coord->tdd_workers_count; w++) {
-        if (coord->tdd_workers[w].coordinator != NULL)
-            col_worker_session_destroy(&coord->tdd_workers[w]);
-        memset(&coord->tdd_workers[w], 0, sizeof(wl_col_session_t));
+    for (uint32_t w = coord->tdd_workers_count; w > 0; w--) {
+        uint32_t worker_index = w - 1;
+        if (coord->tdd_workers[worker_index].coordinator != NULL)
+            col_worker_session_destroy(&coord->tdd_workers[worker_index]);
+        memset(&coord->tdd_workers[worker_index], 0,
+            sizeof(wl_col_session_t));
     }
     coord->tdd_workers_count = 0;
     coord->tdd_active_workers = 0;
@@ -1000,7 +1002,7 @@ tdd_seed_global_read_initial_deltas(const wl_plan_stratum_t *sp,
         const char *rel_name = sp->relations[ri].name;
         col_rel_t *src = session_find_rel(coord, rel_name);
 
-        for (uint32_t w = 0; w < W; w++)
+        for (uint32_t w = W; w-- > 0; )
             session_remove_rel(&coord->tdd_workers[w], dname);
 
         if (!src || src->nrows == 0)
@@ -1991,7 +1993,7 @@ tdd_broadcast_relation_delta(const wl_plan_stratum_t *sp, uint32_t ri,
 {
     const char *dname = sp->relations[ri].delta_name;
 
-    for (uint32_t w = 0; w < W; w++)
+    for (uint32_t w = W; w-- > 0; )
         session_remove_rel(&coord->tdd_workers[w], dname);
 
     uint32_t total = 0, ncols = 0;
@@ -2284,7 +2286,7 @@ tdd_exchange_deltas(const wl_plan_stratum_t *sp,
         }
 
         /* Remove stale $d$ from every worker before scatter. */
-        for (uint32_t w = 0; w < W; w++)
+        for (uint32_t w = W; w-- > 0; )
             session_remove_rel(&coord->tdd_workers[w], dname);
 
         /* Issue #361: Relations without EXCHANGE ops use default col0
@@ -3356,7 +3358,7 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
         uint64_t prepare_t0 = now_ns();
 
         /* Remove stale $d$ from workers */
-        for (uint32_t w = 0; w < W; w++)
+        for (uint32_t w = W; w-- > 0; )
             session_remove_rel(&coord->tdd_workers[w], dname);
 
         /* Step 1: Union all worker deltas */
@@ -3564,7 +3566,7 @@ tdd_owner_exchange_deltas(const wl_plan_stratum_t *sp,
         const char *rel_name = sp->relations[ri].name;
         uint64_t prepare_t0 = now_ns();
 
-        for (uint32_t w = 0; w < W; w++)
+        for (uint32_t w = W; w-- > 0; )
             session_remove_rel(&coord->tdd_workers[w], dname);
 
         uint32_t total = 0, ncols = 0;
@@ -3766,7 +3768,7 @@ tdd_global_read_exchange_deltas(const wl_plan_stratum_t *sp,
         const char *dname = sp->relations[ri].delta_name;
         const char *rel_name = sp->relations[ri].name;
 
-        for (uint32_t w = 0; w < W; w++)
+        for (uint32_t w = W; w-- > 0; )
             session_remove_rel(&coord->tdd_workers[w], dname);
 
         uint32_t total = 0;

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -300,7 +300,7 @@ col_columns_copy_row(int64_t **dst_cols, uint32_t dst_row,
  *   - mem_ledger is also NULL on the copy (Issue #554, R-1)
  *   See wirelog/columnar/ownership_flags_design.md for the full rationale.
  */
-typedef struct {
+typedef struct col_rel {
     char *name;                /* owned, null-terminated                */
     uint32_t ncols;            /* columns per tuple (0 = unset)         */
     int64_t **columns;         /* owned, column-major: columns[col][row] */
@@ -477,6 +477,17 @@ typedef struct {
     uint64_t relation_identity;
     uint64_t view_generation;
     uint64_t storage_generation;
+
+    /* Source-storage ownership for zero-copy shared views (Issue #1493).
+     * Shared views canonicalize this pointer to the ultimate relation that
+     * owns the borrowed column buffers.  Alias chains are never persisted:
+     * an alias has storage_alias_borrows == 0, while the root counts its
+     * direct and flattened aliases.  The gate is intentionally not wired to
+     * production mutation/teardown until the later lifecycle units. */
+    struct col_rel *storage_owner;
+    uint64_t storage_owner_identity;
+    uint64_t storage_owner_generation;
+    uint32_t storage_alias_borrows;
 } col_rel_t;
 
 /* MSVC in its default C mode neither defines __STDC_VERSION__ >= 201112L
@@ -568,9 +579,12 @@ wl_columnar_relation_touch_view(col_rel_t *rel)
 static inline void
 wl_columnar_relation_touch_storage(col_rel_t *rel)
 {
-    if (rel)
+    if (rel) {
         (void)wl_columnar_relation_generation_advance(
             &rel->storage_generation);
+        if (!rel->storage_owner || rel->storage_owner == rel)
+            rel->storage_owner_generation = rel->storage_generation;
+    }
 }
 
 static inline void
@@ -1836,6 +1850,8 @@ col_rel_ledger_release(col_rel_t *r);
 void
 col_rel_destroy(col_rel_t *r);
 int
+col_rel_destroy_checked(col_rel_t *r);
+int
 col_rel_set_schema(col_rel_t *r, uint32_t ncols, const char *const *col_names);
 int
 col_rel_set_column_types(col_rel_t *r,
@@ -2079,6 +2095,14 @@ col_rel_compact(col_rel_t *r);
 int
 col_rel_install_shared_view(col_rel_t *dst, const col_rel_t *src);
 
+/* Source-storage ownership helpers (Issue #1493).  These are internal
+ * bookkeeping operations; caller exclusion and public teardown remain the
+ * responsibility of the follow-up lifecycle units. */
+int col_rel_storage_owner_resolve(const col_rel_t *src,
+    col_rel_t **out_owner);
+int col_rel_storage_alias_release(col_rel_t *alias);
+int col_rel_storage_owner_destroy_status(const col_rel_t *owner);
+
 /* Test seam for the non-wrapping relation identity allocator. */
 int
 col_rel_test_set_next_identity(uint64_t next);
@@ -2214,7 +2238,7 @@ col_rel_t *
 session_find_rel(wl_col_session_t *sess, const char *name);
 int
 session_add_rel(wl_col_session_t *sess, col_rel_t *r);
-void
+int
 session_remove_rel(wl_col_session_t *sess, const char *name);
 
 /* ======================================================================== */

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -108,6 +108,70 @@ wl_columnar_relation_radix_bench_enabled(void)
 
 static int col_rel_grow_owned_transition(col_rel_t *r, uint32_t new_cap);
 
+static void
+col_rel_storage_owner_init(col_rel_t *r)
+{
+    if (!r)
+        return;
+    r->storage_owner = r;
+    r->storage_owner_identity = r->relation_identity;
+    r->storage_owner_generation = r->storage_generation;
+    r->storage_alias_borrows = 0;
+}
+
+int
+col_rel_storage_owner_resolve(const col_rel_t *src, col_rel_t **out_owner)
+{
+    col_rel_t *owner;
+    if (!src || !out_owner)
+        return EINVAL;
+    owner = src->storage_owner;
+    if (!owner) {
+        owner = (col_rel_t *)src; /* legacy zero-initialized relation */
+        owner->storage_owner = owner;
+        owner->storage_owner_identity = owner->relation_identity;
+        owner->storage_owner_generation = owner->storage_generation;
+    }
+    if (owner->storage_owner != owner
+        || owner->storage_owner_identity != owner->relation_identity
+        || owner->storage_owner_generation == 0
+        || !wl_columnar_relation_generation_valid(
+            owner->storage_owner_generation))
+        return EINVAL;
+    if (owner != src && src->storage_owner != owner)
+        return EINVAL;
+    *out_owner = owner;
+    return 0;
+}
+
+int
+col_rel_storage_alias_release(col_rel_t *alias)
+{
+    col_rel_t *owner;
+    if (!alias || !alias->storage_owner)
+        return 0;
+    if (alias->storage_owner == alias)
+        return 0;
+    owner = alias->storage_owner;
+    if (owner->storage_owner != owner
+        || owner->storage_owner_identity != owner->relation_identity
+        || owner->storage_alias_borrows == 0
+        || alias->storage_owner_identity != owner->relation_identity)
+        return EINVAL;
+    owner->storage_alias_borrows--;
+    col_rel_storage_owner_init(alias);
+    return 0;
+}
+
+int
+col_rel_storage_owner_destroy_status(const col_rel_t *owner)
+{
+    if (!owner || owner->storage_owner != owner
+        || owner->storage_owner_identity != owner->relation_identity)
+        return EINVAL;
+    return owner->storage_alias_borrows == 0 ? 0 : EBUSY;
+}
+
 /* Prepare a complete private replacement for a relation resize.  This is
  * deliberately independent of the current ownership mode: a shared or arena
  * relation is copied into heap storage and is not changed until the caller
@@ -423,6 +487,7 @@ col_rel_grow_owned_transition(col_rel_t *r, uint32_t new_cap)
     free(old_shared_flags);
     free(old_timestamps);
     col_rel_ledger_reconcile(r, ledger_before);
+    (void)col_rel_storage_alias_release(r);
     wl_columnar_relation_touch_storage(r);
     return 0;
 
@@ -505,6 +570,7 @@ col_rel_cow_unshare(col_rel_t *r, uint32_t new_cap)
     }
     col_rel_ledger_reconcile(r, ledger_before);
     /* Private columns replaced the borrowed view: one storage epoch. */
+    (void)col_rel_storage_alias_release(r);
     wl_columnar_relation_touch_storage(r);
     return 0;
 
@@ -641,6 +707,12 @@ col_rel_free_contents(col_rel_t *r)
 {
     if (!r)
         return;
+    if (r->storage_owner == r && r->storage_alias_borrows > 0)
+        return;
+    /* Alias bookkeeping is released before the relation is zeroed.  The
+     * owner itself is not denied destruction here; #1494 wires this status
+     * into the synchronous teardown transaction. */
+    (void)col_rel_storage_alias_release(r);
     if (r->memory_governor) {
         if (r->retained_reserved_bytes > 0)
             (void)wl_columnar_memory_release(&r->retained_reservation);
@@ -690,16 +762,25 @@ col_rel_free_contents(col_rel_t *r)
  * itself.  Pool-owned structs have their memory reclaimed on pool_reset();
  * calling free() on them would corrupt the pool allocator.
  */
-void
-col_rel_destroy(col_rel_t *r)
+int
+col_rel_destroy_checked(col_rel_t *r)
 {
     if (!r)
-        return;
+        return 0;
+    if (col_rel_storage_owner_destroy_status(r) == EBUSY)
+        return EBUSY;
     bool from_pool = r->pool_owned;
     col_rel_free_contents(r); /* memset zeroes pool_owned */
     if (!from_pool)
         free(r);
     /* If pool_owned: struct memory freed on pool_reset(), skip free(). */
+    return 0;
+}
+
+void
+col_rel_destroy(col_rel_t *r)
+{
+    (void)col_rel_destroy_checked(r);
 }
 
 /*
@@ -1001,6 +1082,7 @@ col_rel_alloc(col_rel_t **out, const char *name)
     r->view_generation = 1u;
     r->storage_generation = 1u;
     r->pool_owned = false;
+    col_rel_storage_owner_init(r);
     *out = r;
     return 0;
 }
@@ -1643,6 +1725,8 @@ free_merge_buf:
 int
 col_rel_install_shared_view(col_rel_t *dst, const col_rel_t *src)
 {
+    col_rel_t *source_owner = NULL;
+    col_rel_t *old_owner = NULL;
     wirelog_column_type_t *shared_types = NULL;
     int64_t **shared_columns = NULL;
     bool *shared_flags = NULL;
@@ -1661,6 +1745,23 @@ col_rel_install_shared_view(col_rel_t *dst, const col_rel_t *src)
     bool prepared_schema_ok = false;
     int prepare_rc = ENOMEM;
     if (!dst || !src || dst == src || dst->ncols != src->ncols)
+        return EINVAL;
+    if (!dst->storage_owner)
+        col_rel_storage_owner_init(dst);
+    if (col_rel_storage_owner_resolve(src, &source_owner) != 0
+        || col_rel_storage_owner_resolve(dst, &old_owner) != 0)
+        return EINVAL;
+    /* Pool and arena owners can outlive their relation descriptors through
+     * allocator reset, so they cannot be represented by a raw owner pointer
+     * until the later allocator-lifetime unit adds a stable control block. */
+    if (source_owner->pool_owned || source_owner->arena_owned)
+        return EINVAL;
+    /* A relation with live flattened aliases cannot itself become an alias:
+     * doing so would invalidate the children's canonical owner. */
+    if (dst->storage_alias_borrows > 0 || source_owner == dst
+        || source_owner->storage_alias_borrows == UINT32_MAX)
+        return source_owner == dst ? EINVAL : EBUSY;
+    if (old_owner != dst && old_owner->storage_alias_borrows == 0)
         return EINVAL;
     /* A shared-view publication is a new epoch on the destination.  Reserve
      * the next values before replacing any buffers so exhaustion cannot leave
@@ -1793,6 +1894,12 @@ col_rel_install_shared_view(col_rel_t *dst, const col_rel_t *src)
         bool old_arena_owned = dst->arena_owned;
         uint64_t ledger_before = col_rel_owned_ledger_bytes(dst);
 
+        /* Ownership metadata is committed with the borrowed columns. Both
+        * counters were validated before any destination state changed. */
+        if (old_owner != dst)
+            old_owner->storage_alias_borrows--;
+        source_owner->storage_alias_borrows++;
+
         /* Commit point: all allocations and schema preparation succeeded. */
         if (!old_arena_owned && old_columns) {
             for (uint32_t c = 0; c < dst->ncols; c++)
@@ -1849,6 +1956,10 @@ col_rel_install_shared_view(col_rel_t *dst, const col_rel_t *src)
         memcpy(dst->run_ends, src->run_ends, sizeof(dst->run_ends));
         dst->schema = prepared_schema;
         dst->schema_ok = prepared_schema_ok;
+        dst->storage_owner = source_owner;
+        dst->storage_owner_identity = source_owner->relation_identity;
+        dst->storage_owner_generation = source_owner->storage_generation;
+        dst->storage_alias_borrows = 0;
         dst->view_generation++;
         dst->storage_generation++;
         col_rel_ledger_reconcile(dst, ledger_before);
@@ -2063,6 +2174,7 @@ col_rel_pool_new_like(delta_pool_t *pool, const char *name,
         r->relation_identity = identity;
         r->view_generation = 1u;
         r->storage_generation = 1u;
+        col_rel_storage_owner_init(r);
         r->name = wl_strdup(name);
         if (!r->name) {
             return col_rel_pool_fallback_like(pool, r, name, like);
@@ -2123,6 +2235,7 @@ col_rel_pool_new_auto(delta_pool_t *pool, wl_arena_t *arena,
         r->relation_identity = identity;
         r->view_generation = 1u;
         r->storage_generation = 1u;
+        col_rel_storage_owner_init(r);
         r->name = wl_strdup(name);
         if (!r->name) {
             return col_rel_pool_fallback_auto(pool, r, name, ncols);
@@ -2274,6 +2387,7 @@ col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)
     }
     dst->view_generation = src->view_generation;
     dst->storage_generation = src->storage_generation;
+    col_rel_storage_owner_init(dst);
     dst->ncols = src->ncols;
     dst->nrows = src->nrows;
     dst->capacity = src->capacity;

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -155,6 +155,32 @@ session_note_inserted_input(wl_col_session_t *sess, const col_rel_t *relation,
     sess->snapshot_stable_valid = false;
 }
 
+/* Shared views borrow a root relation's columns. Teardown must release the
+ * aliases before their root; otherwise the root's owner metadata would point
+ * at freed storage. A root owned by another session is left for that owner
+ * to retry after its aliases have drained. */
+static void
+session_destroy_relation_array(col_rel_t **relations, uint32_t count)
+{
+    for (int pass = 0; pass < 2; pass++) {
+        for (uint32_t i = 0; i < count; i++) {
+            col_rel_t *relation = relations[i];
+            bool is_alias;
+            if (!relation)
+                continue;
+            is_alias = relation->storage_owner
+                && relation->storage_owner != relation;
+            if ((pass == 0) != is_alias)
+                continue;
+            if (!is_alias
+                && col_rel_storage_owner_destroy_status(relation) == EBUSY)
+                continue;
+            col_rel_destroy(relation);
+            relations[i] = NULL;
+        }
+    }
+}
+
 int
 session_add_rel(wl_col_session_t *sess, col_rel_t *r)
 {
@@ -167,6 +193,10 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
             return ENOMEM;
         *heap = *r;
         heap->pool_owned = false;
+        heap->storage_owner = heap;
+        heap->storage_owner_identity = heap->relation_identity;
+        heap->storage_owner_generation = heap->storage_generation;
+        heap->storage_alias_borrows = 0;
         /* Zero out source slot so pool_reset doesn't double-free contents */
         memset(r, 0, sizeof(*r));
         pool_src = r;
@@ -187,7 +217,9 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
             if (sess->rels[i] == r)
                 return 0;
             session_invalidate_relation_caches(sess, r->name);
-            col_rel_destroy(sess->rels[i]);
+            int destroy_rc = col_rel_destroy_checked(sess->rels[i]);
+            if (destroy_rc != 0)
+                goto busy;
             sess->rels[i] = r;
             return 0;
         }
@@ -227,6 +259,18 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
 
     return 0;
 
+busy:
+    if (pool_src) {
+        *pool_src = *r;
+        pool_src->pool_owned = true;
+        pool_src->storage_owner = pool_src;
+        pool_src->storage_owner_identity = pool_src->relation_identity;
+        pool_src->storage_owner_generation = pool_src->storage_generation;
+        pool_src->storage_alias_borrows = 0;
+        free(r);
+    }
+    return EBUSY;
+
 oom:
     /* Undo the pool-to-heap promotion.  A failed session_add_rel leaves the
      * relation with the caller, which destroys it via col_rel_destroy(), so
@@ -241,23 +285,29 @@ oom:
     if (pool_src) {
         *pool_src = *r;
         pool_src->pool_owned = true;
+        pool_src->storage_owner = pool_src;
+        pool_src->storage_owner_identity = pool_src->relation_identity;
+        pool_src->storage_owner_generation = pool_src->storage_generation;
+        pool_src->storage_alias_borrows = 0;
         free(r);
     }
     return ENOMEM;
 }
 
-void
+int
 session_remove_rel(wl_col_session_t *sess, const char *name)
 {
     for (uint32_t i = 0; i < sess->nrels; i++) {
         if (sess->rels[i] && strcmp(sess->rels[i]->name, name) == 0) {
             session_invalidate_relation_caches(sess, name);
-            col_rel_destroy(sess->rels[i]);
+            if (col_rel_destroy_checked(sess->rels[i]) != 0)
+                return EBUSY;
             sess->rels[i] = NULL;
             session_rel_free_hash(sess);
-            return;
+            return 0;
         }
     }
+    return ENOENT;
 }
 
 typedef struct wl_columnar_session_tdd_decision {
@@ -1529,10 +1579,7 @@ col_session_create_internal(const wl_plan_t *plan, uint32_t num_workers,
     return 0;
 
 oom:
-    for (uint32_t i = 0; i < sess->nrels; i++) {
-        col_rel_free_contents(sess->rels[i]);
-        free(sess->rels[i]);
-    }
+    session_destroy_relation_array(sess->rels, sess->nrels);
     free((void *)sess->rels);
     wl_workqueue_destroy(sess->wq);       /* NULL-safe */
     delta_pool_destroy(sess->delta_pool); /* NULL-safe */
@@ -1617,10 +1664,17 @@ col_session_destroy(wl_session_t *session)
      * etc.) before any of the other teardown frees them. NULL-safe. */
     if (sess->rotation_ops && sess->rotation_ops->destroy)
         sess->rotation_ops->destroy(sess);
-    for (uint32_t i = 0; i < sess->nrels; i++) {
-        col_rel_free_contents(sess->rels[i]);
-        free(sess->rels[i]);
+    /* Worker views may borrow coordinator relation storage.  Drain workers
+     * before coordinator relations so their owner borrows are released before
+     * the coordinator root is destroyed. */
+    if (sess->tdd_workers) {
+        for (uint32_t w = sess->tdd_workers_count; w > 0; w--)
+            col_worker_session_destroy(&sess->tdd_workers[w - 1]);
+        free(sess->tdd_workers);
+        sess->tdd_workers = NULL;
+        sess->tdd_workers_count = 0;
     }
+    session_destroy_relation_array(sess->rels, sess->nrels);
     free((void *)sess->rels);
     /* Free relation name hash table (Issue #281) */
     session_rel_free_hash(sess);
@@ -1674,15 +1728,6 @@ col_session_destroy(wl_session_t *session)
      * Worker sessions have progress.entries == NULL (set in col_worker_session_create)
      * so this is safe to call on both coordinator and worker sessions. */
     wl_frontier_progress_destroy(&sess->progress);
-    /* Issue #318: Free TDD worker sessions array.
-     * Workers that have been initialized (w < tdd_workers_count) are destroyed
-     * first, then the array itself is freed.  Worker sessions that were
-     * initialized via col_worker_session_create own their own arena/pool/rels. */
-    if (sess->tdd_workers) {
-        for (uint32_t w = 0; w < sess->tdd_workers_count; w++)
-            col_worker_session_destroy(&sess->tdd_workers[w]);
-        free(sess->tdd_workers);
-    }
     /* Issue #386: Free filtered relation cache */
     for (uint32_t i = 0; i < sess->filt_cache_count; i++) {
         free(sess->filt_cache[i].rel_name);
@@ -1988,12 +2033,7 @@ col_worker_session_destroy(wl_col_session_t *worker)
     col_session_free_filt_arrangements(worker);
 
     /* Free owned relations (partition data) */
-    for (uint32_t i = 0; i < worker->nrels; i++) {
-        if (worker->rels[i]) {
-            col_rel_free_contents(worker->rels[i]);
-            free(worker->rels[i]);
-        }
-    }
+    session_destroy_relation_array(worker->rels, worker->nrels);
     free((void *)worker->rels);
 
     /* Free hash table (may have been lazily built) */
@@ -2589,8 +2629,9 @@ col_session_step(wl_session_t *session)
     for (uint32_t i = 0; i < sess->nrels;) {
         col_rel_t *r = sess->rels[i];
         if (r && strncmp(r->name, "$r$", 3) == 0) {
-            session_remove_rel(sess, r->name);
-            /* session_remove_rel shifts array, so don't increment i */
+            if (session_remove_rel(sess, r->name) != 0)
+                i++;
+            /* A successful removal leaves the same index for the next slot. */
         } else {
             i++;
         }


### PR DESCRIPTION
Closes #1493

Depends on #1502 and is intentionally stacked on `issue-1492-source-gate`.

This adds canonical source-owner tracking for shared columnar relations, flattens aliases, releases ownership on COW, rejects pool/arena sources, and makes teardown alias-safe across TDD worker/coordinator sessions.

Validation:
- Normal focused: 4/4 passed
- ASan/UBSan focused: 4/4 passed
- Normal broad: 356 passed, 13 skipped, 0 failed
- `git diff --check`: passed