### PR TITLE
Add session teardown admission and workqueue drain

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5407,6 +5407,24 @@ test_workers_as_cap_exe = executable(
 
 test('workers_as_cap', test_workers_as_cap_exe)
 
+test_columnar_teardown_exe = executable(
+  'test_columnar_teardown',
+  files('test_columnar_teardown.c'),
+  backend_src,
+  parser_src,
+  ir_src,
+  optimizer_src,
+  arena_src,
+  io_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('columnar_teardown', test_columnar_teardown_exe,
+     suite: 'unit', timeout: 60)
+
 # ============================================================================
 # Queue Transport Equivalence and Stress Tests (Issue #410)
 # ============================================================================
@@ -5786,6 +5804,20 @@ test_session_options_exe = executable(
   install: false,
 )
 test('session_options', test_session_options_exe)
+
+# Internal operation admission closes synchronously around backend teardown.
+test_session_admission_exe = executable(
+  'test_session_admission',
+  files('test_session_admission.c', '../wirelog/session.c',
+        '../wirelog/extension_registry.c'),
+  thread_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  c_args: ['-DWIRELOG_BUILDING'],
+  dependencies: [threads_dep],
+  install: false,
+)
+test('session_admission', test_session_admission_exe,
+     suite: 'unit', timeout: 60)
 
 test_extension_filter_exe = executable(
   'test_extension_filter',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4309,6 +4309,7 @@ test_relation_generations_exe = executable(
   workqueue_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+  c_args: ['-DWL_TEST_APPEND_HOOK=1'],
 )
 
 test('relation_generations', test_relation_generations_exe)
@@ -4324,7 +4325,7 @@ if host_machine.system() == 'linux'
     workqueue_src,
     include_directories: [wirelog_inc, wirelog_src_inc],
     dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
-    c_args: ['-DWL_TEST_ALLOC_WRAP=1'],
+    c_args: ['-DWL_TEST_ALLOC_WRAP=1', '-DWL_TEST_APPEND_HOOK=1'],
     link_args: [
       '-Wl,--wrap=malloc', '-Wl,--wrap=calloc', '-Wl,--wrap=realloc',
     ],

--- a/tests/test_columnar_teardown.c
+++ b/tests/test_columnar_teardown.c
@@ -1,0 +1,126 @@
+/* Columnar teardown must drain queued work before owned state is released. */
+
+#include "wirelog/columnar/internal.h"
+#include "wirelog/exec_plan_gen.h"
+#include "wirelog/passes/fusion.h"
+#include "wirelog/passes/jpp.h"
+#include "wirelog/passes/sip.h"
+#include "wirelog/session.h"
+#include "wirelog/wirelog.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    col_rel_t *relation;
+    bool completed;
+    bool relation_was_live;
+} queued_check_t;
+
+static int
+expect(bool condition, const char *message)
+{
+    if (!condition)
+        fprintf(stderr, "FAIL: %s\n", message);
+    return condition ? 0 : 1;
+}
+
+static void
+check_relation_before_teardown(void *opaque)
+{
+    queued_check_t *check = (queued_check_t *)opaque;
+
+    check->relation_was_live = check->relation
+        && check->relation->name
+        && strcmp(check->relation->name, "edge") == 0
+        && check->relation->nrows == 1;
+    check->completed = true;
+}
+
+static wl_plan_t *
+build_plan(wirelog_program_t **program_out)
+{
+    const char *source =
+        ".decl edge(x: int32, y: int32)\n"
+        ".decl reach(x: int32, y: int32)\n"
+        "reach(x, y) :- edge(x, y).\n";
+    wirelog_error_t error;
+    wirelog_program_t *program = wirelog_parse_string(source, &error);
+    wl_plan_t *plan = NULL;
+
+    if (!program)
+        return NULL;
+    wl_fusion_apply(program, NULL);
+    wl_jpp_apply(program, NULL);
+    wl_sip_apply(program, NULL);
+    if (wl_plan_from_program(program, &plan) != 0) {
+        wirelog_program_free(program);
+        return NULL;
+    }
+    *program_out = program;
+    return plan;
+}
+
+int
+main(void)
+{
+    wirelog_program_t *program = NULL;
+    wl_plan_t *plan = build_plan(&program);
+    wl_session_t *base = NULL;
+    wl_col_session_t *session;
+    wl_col_session_t worker = { 0 };
+    queued_check_t check = { 0 };
+    int64_t edge[] = { 1, 2 };
+    int failures = 0;
+    int rc;
+
+    failures += expect(plan != NULL, "plan builds");
+    if (!plan)
+        return 1;
+    rc = wl_session_create(wl_backend_columnar(), plan, 2, &base);
+    failures += expect(rc == 0 && base != NULL, "columnar session creates");
+    if (rc != 0 || !base) {
+        wl_plan_free(plan);
+        wirelog_program_free(program);
+        return 1;
+    }
+    session = COL_SESSION(base);
+
+    failures += expect(session->base.operation_admission != NULL
+            && session->base.owns_operation_admission,
+            "coordinator owns operation admission");
+    rc = col_worker_session_create(session, 0, NULL, 0, &worker);
+    failures += expect(rc == 0, "worker session creates");
+    if (rc == 0) {
+        failures += expect(worker.base.operation_admission == NULL
+                && !worker.base.owns_operation_admission,
+                "worker does not own coordinator admission");
+        col_worker_session_destroy(&worker);
+    }
+
+    rc = wl_session_insert(base, "edge", edge, 1, 2);
+    failures += expect(rc == 0, "edge insertion succeeds");
+    check.relation = session_find_rel(session, "edge");
+    failures += expect(check.relation != NULL, "edge relation exists");
+    rc = wl_columnar_session_ensure_workqueue(session, 2);
+    failures += expect(rc == 0 && session->wq != NULL,
+            "workqueue creates");
+    if (rc == 0 && session->wq)
+        rc = wl_workqueue_submit(session->wq,
+                check_relation_before_teardown, &check);
+    failures += expect(rc == 0, "submit-only work item queues");
+    failures += expect(!check.completed,
+            "submit-only item remains pending before destroy");
+
+    wl_session_destroy(base);
+    failures += expect(check.completed,
+            "destroy drains queued work item");
+    failures += expect(check.relation_was_live,
+            "queued work completes before relation teardown");
+
+    wl_plan_free(plan);
+    wirelog_program_free(program);
+    return failures != 0;
+}

--- a/tests/test_relation_generations.c
+++ b/tests/test_relation_generations.c
@@ -46,6 +46,50 @@ static int failures;
 static col_rel_t *owned_relations[32];
 static size_t owned_relation_count;
 
+#ifdef WL_TEST_APPEND_HOOK
+static col_rel_t *append_hook_expected;
+static col_rel_t *append_hook_source;
+static bool append_hook_called;
+static bool append_hook_state_ok;
+static bool append_hook_expect_growth;
+static uint32_t append_hook_expected_rows;
+static uint32_t append_hook_expected_capacity;
+static int64_t **append_hook_source_columns;
+static uint32_t append_hook_source_aliases;
+static uint64_t append_hook_view_generation;
+static uint64_t append_hook_storage_generation;
+static int append_hook_reader_rc;
+
+static void
+append_transition_probe(col_rel_t *rel)
+{
+    wl_columnar_source_access_reader_t reader = { 0 };
+
+    if (rel != append_hook_expected)
+        return;
+    append_hook_called = true;
+    append_hook_state_ok = rel->storage_owner == append_hook_source
+        && rel->storage_owner_identity == append_hook_source->relation_identity
+        && rel->storage_owner_generation
+        == append_hook_source->storage_generation
+        && rel->nrows == append_hook_expected_rows
+        && (append_hook_expect_growth
+            ? rel->capacity > append_hook_expected_capacity
+            : rel->capacity == append_hook_expected_capacity)
+        && rel->view_generation == append_hook_view_generation
+        && rel->storage_generation != append_hook_storage_generation
+        && rel->col_shared == NULL
+        && rel->storage_alias_borrows == 0
+        && append_hook_source->columns == append_hook_source_columns
+        && append_hook_source->nrows == append_hook_expected_rows
+        && append_hook_source->storage_alias_borrows
+        == append_hook_source_aliases;
+    append_hook_reader_rc = col_rel_source_reader_acquire(rel, &reader);
+    if (append_hook_reader_rc == 0)
+        (void)col_rel_source_reader_release(&reader);
+}
+#endif
+
 static void
 cleanup_relations(void)
 {
@@ -246,6 +290,326 @@ test_source_reader_blocks_checked_destroy(void)
     CHECK(col_rel_destroy_checked(rel) == 0,
         "destroy retry after reader release");
     owned_relation_count--;
+}
+
+static void
+test_source_reader_blocks_direct_append_row(void)
+{
+    col_rel_t *rel = new_relation();
+    wl_columnar_source_access_reader_t reader = { 0 };
+    int64_t first = 17;
+    int64_t extra = 23;
+    int64_t **columns;
+    col_delta_timestamp_t *timestamps;
+    uint32_t rows;
+    uint32_t capacity;
+    uint64_t view_generation;
+    uint64_t storage_generation;
+    uint64_t owner_generation;
+    uint64_t reserved_bytes;
+    uint32_t aliases;
+
+    CHECK(rel != NULL, "direct append reader exclusion relation");
+    CHECK(col_rel_append_row(rel, &first) == 0,
+        "direct append reader exclusion seed");
+    CHECK(col_rel_enable_timestamps(rel) == 0,
+        "direct append reader exclusion timestamps");
+    rel->timestamps[0].iteration = 41;
+    rel->timestamps[0].multiplicity = 7;
+    CHECK(col_rel_source_reader_acquire(rel, &reader) == 0,
+        "direct spare append reader");
+    columns = rel->columns;
+    timestamps = rel->timestamps;
+    rows = rel->nrows;
+    capacity = rel->capacity;
+    view_generation = rel->view_generation;
+    storage_generation = rel->storage_generation;
+    owner_generation = rel->storage_owner_generation;
+    reserved_bytes = rel->retained_reserved_bytes;
+    aliases = rel->storage_alias_borrows;
+    int blocked_rc = col_rel_append_row(rel, &extra);
+    int release_rc = col_rel_source_reader_release(&reader);
+    CHECK(blocked_rc == EBUSY && release_rc == 0
+        && rel->columns == columns
+        && rel->columns[0][0] == first
+        && rel->timestamps == timestamps
+        && rel->timestamps[0].iteration == 41
+        && rel->timestamps[0].multiplicity == 7
+        && rel->nrows == rows
+        && rel->capacity == capacity
+        && rel->view_generation == view_generation
+        && rel->storage_generation == storage_generation
+        && rel->storage_owner == rel
+        && rel->storage_owner_identity == rel->relation_identity
+        && rel->storage_owner_generation == owner_generation
+        && rel->retained_reserved_bytes == reserved_bytes
+        && rel->storage_alias_borrows == aliases,
+        "reader-blocked spare append is transactional");
+    CHECK(col_rel_append_row(rel, &extra) == 0
+        && rel->nrows == rows + 1u
+        && rel->columns[0][rows] == extra,
+        "direct spare append succeeds after release");
+    cleanup_relations();
+
+    rel = new_relation();
+    CHECK(rel != NULL, "direct resize reader exclusion relation");
+    for (uint32_t i = 0; i < COL_REL_INIT_CAP; i++) {
+        int64_t value = (int64_t)i;
+        CHECK(col_rel_append_row(rel, &value) == 0,
+            "direct resize reader exclusion seed");
+    }
+    CHECK(col_rel_enable_timestamps(rel) == 0,
+        "direct resize reader exclusion timestamps");
+    rel->timestamps[COL_REL_INIT_CAP - 1u].stratum = 9;
+    rel->timestamps[COL_REL_INIT_CAP - 1u].multiplicity = 11;
+    CHECK(col_rel_source_reader_acquire(rel, &reader) == 0,
+        "direct resize append reader");
+    columns = rel->columns;
+    timestamps = rel->timestamps;
+    rows = rel->nrows;
+    capacity = rel->capacity;
+    view_generation = rel->view_generation;
+    storage_generation = rel->storage_generation;
+    owner_generation = rel->storage_owner_generation;
+    reserved_bytes = rel->retained_reserved_bytes;
+    aliases = rel->storage_alias_borrows;
+    blocked_rc = col_rel_append_row(rel, &extra);
+    release_rc = col_rel_source_reader_release(&reader);
+    CHECK(blocked_rc == EBUSY && release_rc == 0
+        && rel->columns == columns
+        && rel->columns[0][COL_REL_INIT_CAP - 1u]
+        == (int64_t)(COL_REL_INIT_CAP - 1u)
+        && rel->timestamps == timestamps
+        && rel->timestamps[COL_REL_INIT_CAP - 1u].stratum == 9
+        && rel->timestamps[COL_REL_INIT_CAP - 1u].multiplicity == 11
+        && rel->nrows == rows
+        && rel->capacity == capacity
+        && rel->view_generation == view_generation
+        && rel->storage_generation == storage_generation
+        && rel->storage_owner == rel
+        && rel->storage_owner_identity == rel->relation_identity
+        && rel->storage_owner_generation == owner_generation
+        && rel->retained_reserved_bytes == reserved_bytes
+        && rel->storage_alias_borrows == aliases,
+        "reader-blocked resize append is transactional");
+    CHECK(col_rel_append_row(rel, &extra) == 0
+        && rel->nrows == rows + 1u
+        && rel->capacity > capacity
+        && rel->columns[0][rows] == extra,
+        "direct resize append succeeds after release");
+    cleanup_relations();
+}
+
+static void
+test_source_reader_blocks_append_row(void)
+{
+    col_rel_t *source = new_relation();
+    col_rel_t *view = new_relation();
+    wl_columnar_source_access_reader_t reader = { 0 };
+    int64_t first = 17;
+    int64_t extra = 23;
+    int64_t **source_columns;
+    int64_t **view_columns;
+    int64_t *view_column0;
+    col_delta_timestamp_t *source_timestamps;
+    col_delta_timestamp_t *view_timestamps;
+    uint32_t source_rows;
+    uint32_t source_capacity;
+    uint32_t view_rows;
+    uint32_t view_capacity;
+    uint64_t source_view;
+    uint64_t source_storage;
+    uint64_t source_owner_identity;
+    uint64_t view_view;
+    uint64_t view_storage;
+    uint64_t source_owner_generation;
+    uint64_t source_reserved;
+    uint64_t view_reserved;
+    uint32_t source_aliases;
+    uint32_t view_aliases;
+
+    CHECK(source && view, "append reader exclusion relations");
+    CHECK(col_rel_append_row(source, &first) == 0,
+        "append reader exclusion seed");
+    CHECK(col_rel_enable_timestamps(source) == 0,
+        "append reader exclusion timestamps");
+    source->timestamps[0].iteration = 41;
+    source->timestamps[0].multiplicity = 7;
+    CHECK(col_rel_install_shared_view(view, source) == 0,
+        "append reader exclusion shared view");
+    source_columns = source->columns;
+    source_timestamps = source->timestamps;
+    source_rows = source->nrows;
+    source_capacity = source->capacity;
+    source_view = source->view_generation;
+    source_storage = source->storage_generation;
+    source_owner_identity = source->storage_owner_identity;
+    source_owner_generation = source->storage_owner_generation;
+    source_reserved = source->retained_reserved_bytes;
+    source_aliases = source->storage_alias_borrows;
+    view_columns = view->columns;
+    view_column0 = view->columns[0];
+    view_timestamps = view->timestamps;
+    view_rows = view->nrows;
+    view_capacity = view->capacity;
+    view_view = view->view_generation;
+    view_storage = view->storage_generation;
+    view_reserved = view->retained_reserved_bytes;
+    view_aliases = view->storage_alias_borrows;
+#ifdef WL_TEST_APPEND_HOOK
+    append_hook_source = source;
+    append_hook_expected = view;
+    append_hook_called = false;
+    append_hook_state_ok = false;
+    append_hook_expect_growth = false;
+    append_hook_expected_rows = view_rows;
+    append_hook_expected_capacity = view_capacity;
+    append_hook_source_columns = source_columns;
+    append_hook_source_aliases = source_aliases;
+    append_hook_view_generation = view_view;
+    append_hook_storage_generation = view_storage;
+    append_hook_reader_rc = 0;
+    wl_columnar_append_transition_hook = append_transition_probe;
+#endif
+    CHECK(col_rel_append_row(view, &extra) == 0,
+        "spare-capacity alias append");
+#ifdef WL_TEST_APPEND_HOOK
+    wl_columnar_append_transition_hook = NULL;
+    append_hook_expected = NULL;
+#endif
+    CHECK(append_hook_called && append_hook_state_ok
+        && append_hook_reader_rc == EBUSY,
+        "reader blocks spare-capacity alias append transition");
+    CHECK(source->columns == source_columns
+        && source->columns[0][0] == first
+        && source->timestamps == source_timestamps
+        && source->timestamps[0].iteration == 41
+        && source->timestamps[0].multiplicity == 7
+        && source->nrows == source_rows
+        && source->capacity == source_capacity
+        && source->view_generation == source_view
+        && source->storage_generation == source_storage
+        && source->storage_owner == source
+        && source->storage_owner_identity == source_owner_identity
+        && source->storage_owner_generation == source_owner_generation
+        && source->retained_reserved_bytes == source_reserved
+        && source->storage_alias_borrows == source_aliases - 1u
+        && view->columns[0] != view_column0
+        && view->columns[0][0] == first
+        && view->timestamps == view_timestamps
+        && view->timestamps[0].iteration == 41
+        && view->timestamps[0].multiplicity == 7
+        && view->nrows == view_rows + 1u
+        && view->columns[0][view_rows] == extra
+        && view->capacity == view_capacity
+        && view->view_generation != view_view
+        && view->storage_generation != view_storage
+        && view->storage_owner == view
+        && view->storage_owner_identity == view->relation_identity
+        && view->retained_reserved_bytes == view_reserved
+        && view->storage_alias_borrows == view_aliases
+        && view->col_shared == NULL
+        && source->storage_alias_borrows == source_aliases - 1u,
+        "spare-capacity alias append commits after transition");
+    CHECK(col_rel_source_reader_acquire(view, &reader) == 0
+        && col_rel_source_reader_release(&reader) == 0,
+        "view reader succeeds after spare-capacity append");
+    cleanup_relations();
+
+    source = new_relation();
+    view = new_relation();
+    CHECK(source && view, "resize reader exclusion relations");
+    for (uint32_t i = 0; i < COL_REL_INIT_CAP; i++) {
+        int64_t value = (int64_t)i;
+        CHECK(col_rel_append_row(source, &value) == 0,
+            "resize reader exclusion seed");
+    }
+    CHECK(col_rel_enable_timestamps(source) == 0,
+        "resize reader exclusion timestamps");
+    source->timestamps[COL_REL_INIT_CAP - 1u].stratum = 9;
+    source->timestamps[COL_REL_INIT_CAP - 1u].multiplicity = 11;
+    CHECK(col_rel_install_shared_view(view, source) == 0,
+        "resize reader exclusion shared view");
+    source_columns = source->columns;
+    source_timestamps = source->timestamps;
+    source_rows = source->nrows;
+    source_capacity = source->capacity;
+    source_view = source->view_generation;
+    source_storage = source->storage_generation;
+    source_owner_identity = source->storage_owner_identity;
+    source_owner_generation = source->storage_owner_generation;
+    source_reserved = source->retained_reserved_bytes;
+    source_aliases = source->storage_alias_borrows;
+    view_columns = view->columns;
+    view_column0 = view->columns[0];
+    view_timestamps = view->timestamps;
+    view_rows = view->nrows;
+    view_capacity = view->capacity;
+    view_view = view->view_generation;
+    view_storage = view->storage_generation;
+    view_reserved = view->retained_reserved_bytes;
+    view_aliases = view->storage_alias_borrows;
+#ifdef WL_TEST_APPEND_HOOK
+    append_hook_source = source;
+    append_hook_expected = view;
+    append_hook_called = false;
+    append_hook_state_ok = false;
+    append_hook_expect_growth = true;
+    append_hook_expected_rows = view_rows;
+    append_hook_expected_capacity = view_capacity;
+    append_hook_source_columns = source_columns;
+    append_hook_source_aliases = source_aliases;
+    append_hook_view_generation = view_view;
+    append_hook_storage_generation = view_storage;
+    append_hook_reader_rc = 0;
+    wl_columnar_append_transition_hook = append_transition_probe;
+#endif
+    CHECK(col_rel_append_row(view, &extra) == 0,
+        "resize alias append");
+#ifdef WL_TEST_APPEND_HOOK
+    wl_columnar_append_transition_hook = NULL;
+    append_hook_expected = NULL;
+#endif
+    CHECK(append_hook_called && append_hook_state_ok
+        && append_hook_reader_rc == EBUSY,
+        "reader blocks resize alias append transition");
+    CHECK(source->columns == source_columns
+        && source->columns[0][COL_REL_INIT_CAP - 1u]
+        == (int64_t)(COL_REL_INIT_CAP - 1u)
+        && source->timestamps == source_timestamps
+        && source->timestamps[COL_REL_INIT_CAP - 1u].stratum == 9
+        && source->timestamps[COL_REL_INIT_CAP - 1u].multiplicity == 11
+        && source->nrows == source_rows
+        && source->capacity == source_capacity
+        && source->view_generation == source_view
+        && source->storage_generation == source_storage
+        && source->storage_owner == source
+        && source->storage_owner_identity == source_owner_identity
+        && source->storage_owner_generation == source_owner_generation
+        && source->retained_reserved_bytes == source_reserved
+        && source->storage_alias_borrows == source_aliases - 1u
+        && view->columns != view_columns
+        && view->columns[0][COL_REL_INIT_CAP - 1u]
+        == (int64_t)(COL_REL_INIT_CAP - 1u)
+        && view->timestamps != view_timestamps
+        && view->timestamps[COL_REL_INIT_CAP - 1u].stratum == 9
+        && view->timestamps[COL_REL_INIT_CAP - 1u].multiplicity == 11
+        && view->nrows == view_rows + 1u
+        && view->capacity > view_capacity
+        && view->view_generation != view_view
+        && view->storage_generation != view_storage
+        && view->storage_owner == view
+        && view->storage_owner_identity == view->relation_identity
+        && view->retained_reserved_bytes == view_reserved
+        && view->storage_alias_borrows == view_aliases
+        && view->columns[0][view_rows] == extra
+        && view->col_shared == NULL
+        && source->storage_alias_borrows == source_aliases - 1u,
+        "resize alias append commits after transition");
+    CHECK(col_rel_source_reader_acquire(view, &reader) == 0
+        && col_rel_source_reader_release(&reader) == 0,
+        "view reader succeeds after resize append");
+    cleanup_relations();
 }
 
 static void
@@ -1194,6 +1558,8 @@ main(void)
     test_storage_only_cow_and_compaction();
     test_flattened_storage_ownership();
     test_source_reader_blocks_checked_destroy();
+    test_source_reader_blocks_direct_append_row();
+    test_source_reader_blocks_append_row();
     test_copy_and_shared_semantics();
     test_rollback_fresh_generation();
     test_overflow_boundary();

--- a/tests/test_session_admission.c
+++ b/tests/test_session_admission.c
@@ -1,0 +1,352 @@
+/* Internal session operation admission and teardown concurrency regressions. */
+
+#include "wirelog/session.h"
+#include "wirelog/thread.h"
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef enum {
+    TEST_OP_INSERT,
+    TEST_OP_MAKE_COMPOUND,
+    TEST_OP_REMOVE,
+    TEST_OP_STEP,
+    TEST_OP_SET_DELTA_CB,
+    TEST_OP_SNAPSHOT,
+    TEST_OP_MEMORY_GOVERNOR,
+    TEST_OP_COUNT,
+} test_operation_t;
+
+typedef struct {
+    mutex_t mutex;
+    cond_t changed;
+    test_operation_t blocked_operation;
+    bool operation_entered;
+    bool release_operation;
+    bool backend_destroy_entered;
+    bool destroy_returned;
+    unsigned calls[TEST_OP_COUNT];
+} test_sync_t;
+
+typedef struct {
+    wl_session_t base;
+    test_sync_t *sync;
+} fake_session_t;
+
+typedef struct {
+    wl_session_t *session;
+    test_sync_t *sync;
+    test_operation_t operation;
+    int rc;
+} thread_context_t;
+
+static test_sync_t *creation_sync;
+
+static void
+record_operation(fake_session_t *session, test_operation_t operation)
+{
+    test_sync_t *sync = session->sync;
+
+    mutex_lock(&sync->mutex);
+    sync->calls[operation]++;
+    if (sync->blocked_operation == operation) {
+        sync->operation_entered = true;
+        cond_broadcast(&sync->changed);
+        while (!sync->release_operation)
+            cond_wait(&sync->changed, &sync->mutex);
+    }
+    mutex_unlock(&sync->mutex);
+}
+
+static int
+fake_create(const wl_plan_t *plan, uint32_t num_workers, wl_session_t **out)
+{
+    fake_session_t *session;
+
+    (void)plan;
+    (void)num_workers;
+    session = (fake_session_t *)calloc(1, sizeof(*session));
+    if (!session)
+        return ENOMEM;
+    session->sync = creation_sync;
+    *out = &session->base;
+    return 0;
+}
+
+static void
+fake_destroy(wl_session_t *base)
+{
+    fake_session_t *session = (fake_session_t *)base;
+    test_sync_t *sync = session->sync;
+
+    mutex_lock(&sync->mutex);
+    sync->backend_destroy_entered = true;
+    cond_broadcast(&sync->changed);
+    mutex_unlock(&sync->mutex);
+    free(session);
+}
+
+static int
+fake_insert(wl_session_t *base, const char *relation, const int64_t *data,
+    uint32_t num_rows, uint32_t num_cols)
+{
+    (void)relation;
+    (void)data;
+    (void)num_rows;
+    (void)num_cols;
+    record_operation((fake_session_t *)base, TEST_OP_INSERT);
+    return 0;
+}
+
+static int
+fake_make_compound(wl_session_t *base, const char *functor, uint32_t arity,
+    const wirelog_compound_arg_t *args, uint64_t *handle_out)
+{
+    (void)functor;
+    (void)arity;
+    (void)args;
+    record_operation((fake_session_t *)base, TEST_OP_MAKE_COMPOUND);
+    if (handle_out)
+        *handle_out = 1;
+    return 0;
+}
+
+static int
+fake_remove(wl_session_t *base, const char *relation, const int64_t *data,
+    uint32_t num_rows, uint32_t num_cols)
+{
+    (void)relation;
+    (void)data;
+    (void)num_rows;
+    (void)num_cols;
+    record_operation((fake_session_t *)base, TEST_OP_REMOVE);
+    return 0;
+}
+
+static int
+fake_step(wl_session_t *base)
+{
+    record_operation((fake_session_t *)base, TEST_OP_STEP);
+    return 0;
+}
+
+static void
+fake_set_delta_cb(wl_session_t *base, wirelog_on_delta_fn callback,
+    void *user_data)
+{
+    (void)callback;
+    (void)user_data;
+    record_operation((fake_session_t *)base, TEST_OP_SET_DELTA_CB);
+}
+
+static int
+fake_snapshot(wl_session_t *base, wirelog_on_tuple_fn callback,
+    void *user_data)
+{
+    (void)callback;
+    (void)user_data;
+    record_operation((fake_session_t *)base, TEST_OP_SNAPSHOT);
+    return 0;
+}
+
+static wl_columnar_memory_governor_t *
+fake_memory_governor(wl_session_t *base)
+{
+    record_operation((fake_session_t *)base, TEST_OP_MEMORY_GOVERNOR);
+    return (wl_columnar_memory_governor_t *)base;
+}
+
+static const wl_compute_backend_t fake_backend = {
+    .name = "admission-test",
+    .session_create = fake_create,
+    .session_destroy = fake_destroy,
+    .session_insert = fake_insert,
+    .session_make_compound = fake_make_compound,
+    .session_remove = fake_remove,
+    .session_step = fake_step,
+    .session_set_delta_cb = fake_set_delta_cb,
+    .session_snapshot = fake_snapshot,
+    .session_memory_governor = fake_memory_governor,
+};
+
+static void *
+operation_thread(void *opaque)
+{
+    thread_context_t *ctx = (thread_context_t *)opaque;
+
+    if (ctx->operation == TEST_OP_STEP)
+        ctx->rc = wl_session_step(ctx->session);
+    else
+        ctx->rc = wl_session_snapshot(ctx->session, NULL, NULL);
+    return NULL;
+}
+
+static void *
+destroy_thread(void *opaque)
+{
+    thread_context_t *ctx = (thread_context_t *)opaque;
+
+    wl_session_destroy(ctx->session);
+    mutex_lock(&ctx->sync->mutex);
+    ctx->sync->destroy_returned = true;
+    cond_broadcast(&ctx->sync->changed);
+    mutex_unlock(&ctx->sync->mutex);
+    return NULL;
+}
+
+static void
+noop_delta(const char *relation, const int64_t *row, uint32_t ncols,
+    int32_t diff, void *user_data)
+{
+    (void)relation;
+    (void)row;
+    (void)ncols;
+    (void)diff;
+    (void)user_data;
+}
+
+static int
+expect(bool condition, const char *message)
+{
+    if (!condition)
+        fprintf(stderr, "FAIL: %s\n", message);
+    return condition ? 0 : 1;
+}
+
+static int
+run_destroy_race(test_operation_t blocked_operation)
+{
+    test_sync_t sync = { 0 };
+    thread_context_t operation_ctx = { 0 };
+    thread_context_t destroy_ctx = { 0 };
+    thread_t operation_tid;
+    thread_t destroy_tid;
+    wl_session_t *session = NULL;
+    unsigned before[TEST_OP_COUNT];
+    int64_t row = 1;
+    wirelog_compound_arg_t arg = { WIRELOG_TYPE_INT64, 1 };
+    uint64_t handle = 0;
+    int denied_rc = 0;
+    int failures = 0;
+
+    if (mutex_init(&sync.mutex) != 0) {
+        fprintf(stderr, "FAIL: synchronization initialization\n");
+        return 1;
+    }
+    if (cond_init(&sync.changed) != 0) {
+        mutex_destroy(&sync.mutex);
+        fprintf(stderr, "FAIL: synchronization initialization\n");
+        return 1;
+    }
+    sync.blocked_operation = blocked_operation;
+    creation_sync = &sync;
+    if (wl_session_create(&fake_backend, NULL, 1, &session) != 0
+        || !session) {
+        cond_destroy(&sync.changed);
+        mutex_destroy(&sync.mutex);
+        fprintf(stderr, "FAIL: fake session creation\n");
+        return 1;
+    }
+
+    operation_ctx.session = session;
+    operation_ctx.sync = &sync;
+    operation_ctx.operation = blocked_operation;
+    if (thread_create(&operation_tid, operation_thread, &operation_ctx) != 0) {
+        wl_session_destroy(session);
+        cond_destroy(&sync.changed);
+        mutex_destroy(&sync.mutex);
+        fprintf(stderr, "FAIL: operation thread creation\n");
+        return 1;
+    }
+
+    mutex_lock(&sync.mutex);
+    while (!sync.operation_entered)
+        cond_wait(&sync.changed, &sync.mutex);
+    mutex_unlock(&sync.mutex);
+
+    destroy_ctx.session = session;
+    destroy_ctx.sync = &sync;
+    if (thread_create(&destroy_tid, destroy_thread, &destroy_ctx) != 0) {
+        mutex_lock(&sync.mutex);
+        sync.release_operation = true;
+        cond_broadcast(&sync.changed);
+        mutex_unlock(&sync.mutex);
+        thread_join(&operation_tid);
+        wl_session_destroy(session);
+        cond_destroy(&sync.changed);
+        mutex_destroy(&sync.mutex);
+        fprintf(stderr, "FAIL: destroy thread creation\n");
+        return 1;
+    }
+
+    /* The active backend call proves destroy cannot complete.  Probe the
+     * other quick operation until destroy has closed admission. */
+    for (unsigned attempt = 0; attempt < 1000000; attempt++) {
+        denied_rc = blocked_operation == TEST_OP_SNAPSHOT
+            ? wl_session_step(session)
+            : wl_session_snapshot(session, NULL, NULL);
+        if (denied_rc == EBUSY || denied_rc != 0)
+            break;
+    }
+    failures += expect(denied_rc == EBUSY,
+            "new operation denied while destroy waits");
+
+    mutex_lock(&sync.mutex);
+    for (unsigned i = 0; i < TEST_OP_COUNT; i++)
+        before[i] = sync.calls[i];
+    failures += expect(!sync.backend_destroy_entered,
+            "backend destroy waits for active operation");
+    mutex_unlock(&sync.mutex);
+
+    failures += expect(wl_session_insert(session, "r", &row, 1, 1) == EBUSY,
+            "insert denied after admission closes");
+    failures += expect(wl_session_make_compound(session, "f", 1, &arg,
+            &handle) == EBUSY,
+            "compound creation denied after admission closes");
+    failures += expect(wl_session_remove(session, "r", &row, 1, 1) == EBUSY,
+            "remove denied after admission closes");
+    failures += expect(wl_session_step(session) == EBUSY,
+            "step denied after admission closes");
+    wl_session_set_delta_cb(session, noop_delta, NULL);
+    failures += expect(wl_session_snapshot(session, NULL, NULL) == EBUSY,
+            "snapshot denied after admission closes");
+    failures += expect(wl_session_memory_governor(session) == NULL,
+            "memory governor access denied after admission closes");
+
+    mutex_lock(&sync.mutex);
+    for (unsigned i = 0; i < TEST_OP_COUNT; i++)
+        failures += expect(sync.calls[i] == before[i],
+                "denied operation did not enter backend");
+    sync.release_operation = true;
+    cond_broadcast(&sync.changed);
+    mutex_unlock(&sync.mutex);
+
+    thread_join(&operation_tid);
+    thread_join(&destroy_tid);
+    failures += expect(operation_ctx.rc == 0,
+            "admitted operation completes successfully");
+    mutex_lock(&sync.mutex);
+    failures += expect(sync.backend_destroy_entered,
+            "backend destroy runs after operation completes");
+    failures += expect(sync.destroy_returned,
+            "session destroy returns synchronously");
+    mutex_unlock(&sync.mutex);
+
+    cond_destroy(&sync.changed);
+    mutex_destroy(&sync.mutex);
+    return failures;
+}
+
+int
+main(void)
+{
+    int failures = 0;
+
+    failures += run_destroy_race(TEST_OP_SNAPSHOT);
+    failures += run_destroy_race(TEST_OP_STEP);
+    if (failures)
+        fprintf(stderr, "session_admission: %d failure(s)\n", failures);
+    return failures != 0;
+}

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -496,6 +496,14 @@ typedef struct col_rel {
     wl_columnar_source_access_gate_t source_access;
 } col_rel_t;
 
+#ifdef WL_TEST_APPEND_HOOK
+/* Test-only seam for the append ownership-transition window.  This is not
+ * part of the installed/public header surface. */
+typedef void (*wl_columnar_append_transition_hook_t)(col_rel_t *);
+extern wl_columnar_append_transition_hook_t
+    wl_columnar_append_transition_hook;
+#endif
+
 /* MSVC in its default C mode neither defines __STDC_VERSION__ >= 201112L
  * nor accepts offsetof() inside _Static_assert (C2059); mirror the guard
  * used by diff_trace.c so the layout contract is still checked everywhere

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -25,6 +25,10 @@
  * sufficient: the counter only has to hand out distinct values. */
 static wl_atomic_u64 wl_next_relation_identity = 1u;
 
+#ifdef WL_TEST_APPEND_HOOK
+wl_columnar_append_transition_hook_t wl_columnar_append_transition_hook;
+#endif
+
 static int
 col_rel_new_identity(uint64_t *out)
 {
@@ -106,7 +110,16 @@ wl_columnar_relation_radix_bench_enabled(void)
 
 /* ---- COW helpers --------------------------------------------------------- */
 
-static int col_rel_grow_owned_transition(col_rel_t *r, uint32_t new_cap);
+static int col_rel_grow_owned_transition_impl(col_rel_t *r,
+    uint32_t new_cap, bool defer_alias_release);
+static int col_rel_cow_unshare_impl(col_rel_t *r, uint32_t new_cap,
+    bool defer_alias_release);
+
+static int
+col_rel_grow_owned_transition(col_rel_t *r, uint32_t new_cap)
+{
+    return col_rel_grow_owned_transition_impl(r, new_cap, false);
+}
 
 static void
 col_rel_storage_owner_init(col_rel_t *r)
@@ -196,6 +209,22 @@ int
 col_rel_source_reader_release(wl_columnar_source_access_reader_t *token)
 {
     return wl_columnar_source_access_reader_release(token);
+}
+
+static int
+col_rel_source_writer_acquire(const col_rel_t *rel,
+    wl_columnar_source_access_writer_t *token)
+{
+    col_rel_t *owner = NULL;
+    int rc;
+
+    if (!rel || !token)
+        return EINVAL;
+    rc = col_rel_storage_owner_resolve(rel, &owner);
+    if (rc != 0)
+        return rc;
+    return wl_columnar_source_access_writer_acquire(
+        &owner->source_access, token);
 }
 
 /* Prepare a complete private replacement for a relation resize.  This is
@@ -455,7 +484,8 @@ col_rel_reserve_transition(const col_rel_t *r, uint32_t capacity,
  * prepared before the relation is changed, so admission or allocation
  * failure leaves the old ownership and reservation untouched. */
 static int
-col_rel_grow_owned_transition(col_rel_t *r, uint32_t new_cap)
+col_rel_grow_owned_transition_impl(col_rel_t *r, uint32_t new_cap,
+    bool defer_alias_release)
 {
     wl_columnar_memory_reservation_t pending;
     int pending_rc;
@@ -513,7 +543,8 @@ col_rel_grow_owned_transition(col_rel_t *r, uint32_t new_cap)
     free(old_shared_flags);
     free(old_timestamps);
     col_rel_ledger_reconcile(r, ledger_before);
-    (void)col_rel_storage_alias_release(r);
+    if (!defer_alias_release)
+        (void)col_rel_storage_alias_release(r);
     wl_columnar_relation_touch_storage(r);
     return 0;
 
@@ -538,6 +569,13 @@ col_rel_promote_arena_admitted(col_rel_t *r)
 int
 col_rel_cow_unshare(col_rel_t *r, uint32_t new_cap)
 {
+    return col_rel_cow_unshare_impl(r, new_cap, false);
+}
+
+static int
+col_rel_cow_unshare_impl(col_rel_t *r, uint32_t new_cap,
+    bool defer_alias_release)
+{
     wl_columnar_memory_reservation_t pending;
     int pending_rc;
     uint64_t new_bytes;
@@ -550,7 +588,8 @@ col_rel_cow_unshare(col_rel_t *r, uint32_t new_cap)
     capacity = new_cap ? new_cap : (r->capacity ? r->capacity
                                                     : COL_REL_INIT_CAP);
     if (capacity > r->capacity)
-        return col_rel_grow_owned_transition(r, capacity);
+        return col_rel_grow_owned_transition_impl(r, capacity,
+                   defer_alias_release);
     pending_rc = col_rel_reserve_transition(r, capacity, &pending,
             &new_bytes);
     if (pending_rc < 0)
@@ -596,7 +635,8 @@ col_rel_cow_unshare(col_rel_t *r, uint32_t new_cap)
     }
     col_rel_ledger_reconcile(r, ledger_before);
     /* Private columns replaced the borrowed view: one storage epoch. */
-    (void)col_rel_storage_alias_release(r);
+    if (!defer_alias_release)
+        (void)col_rel_storage_alias_release(r);
     wl_columnar_relation_touch_storage(r);
     return 0;
 
@@ -1291,6 +1331,10 @@ col_rel_apply_compound_schema(col_rel_t *r,
 int
 col_rel_append_row(col_rel_t *r, const int64_t *row)
 {
+    wl_columnar_source_access_writer_t writer = { 0 };
+    bool alias_release_pending = false;
+    int rc;
+
     if (!r || !row)
         return EINVAL;
     /* Do all structural validation before any resize, COW, or timestamp
@@ -1315,18 +1359,28 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
                 return EINVAL;
         }
     }
+
+    /* Resolve and admit the canonical storage owner only after validation,
+     * but before any resize, COW, timestamp, value, or generation mutation.
+     * A reader on an alias therefore excludes append on every view of the
+     * same backing storage. */
+    rc = col_rel_source_writer_acquire(r, &writer);
+    if (rc != 0)
+        return rc;
+
     bool needs_resize = r->nrows >= r->capacity;
     if (needs_resize) {
         uint64_t ledger_before = col_rel_owned_ledger_bytes(r);
         uint32_t new_cap = r->capacity ? r->capacity * 2 : COL_REL_INIT_CAP;
         if (new_cap <= r->capacity) /* overflow guard */
-            return ENOMEM;
+            goto enomem;
         if (r->col_shared || r->arena_owned) {
             /* Ownership transitions stage columns and timestamps together;
              * admission happens before any source buffer is copied and the
              * helper publishes the storage generation on success. */
-            if (col_rel_grow_owned_transition(r, new_cap) != 0)
-                return ENOMEM;
+            if (col_rel_grow_owned_transition_impl(r, new_cap, true) != 0)
+                goto enomem;
+            alias_release_pending = true;
         } else {
             /* Heap-owned growth is one transaction: admit the new footprint
              * (retained relations only), prepare private buffers, commit the
@@ -1338,11 +1392,11 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
             if (admitted) {
                 pending_rc = col_rel_reserve_retained(r, new_cap, &pending);
                 if (pending_rc < 0)
-                    return ENOMEM;
+                    goto enomem;
                 if (!col_rel_retained_bytes(r->ncols, new_cap,
                     r->timestamps != NULL, &new_bytes)) {
                     col_rel_reservation_rollback(&pending);
-                    return ENOMEM;
+                    goto enomem;
                 }
             }
             int64_t **new_cols = NULL;
@@ -1352,7 +1406,8 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
             if (prepare_rc != 0) {
                 if (admitted)
                     col_rel_reservation_rollback(&pending);
-                return prepare_rc;
+                rc = prepare_rc;
+                goto release_writer;
             }
             if (admitted && pending_rc > 0
                 && col_rel_publish_retained_reservation(r, &pending,
@@ -1360,7 +1415,7 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
                 col_rel_reservation_rollback(&pending);
                 col_columns_free(new_cols, r->ncols);
                 free(new_ts);
-                return ENOMEM;
+                goto enomem;
             }
             col_rel_publish_resize(r, new_cols, new_ts, new_cap);
             col_rel_ledger_reconcile(r, ledger_before);
@@ -1369,14 +1424,21 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
     }
     /* A shared view can still have spare capacity.  Privatize it before the
      * in-place row write even when no capacity growth is needed. */
-    if (r->col_shared && col_rel_cow_unshare(r, 0) != 0)
-        return ENOMEM;
+    if (r->col_shared) {
+        if (col_rel_cow_unshare_impl(r, 0, true) != 0)
+            goto enomem;
+        alias_release_pending = true;
+    }
+#ifdef WL_TEST_APPEND_HOOK
+    if (alias_release_pending && wl_columnar_append_transition_hook)
+        wl_columnar_append_transition_hook(r);
+#endif
     if (r->timestamps)
         memset(&r->timestamps[r->nrows], 0, sizeof(col_delta_timestamp_t));
     /* Structural and value validation above makes this raw copy
     * non-failing; retain the check as a defensive invariant. */
     if (col_rel_row_copy_in_raw(r, r->nrows, row) != 0)
-        return EINVAL;
+        goto einval;
     if (r->column_types) {
         for (uint32_t c = 0; c < r->ncols; c++) {
             if (r->column_types[c] == WIRELOG_TYPE_FLOAT
@@ -1386,7 +1448,23 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
     }
     r->nrows++;
     wl_columnar_relation_touch_view(r);
-    return 0;
+    rc = 0;
+    goto release_writer;
+
+enomem:
+    rc = ENOMEM;
+    goto release_writer;
+einval:
+    rc = EINVAL;
+release_writer:
+    if (alias_release_pending) {
+        int alias_rc = col_rel_storage_alias_release(r);
+        if (alias_rc != 0 && rc == 0)
+            rc = alias_rc;
+    }
+    if (wl_columnar_source_access_writer_release(&writer) != 0 && rc == 0)
+        rc = EINVAL;
+    return rc;
 }
 
 /* Copy all rows from src into dst (must have same ncols).

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1895,6 +1895,11 @@ col_session_destroy(wl_session_t *session)
      * etc.) before any of the other teardown frees them. NULL-safe. */
     if (sess->rotation_ops && sess->rotation_ops->destroy)
         sess->rotation_ops->destroy(sess);
+    /* Admission is closed and all backend operations are quiescent before
+     * this vtable entry is called.  Finish any submit-only or in-flight batch
+     * while its worker/view/relation/allocator contexts are still alive. */
+    if (sess->wq)
+        (void)wl_workqueue_drain(sess->wq);
     /* Worker views may borrow coordinator relation storage.  Drain workers
      * before coordinator relations so their owner borrows are released before
      * the coordinator root is destroyed. */
@@ -2042,6 +2047,8 @@ col_worker_session_create(wl_col_session_t *coordinator,
     /* Prevent accidental wl_session_destroy on stack-allocated worker */
     out_worker->base.backend = NULL;
     out_worker->base.owns_extension_snapshot = false;
+    out_worker->base.operation_admission = NULL;
+    out_worker->base.owns_operation_admission = false;
 
     /* Step 3: NULL all owned pointers (safe for cleanup on early abort) */
     out_worker->wq = NULL;

--- a/wirelog/session.c
+++ b/wirelog/session.c
@@ -21,8 +21,87 @@
  */
 
 #include "session.h"
+#include "thread.h"
 #include <errno.h>
 #include <stddef.h>
+#include <stdlib.h>
+
+struct wl_session_admission {
+    mutex_t mutex;
+    cond_t idle;
+    size_t active_operations;
+    bool closing;
+};
+
+static wl_session_admission_t *
+wl_session_admission_create(void)
+{
+    wl_session_admission_t *admission =
+        (wl_session_admission_t *)calloc(1, sizeof(*admission));
+    if (!admission)
+        return NULL;
+    if (mutex_init(&admission->mutex) != 0) {
+        free(admission);
+        return NULL;
+    }
+    if (cond_init(&admission->idle) != 0) {
+        mutex_destroy(&admission->mutex);
+        free(admission);
+        return NULL;
+    }
+    return admission;
+}
+
+static void
+wl_session_admission_destroy(wl_session_admission_t *admission)
+{
+    if (!admission)
+        return;
+    cond_destroy(&admission->idle);
+    mutex_destroy(&admission->mutex);
+    free(admission);
+}
+
+static int
+wl_session_operation_begin(wl_session_t *session)
+{
+    wl_session_admission_t *admission = session->operation_admission;
+    if (!admission)
+        return 0;
+
+    mutex_lock(&admission->mutex);
+    if (admission->closing) {
+        mutex_unlock(&admission->mutex);
+        return EBUSY;
+    }
+    admission->active_operations++;
+    mutex_unlock(&admission->mutex);
+    return 0;
+}
+
+static void
+wl_session_operation_end(wl_session_t *session)
+{
+    wl_session_admission_t *admission = session->operation_admission;
+    if (!admission)
+        return;
+
+    mutex_lock(&admission->mutex);
+    admission->active_operations--;
+    if (admission->closing && admission->active_operations == 0)
+        cond_signal(&admission->idle);
+    mutex_unlock(&admission->mutex);
+}
+
+static void
+wl_session_admission_close_and_wait(wl_session_admission_t *admission)
+{
+    mutex_lock(&admission->mutex);
+    admission->closing = true;
+    while (admission->active_operations != 0)
+        cond_wait(&admission->idle, &admission->mutex);
+    mutex_unlock(&admission->mutex);
+}
 
 void
 wl_session_options_init(wl_session_options_t *options)
@@ -103,6 +182,7 @@ wl_session_create_with_snapshot_options(const wl_compute_backend_t *backend,
     const wl_session_options_t *options, wl_session_t **out)
 {
     int rc;
+    wl_session_admission_t *admission;
 #ifdef WL_SESSION_TEST_HOOKS
     if (!options)
         options = testhook_options;
@@ -110,6 +190,10 @@ wl_session_create_with_snapshot_options(const wl_compute_backend_t *backend,
     if (!backend || !backend->session_create || !out
         || !wl_session_options_valid(options))
         return -1;
+
+    admission = wl_session_admission_create();
+    if (!admission)
+        return ENOMEM;
 
     if (options && backend->session_create_with_options)
         rc = backend->session_create_with_options(plan, num_workers, options,
@@ -119,11 +203,15 @@ wl_session_create_with_snapshot_options(const wl_compute_backend_t *backend,
     if (rc == 0 && *out) {
         /* Ensure the backend pointer is correctly bound */
         (*out)->backend = backend;
+        (*out)->operation_admission = admission;
+        (*out)->owns_operation_admission = true;
         if (snapshot) {
             wirelog_extension_snapshot_retain(snapshot);
             (*out)->extension_snapshot = snapshot;
             (*out)->owns_extension_snapshot = true;
         }
+    } else {
+        wl_session_admission_destroy(admission);
     }
     return rc;
 }
@@ -131,35 +219,56 @@ wl_session_create_with_snapshot_options(const wl_compute_backend_t *backend,
 void
 wl_session_destroy(wl_session_t *session)
 {
+    const wl_compute_backend_t *backend;
     wirelog_extension_snapshot_t *snapshot;
+    wl_session_admission_t *admission;
     if (!session)
         return;
+    admission = session->owns_operation_admission
+        ? session->operation_admission : NULL;
+    if (admission)
+        wl_session_admission_close_and_wait(admission);
+    backend = session->backend;
     snapshot = session->owns_extension_snapshot
         ? session->extension_snapshot : NULL;
-    if (session->backend && session->backend->session_destroy)
-        session->backend->session_destroy(session);
+    if (backend && backend->session_destroy)
+        backend->session_destroy(session);
     wirelog_extension_snapshot_release(snapshot);
+    wl_session_admission_destroy(admission);
 }
 
 int
 wl_session_insert(wl_session_t *session, const char *relation,
     const int64_t *data, uint32_t num_rows, uint32_t num_cols)
 {
-    if (!session || !session->backend || !session->backend->session_insert)
+    int rc;
+    if (!session)
         return -1;
-    if (session->input_load_failed)
-        return -1;
-    return session->backend->session_insert(session, relation, data, num_rows,
-               num_cols);
+    rc = wl_session_operation_begin(session);
+    if (rc != 0)
+        return rc;
+    if (!session->backend || !session->backend->session_insert
+        || session->input_load_failed)
+        rc = -1;
+    else
+        rc = session->backend->session_insert(session, relation, data,
+                num_rows, num_cols);
+    wl_session_operation_end(session);
+    return rc;
 }
 
 wl_columnar_memory_governor_t *
 wl_session_memory_governor(wl_session_t *session)
 {
-    if (!session || !session->backend
-        || !session->backend->session_memory_governor)
+    wl_columnar_memory_governor_t *governor = NULL;
+    if (!session)
         return NULL;
-    return session->backend->session_memory_governor(session);
+    if (wl_session_operation_begin(session) != 0)
+        return NULL;
+    if (session->backend && session->backend->session_memory_governor)
+        governor = session->backend->session_memory_governor(session);
+    wl_session_operation_end(session);
+    return governor;
 }
 
 int
@@ -167,50 +276,86 @@ wl_session_make_compound(wl_session_t *session, const char *functor,
     uint32_t arity, const wirelog_compound_arg_t *args,
     uint64_t *handle_out)
 {
-    if (!session || !session->backend
-        || !session->backend->session_make_compound)
+    int rc;
+    if (!session)
         return EINVAL;
-    return session->backend->session_make_compound(session, functor, arity,
-               args, handle_out);
+    rc = wl_session_operation_begin(session);
+    if (rc != 0)
+        return rc;
+    if (!session->backend || !session->backend->session_make_compound)
+        rc = EINVAL;
+    else
+        rc = session->backend->session_make_compound(session, functor, arity,
+                args, handle_out);
+    wl_session_operation_end(session);
+    return rc;
 }
 
 int
 wl_session_remove(wl_session_t *session, const char *relation,
     const int64_t *data, uint32_t num_rows, uint32_t num_cols)
 {
-    if (!session || !session->backend || !session->backend->session_remove)
+    int rc;
+    if (!session)
         return -1;
-    return session->backend->session_remove(session, relation, data, num_rows,
-               num_cols);
+    rc = wl_session_operation_begin(session);
+    if (rc != 0)
+        return rc;
+    if (!session->backend || !session->backend->session_remove)
+        rc = -1;
+    else
+        rc = session->backend->session_remove(session, relation, data,
+                num_rows, num_cols);
+    wl_session_operation_end(session);
+    return rc;
 }
 
 int
 wl_session_step(wl_session_t *session)
 {
-    if (!session || !session->backend || !session->backend->session_step)
+    int rc;
+    if (!session)
         return -1;
-    if (session->input_load_failed)
-        return -1;
-    return session->backend->session_step(session);
+    rc = wl_session_operation_begin(session);
+    if (rc != 0)
+        return rc;
+    if (!session->backend || !session->backend->session_step
+        || session->input_load_failed)
+        rc = -1;
+    else
+        rc = session->backend->session_step(session);
+    wl_session_operation_end(session);
+    return rc;
 }
 
 void
 wl_session_set_delta_cb(wl_session_t *session, wirelog_on_delta_fn callback,
     void *user_data)
 {
-    if (!session || !session->backend
-        || !session->backend->session_set_delta_cb)
+    if (!session)
         return;
-    session->backend->session_set_delta_cb(session, callback, user_data);
+    if (wl_session_operation_begin(session) != 0)
+        return;
+    if (session->backend && session->backend->session_set_delta_cb)
+        session->backend->session_set_delta_cb(session, callback, user_data);
+    wl_session_operation_end(session);
 }
 
 int
 wl_session_snapshot(wl_session_t *session, wirelog_on_tuple_fn callback,
     void *user_data)
 {
-    if (!session || !session->backend || !session->backend->session_snapshot)
+    int rc;
+    if (!session)
         return -1;
-    if (session->input_load_failed)
-        return -1;
-    return session->backend->session_snapshot(session, callback, user_data);
+    rc = wl_session_operation_begin(session);
+    if (rc != 0)
+        return rc;
+    if (!session->backend || !session->backend->session_snapshot
+        || session->input_load_failed)
+        rc = -1;
+    else
+        rc = session->backend->session_snapshot(session, callback, user_data);
+    wl_session_operation_end(session);
+    return rc;
 }

--- a/wirelog/session.h
+++ b/wirelog/session.h
@@ -30,6 +30,8 @@ extern "C" {
 #include "backend.h"
 #include "wirelog/wirelog-extension.h"
 
+typedef struct wl_session_admission wl_session_admission_t;
+
 /*
  * Note: concrete session types embed wl_session_t as their first field,
  * or allocate a struct where the backend pointer is tracked. For our purposes,
@@ -47,6 +49,13 @@ struct wl_session {
      * destroyed; otherwise a later snapshot could evaluate truncated facts.
      */
     bool input_load_failed;
+    /*
+     * Heap-owned because columnar worker sessions begin as bitwise copies of
+     * the coordinator.  Workers clear both fields and never close or destroy
+     * the coordinator's admission state.
+     */
+    wl_session_admission_t *operation_admission;
+    bool owns_operation_admission;
 };
 
 /* Wrapper functions that delegate to the backend vtable */
@@ -114,6 +123,10 @@ wl_session_testhook_default_options(void);
  * @session:  The session to destroy (NULL-safe).
  *
  * Destroy an active execution session and release all associated resources.
+ * Callers must not invoke this function from a session operation or from a
+ * tuple/delta callback; such reentrant destruction is unsupported.  The
+ * operation admission guard waits for admitted work to finish before backend
+ * teardown and therefore cannot safely wait for the operation that called it.
  */
 void
 wl_session_destroy(wl_session_t *session);


### PR DESCRIPTION
## Summary

- add internal operation admission for session wrappers
- close admission and wait for active operations before backend teardown
- drain columnar workqueues before worker/relation/allocator cleanup
- add concurrent teardown and queued-work regression tests
- update the threading atomic inventory for transferable source readers

Closes #1494

Stacked on PR #1514 (`issue-1494-source-scope`). This is the lifecycle admission/drain unit; mutation-family enforcement, arrangement activation, and final qualification remain subsequent units in #1494/#1495/#1496/#1497.

## Validation

- focused normal: 8/8 passed
- focused ASan/UBSan: 8/8 passed
- focused TSan: passed
- native `clang_tidy_ratchet`: passed
- full `-Dthreads=posix` local suite: 356 passed, 14 skipped; its only failure was the expected source partition mismatch for the non-native backend
