### PR TITLE
fix(#1500): treat a built empty arrangement as fresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ All notable changes to wirelog are documented in this file.
   rather than dropping it. Registry lookups, invalidation and worker
   cloning tolerate a slot without a name.
 
+- **A built arrangement over an empty relation is fresh, not unbuilt**
+  (#1500). The primary arrangement registry no longer treats zero indexed
+  rows as "needs a build": unbuilt now means freed buffers or a cleared
+  source token, which invalidation, deferred release and eviction set. An
+  empty index is returned as is and admits a second lease instead of being
+  rebuilt on every lookup or deferred under a lease.
+
 - **Unfused recursive SCCs no longer terminate with incomplete results**
   (#1376). The forced-delta pre-scan now leaves concatenated rule alternatives
   to normal evaluation instead of treating one empty input as an empty union.

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -580,10 +580,16 @@ exactly once, including on allocation and join-error paths.
 
 | Event | Pinned entry | Unpinned entry |
 |---|---|---|
-| LRU eviction | skip and defer reclamation | reclaim normally |
-| relation invalidation | mark rebuild deferred; keep the old index readable | invalidate immediately |
-| stale generation, row growth, or pending invalidation on lookup | defer rebuild and return unavailable; preserve hash buffers and chains | rebuild before returning |
-| final lease release | apply deferred invalidation, without rebuilding; next lookup rebuilds lazily | no action |
+| LRU eviction | skip and defer reclamation | reclaim and clear the token |
+| relation invalidation | mark rebuild deferred; keep the old index readable | clear the token immediately |
+| stale or cleared token, row growth, or pending invalidation on lookup | defer rebuild and return unavailable; preserve hash buffers and chains | rebuild before returning |
+| final lease release | apply deferred invalidation by clearing the token, without rebuilding; next lookup rebuilds lazily | no action |
+
+An index is unbuilt exactly when its buffers are freed or its source token is
+invalid; invalidation, deferred release and eviction clear the token (#1500).
+An empty relation's index is built (16 buckets, no chain array) and is not
+stale: it is handed out as is, leased or not, and a second lease on it
+succeeds.
 
 This is an internal coordinator/worker-session contract, not a public API or a
 general concurrent-reader mechanism. Release all leases before session teardown.

--- a/tests/test_arrangement_lru_eviction.c
+++ b/tests/test_arrangement_lru_eviction.c
@@ -246,7 +246,8 @@ test_env_var_limit(void)
 static void
 test_tombstone_rebuild(void)
 {
-    TEST("Tombstoned entry (indexed_rows=0) rebuilds on re-access");
+    TEST(
+        "Tombstoned entry (buffers freed, token cleared) rebuilds on re-access");
 
     const char *src = ".decl edge(x: int32, y: int32)\n"
         "edge(10, 1). edge(20, 2). edge(30, 3).\n"
@@ -293,6 +294,25 @@ test_tombstone_rebuild(void)
     ASSERT(entry->mem_bytes > 0, "mem_bytes must be restored after rebuild");
     ASSERT(cs->arr_total_bytes >= entry->mem_bytes,
         "arr_total_bytes must include rebuilt entry");
+    ASSERT(wl_columnar_relation_snapshot_valid(entry->source_snapshot),
+        "rebuild must leave a valid source token");
+    /* Issue #1500: a real LRU eviction clears the token as well, so the
+     * tombstone reads as unbuilt by token and by freed buffers.  Lease the
+     * entry through the pressured lookup so it is deferred rather than
+     * reused as the new entry's slot; the release then performs the
+     * deferred eviction with no lookup to reuse the tombstone. */
+    col_arrangement_pin_t pin = { 0 };
+    ASSERT(col_session_pin_arrangement(sess, "edge", key_cols, 1, &pin) == 0
+        && pin.entry == entry, "pin before pressure");
+    uint32_t alternate[1] = { 1 };
+    cs->arr_cache_limit_bytes = 0;
+    (void)col_session_get_arrangement(sess, "edge", alternate, 1);
+    ASSERT(entry->evict_deferred && entry->mem_bytes > 0,
+        "pressure must defer eviction of the leased entry");
+    col_arrangement_pin_release(&pin);
+    ASSERT(entry->mem_bytes == 0 && entry->arr.nbuckets == 0
+        && !wl_columnar_relation_snapshot_valid(entry->source_snapshot),
+        "deferred eviction must free the buffers and clear the source token");
 
     free_session(sess, plan, prog);
     PASS();
@@ -390,14 +410,21 @@ test_pinned_invalidation(void)
     ASSERT(arr->indexed_rows == 3,
         "pinned arrangement must remain readable until release");
 
+    col_arr_entry_t *pinned_entry = pin.entry;
     col_arrangement_pin_release(&pin);
     ASSERT(pin.active == false, "release must deactivate the lease");
     ASSERT(arr->indexed_rows == 0,
         "deferred invalidation must take effect on final release");
+    /* Issue #1500: the deferred invalidation clears the token, which is
+     * what makes the entry unbuilt for the next lookup. */
+    ASSERT(!wl_columnar_relation_snapshot_valid(pinned_entry->source_snapshot),
+        "deferred release must clear the source token");
 
     arr = col_session_get_arrangement(sess, "edge", key_cols, 1);
     ASSERT(arr != NULL && arr->indexed_rows == 3,
         "next access must rebuild the invalidated arrangement");
+    ASSERT(wl_columnar_relation_snapshot_valid(pinned_entry->source_snapshot),
+        "rebuild must restore a valid source token");
 
     free_session(sess, plan, prog);
     PASS();
@@ -411,7 +438,7 @@ test_pinned_rebuild(unsigned scenario)
     const char *names[] = {
         "same-count mutation", "append within capacity", "append with growth",
         "synthetic incremental append", "synthetic incremental growth",
-        "explicit invalidation", "empty index", "deferred eviction",
+        "explicit invalidation", "deferred eviction",
     };
     TEST(names[scenario]);
     const char *src = ".decl edge(x: int32, y: int32)\n"
@@ -433,20 +460,14 @@ test_pinned_rebuild(unsigned scenario)
     col_rel_t *rel = session_find_rel(cs, "edge");
     uint32_t key[1] = { 0 };
     PIN_CHECK(rel != NULL, "source relation missing");
-    if (scenario == 6) {
-        rel->nrows = 0;
-        wl_columnar_relation_touch_view(rel);
-    }
     PIN_CHECK(col_session_pin_arrangement(sess, "edge", key, 1, &first) == 0,
         "first pin");
-    /* Empty indexes always need a build, so a nested acquisition may defer. */
-    if (scenario != 6)
-        PIN_CHECK(col_session_pin_arrangement(sess, "edge", key, 1,
-            &second) == 0,
-            "fresh nested pin");
+    PIN_CHECK(col_session_pin_arrangement(sess, "edge", key, 1,
+        &second) == 0,
+        "fresh nested pin");
     col_arr_entry_t *entry = first.entry;
     col_arrangement_t *arr = first.arr;
-    if (scenario == 0 || scenario == 7)
+    if (scenario == 0 || scenario == 6)
         PIN_CHECK(col_rel_set(rel, 0, 0, 11) == 0, "same-count mutation");
     if (scenario >= 1 && scenario <= 4) {
         unsigned count = (scenario == 2 || scenario == 4) ? 40 : 1;
@@ -461,7 +482,7 @@ test_pinned_rebuild(unsigned scenario)
     }
     if (scenario == 5)
         col_session_invalidate_arrangements(sess, "edge");
-    if (scenario == 7) {
+    if (scenario == 6) {
         uint32_t alternate[1] = { 1 };
         cs->arr_cache_limit_bytes = 0;
         cs->arr_cap = cs->arr_count;
@@ -483,7 +504,7 @@ test_pinned_rebuild(unsigned scenario)
         "lookup rebuilt or returned a stale pinned index");
     PIN_CHECK(col_session_pin_arrangement(sess, "edge", key, 1, &denied) != 0
         && !denied.active, "stale acquisition must remain inactive");
-    PIN_CHECK(entry->pin_count == (scenario == 6 ? 1u : 2u)
+    PIN_CHECK(entry->pin_count == 2u
         && entry->rebuild_deferred, "deferred lease count");
     PIN_CHECK(arr->ht_head == saved.ht_head && arr->ht_next == saved.ht_next
         && arr->nbuckets == saved.nbuckets && arr->ht_cap == saved.ht_cap
@@ -503,7 +524,7 @@ test_pinned_rebuild(unsigned scenario)
     col_arrangement_pin_release(&first);
     PIN_CHECK(entry->pin_count == 0 && !entry->rebuild_deferred
         && arr->indexed_rows == 0
-        && (scenario == 7 ? entry->mem_bytes == 0
+        && (scenario == 6 ? entry->mem_bytes == 0
             : arr->generation == saved.generation),
         "final release must invalidate without rebuilding");
     arr = col_session_get_arrangement(sess, "edge", key, 1);
@@ -524,7 +545,7 @@ test_pinned_rebuild(unsigned scenario)
         PIN_CHECK(found == UINT32_MAX && matches == 1,
             "rebuilt key multiplicity or cycle mismatch");
     }
-    if (scenario == 0 || scenario == 7) {
+    if (scenario == 0 || scenario == 6) {
         int64_t old[2] = { 10, 1 };
         PIN_CHECK(col_arrangement_find_first(arr, rel->columns, 2, old)
             == UINT32_MAX, "removed key still indexed");
@@ -533,7 +554,7 @@ test_pinned_rebuild(unsigned scenario)
     for (uint32_t i = 0; i < cs->arr_count; i++)
         sum += cs->arr_entries[i].mem_bytes;
     PIN_CHECK(sum == cs->arr_total_bytes, "rebuild accounting sum");
-    if (scenario != 6) {
+    {
         uint32_t generation = arr->generation;
         PIN_CHECK(col_session_get_arrangement(sess, "edge", key, 1) == arr
             && arr->generation == generation,
@@ -551,6 +572,135 @@ cleanup:
         FAIL(failure);
     PASS();
 #undef PIN_CHECK
+}
+
+/* ================================================================
+ * Issue #1500: a built empty index is fresh, not unbuilt.
+ *
+ * Fixture: a declared EDB with no facts.  Session creation registers it
+ * with its schema and a valid token; the fallback below covers a build
+ * that leaves ncols at 0 (as seen for int-only EDBs elsewhere).
+ * ================================================================ */
+static int
+make_empty_edge_session(wl_session_t **sess, wl_plan_t **plan,
+    wirelog_program_t **prog, col_rel_t **edge_out)
+{
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n";
+    if (make_session(src, sess, plan, prog) != 0)
+        return -1;
+    col_rel_t *edge = session_find_rel(COL_SESSION(*sess), "edge");
+    if (!edge)
+        return -1;
+    if (edge->ncols == 0 && col_rel_set_schema(edge, 2, NULL) != 0)
+        return -1;
+    if (edge->ncols != 2 || edge->nrows != 0
+        || !wl_columnar_relation_snapshot_valid(
+            wl_columnar_relation_snapshot(edge)))
+        return -1;
+    *edge_out = edge;
+    return 0;
+}
+
+static col_arr_entry_t *
+find_entry(wl_col_session_t *cs, const char *name)
+{
+    for (uint32_t i = 0; i < cs->arr_count; i++) {
+        if (cs->arr_entries[i].rel_name
+            && strcmp(cs->arr_entries[i].rel_name, name) == 0)
+            return &cs->arr_entries[i];
+    }
+    return NULL;
+}
+
+/* A leased empty index is returned as is by a later lookup, admits a
+ * second lease, and is neither deferred nor invalidated by the releases.
+ * On the previous clause the lookup returned NULL and the second lease
+ * failed. */
+static void
+test_pinned_empty_index(void)
+{
+    TEST("pinned empty index stays available and admits a second lease");
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    col_rel_t *edge = NULL;
+    ASSERT(make_empty_edge_session(&sess, &plan, &prog, &edge) == 0,
+        "empty-relation fixture");
+    wl_col_session_t *cs = COL_SESSION(sess);
+    uint32_t key[1] = { 0 };
+    col_arrangement_pin_t first = { 0 }, second = { 0 };
+    int ok = col_session_pin_arrangement(sess, "edge", key, 1, &first) == 0;
+    col_arr_entry_t *entry = ok ? first.entry : NULL;
+    col_arrangement_t *arr = ok ? first.arr : NULL;
+    if (ok)
+        ok = entry && arr && arr->indexed_rows == 0 && arr->nbuckets == 16
+            && arr->ht_cap == 0 && entry->mem_bytes == 128
+            && wl_columnar_relation_snapshot_valid(entry->source_snapshot);
+    uint64_t *heads = ok ? arr->ht_head : NULL;
+    uint32_t generation = ok ? arr->generation : 0;
+    size_t bytes = ok ? entry->mem_bytes : 0, total = cs->arr_total_bytes;
+    if (ok)
+        ok = col_session_get_arrangement(sess, "edge", key, 1) == arr
+            && !entry->rebuild_deferred && arr->ht_head == heads
+            && arr->generation == generation && arr->nbuckets == 16
+            && entry->mem_bytes == bytes && cs->arr_total_bytes == total;
+    if (ok)
+        ok = col_session_pin_arrangement(sess, "edge", key, 1, &second) == 0
+            && second.arr == arr && entry->pin_count == 2;
+    col_arrangement_pin_release(&second);
+    col_arrangement_pin_release(&first);
+    if (ok)
+        ok = entry->pin_count == 0 && !entry->rebuild_deferred
+            && arr->indexed_rows == 0 && arr->generation == generation
+            && wl_columnar_relation_snapshot_valid(entry->source_snapshot);
+    free_session(sess, plan, prog);
+    ASSERT(ok, "pinned empty index was deferred, rebuilt or refused a lease");
+    PASS();
+}
+
+/* An unpinned empty index is not rebuilt on every lookup; invalidation
+ * clears its token and the next lookup rebuilds.  On the previous clause
+ * the second lookup re-entered the full build (generation bumped). */
+static void
+test_unpinned_empty_index_no_rebuild(void)
+{
+    TEST("unpinned empty index is not rebuilt on every lookup");
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    col_rel_t *edge = NULL;
+    ASSERT(make_empty_edge_session(&sess, &plan, &prog, &edge) == 0,
+        "empty-relation fixture");
+    wl_col_session_t *cs = COL_SESSION(sess);
+    uint32_t key[1] = { 0 };
+    col_arrangement_t *arr = col_session_get_arrangement(sess, "edge", key, 1);
+    col_arr_entry_t *entry = find_entry(cs, "edge");
+    int ok = arr && entry && &entry->arr == arr && arr->indexed_rows == 0
+        && arr->nbuckets == 16 && entry->mem_bytes == 128
+        && wl_columnar_relation_snapshot_valid(entry->source_snapshot);
+    uint64_t *heads = ok ? arr->ht_head : NULL;
+    uint32_t generation = ok ? arr->generation : 0;
+    size_t total = cs->arr_total_bytes;
+    if (ok)
+        ok = col_session_get_arrangement(sess, "edge", key, 1) == arr
+            && arr->generation == generation && arr->ht_head == heads
+            && entry->mem_bytes == 128 && cs->arr_total_bytes == total;
+    if (ok) {
+        col_session_invalidate_arrangements(sess, "edge");
+        ok = !wl_columnar_relation_snapshot_valid(entry->source_snapshot)
+            && arr->indexed_rows == 0;
+    }
+    if (ok)
+        ok = col_session_get_arrangement(sess, "edge", key, 1) == arr
+            && arr->generation == generation + 1
+            && wl_columnar_relation_snapshot_valid(entry->source_snapshot)
+            && cs->arr_total_bytes == total;
+    free_session(sess, plan, prog);
+    ASSERT(ok,
+        "unpinned empty index was rebuilt needlessly or not after invalidation");
+    PASS();
 }
 
 /* ================================================================
@@ -762,8 +912,10 @@ main(void)
     test_append_failure_rolls_back();
     test_total_bytes_accounting();
     test_pinned_invalidation();
-    for (unsigned scenario = 0; scenario < 8; scenario++)
+    for (unsigned scenario = 0; scenario < 7; scenario++)
         test_pinned_rebuild(scenario);
+    test_pinned_empty_index();
+    test_unpinned_empty_index_no_rebuild();
 
     printf("\n%d/%d tests passed", pass_count, test_count);
     if (fail_count > 0)

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -326,6 +326,27 @@ arr_free_contents(col_arrangement_t *arr)
     arr->generation = 0;
 }
 
+/* A primary registry entry is unbuilt exactly when its buffers are freed
+ * (arr_free_contents zeroes nbuckets) or its source token was cleared by
+ * invalidation, deferred release or eviction (Issue #1500).  A built empty
+ * index (16 buckets, no chain array, fresh token) is not unbuilt: it is
+ * handed out as is, leased or not.  indexed_rows == 0 is therefore no
+ * longer the primary registry's "unbuilt" marker; the delta, filtered,
+ * sorted and differential arrangements keep it as theirs. */
+static inline bool
+arr_entry_unbuilt(const col_arr_entry_t *e)
+{
+    return e->arr.nbuckets == 0
+           || !wl_columnar_relation_snapshot_valid(e->source_snapshot);
+}
+
+static inline void
+arr_entry_mark_unbuilt(col_arr_entry_t *e)
+{
+    e->arr.indexed_rows = 0;
+    e->source_snapshot = (col_relation_snapshot_t){ 0, 0, 0 };
+}
+
 /**
  * col_arr_entry_clone - Deep-copy one arrangement registry entry (#260).
  *
@@ -729,12 +750,14 @@ arr_update_incremental(col_arrangement_t *arr, const col_rel_t *rel,
  * drops below target_bytes, or until no more evictable entries remain.
  *
  * Priority:
- *   1. indexed_rows == 0 (already tombstoned — zero memory cost, but frees slot)
+ *   1. unbuilt entries (token cleared by invalidation) that still hold
+ *      buffers: nothing readable is lost
  *   2. smallest lru_clock (least recently used)
  *
- * Eviction is a tombstone: arr_free_contents clears ht_head/ht_next and resets
- * indexed_rows to 0.  The slot (rel_name, key_cols) is retained so the next
- * access can rebuild without re-allocating the entry.
+ * Eviction is a tombstone: arr_free_contents clears ht_head/ht_next and the
+ * entry's source token is cleared, so the entry reads as unbuilt.  The slot
+ * (rel_name, key_cols) is retained so the next access can rebuild without
+ * re-allocating the entry.
  */
 static void
 col_arr_cache_evict_lru(wl_col_session_t *cs, size_t target_bytes)
@@ -757,8 +780,8 @@ col_arr_cache_evict_lru(wl_col_session_t *cs, size_t target_bytes)
                 continue;
             }
 
-            /* Prefer indexed_rows == 0 (invalidated) entries first. */
-            if (e->arr.indexed_rows == 0) {
+            /* Prefer invalidated (unbuilt) entries first. */
+            if (arr_entry_unbuilt(e)) {
                 victim = (int)i;
                 break;
             }
@@ -775,6 +798,7 @@ col_arr_cache_evict_lru(wl_col_session_t *cs, size_t target_bytes)
         col_arr_entry_t *e = &cs->arr_entries[victim];
         cs->arr_total_bytes -= e->mem_bytes;
         arr_free_contents(&e->arr);
+        arr_entry_mark_unbuilt(e);
         e->mem_bytes = 0;
         e->evict_deferred = false;
     }
@@ -840,14 +864,17 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
         bool snapshot_match = wl_columnar_relation_snapshot_equal(
             e->source_snapshot, wl_columnar_relation_snapshot(rel));
         /* Even a same-capacity rebuild rewrites bucket generations/chains.
-         * Keep every index mutation behind the last reader's release. */
+         * Keep every index mutation behind the last reader's release.  A
+         * built empty index (Issue #1500) is fresh and is returned below;
+         * the unbuilt term mirrors the rebuild clause for symmetry, since
+         * no path frees a leased entry's buffers. */
         if (e->pin_count > 0
-            && (!snapshot_match || e->arr.indexed_rows == 0
+            && (!snapshot_match || arr_entry_unbuilt(e)
             || e->arr.indexed_rows < rel->nrows || e->rebuild_deferred)) {
             e->rebuild_deferred = true;
             return NULL;
         }
-        if (!snapshot_match || e->arr.indexed_rows == 0) {
+        if (!snapshot_match || arr_entry_unbuilt(e)) {
             /* Deduct stale bytes before rebuild; restore on failure. */
             cs->arr_total_bytes -= e->mem_bytes;
             if (arr_build_full(&e->arr, rel) != 0) {
@@ -856,6 +883,7 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
             }
             if (!arr_memory_bytes(&e->arr, &e->mem_bytes)) {
                 arr_free_contents(&e->arr);
+                arr_entry_mark_unbuilt(e);
                 e->mem_bytes = 0;
                 return NULL;
             }
@@ -870,6 +898,7 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
             }
             if (!arr_memory_bytes(&e->arr, &e->mem_bytes)) {
                 arr_free_contents(&e->arr);
+                arr_entry_mark_unbuilt(e);
                 e->mem_bytes = 0;
                 return NULL;
             }
@@ -890,13 +919,12 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
     }
 
     /* Prefer reusing a tombstone slot to keep arr_count bounded at
-     * COL_ARR_CACHE_MAX.  A tombstone has indexed_rows == 0 and mem_bytes == 0
-     * (hash tables freed); rel_name/key_cols are still valid and must be
-     * replaced below. */
+     * COL_ARR_CACHE_MAX.  A tombstone has mem_bytes == 0 (hash tables
+     * freed; a build never yields zero bytes); rel_name/key_cols are still
+     * valid and must be replaced below. */
     uint32_t slot = cs->arr_count; /* default: append */
     for (uint32_t i = 0; i < cs->arr_count; i++) {
-        if (cs->arr_entries[i].arr.indexed_rows == 0
-            && cs->arr_entries[i].mem_bytes == 0
+        if (cs->arr_entries[i].mem_bytes == 0
             && cs->arr_entries[i].pin_count == 0) {
             slot = i;
             break;
@@ -1022,7 +1050,9 @@ col_arrangement_pin_release(col_arrangement_pin_t *pin)
     if (entry->pin_count > 0)
         entry->pin_count--;
     if (entry->pin_count == 0 && entry->rebuild_deferred) {
-        entry->arr.indexed_rows = 0;
+        /* Apply the deferred invalidation without rebuilding: the next
+         * lookup sees an unbuilt entry and rebuilds lazily. */
+        arr_entry_mark_unbuilt(entry);
         entry->rebuild_deferred = false;
     }
     evict_deferred = entry->pin_count == 0 && entry->evict_deferred;
@@ -1117,7 +1147,7 @@ col_session_invalidate_arrangements(wl_session_t *sess, const char *rel_name)
             if (cs->arr_entries[i].pin_count > 0)
                 cs->arr_entries[i].rebuild_deferred = true;
             else
-                cs->arr_entries[i].arr.indexed_rows = 0;
+                arr_entry_mark_unbuilt(&cs->arr_entries[i]);
         }
     }
 


### PR DESCRIPTION
Refs #1500 (re-scoped after #1491). Based on `main`.

## What

The primary arrangement registry used `indexed_rows == 0` as its "unbuilt" marker in both lookup clauses of `col_session_get_arrangement`. A built index over an empty relation also has zero indexed rows, so every unpinned lookup of an empty relation re-entered the full build (generation churn), and a pinned empty index was reported unavailable and marked deferred, refusing a second lease. #1474's bounded keyed join hits the second case (operator window lease, then the producer's lease on the same empty index) and currently works around it.

Now "unbuilt" means what it says: buffers freed (`nbuckets == 0`) or source token invalid (`arr_entry_unbuilt`). Invalidation, deferred release on the last lease and LRU eviction clear the token (`arr_entry_mark_unbuilt`), the two hit-branch failure paths that free a rebuilt index clear it too, and both lookup clauses test that predicate. Eviction prefers token-cleared entries; tombstone reuse keys on `mem_bytes == 0`, which a build never yields. A built empty index (16 buckets, no chain array, fresh token) is returned as is, leased or not, and admits further leases. Primary registry only: delta, filtered, sorted and differential arrangements keep `indexed_rows` as their flag; probe functions unchanged.

## Tests

`tests/test_arrangement_lru_eviction.c`: the parameterised "empty index" scenario (which asserted the removed behaviour) is replaced by `test_pinned_empty_index` and `test_unpinned_empty_index_no_rebuild` on a fact-less declared EDB; the deferred-invalidation and tombstone tests assert the token is cleared and restored, and the tombstone test drives a real deferred eviction. On the previous registry code four tests fail (3, 5, 13, 14); 14/14 with the fix.

## Validation

Full suite 353 OK / 0 failed / 14 skipped with the clang-tidy ratchet (arrangement.c is allowlisted); ASan/UBSan+LSan clean on arrangement_lru_eviction, arrangement_cache_reuse, arrangement_incremental_invalidation, generation_cache, join_arrangement, worker_session, diff_join, tdd_recursive; uncrustify and `git diff --check` clean; text-size gate -8901 B against the baseline; changelog format gate OK.

## Review

Reviewer, Architect and Critic approved tree `885966f5` (two rounds; the code was byte-identical between rounds). Follow-up filed: #1515 (pre-existing: a failed tombstone-slot reuse leaves a NULL `rel_name` inside `arr_count`). Interaction: #1474's empty-right guard remains a valid short-circuit; its comment citing #1500 as open can be refreshed when that PR next rebases.
