### PR TITLE
ci: guard program lifetime in plan fixtures (#1471)

### DIFF
--- a/scripts/ci/check-program-lifetime.py
+++ b/scripts/ci/check-program-lifetime.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Guard against freeing a program before the sessions built from its plan.
+
+A ``wl_plan_t`` and every session created from it borrow the program's
+intern table (the borrow note in ``wirelog/exec_plan_gen.c`` and the
+executor contract in ``wirelog/wirelog.h``).  Test helpers used to free the
+program right after ``wl_plan_from_program()``; that became a use after free
+once session creation attaches the memory governor to ``plan->intern``
+(Issue #1431), and nothing stopped a new helper from reintroducing the
+pattern (Issue #1471).  ``tests/plan_fixture.h`` provides
+``plan_fixture_hold()``, which keeps a program alive until exit.
+
+The gate is a deterministic text scan over ``tests/`` and ``bench/`` (no C
+parser).  For every function that calls ``wl_plan_from_program()`` or
+``wl_plan_from_program_with_snapshot()`` and does not call
+``plan_fixture_hold()``, it opens a region at the plan call and walks the
+lines that follow.  A line is *unconditional* when it sits at the plan
+call's brace depth and indentation and does not open a control statement,
+so the plan-generation failure branch (``if (rc != 0) { free; return }``,
+braced or not) is never unconditional.  The region ends at an unconditional
+``return``/``continue``/``break``/``goto``, an unconditional
+``wl_plan_free()`` of the plan, an unconditional session destroy, or when
+the enclosing block closes.  Inside the region an unconditional
+``wirelog_program_free()`` of the program is an offender when the plan is
+still live: before the free the plan escaped (stored through an assignment,
+returned, or handed to a session create), or after the free the plan is
+referenced at all, other than by ``wl_plan_free()``.
+
+Known limitations, deliberately accepted: a program freed under another
+name, a free wrapped in a macro or split across lines, a plan built in a
+nested block and used after that block closes, a plan handed to a storing
+function other than session create, ``goto`` to a label that frees on the
+success path, and ``#if 0`` blocks (the preprocessor is not evaluated).
+A conditional ``return plan;`` followed by an unconditional free of the
+program is reported even though the free is on the failure path; brace the
+failure branch or hold the program.  The fix for a finding is always
+``plan_fixture_hold()``.
+
+Exit codes: 0 clean, 1 offenders or usage or vacuity (no plan-building helper
+scanned), 77 when ``tests/`` or ``bench/`` is missing; ``WIRELOG_ABI_REQUIRED=1``
+turns that skip into a failure.
+
+Usage: check-program-lifetime.py <source-root>
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+PLAN_CALL = re.compile(r"\bwl_plan_from_program(?:_with_snapshot)?\s*\(")
+# The program is the first argument and the plan the ``&plan`` out
+# parameter (never ``&&``); a call without such an argument, for example
+# ``wl_plan_from_program(prog, NULL)``, opens no region but still counts
+# the function as a helper.
+PLAN_ARGS = re.compile(
+    r"\bwl_plan_from_program(?:_with_snapshot)?\s*\(\s*(\w+)\s*,[^;]*?"
+    r"(?<!&)&(?!&)\s*(\w+)")
+HOLD_CALL = re.compile(r"\bplan_fixture_hold\s*\(")
+SESSION_CREATE = re.compile(r"\b(?:wl|col)_session_create\w*\s*\(")
+SESSION_DESTROY = re.compile(r"\b(?:wl|col)_session_destroy\w*\s*\(")
+CONTROL_WORD = re.compile(r"^\s*(?:if|else|for|while|do|switch|case|default)\b")
+LABEL_LINE = re.compile(r"^\s*[A-Za-z_]\w*\s*:\s*$")
+TERMINATOR = re.compile(r"^\s*(?:return|continue|break|goto)\b")
+FUNCTION_NAME = re.compile(r"^\s*(?:static\s+)?[\w\s\*]*?\b([A-Za-z_]\w*)\s*\(")
+SCAN_DIRS = ("tests", "bench")
+SKIP_FILES = {"plan_fixture.h"}
+
+
+def fail(message: str) -> int:
+    print(f"check-program-lifetime: FAIL: {message}", file=sys.stderr)
+    return 1
+
+
+def skip(message: str) -> int:
+    if os.environ.get("WIRELOG_ABI_REQUIRED") == "1":
+        return fail(f"gate required but would skip: {message}")
+    print(f"check-program-lifetime: SKIP: {message}")
+    return 77
+
+
+def strip_source(text: str) -> str:
+    """Blank out comments and string/char literals, preserving newlines.
+
+    A single pass keeps the states exclusive, so a ``//`` inside a string
+    or a ``{`` inside a comment cannot leak into the brace count.
+    """
+    out = []
+    i = 0
+    n = len(text)
+    state = "code"
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if state == "code":
+            if c == "/" and nxt == "/":
+                state = "line"
+                out.append("  ")
+                i += 2
+                continue
+            if c == "/" and nxt == "*":
+                state = "block"
+                out.append("  ")
+                i += 2
+                continue
+            if c == '"':
+                state = "string"
+                out.append(" ")
+                i += 1
+                continue
+            if c == "'":
+                state = "char"
+                out.append(" ")
+                i += 1
+                continue
+            out.append(c)
+            i += 1
+            continue
+        if state == "line":
+            if c == "\n":
+                state = "code"
+                out.append(c)
+            else:
+                out.append(" ")
+            i += 1
+            continue
+        if state == "block":
+            if c == "*" and nxt == "/":
+                state = "code"
+                out.append("  ")
+                i += 2
+                continue
+            out.append(c if c == "\n" else " ")
+            i += 1
+            continue
+        # string or char literal: honour escapes, keep newlines
+        if c == "\\" and i + 1 < n:
+            out.append("  " if nxt != "\n" else " \n")
+            i += 2
+            continue
+        if (state == "string" and c == '"') or (state == "char" and c == "'"):
+            state = "code"
+            out.append(" ")
+            i += 1
+            continue
+        out.append(c if c == "\n" else " ")
+        i += 1
+    return "".join(out)
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" \t"))
+
+
+def split_functions(lines: list[str]) -> list[tuple[str, int, int]]:
+    """Return (name, first_line_index, last_line_index) per function body.
+
+    A body opens at a ``{`` seen while the brace depth is zero.  The name is
+    taken from the nearest earlier line, since the previous body closed, that
+    looks like a declarator; ``?`` when none does.
+    """
+    functions = []
+    depth = 0
+    last_close = -1
+    body_start = None
+    name = "?"
+    for index, line in enumerate(lines):
+        for ch in line:
+            if ch == "{":
+                if depth == 0:
+                    body_start = index
+                    name = "?"
+                    for back in range(index, last_close, -1):
+                        match = FUNCTION_NAME.match(lines[back])
+                        if match:
+                            name = match.group(1)
+                            break
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0 and body_start is not None:
+                    functions.append((name, body_start, index))
+                    body_start = None
+                    last_close = index
+                elif depth < 0:
+                    depth = 0
+    return functions
+
+
+def depth_at_line_starts(lines: list[str]) -> list[int]:
+    depths = []
+    depth = 0
+    for line in lines:
+        depths.append(depth)
+        depth += line.count("{") - line.count("}")
+        if depth < 0:
+            depth = 0
+    return depths
+
+
+def plan_call_args(lines: list[str], index: int) -> tuple[str, str] | None:
+    joined = " ".join(item.strip() for item in lines[index:index + 4])
+    match = PLAN_ARGS.search(joined)
+    return (match.group(1), match.group(2)) if match else None
+
+
+def references_plan(line: str, planv: str, ignore_plan_free: bool) -> bool:
+    text = line
+    if ignore_plan_free:
+        text = re.sub(r"\bwl_plan_free\s*\(\s*%s\s*\)" % re.escape(planv), "",
+                      text)
+    return re.search(r"\b%s\b" % re.escape(planv), text) is not None
+
+
+def escapes_plan(line: str, planv: str) -> bool:
+    """True when the plan leaves the helper alive on this line.
+
+    Before the free only real escapes count: the plan is stored somewhere
+    (``*out = plan;``, ``ctx->plan = plan;``), returned, or handed to a
+    session.  Reads such as ``ASSERT(plan == NULL)`` or ``plan->strata``
+    are not escapes; after the free every reference counts instead.
+    """
+    name = re.escape(planv)
+    return (SESSION_CREATE.search(line) is not None
+            or re.search(r"=\s*%s\s*;" % name, line) is not None
+            or re.search(r"\breturn\s+%s\b" % name, line) is not None)
+
+
+def scan_function(lines: list[str], depths: list[int], name: str,
+                  start: int, end: int, rel: str) -> tuple[bool, list[str]]:
+    """Scan one function; return (is_helper, offender messages)."""
+    body = "\n".join(lines[start:end + 1])
+    if not PLAN_CALL.search(body):
+        return False, []
+    if HOLD_CALL.search(body):
+        return True, []
+    offenders = []
+    for index in range(start, end + 1):
+        if not PLAN_CALL.search(lines[index]):
+            continue
+        args = plan_call_args(lines, index)
+        if not args:
+            continue
+        progv, planv = args
+        region_depth = depths[index]
+        region_indent = indent_of(lines[index])
+        free_re = re.compile(r"\bwirelog_program_free\s*\(\s*%s\s*\)"
+                             % re.escape(progv))
+        plan_free_re = re.compile(r"\bwl_plan_free\s*\(\s*%s\s*\)"
+                                  % re.escape(planv))
+        escaped = False
+        cursor = index + 1
+        while cursor <= end:
+            line = lines[cursor]
+            if not line.strip():
+                cursor += 1
+                continue
+            if depths[cursor] < region_depth:
+                break
+            unconditional = (depths[cursor] <= region_depth
+                             and indent_of(line) <= region_indent
+                             and not CONTROL_WORD.match(line)
+                             and not LABEL_LINE.match(line))
+            if unconditional and plan_free_re.search(line):
+                break
+            if unconditional and SESSION_DESTROY.search(line):
+                break
+            if unconditional and free_re.search(line):
+                # The plan must be dead by now: no escape before the free,
+                # no reference on this line, and none later in the region.
+                later_live = references_plan(line, planv, True)
+                probe = cursor + 1
+                while probe <= end and not later_live:
+                    probe_line = lines[probe]
+                    if depths[probe] < region_depth:
+                        break
+                    probe_unconditional = (depths[probe] <= region_depth
+                                           and indent_of(probe_line)
+                                           <= region_indent
+                                           and not CONTROL_WORD.match(
+                                               probe_line)
+                                           and not LABEL_LINE.match(
+                                               probe_line))
+                    if probe_unconditional and plan_free_re.search(probe_line):
+                        break
+                    if (SESSION_CREATE.search(probe_line)
+                            or references_plan(probe_line, planv, True)):
+                        later_live = True
+                    if probe_unconditional and TERMINATOR.match(probe_line):
+                        break
+                    probe += 1
+                if escaped or later_live:
+                    offenders.append(
+                        f"{rel}:{name}:{cursor + 1}: wirelog_program_free("
+                        f"{progv}) while the plan built at line {index + 1} "
+                        f"is still live; hold the program with "
+                        f"plan_fixture_hold() (tests/plan_fixture.h)")
+                break
+            if escapes_plan(line, planv):
+                escaped = True
+            if unconditional and TERMINATOR.match(line):
+                break
+            cursor += 1
+    return True, offenders
+
+
+def scan_file(path: Path, rel: str) -> tuple[int, list[str]]:
+    text = path.read_text(encoding="utf-8")
+    lines = strip_source(text).split("\n")
+    depths = depth_at_line_starts(lines)
+    helpers = 0
+    offenders: list[str] = []
+    for name, start, end in split_functions(lines):
+        is_helper, found = scan_function(lines, depths, name, start, end, rel)
+        if is_helper:
+            helpers += 1
+        offenders.extend(found)
+    return helpers, offenders
+
+
+def scan_tree(root: Path) -> tuple[int, int, list[str]]:
+    """Return (helpers scanned, files scanned, offender lines)."""
+    helpers = 0
+    files = 0
+    offenders: list[str] = []
+    for sub in SCAN_DIRS:
+        base = root / sub
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*")):
+            if path.suffix not in (".c", ".h") or path.name in SKIP_FILES:
+                continue
+            if not path.is_file():
+                continue
+            files += 1
+            rel = path.relative_to(root).as_posix()
+            count, found = scan_file(path, rel)
+            helpers += count
+            offenders.extend(found)
+    return helpers, files, offenders
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        return fail("usage: check-program-lifetime.py <source-root>")
+    root = Path(argv[1]).resolve()
+    for sub in SCAN_DIRS:
+        if not (root / sub).is_dir():
+            return skip(f"{root / sub} is missing")
+    try:
+        helpers, files, offenders = scan_tree(root)
+    except (OSError, UnicodeDecodeError) as exc:
+        return fail(f"cannot scan {root}: {exc}")
+    if helpers == 0:
+        return fail("no plan-building helper was scanned; the scanner or the "
+                    "test tree has changed shape")
+    if offenders:
+        return fail("\n".join(offenders))
+    print(f"check-program-lifetime: ok {helpers} plan-building helpers in "
+          f"{files} files, none free the program early")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/ci/test-check-program-lifetime.py
+++ b/scripts/ci/test-check-program-lifetime.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Self-test for check-program-lifetime.py (#1471).
+
+Drives the gate over synthetic C sources in a temporary tree so every
+verdict (offender shapes, allowed shapes, vacuity, skip, required
+escalation) is exercised, plus one case over the real repository that must
+report no offender and a sane number of scanned helpers and files.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+GATE = SCRIPT_DIR / "check-program-lifetime.py"
+REPO_ROOT = SCRIPT_DIR.parents[1]
+
+
+def load_gate():
+    spec = importlib.util.spec_from_file_location("_program_lifetime", GATE)
+    assert spec is not None and spec.loader is not None, GATE
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+HEADER = (
+    "#include \"../wirelog/wirelog.h\"\n"
+    "#include \"../wirelog/exec_plan_gen.h\"\n"
+    "#include \"../wirelog/session.h\"\n\n"
+)
+
+# A caller that creates a session from the helper's plan, so a helper's
+# escaping plan is what the guard must reason about.
+CALLER = (
+    "static int\n"
+    "run(const char *src)\n"
+    "{\n"
+    "    wl_plan_t *plan = build_plan(src);\n"
+    "    wl_session_t *sess = NULL;\n"
+    "    if (!plan || wl_session_create(wl_backend_columnar(), plan, 1,\n"
+    "        &sess) != 0)\n"
+    "        return 1;\n"
+    "    wl_session_destroy(sess);\n"
+    "    wl_plan_free(plan);\n"
+    "    return 0;\n"
+    "}\n"
+)
+
+OFFENDER_RETURN = (
+    "static wl_plan_t *\n"
+    "build_plan(const char *src)\n"
+    "{\n"
+    "    wirelog_error_t err;\n"
+    "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+    "    wl_plan_t *plan = NULL;\n"
+    "    int rc = wl_plan_from_program(prog, &plan);\n"
+    "    wirelog_program_free(prog);\n"
+    "    if (rc != 0)\n"
+    "        return NULL;\n"
+    "    return plan;\n"
+    "}\n"
+)
+
+HELD = (
+    "static wl_plan_t *\n"
+    "build_plan(const char *src)\n"
+    "{\n"
+    "    wirelog_error_t err;\n"
+    "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+    "    wl_plan_t *plan = NULL;\n"
+    "    int rc = wl_plan_from_program(prog, &plan);\n"
+    "    if (rc != 0) {\n"
+    "        wirelog_program_free(prog);\n"
+    "        return NULL;\n"
+    "    }\n"
+    "    plan_fixture_hold(prog);\n"
+    "    return plan;\n"
+    "}\n"
+)
+
+
+class GateCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gate = load_gate()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        (self.root / "tests").mkdir()
+        (self.root / "bench").mkdir()
+        self.environ = dict(os.environ)
+        os.environ.pop("WIRELOG_ABI_REQUIRED", None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self.environ)
+        self.tmp.cleanup()
+
+    def write(self, name: str, body: str, sub: str = "tests") -> None:
+        (self.root / sub / name).write_text(HEADER + body + CALLER,
+                                            encoding="utf-8")
+
+    def run_gate(self, root: Path | None = None) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = self.gate.main(["gate", str(root or self.root)])
+        return rc, out.getvalue(), err.getvalue()
+
+    def assert_offender(self, name: str, function: str, line: int) -> None:
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1, err)
+        self.assertIn(f"tests/{name}:{function}:{line}:", err)
+
+    def assert_clean(self, helpers: int = 1) -> None:
+        rc, out, err = self.run_gate()
+        self.assertEqual(rc, 0, err)
+        self.assertIn(f"ok {helpers} plan-building helpers", out)
+
+    # ---- offenders -----------------------------------------------------
+
+    def test_free_before_returning_plan(self) -> None:
+        self.write("a.c", OFFENDER_RETURN)
+        self.assert_offender("a.c", "build_plan", 12)
+
+    def test_free_before_session_create(self) -> None:
+        self.write("a.c",
+                   "static int\n"
+                   "build_plan_and_run(const char *src)\n"
+                   "{\n"
+                   "    wirelog_error_t err;\n"
+                   "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+                   "    wl_plan_t *plan = NULL;\n"
+                   "    wl_session_t *sess = NULL;\n"
+                   "    if (wl_plan_from_program(prog, &plan) != 0) {\n"
+                   "        wirelog_program_free(prog);\n"
+                   "        return 1;\n"
+                   "    }\n"
+                   "    wirelog_program_free(prog);\n"
+                   "    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0)\n"
+                   "        return 1;\n"
+                   "    wl_session_destroy(sess);\n"
+                   "    return 0;\n"
+                   "}\n"
+                   "static wl_plan_t *build_plan(const char *s) { (void)s; return NULL; }\n")
+        self.assert_offender("a.c", "build_plan_and_run", 16)
+
+    def test_free_after_out_parameter_store(self) -> None:
+        self.write("a.c",
+                   "static int\n"
+                   "build_plan_into(const char *src, wl_plan_t **out_plan)\n"
+                   "{\n"
+                   "    wirelog_error_t err;\n"
+                   "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+                   "    wl_plan_t *plan = NULL;\n"
+                   "    if (wl_plan_from_program(prog, &plan) != 0) {\n"
+                   "        wirelog_program_free(prog);\n"
+                   "        return -1;\n"
+                   "    }\n"
+                   "    *out_plan = plan;\n"
+                   "    wirelog_program_free(prog);\n"
+                   "    return 0;\n"
+                   "}\n"
+                   "static wl_plan_t *build_plan(const char *s) { (void)s; return NULL; }\n")
+        self.assert_offender("a.c", "build_plan_into", 16)
+
+    def test_free_and_return_on_one_line(self) -> None:
+        self.write("a.c",
+                   "static wl_plan_t *\n"
+                   "build_plan(const char *src)\n"
+                   "{\n"
+                   "    wirelog_error_t err;\n"
+                   "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+                   "    wl_plan_t *plan = NULL;\n"
+                   "    (void)wl_plan_from_program(prog, &plan);\n"
+                   "    wirelog_program_free(prog); return plan;\n"
+                   "}\n")
+        self.assert_offender("a.c", "build_plan", 12)
+
+    def test_create_before_free_with_conditional_destroy(self) -> None:
+        self.write("a.c",
+                   "static int\n"
+                   "build_plan_and_run(const char *src)\n"
+                   "{\n"
+                   "    wirelog_error_t err;\n"
+                   "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+                   "    wl_plan_t *plan = NULL;\n"
+                   "    wl_session_t *sess = NULL;\n"
+                   "    if (wl_plan_from_program(prog, &plan) != 0) {\n"
+                   "        wirelog_program_free(prog);\n"
+                   "        return 1;\n"
+                   "    }\n"
+                   "    int rc = wl_session_create(wl_backend_columnar(), plan, 1, &sess);\n"
+                   "    if (sess)\n"
+                   "        wl_session_destroy(sess);\n"
+                   "    wirelog_program_free(prog);\n"
+                   "    return rc == 0 && plan != NULL ? 0 : 1;\n"
+                   "}\n"
+                   "static wl_plan_t *build_plan(const char *s) { (void)s; return NULL; }\n")
+        self.assert_offender("a.c", "build_plan_and_run", 19)
+
+    def test_with_snapshot_variant_is_scanned(self) -> None:
+        self.write("a.c", OFFENDER_RETURN.replace(
+            "wl_plan_from_program(prog, &plan)",
+            "wl_plan_from_program_with_snapshot(prog, NULL, &plan)"))
+        self.assert_offender("a.c", "build_plan", 12)
+
+    def test_bench_tree_is_scanned(self) -> None:
+        self.write("b.c", OFFENDER_RETURN, sub="bench")
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("bench/b.c:build_plan:12:", err)
+
+    # ---- allowed shapes ------------------------------------------------
+
+    def test_held_program_is_clean(self) -> None:
+        self.write("a.c", HELD)
+        self.assert_clean()
+
+    def test_held_helper_does_not_exempt_sibling(self) -> None:
+        self.write("a.c", HELD + OFFENDER_RETURN.replace("build_plan",
+                                                         "build_other"))
+        self.assert_offender("a.c", "build_other", 26)
+
+    def test_failure_branch_free_braced_and_braceless(self) -> None:
+        self.write("a.c",
+                   "static wl_plan_t *\n"
+                   "build_plan(const char *src)\n"
+                   "{\n"
+                   "    wirelog_error_t err;\n"
+                   "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+                   "    wl_plan_t *plan = NULL;\n"
+                   "    int rc = wl_plan_from_program(prog, &plan);\n"
+                   "    if (rc != 0)\n"
+                   "        wirelog_program_free(prog);\n"
+                   "    if (rc != 0) {\n"
+                   "        wirelog_program_free(prog);\n"
+                   "        return NULL;\n"
+                   "    }\n"
+                   "    plan_fixture_hold(prog);\n"
+                   "    return plan;\n"
+                   "}\n")
+        self.assert_clean()
+
+    def test_free_after_plan_free_is_clean(self) -> None:
+        self.write("a.c",
+                   "static int\n"
+                   "roundtrip(const char *src)\n"
+                   "{\n"
+                   "    wirelog_error_t err;\n"
+                   "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+                   "    wl_plan_t *plan = NULL;\n"
+                   "    wl_session_t *sess = NULL;\n"
+                   "    if (wl_plan_from_program(prog, &plan) != 0) {\n"
+                   "        wirelog_program_free(prog);\n"
+                   "        return 1;\n"
+                   "    }\n"
+                   "    int rc = wl_session_create(wl_backend_columnar(), plan, 1, &sess);\n"
+                   "    if (sess)\n"
+                   "        wl_session_destroy(sess);\n"
+                   "    wl_plan_free(plan);\n"
+                   "    wirelog_program_free(prog);\n"
+                   "    return rc;\n"
+                   "}\n"
+                   "static wl_plan_t *build_plan(const char *s) { (void)s; return NULL; }\n")
+        self.assert_clean()
+
+    def test_free_after_unconditional_destroy_is_clean(self) -> None:
+        self.write("a.c",
+                   "static int\n"
+                   "roundtrip(const char *src)\n"
+                   "{\n"
+                   "    wirelog_error_t err;\n"
+                   "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+                   "    wl_plan_t *plan = NULL;\n"
+                   "    wl_session_t *sess = NULL;\n"
+                   "    if (wl_plan_from_program(prog, &plan) != 0) {\n"
+                   "        wirelog_program_free(prog);\n"
+                   "        return 1;\n"
+                   "    }\n"
+                   "    if (wl_session_create(wl_backend_columnar(), plan, 1, &sess) != 0) {\n"
+                   "        wl_plan_free(plan);\n"
+                   "        wirelog_program_free(prog);\n"
+                   "        return 1;\n"
+                   "    }\n"
+                   "    wl_session_destroy(sess);\n"
+                   "    wirelog_program_free(prog);\n"
+                   "    wl_plan_free(plan);\n"
+                   "    return 0;\n"
+                   "}\n"
+                   "static wl_plan_t *build_plan(const char *s) { (void)s; return NULL; }\n")
+        self.assert_clean()
+
+    def test_plan_variable_reuse_after_release_is_clean(self) -> None:
+        self.write("a.c",
+                   "static int\n"
+                   "twice(const char *src)\n"
+                   "{\n"
+                   "    wirelog_error_t err;\n"
+                   "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+                   "    wl_plan_t *plan = NULL;\n"
+                   "    if (wl_plan_from_program(prog, &plan) != 0)\n"
+                   "        return 1;\n"
+                   "    wl_plan_free(plan);\n"
+                   "    wirelog_program_free(prog);\n"
+                   "    prog = wirelog_parse_string(src, &err);\n"
+                   "    if (wl_plan_from_program(prog, &plan) != 0)\n"
+                   "        return 1;\n"
+                   "    wl_plan_free(plan);\n"
+                   "    wirelog_program_free(prog);\n"
+                   "    return 0;\n"
+                   "}\n"
+                   "static wl_plan_t *build_plan(const char *s) { (void)s; return NULL; }\n")
+        self.assert_clean()
+
+    def test_plan_call_in_loop_with_continue_is_clean(self) -> None:
+        self.write("a.c",
+                   "static int\n"
+                   "many(const char *const *srcs, int n)\n"
+                   "{\n"
+                   "    for (int i = 0; i < n; i++) {\n"
+                   "        wirelog_error_t err;\n"
+                   "        wirelog_program_t *prog = wirelog_parse_string(srcs[i], &err);\n"
+                   "        wl_plan_t *plan = NULL;\n"
+                   "        if (wl_plan_from_program(prog, &plan) != 0) {\n"
+                   "            wirelog_program_free(prog);\n"
+                   "            continue;\n"
+                   "        }\n"
+                   "        wl_plan_free(plan);\n"
+                   "        wirelog_program_free(prog);\n"
+                   "    }\n"
+                   "    return 0;\n"
+                   "}\n"
+                   "static wl_plan_t *build_plan(const char *s) { (void)s; return NULL; }\n")
+        self.assert_clean()
+
+    def test_strings_and_comments_do_not_skew_depth(self) -> None:
+        # Three lines of brace-carrying literals and comments precede an
+        # offender, whose line must still be reported at the right place.
+        self.write("a.c",
+                   "static const char *SRC = \"rule(x) :- { // not a comment {\";\n"
+                   "static const char BRACE = '{';\n"
+                   "/* { a brace in a comment */\n"
+                   + OFFENDER_RETURN.replace("wirelog_error_t err;",
+                                             "wirelog_error_t err; // {"))
+        self.assert_offender("a.c", "build_plan", 15)
+
+    @unittest.expectedFailure
+    def test_goto_label_free_is_a_documented_gap(self) -> None:
+        self.write("a.c",
+                   "static int\n"
+                   "build_plan_into(const char *src, wl_plan_t **out_plan)\n"
+                   "{\n"
+                   "    wirelog_error_t err;\n"
+                   "    wirelog_program_t *prog = wirelog_parse_string(src, &err);\n"
+                   "    wl_plan_t *plan = NULL;\n"
+                   "    int rc = wl_plan_from_program(prog, &plan);\n"
+                   "    if (rc != 0)\n"
+                   "        goto done;\n"
+                   "    *out_plan = plan;\n"
+                   "    goto done;\n"
+                   "done:\n"
+                   "    wirelog_program_free(prog);\n"
+                   "    return rc;\n"
+                   "}\n"
+                   "static wl_plan_t *build_plan(const char *s) { (void)s; return NULL; }\n")
+        self.assert_offender("a.c", "build_plan_into", 17)
+
+    # ---- gate mechanics --------------------------------------------------
+
+    def test_vacuity_floor(self) -> None:
+        (self.root / "tests" / "a.c").write_text(HEADER + CALLER,
+                                                 encoding="utf-8")
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("no plan-building helper", err)
+
+    def test_missing_tree_skips(self) -> None:
+        rc, out, _ = self.run_gate(self.root / "absent")
+        self.assertEqual(rc, 77)
+        self.assertIn("SKIP", out)
+
+    def test_required_turns_skip_into_failure(self) -> None:
+        os.environ["WIRELOG_ABI_REQUIRED"] = "1"
+        rc, _, err = self.run_gate(self.root / "absent")
+        self.assertEqual(rc, 1)
+        self.assertIn("gate required but would skip", err)
+
+    def test_usage(self) -> None:
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = self.gate.main(["gate"])
+        self.assertEqual(rc, 1)
+        self.assertIn("usage", err.getvalue())
+
+    def test_repository_is_clean(self) -> None:
+        """The real tree must have no offender and a sane scan extent."""
+        helpers, files, offenders = self.gate.scan_tree(REPO_ROOT)
+        self.assertEqual(offenders, [])
+        self.assertGreater(helpers, 100)
+        self.assertGreaterEqual(files, 26)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -792,6 +792,18 @@ test('changelog_format', py3,
             meson.project_source_root() / 'CHANGELOG.md'],
      suite: 'abi')
 
+# Issue #1471: plan-building helpers under tests/ and bench/ must keep the
+# program alive (plan_fixture_hold) instead of freeing it while the plan is
+# still live; a text scan, no build-tree input.  Python gates are outside
+# the #1462 shell timeout rule.
+test('program_lifetime', py3,
+     args: [meson.project_source_root() / 'scripts/ci/check-program-lifetime.py',
+            meson.project_source_root()],
+     suite: 'abi')
+test('program_lifetime_selftest', py3,
+     args: [meson.project_source_root() / 'scripts/ci/test-check-program-lifetime.py'],
+     suite: 'abi')
+
 # Shell interpreter for the abi-suite shell scripts below.  Resolved
 # once and reused; tests that depend on `sh.found()` are gated on
 # the same handle so platforms without bash (e.g. some Windows

--- a/tests/plan_fixture.h
+++ b/tests/plan_fixture.h
@@ -25,6 +25,12 @@
  * main() returns and after every session and plan has been destroyed.
  * plan_fixture_release() may also be called explicitly; it is idempotent.
  *
+ * The pattern is enforced by scripts/ci/check-program-lifetime.py (meson
+ * test program_lifetime, suite abi, Issue #1471): an unconditional
+ * wirelog_program_free() after wl_plan_from_program() in a helper under
+ * tests/ or bench/ whose plan is still live (returned, stored, or handed to
+ * a session) fails CI unless the helper calls plan_fixture_hold().
+ *
  * Header-only, no dependencies beyond wirelog.h.
  */
 #ifndef WIRELOG_TESTS_PLAN_FIXTURE_H

--- a/tests/test_plan_exchange.c
+++ b/tests/test_plan_exchange.c
@@ -17,6 +17,7 @@
 #include "../wirelog/passes/jpp.h"
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/wirelog.h"
+#include "plan_fixture.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -73,9 +74,14 @@ make_plan(const char *src)
 
     wl_plan_t *plan = NULL;
     int rc = wl_plan_from_program(prog, &plan);
-    wirelog_program_free(prog);
-    if (rc != 0)
+    if (rc != 0) {
+        wirelog_program_free(prog);
         return NULL;
+    }
+    /* The plan borrows the program's intern table; keep the program alive
+     * until exit (Issue #1431), which is also what the program-lifetime
+     * gate (Issue #1471) enforces for every plan-building helper. */
+    plan_fixture_hold(prog);
     return plan;
 }
 


### PR DESCRIPTION
Refs #1471. Based on `main`, two commits.

## What

1. `test: hold the program in test_plan_exchange fixtures`: the last plan-building helper that freed its program right after `wl_plan_from_program()` now keeps it alive with `plan_fixture_hold()`, like every other fixture since #1431.
2. `ci: guard program lifetime in plan fixtures (#1471)`: a new gate, `scripts/ci/check-program-lifetime.py`, scans `tests/` and `bench/` and fails when a helper frees a program with `wirelog_program_free()` while the plan it built from that program is still live (before the free: stored through an assignment, returned, or handed to a session create; after the free: referenced at all, other than by `wl_plan_free()`). Frees in the plan-generation failure branch, after an unconditional `wl_plan_free()` or session destroy, and in helpers that call `plan_fixture_hold()` are allowed. Comments and string literals are blanked before counting braces. The gate and its self-test are registered in the `abi` suite, which every CI job runs on Linux, macOS and Windows; `tidy` was not used because it is Linux-only and skip-gated, and no workflow edit is needed.

Documented limitations (in the script's docstring): a program freed under another name, a free wrapped in a macro or split across lines, a plan built in a nested block and used after it closes, a plan handed to a storing function other than session create, a goto to a label that frees on the success path (kept as an expected-failure self-test case), and preprocessor conditionals; a conditional `return plan;` followed by an unconditional free is reported conservatively.

## Evidence

- On the current tree the scanner reports 169 plan-building helpers in 283 files and no offender; with the first commit reverted it flags `tests/test_plan_exchange.c:make_plan:76`.
- Self-test: 21 cases (offender shapes, allowed shapes, stripping inputs, vacuity floor, skip and `WIRELOG_ABI_REQUIRED` escalation, and a repository case expecting no offender with at least 100 helpers and 26 files), 1 expected failure for the documented goto gap.
- `program_lifetime`, `program_lifetime_selftest` and `plan_exchange` meson tests pass; `plan_exchange` is clean under ASan/UBSan with leak detection; abi suite 62 OK / 0 failed / 2 skipped; full suite 355 OK / 0 failed / 14 skipped.

## Review

Reviewer, Architect and Critic approved both trees (two rounds; the second folded in docstring precision, an `&&`-safe capture, a stronger stripping case and moved the header comment into the gate commit).
