### PR TITLE
Attach relation source gates to checked teardown

### DIFF
--- a/tests/test_relation_generations.c
+++ b/tests/test_relation_generations.c
@@ -220,6 +220,35 @@ test_copy_and_shared_semantics(void)
 }
 
 static void
+test_source_reader_blocks_checked_destroy(void)
+{
+    col_rel_t *rel = new_relation();
+    wl_columnar_source_access_reader_t reader = { 0 };
+    char *name;
+    uint64_t identity;
+    uint64_t generation;
+    uint32_t rows;
+
+    CHECK(rel != NULL, "source reader relation allocation");
+    name = rel->name;
+    identity = rel->relation_identity;
+    generation = rel->storage_generation;
+    rows = rel->nrows;
+    CHECK(col_rel_source_reader_acquire(rel, &reader) == 0,
+        "source reader acquisition");
+    CHECK(col_rel_destroy_checked(rel) == EBUSY,
+        "active source reader blocks checked destroy");
+    CHECK(rel->name == name && rel->relation_identity == identity
+        && rel->storage_generation == generation && rel->nrows == rows,
+        "busy destroy changed relation state");
+    CHECK(col_rel_source_reader_release(&reader) == 0,
+        "source reader release");
+    CHECK(col_rel_destroy_checked(rel) == 0,
+        "destroy retry after reader release");
+    owned_relation_count--;
+}
+
+static void
 test_rollback_fresh_generation(void)
 {
     col_rel_t *rel = new_relation();
@@ -1164,6 +1193,7 @@ main(void)
     test_same_row_count_mutation();
     test_storage_only_cow_and_compaction();
     test_flattened_storage_ownership();
+    test_source_reader_blocks_checked_destroy();
     test_copy_and_shared_semantics();
     test_rollback_fresh_generation();
     test_overflow_boundary();

--- a/tests/test_source_access.c
+++ b/tests/test_source_access.c
@@ -4,6 +4,7 @@
 #include "wirelog/thread.h"
 
 #include <stdio.h>
+#include <string.h>
 
 static int failures;
 
@@ -89,6 +90,20 @@ test_invalid_and_cross_thread(void)
         "owning thread release");
     CHECK(wl_columnar_source_access_reader_release(&reader) == EINVAL,
         "duplicate release rejected");
+
+    memset(&reader, 0, sizeof(reader));
+    arg.result = EINVAL;
+    CHECK(wl_columnar_source_access_reader_acquire_transferable(&gate,
+        &reader) == 0, "transferable reader acquire");
+    copy = reader;
+    CHECK(wl_columnar_source_access_reader_release(&copy) == EINVAL,
+        "copied transferable reader release rejected");
+    CHECK(thread_create(&thread, cross_thread_release, &arg) == 0,
+        "transferable cross-thread setup");
+    CHECK(thread_join(&thread) == 0 && arg.result == 0,
+        "transferable cross-thread release");
+    CHECK(atomic_load_explicit(&gate.state, memory_order_relaxed) == 0
+        && reader.owner == NULL, "transferable release balanced gate");
 }
 
 static void

--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -1050,7 +1050,7 @@ test_hash_table_independent(void)
 static int
 test_shared_view_relation_destroy(void)
 {
-    TEST("worker shared-view relation destroy does not free coordinator data");
+    TEST("worker shared-view lease blocks source destroy until cleanup");
 
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
@@ -1061,27 +1061,27 @@ test_shared_view_relation_destroy(void)
     }
 
     int64_t rows[] = { 1, 2, 2, 3, 3, 4, 4, 5 };
-    if (insert_edges(coord, rows, 4) != 0) {
+    col_rel_t *src = col_rel_new_auto("borrowed", 2);
+    int source_rc = src ? 0 : ENOMEM;
+    for (uint32_t i = 0; i < 4 && source_rc == 0; i++)
+        source_rc = col_rel_append_row(src, &rows[i * 2]);
+    if (source_rc != 0) {
+        col_rel_destroy(src);
         cleanup_coordinator(coord, plan, prog);
-        FAIL("insert edges");
+        FAIL("standalone source creation");
         return 1;
     }
 
-    col_rel_t *src = session_find_rel(coord, "edge");
-    if (!src) {
-        cleanup_coordinator(coord, plan, prog);
-        FAIL("source relation missing");
-        return 1;
-    }
-
-    col_rel_t *view = col_rel_new_auto("edge", src->ncols);
+    col_rel_t *view = col_rel_new_auto("borrowed", src->ncols);
     if (!view) {
+        col_rel_destroy(src);
         cleanup_coordinator(coord, plan, prog);
         FAIL("view allocation");
         return 1;
     }
     if (col_rel_install_shared_view(view, src) != 0) {
         col_rel_destroy(view);
+        col_rel_destroy(src);
         cleanup_coordinator(coord, plan, prog);
         FAIL("shared view install");
         return 1;
@@ -1092,39 +1092,123 @@ test_shared_view_relation_destroy(void)
     memset(&worker, 0, sizeof(worker));
     if (col_worker_session_create(coord, 0, parts, 1, &worker) != 0) {
         col_rel_destroy(view);
+        col_rel_destroy(src);
         cleanup_coordinator(coord, plan, prog);
         FAIL("worker create");
         return 1;
     }
 
-    col_rel_t *worker_rel = session_find_rel(&worker, "edge");
+    col_rel_t *worker_rel = session_find_rel(&worker, "borrowed");
     if (!worker_rel || worker_rel->columns[0] != src->columns[0]) {
         col_worker_session_destroy(&worker);
+        col_rel_destroy(src);
         cleanup_coordinator(coord, plan, prog);
         FAIL("worker relation is not a shared view");
         return 1;
     }
 
+    int ok = atomic_load_explicit(&src->source_access.state,
+            memory_order_acquire) == 1
+        && src->storage_alias_borrows == 1;
     for (int i = 0; i < 16; i++) {
-        if (col_rel_install_shared_view(worker_rel, src) != 0) {
+        if (wl_columnar_session_install_shared_view(&worker, worker_rel,
+            src) != 0) {
             col_worker_session_destroy(&worker);
+            col_rel_destroy(src);
             cleanup_coordinator(coord, plan, prog);
             FAIL("shared view refresh");
             return 1;
         }
+        if (atomic_load_explicit(&src->source_access.state,
+            memory_order_acquire) != 1
+            || src->storage_alias_borrows != 1)
+            ok = 0;
     }
 
-    col_worker_session_destroy(&worker);
+    char *source_name = src->name;
+    uint64_t source_identity = src->relation_identity;
+    if (col_rel_destroy_checked(src) != EBUSY
+        || src->name != source_name
+        || src->relation_identity != source_identity)
+        ok = 0;
 
-    col_rel_t *coord_rel = session_find_rel(coord, "edge");
-    int ok = coord_rel && coord_rel->nrows == 4
-        && coord_rel->columns[0][0] == 1
-        && coord_rel->columns[1][3] == 5;
+    col_rel_t *next_src = col_rel_new_auto("replacement", 2);
+    int next_source_rc = next_src ? 0 : ENOMEM;
+    for (uint32_t i = 0; i < 4 && next_source_rc == 0; i++)
+        next_source_rc = col_rel_append_row(next_src, &rows[i * 2]);
+    if (next_source_rc != 0) {
+        col_rel_destroy(next_src);
+        col_worker_session_destroy(&worker);
+        col_rel_destroy(src);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("replacement source creation");
+        return 1;
+    }
+
+    wl_columnar_source_access_writer_t writer = { 0 };
+    if (wl_columnar_source_access_writer_acquire(&next_src->source_access,
+        &writer) != 0) {
+        col_rel_destroy(next_src);
+        col_worker_session_destroy(&worker);
+        col_rel_destroy(src);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("source writer claim");
+        return 1;
+    }
+    int64_t *old_column = worker_rel->columns[0];
+    uint32_t old_nrows = worker_rel->nrows;
+    uint64_t old_view_generation = worker_rel->view_generation;
+    if (wl_columnar_session_install_shared_view(&worker, worker_rel,
+        next_src) != EBUSY
+        || worker_rel->columns[0] != old_column
+        || worker_rel->nrows != old_nrows
+        || worker_rel->view_generation != old_view_generation
+        || atomic_load_explicit(&src->source_access.state,
+        memory_order_acquire) != 1
+        || src->storage_alias_borrows != 1)
+        ok = 0;
+    if (wl_columnar_source_access_writer_release(&writer) != 0)
+        ok = 0;
+
+    if (wl_columnar_session_install_shared_view(&worker, worker_rel,
+        next_src) != 0) {
+        col_worker_session_destroy(&worker);
+        col_rel_destroy(next_src);
+        col_rel_destroy(src);
+        cleanup_coordinator(coord, plan, prog);
+        FAIL("transactional source refresh");
+        return 1;
+    }
+    if (worker_rel->columns[0] != next_src->columns[0]
+        || atomic_load_explicit(&src->source_access.state,
+        memory_order_acquire) != 0
+        || src->storage_alias_borrows != 0
+        || atomic_load_explicit(&next_src->source_access.state,
+        memory_order_acquire) != 1
+        || next_src->storage_alias_borrows != 1)
+        ok = 0;
+    if (col_rel_destroy_checked(src) != 0)
+        ok = 0;
+    src = NULL;
+
+    source_name = next_src->name;
+    source_identity = next_src->relation_identity;
+    if (col_rel_destroy_checked(next_src) != EBUSY
+        || next_src->name != source_name
+        || next_src->relation_identity != source_identity)
+        ok = 0;
+
+    col_worker_session_destroy(&worker);
+    if (atomic_load_explicit(&next_src->source_access.state,
+        memory_order_acquire) != 0
+        || next_src->storage_alias_borrows != 0
+        || col_rel_destroy_checked(next_src) != 0)
+        ok = 0;
 
     cleanup_coordinator(coord, plan, prog);
 
     if (!ok) {
-        FAIL("coordinator relation corrupted");
+        FAIL("source lease lifetime or retry contract");
         return 1;
     }
     PASS();

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -339,6 +339,10 @@ nonrec_copy_relation_slice(const col_rel_t *src, const char *name,
 }
 
 static int
+tdd_shared_view_deep_copy_fallback(wl_col_session_t *sess, col_rel_t *dst,
+    const col_rel_t *src, int shared_view_rc);
+
+static int
 nonrec_make_shared_relation_view(const col_rel_t *src, col_rel_t **out)
 {
     if (!src || !out)
@@ -348,7 +352,7 @@ nonrec_make_shared_relation_view(const col_rel_t *src, col_rel_t **out)
         return ENOMEM;
     int rc = col_rel_install_shared_view(view, src);
     if (rc != 0) {
-        rc = col_rel_append_all(view, src, NULL);
+        rc = tdd_shared_view_deep_copy_fallback(NULL, view, src, rc);
         if (rc != 0) {
             col_rel_destroy(view);
             return rc;
@@ -356,6 +360,40 @@ nonrec_make_shared_relation_view(const col_rel_t *src, col_rel_t **out)
     }
     *out = view;
     return 0;
+}
+
+static int
+tdd_shared_view_deep_copy_fallback(wl_col_session_t *sess, col_rel_t *dst,
+    const col_rel_t *src, int shared_view_rc)
+{
+    wl_columnar_source_access_reader_t reader = { 0 };
+    int rc;
+
+    /* EBUSY can mean terminal source destruction already claimed the gate.
+     * Never turn that exclusion result into an unprotected source read. */
+    if (shared_view_rc != ENOMEM && shared_view_rc != EINVAL
+        && shared_view_rc != EOVERFLOW)
+        return shared_view_rc;
+    rc = col_rel_source_reader_acquire(src, &reader);
+    if (rc != 0)
+        return rc;
+    if (sess) {
+        dst->nrows = 0;
+        wl_columnar_relation_touch_view(dst);
+    }
+    rc = col_rel_append_all(dst, src, NULL);
+    int release_rc = col_rel_source_reader_release(&reader);
+    if (rc == 0 && release_rc != 0)
+        rc = release_rc;
+    if (rc == 0 && sess) {
+        /* append_all COW-detaches a non-empty shared destination before it
+         * returns.  Empty copies may remain aliases and retain their lease. */
+        int retire_rc
+            = wl_columnar_session_retire_source_lease(sess, dst);
+        if (retire_rc != 0 && retire_rc != EBUSY)
+            rc = retire_rc;
+    }
+    return rc;
 }
 
 int
@@ -964,21 +1002,39 @@ tdd_refresh_global_read_relation(const wl_plan_stratum_t *sp,
             continue;
         if (src->ncols > 0) {
             if (dst->ncols != src->ncols) {
-                col_rel_t *view = NULL;
-                int rc = nonrec_make_shared_relation_view(src, &view);
-                if (rc != 0)
-                    return rc;
+                col_rel_t *view = col_rel_new_like(src->name, src);
+                if (!view)
+                    return ENOMEM;
+                int rc = col_rel_install_shared_view(view, src);
+                bool shared = rc == 0;
+                if (!shared) {
+                    rc = tdd_shared_view_deep_copy_fallback(NULL, view,
+                            src, rc);
+                    if (rc != 0) {
+                        col_rel_destroy(view);
+                        return rc;
+                    }
+                }
                 rc = session_add_rel(&coord->tdd_workers[w], view);
                 if (rc != 0) {
                     col_rel_destroy(view);
                     return rc;
                 }
+                if (shared) {
+                    rc = wl_columnar_session_adopt_shared_view(
+                        &coord->tdd_workers[w], view);
+                    if (rc != 0) {
+                        (void)session_remove_rel(&coord->tdd_workers[w],
+                            view->name);
+                        return rc;
+                    }
+                }
             } else {
-                int rc = col_rel_install_shared_view(dst, src);
+                int rc = wl_columnar_session_install_shared_view(
+                    &coord->tdd_workers[w], dst, src);
                 if (rc != 0) {
-                    dst->nrows = 0;
-                    wl_columnar_relation_touch_view(dst);
-                    rc = col_rel_append_all(dst, src, NULL);
+                    rc = tdd_shared_view_deep_copy_fallback(
+                        &coord->tdd_workers[w], dst, src, rc);
                 }
                 if (rc != 0)
                     return rc;
@@ -2057,9 +2113,11 @@ tdd_broadcast_relation_delta(const wl_plan_stratum_t *sp, uint32_t ri,
         if (!view)
             return ENOMEM;
         rc = col_rel_install_shared_view(view, union_d);
-        if (rc != 0) {
+        bool shared = rc == 0;
+        if (!shared) {
             /* Fallback: deep copy on shared-view alloc failure */
-            rc = col_rel_append_all(view, union_d, NULL);
+            rc = tdd_shared_view_deep_copy_fallback(NULL, view, union_d,
+                    rc);
             if (rc != 0) {
                 col_rel_destroy(view);
                 return rc;
@@ -2069,6 +2127,14 @@ tdd_broadcast_relation_delta(const wl_plan_stratum_t *sp, uint32_t ri,
         if (rc != 0) {
             col_rel_destroy(view);
             return rc;
+        }
+        if (shared) {
+            rc = wl_columnar_session_adopt_shared_view(
+                &coord->tdd_workers[dst], view);
+            if (rc != 0) {
+                (void)session_remove_rel(&coord->tdd_workers[dst], dname);
+                return rc;
+            }
         }
     }
     return 0;
@@ -2696,7 +2762,8 @@ tdd_init_workers_hybrid(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
                 if (rc != 0) {
                     /* Preserve the pre-existing deep-copy fallback when
                      * the shared-view bookkeeping allocation is rejected. */
-                    rc = col_rel_append_all(view, rel, NULL);
+                    rc = tdd_shared_view_deep_copy_fallback(NULL, view,
+                            rel, rc);
                     if (rc != 0) {
                         col_rel_destroy(view);
                         break;
@@ -2845,12 +2912,12 @@ tdd_broadcast_deltas(const wl_plan_stratum_t *sp,
                 &coord->tdd_workers[w], dname);
             if (worker_d && worker_d->ncols == ncols) {
                 /* Reuse: install shared view (O(ncols) pointer setup) */
-                int rc = col_rel_install_shared_view(worker_d, union_d);
+                int rc = wl_columnar_session_install_shared_view(
+                    &coord->tdd_workers[w], worker_d, union_d);
                 if (rc != 0) {
                     /* Fallback: deep copy on shared-view alloc failure */
-                    worker_d->nrows = 0;
-                    wl_columnar_relation_touch_view(worker_d);
-                    rc = col_rel_append_all(worker_d, union_d, NULL);
+                    rc = tdd_shared_view_deep_copy_fallback(
+                        &coord->tdd_workers[w], worker_d, union_d, rc);
                     if (rc != 0)
                         return rc;
                 }
@@ -2860,9 +2927,11 @@ tdd_broadcast_deltas(const wl_plan_stratum_t *sp,
                 if (!new_d)
                     return ENOMEM;
                 int rc = col_rel_install_shared_view(new_d, union_d);
-                if (rc != 0) {
+                bool shared = rc == 0;
+                if (!shared) {
                     /* Fallback: deep copy on shared-view alloc failure */
-                    rc = col_rel_append_all(new_d, union_d, NULL);
+                    rc = tdd_shared_view_deep_copy_fallback(NULL, new_d,
+                            union_d, rc);
                     if (rc != 0) {
                         col_rel_destroy(new_d);
                         return rc;
@@ -2872,6 +2941,15 @@ tdd_broadcast_deltas(const wl_plan_stratum_t *sp,
                 if (rc != 0) {
                     col_rel_destroy(new_d);
                     return rc;
+                }
+                if (shared) {
+                    rc = wl_columnar_session_adopt_shared_view(
+                        &coord->tdd_workers[w], new_d);
+                    if (rc != 0) {
+                        (void)session_remove_rel(&coord->tdd_workers[w],
+                            dname);
+                        return rc;
+                    }
                 }
             }
         }
@@ -3530,8 +3608,10 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
             if (!view)
                 return ENOMEM;
             rc = col_rel_install_shared_view(view, combined);
-            if (rc != 0) {
-                rc = col_rel_append_all(view, combined, NULL);
+            bool shared = rc == 0;
+            if (!shared) {
+                rc = tdd_shared_view_deep_copy_fallback(NULL, view,
+                        combined, rc);
                 if (rc != 0) {
                     col_rel_destroy(view);
                     return rc;
@@ -3541,6 +3621,15 @@ tdd_bdx_exchange_deltas(const wl_plan_stratum_t *sp,
             if (rc != 0) {
                 col_rel_destroy(view);
                 return rc;
+            }
+            if (shared) {
+                rc = wl_columnar_session_adopt_shared_view(
+                    &coord->tdd_workers[dst], view);
+                if (rc != 0) {
+                    (void)session_remove_rel(&coord->tdd_workers[dst],
+                        dname);
+                    return rc;
+                }
             }
         }
         coord->tdd_exchange_broadcast_ns += now_ns() - broadcast_t0;
@@ -4365,11 +4454,11 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                 col_rel_t *dw = session_find_rel(
                     &coord->tdd_workers[w], dname);
                 if (dw && dw->ncols == ncols) {
-                    rc = col_rel_install_shared_view(dw, d0);
+                    rc = wl_columnar_session_install_shared_view(
+                        &coord->tdd_workers[w], dw, d0);
                     if (rc != 0) {
-                        dw->nrows = 0;
-                        wl_columnar_relation_touch_view(dw);
-                        rc = col_rel_append_all(dw, d0, NULL);
+                        rc = tdd_shared_view_deep_copy_fallback(
+                            &coord->tdd_workers[w], dw, d0, rc);
                     }
                 } else {
                     dw = col_rel_new_auto(dname, ncols);
@@ -4377,12 +4466,21 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
                         rc = ENOMEM; break;
                     }
                     int vrc = col_rel_install_shared_view(dw, d0);
+                    bool shared = vrc == 0;
                     if (vrc != 0)
-                        rc = col_rel_append_all(dw, d0, NULL);
+                        rc = tdd_shared_view_deep_copy_fallback(NULL, dw,
+                                d0, vrc);
                     if (rc == 0)
                         rc = session_add_rel(&coord->tdd_workers[w], dw);
-                    else
+                    if (rc != 0) {
                         col_rel_destroy(dw);
+                    } else if (shared) {
+                        rc = wl_columnar_session_adopt_shared_view(
+                            &coord->tdd_workers[w], dw);
+                        if (rc != 0)
+                            (void)session_remove_rel(
+                                &coord->tdd_workers[w], dname);
+                    }
                 }
             }
             if (rc != 0)

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -21,6 +21,7 @@
 #include "columnar/diff_trace.h"
 #include "columnar/delta_pool.h"
 #include "columnar/mem_ledger.h"
+#include "columnar/source_access.h"
 #include "columnar/memory_governor.h"
 #include "columnar/continuation.h"
 #include "columnar/kfusion_adaptive.h"
@@ -488,6 +489,11 @@ typedef struct col_rel {
     uint64_t storage_owner_identity;
     uint64_t storage_owner_generation;
     uint32_t storage_alias_borrows;
+
+    /* Operation-scoped readers protect the ultimate storage owner from
+     * checked destruction.  Production read paths are wired in later
+     * lifecycle units. */
+    wl_columnar_source_access_gate_t source_access;
 } col_rel_t;
 
 /* MSVC in its default C mode neither defines __STDC_VERSION__ >= 201112L
@@ -2102,6 +2108,9 @@ int col_rel_storage_owner_resolve(const col_rel_t *src,
     col_rel_t **out_owner);
 int col_rel_storage_alias_release(col_rel_t *alias);
 int col_rel_storage_owner_destroy_status(const col_rel_t *owner);
+int col_rel_source_reader_acquire(const col_rel_t *,
+    wl_columnar_source_access_reader_t *);
+int col_rel_source_reader_release(wl_columnar_source_access_reader_t *);
 
 /* Test seam for the non-wrapping relation identity allocator. */
 int

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1414,6 +1414,18 @@ typedef struct {
     int32_t diff;
 } wl_col_delta_event_t;
 
+/* Stable session-owned source-reader lease.  The reader token's identity is
+* its address, so entries are individually allocated and never moved.  A
+* lease is keyed by the worker relation whose columns borrow owner storage;
+* this lets refresh and relation retirement update the gate exactly once. */
+typedef struct wl_columnar_session_source_lease {
+    col_rel_t *borrower;
+    col_rel_t *owner;
+    uint64_t owner_identity;
+    wl_columnar_source_access_reader_t reader;
+    struct wl_columnar_session_source_lease *next;
+} wl_columnar_session_source_lease_t;
+
 typedef struct wl_col_session_t {
     wl_session_t base;         /* MUST be first field (vtable dispatch)  */
     /* base.extension_snapshot is borrowed from the coordinator in workers;
@@ -1729,6 +1741,10 @@ typedef struct wl_col_session_t {
      *               resources (plan, frontier_ops) in worker destroy. */
     uint32_t worker_id;
     struct wl_col_session_t *coordinator;
+    /* Worker/session-owned registry for persistent shared-view source
+     * readers.  Membership is confined to the coordinator thread between
+     * worker barriers; worker tasks only read the published relations. */
+    wl_columnar_session_source_lease_t *source_leases;
     /* Exchange operator state (Issue #316): W x W partition buffer matrix.
      * Allocated by coordinator before exchange scatter dispatch.
      * exchange_bufs[src_worker][dst_worker] holds rows src sends to dst.
@@ -2700,6 +2716,19 @@ col_worker_session_create(wl_col_session_t *coordinator,
  */
 void
 col_worker_session_destroy(wl_col_session_t *worker);
+
+/* Publish a shared view owned by sess and retain its source for exactly the
+ * borrower's registered lifetime.  Repeated publication from the same source
+ * reuses the stable lease; changing source replaces it transactionally. */
+int
+wl_columnar_session_install_shared_view(wl_col_session_t *sess,
+    col_rel_t *dst, const col_rel_t *src);
+int
+wl_columnar_session_adopt_shared_view(wl_col_session_t *sess,
+    col_rel_t *borrower);
+int
+wl_columnar_session_retire_source_lease(wl_col_session_t *sess,
+    col_rel_t *borrower);
 
 /*
  * col_detect_physical_memory: Detect total physical RAM in bytes (Issue #221).

--- a/wirelog/columnar/kfusion.c
+++ b/wirelog/columnar/kfusion.c
@@ -590,6 +590,9 @@ col_op_k_fusion_dispatch(const wl_plan_op_t *op, eval_stack_t *stack,
         worker_sess[d].tdd_workers = NULL;
         worker_sess[d].tdd_workers_cap = 0;
         worker_sess[d].tdd_workers_count = 0;
+        /* The shallow branch wrapper does not own the parent worker's
+         * persistent source-reader registry. */
+        worker_sess[d].source_leases = NULL;
         /* The shallow session copy must not retain coordinator reclaimer
          * callbacks after the worker cache is replaced below. */
         memset(worker_sess[d].mem_ledger.reclaimers, 0,

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -117,6 +117,7 @@ col_rel_storage_owner_init(col_rel_t *r)
     r->storage_owner_identity = r->relation_identity;
     r->storage_owner_generation = r->storage_generation;
     r->storage_alias_borrows = 0;
+    wl_columnar_source_access_gate_init(&r->source_access);
 }
 
 int
@@ -131,6 +132,7 @@ col_rel_storage_owner_resolve(const col_rel_t *src, col_rel_t **out_owner)
         owner->storage_owner = owner;
         owner->storage_owner_identity = owner->relation_identity;
         owner->storage_owner_generation = owner->storage_generation;
+        wl_columnar_source_access_gate_init(&owner->source_access);
     }
     if (owner->storage_owner != owner
         || owner->storage_owner_identity != owner->relation_identity
@@ -169,7 +171,31 @@ col_rel_storage_owner_destroy_status(const col_rel_t *owner)
     if (!owner || owner->storage_owner != owner
         || owner->storage_owner_identity != owner->relation_identity)
         return EINVAL;
-    return owner->storage_alias_borrows == 0 ? 0 : EBUSY;
+    if (owner->storage_alias_borrows != 0
+        || wl_columnar_source_access_gate_busy(&owner->source_access))
+        return EBUSY;
+    return 0;
+}
+
+int
+col_rel_source_reader_acquire(const col_rel_t *rel,
+    wl_columnar_source_access_reader_t *token)
+{
+    col_rel_t *owner = NULL;
+    int rc;
+    if (!rel || !token)
+        return EINVAL;
+    rc = col_rel_storage_owner_resolve(rel, &owner);
+    if (rc != 0)
+        return rc;
+    return wl_columnar_source_access_reader_acquire(
+        &owner->source_access, token);
+}
+
+int
+col_rel_source_reader_release(wl_columnar_source_access_reader_t *token)
+{
+    return wl_columnar_source_access_reader_release(token);
 }
 
 /* Prepare a complete private replacement for a relation resize.  This is
@@ -765,9 +791,14 @@ col_rel_free_contents(col_rel_t *r)
 int
 col_rel_destroy_checked(col_rel_t *r)
 {
+    int owner_status;
     if (!r)
         return 0;
-    if (col_rel_storage_owner_destroy_status(r) == EBUSY)
+    owner_status = col_rel_storage_owner_destroy_status(r);
+    if (owner_status == EBUSY)
+        return EBUSY;
+    if (owner_status == 0
+        && wl_columnar_source_access_writer_claim(&r->source_access) != 0)
         return EBUSY;
     bool from_pool = r->pool_owned;
     col_rel_free_contents(r); /* memset zeroes pool_owned */
@@ -1722,8 +1753,8 @@ free_merge_buf:
  * Issue #396: used by tdd_broadcast_deltas to eliminate O(|delta|) deep
  * copies when broadcasting the union delta to worker sessions.
  */
-int
-col_rel_install_shared_view(col_rel_t *dst, const col_rel_t *src)
+static int
+col_rel_install_shared_view_unprotected(col_rel_t *dst, const col_rel_t *src)
 {
     col_rel_t *source_owner = NULL;
     col_rel_t *old_owner = NULL;
@@ -1986,6 +2017,27 @@ prepare_fail:
         free((void *)shared_names);
     }
     return prepare_rc;
+}
+
+int
+col_rel_install_shared_view(col_rel_t *dst, const col_rel_t *src)
+{
+    wl_columnar_source_access_reader_t reader = { 0 };
+    col_rel_t *owner = NULL;
+    int rc;
+
+    if (!dst || !src)
+        return EINVAL;
+    rc = col_rel_storage_owner_resolve(src, &owner);
+    if (rc != 0)
+        return rc;
+    rc = col_rel_source_reader_acquire(owner, &reader);
+    if (rc != 0)
+        return rc;
+    rc = col_rel_install_shared_view_unprotected(dst, src);
+    if (col_rel_source_reader_release(&reader) != 0 && rc == 0)
+        rc = EINVAL;
+    return rc;
 }
 
 /* ---- column name lookup ------------------------------------------------- */

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -184,6 +184,13 @@ session_destroy_relation_array(col_rel_t **relations, uint32_t count)
 int
 session_add_rel(wl_col_session_t *sess, col_rel_t *r)
 {
+    if (!r)
+        return EINVAL;
+    /* Promotion copies the descriptor and clears the source slot.  Do not
+     * perform that destructive transition while an operation-scoped reader
+     * still points at the pool/arena relation. */
+    if (wl_columnar_source_access_gate_busy(&r->source_access))
+        return EBUSY;
     /* Pool-owned structs must be promoted to heap before storing in the
      * session, because col_session_destroy calls free() on each entry. */
     col_rel_t *pool_src = NULL;

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -181,6 +181,214 @@ session_destroy_relation_array(col_rel_t **relations, uint32_t count)
     }
 }
 
+static wl_columnar_session_source_lease_t **
+wl_columnar_session_source_lease_slot(wl_col_session_t *sess,
+    const col_rel_t *borrower)
+{
+    wl_columnar_session_source_lease_t **slot = &sess->source_leases;
+
+    while (*slot && (*slot)->borrower != borrower)
+        slot = &(*slot)->next;
+    return slot;
+}
+
+static int
+wl_columnar_session_source_lease_prepare(const col_rel_t *borrower,
+    const col_rel_t *source, wl_columnar_session_source_lease_t **out)
+{
+    col_rel_t *owner = NULL;
+    wl_columnar_session_source_lease_t *lease;
+    int rc;
+
+    if (!borrower || !source || !out)
+        return EINVAL;
+    *out = NULL;
+    rc = col_rel_storage_owner_resolve(source, &owner);
+    if (rc != 0)
+        return rc;
+    lease = (wl_columnar_session_source_lease_t *)calloc(1,
+            sizeof(*lease));
+    if (!lease)
+        return ENOMEM;
+    lease->borrower = (col_rel_t *)borrower;
+    lease->owner = owner;
+    lease->owner_identity = owner->relation_identity;
+    rc = wl_columnar_source_access_reader_acquire_transferable(
+        &owner->source_access, &lease->reader);
+    if (rc != 0) {
+        free(lease);
+        return rc;
+    }
+    *out = lease;
+    return 0;
+}
+
+static int
+wl_columnar_session_source_lease_release(
+    wl_columnar_session_source_lease_t *lease)
+{
+    int rc;
+
+    if (!lease)
+        return 0;
+    rc = col_rel_source_reader_release(&lease->reader);
+    if (rc == 0)
+        free(lease);
+    return rc;
+}
+
+static wl_columnar_session_source_lease_t *
+wl_columnar_session_source_lease_take(wl_col_session_t *sess,
+    const col_rel_t *borrower)
+{
+    wl_columnar_session_source_lease_t **slot;
+    wl_columnar_session_source_lease_t *lease;
+
+    if (!sess || !borrower)
+        return NULL;
+    slot = wl_columnar_session_source_lease_slot(sess, borrower);
+    lease = *slot;
+    if (!lease)
+        return NULL;
+    *slot = lease->next;
+    lease->next = NULL;
+    return lease;
+}
+
+static void
+wl_columnar_session_source_lease_restore(wl_col_session_t *sess,
+    wl_columnar_session_source_lease_t *lease)
+{
+    if (!sess || !lease)
+        return;
+    lease->next = sess->source_leases;
+    sess->source_leases = lease;
+}
+
+int
+wl_columnar_session_adopt_shared_view(wl_col_session_t *sess,
+    col_rel_t *borrower)
+{
+    wl_columnar_session_source_lease_t **slot;
+    wl_columnar_session_source_lease_t *lease;
+    col_rel_t *owner = NULL;
+    int rc;
+
+    if (!sess || !borrower)
+        return EINVAL;
+    rc = col_rel_storage_owner_resolve(borrower, &owner);
+    if (rc != 0)
+        return rc;
+    if (owner == borrower)
+        return 0;
+    slot = wl_columnar_session_source_lease_slot(sess, borrower);
+    if (*slot)
+        return ((*slot)->owner == owner
+               && (*slot)->owner_identity == owner->relation_identity)
+            ? 0 : EINVAL;
+    rc = wl_columnar_session_source_lease_prepare(borrower, owner, &lease);
+    if (rc != 0)
+        return rc;
+    lease->next = sess->source_leases;
+    sess->source_leases = lease;
+    return 0;
+}
+
+int
+wl_columnar_session_retire_source_lease(wl_col_session_t *sess,
+    col_rel_t *borrower)
+{
+    wl_columnar_session_source_lease_t *lease;
+    col_rel_t *owner = NULL;
+    int rc;
+
+    if (!sess || !borrower)
+        return EINVAL;
+    rc = col_rel_storage_owner_resolve(borrower, &owner);
+    if (rc != 0)
+        return rc;
+    /* A live alias still needs its lease.  Callers may retire only after a
+     * successful COW/deep-copy transition made the relation self-owned. */
+    if (owner != borrower)
+        return EBUSY;
+    lease = wl_columnar_session_source_lease_take(sess, borrower);
+    return wl_columnar_session_source_lease_release(lease);
+}
+
+static void
+wl_columnar_session_source_leases_release_all(wl_col_session_t *sess)
+{
+    wl_columnar_session_source_lease_t *lease;
+
+    if (!sess)
+        return;
+    while ((lease = sess->source_leases) != NULL) {
+        sess->source_leases = lease->next;
+        /* Stable registry tokens are explicitly transferable so an
+         * externally serialized worker teardown need not run on the
+         * publication thread. */
+        int rc = wl_columnar_session_source_lease_release(lease);
+        assert(rc == 0);
+        if (rc != 0) {
+            lease->next = sess->source_leases;
+            sess->source_leases = lease;
+            return;
+        }
+    }
+}
+
+int
+wl_columnar_session_install_shared_view(wl_col_session_t *sess,
+    col_rel_t *dst, const col_rel_t *src)
+{
+    wl_columnar_session_source_lease_t **slot;
+    wl_columnar_session_source_lease_t *old_lease;
+    wl_columnar_session_source_lease_t *new_lease = NULL;
+    col_rel_t *owner = NULL;
+    int rc;
+
+    if (!sess || !dst || !src)
+        return EINVAL;
+    rc = col_rel_storage_owner_resolve(src, &owner);
+    if (rc != 0)
+        return rc;
+    slot = wl_columnar_session_source_lease_slot(sess, dst);
+    old_lease = *slot;
+    if (!old_lease || old_lease->owner != owner
+        || old_lease->owner_identity != owner->relation_identity) {
+        rc = wl_columnar_session_source_lease_prepare(dst, owner,
+                &new_lease);
+        if (rc != 0)
+            return rc;
+    }
+
+    rc = col_rel_install_shared_view(dst, src);
+    if (rc != 0) {
+        if (new_lease) {
+            int release_rc
+                = wl_columnar_session_source_lease_release(new_lease);
+            assert(release_rc == 0);
+        }
+        return rc;
+    }
+    if (!new_lease)
+        return 0;
+
+    if (old_lease) {
+        new_lease->next = old_lease->next;
+        *slot = new_lease;
+        old_lease->next = NULL;
+        rc = wl_columnar_session_source_lease_release(old_lease);
+        assert(rc == 0);
+        if (rc != 0)
+            return rc;
+    } else {
+        new_lease->next = sess->source_leases;
+        sess->source_leases = new_lease;
+    }
+    return 0;
+}
+
 int
 session_add_rel(wl_col_session_t *sess, col_rel_t *r)
 {
@@ -224,9 +432,18 @@ session_add_rel(wl_col_session_t *sess, col_rel_t *r)
             if (sess->rels[i] == r)
                 return 0;
             session_invalidate_relation_caches(sess, r->name);
-            int destroy_rc = col_rel_destroy_checked(sess->rels[i]);
-            if (destroy_rc != 0)
+            col_rel_t *old_relation = sess->rels[i];
+            wl_columnar_session_source_lease_t *old_lease
+                = wl_columnar_session_source_lease_take(sess,
+                    old_relation);
+            int destroy_rc = col_rel_destroy_checked(old_relation);
+            if (destroy_rc != 0) {
+                wl_columnar_session_source_lease_restore(sess, old_lease);
                 goto busy;
+            }
+            int release_rc
+                = wl_columnar_session_source_lease_release(old_lease);
+            assert(release_rc == 0);
             sess->rels[i] = r;
             return 0;
         }
@@ -307,8 +524,15 @@ session_remove_rel(wl_col_session_t *sess, const char *name)
     for (uint32_t i = 0; i < sess->nrels; i++) {
         if (sess->rels[i] && strcmp(sess->rels[i]->name, name) == 0) {
             session_invalidate_relation_caches(sess, name);
-            if (col_rel_destroy_checked(sess->rels[i]) != 0)
+            col_rel_t *relation = sess->rels[i];
+            wl_columnar_session_source_lease_t *lease
+                = wl_columnar_session_source_lease_take(sess, relation);
+            if (col_rel_destroy_checked(relation) != 0) {
+                wl_columnar_session_source_lease_restore(sess, lease);
                 return EBUSY;
+            }
+            int release_rc = wl_columnar_session_source_lease_release(lease);
+            assert(release_rc == 0);
             sess->rels[i] = NULL;
             session_rel_free_hash(sess);
             return 0;
@@ -1681,6 +1905,7 @@ col_session_destroy(wl_session_t *session)
         sess->tdd_workers = NULL;
         sess->tdd_workers_count = 0;
     }
+    wl_columnar_session_source_leases_release_all(sess);
     session_destroy_relation_array(sess->rels, sess->nrels);
     free((void *)sess->rels);
     /* Free relation name hash table (Issue #281) */
@@ -1831,6 +2056,7 @@ col_worker_session_create(wl_col_session_t *coordinator,
     out_worker->rel_hash_next = NULL;
     out_worker->rel_hash_nbuckets = 0;
     out_worker->rel_hash_chain_cap = 0;
+    out_worker->source_leases = NULL;
     out_worker->arr_entries = NULL;
     out_worker->arr_count = 0;
     out_worker->arr_cap = 0;
@@ -1920,6 +2146,17 @@ col_worker_session_create(wl_col_session_t *coordinator,
             = (col_rel_t **)calloc(num_partitions, sizeof(col_rel_t *));
         if (!out_worker->rels)
             goto cleanup;
+        /* Shared views are published before the worker exists.  Adopt their
+         * roots while partitions[] is still caller-owned so lease allocation
+         * failure leaves every partition available for caller cleanup. */
+        for (uint32_t i = 0; i < num_partitions; i++) {
+            if (!partitions[i])
+                continue;
+            int rc = wl_columnar_session_adopt_shared_view(out_worker,
+                    partitions[i]);
+            if (rc != 0)
+                goto cleanup;
+        }
         for (uint32_t i = 0; i < num_partitions; i++) {
             out_worker->rels[i] = partitions[i];
             partitions[i] = NULL; /* Mark as transferred */
@@ -2038,6 +2275,10 @@ col_worker_session_destroy(wl_col_session_t *worker)
     col_session_free_sorted_arrangements(worker);
     col_session_free_diff_arrangements(worker);
     col_session_free_filt_arrangements(worker);
+
+    /* Drop persistent source readers before destroying the worker relations
+     * that borrowed those sources. */
+    wl_columnar_session_source_leases_release_all(worker);
 
     /* Free owned relations (partition data) */
     session_destroy_relation_array(worker->rels, worker->nrels);

--- a/wirelog/columnar/source_access.h
+++ b/wirelog/columnar/source_access.h
@@ -60,6 +60,7 @@ typedef struct wl_columnar_source_access_reader {
     pthread_t owner_thread;
 #endif
     bool thread_valid;
+    bool transferable;
 } wl_columnar_source_access_reader_t;
 
 typedef struct wl_columnar_source_access_writer {
@@ -121,7 +122,7 @@ wl_columnar_source_access_reader_acquire(
 {
     uint64_t observed;
     if (!gate || !token || token->owner || token->identity != 0
-        || token->thread_valid)
+        || token->thread_valid || token->transferable)
         return EINVAL;
     observed = atomic_load_explicit(&gate->state, memory_order_acquire);
     for (;;) {
@@ -143,6 +144,37 @@ wl_columnar_source_access_reader_acquire(
     token->owner_thread = pthread_self();
 #endif
     token->thread_valid = true;
+    token->transferable = false;
+    return 0;
+}
+
+/* Session-owned readers have stable token addresses but may be retired by a
+ * later, externally serialized teardown thread.  Identity validation still
+ * rejects copied tokens; the atomic gate makes sequential cross-thread
+ * transfer safe without weakening ordinary operation-token affinity. */
+static inline int
+wl_columnar_source_access_reader_acquire_transferable(
+    wl_columnar_source_access_gate_t *gate,
+    wl_columnar_source_access_reader_t *token)
+{
+    uint64_t observed;
+    if (!gate || !token || token->owner || token->identity != 0
+        || token->thread_valid || token->transferable)
+        return EINVAL;
+    observed = atomic_load_explicit(&gate->state, memory_order_acquire);
+    for (;;) {
+        if (observed == WL_COLUMNAR_SOURCE_ACCESS_WRITER)
+            return EBUSY;
+        if (observed == WL_COLUMNAR_SOURCE_ACCESS_WRITER - 1u)
+            return EOVERFLOW;
+        if (atomic_compare_exchange_weak_explicit(&gate->state, &observed,
+            observed + 1u, memory_order_acquire, memory_order_relaxed))
+            break;
+    }
+    token->owner = gate;
+    token->identity = (uintptr_t)token;
+    token->thread_valid = false;
+    token->transferable = true;
     return 0;
 }
 
@@ -153,7 +185,9 @@ wl_columnar_source_access_reader_release(
     wl_columnar_source_access_gate_t *gate;
     uint64_t observed;
     if (!token || token->identity != (uintptr_t)token || !token->owner
-        || !wl_columnar_source_access_reader_thread_equal(token))
+        || (!token->transferable
+        && !wl_columnar_source_access_reader_thread_equal(token))
+        || (token->transferable && token->thread_valid))
         return EINVAL;
     gate = token->owner;
     observed = atomic_load_explicit(&gate->state, memory_order_acquire);
@@ -167,6 +201,7 @@ wl_columnar_source_access_reader_release(
     token->owner = NULL;
     token->identity = 0;
     token->thread_valid = false;
+    token->transferable = false;
     return 0;
 }
 

--- a/wirelog/columnar/source_access.h
+++ b/wirelog/columnar/source_access.h
@@ -1,7 +1,8 @@
 /*
  * columnar/source_access.h - allocation-free source reader/writer gate
  *
- * Internal, inactive until the source-lifetime integration units enable it.
+ * Internal relation source-reader/writer gate.  Broader operation-scope and
+ * public teardown integration is completed by the subsequent lifecycle units.
  */
 
 #ifndef WL_COLUMNAR_SOURCE_ACCESS_H
@@ -19,6 +20,34 @@
 typedef struct wl_columnar_source_access_gate {
     wl_atomic_u64 state;
 } wl_columnar_source_access_gate_t;
+
+static inline bool
+wl_columnar_source_access_gate_busy(
+    const wl_columnar_source_access_gate_t *gate)
+{
+    return gate
+           && atomic_load_explicit(&gate->state, memory_order_acquire) != 0;
+}
+
+/* Claim the writer state for terminal destruction.  The claim is intentionally
+ * not released: the owning relation is destroyed while it is held. */
+static inline int
+wl_columnar_source_access_writer_claim(
+    wl_columnar_source_access_gate_t *gate)
+{
+    uint64_t expected;
+    if (!gate)
+        return EINVAL;
+    for (;;) {
+        expected = 0;
+        if (atomic_compare_exchange_weak_explicit(&gate->state, &expected,
+            WL_COLUMNAR_SOURCE_ACCESS_WRITER, memory_order_acquire,
+            memory_order_relaxed))
+            return 0;
+        if (expected != 0)
+            return EBUSY;
+    }
+}
 
 typedef struct wl_columnar_source_access_reader {
     wl_columnar_source_access_gate_t *owner;


### PR DESCRIPTION
## Summary

- attach the canonical relation source-access gate to checked teardown
- reject checked destruction without mutation while readers are active
- protect shared-view publication and session promotion with reader/busy checks
- add threading inventory coverage and a regression test

Closes #1494

This is the first atomic unit for #1494, stacked on #1513. Public synchronous worker draining, JOIN/TDD operation scopes, and full allocator reset synchronization remain follow-up units within the issue.

## Validation

- `scripts/ci/check-threading-doc.sh`
- focused normal Meson tests: 5 passed
- focused ASan/UBSan Meson tests: 5 passed
- full normal Meson suite: 355 passed, 14 skipped, 0 failed
