### PR TITLE
fix: exclude append rows from active source readers

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4309,7 +4309,7 @@ test_relation_generations_exe = executable(
   workqueue_src,
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
-  c_args: ['-DWL_TEST_APPEND_HOOK=1'],
+  c_args: ['-DWL_TEST_APPEND_HOOK=1', '-DWL_TEST_SET_HOOK=1'],
 )
 
 test('relation_generations', test_relation_generations_exe)
@@ -4325,7 +4325,8 @@ if host_machine.system() == 'linux'
     workqueue_src,
     include_directories: [wirelog_inc, wirelog_src_inc],
     dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
-    c_args: ['-DWL_TEST_ALLOC_WRAP=1', '-DWL_TEST_APPEND_HOOK=1'],
+    c_args: ['-DWL_TEST_ALLOC_WRAP=1', '-DWL_TEST_APPEND_HOOK=1',
+      '-DWL_TEST_SET_HOOK=1'],
     link_args: [
       '-Wl,--wrap=malloc', '-Wl,--wrap=calloc', '-Wl,--wrap=realloc',
     ],

--- a/tests/test_relation_generations.c
+++ b/tests/test_relation_generations.c
@@ -102,6 +102,46 @@ append_transition_probe(col_rel_t *rel)
 }
 #endif
 
+#ifdef WL_TEST_SET_HOOK
+static col_rel_t *set_hook_expected;
+static col_rel_t *set_hook_owner;
+static int set_hook_reader_rc;
+static int set_hook_writer_rc;
+static bool set_hook_state_ok;
+static int64_t set_hook_source_value;
+static uint64_t set_hook_source_view_generation;
+static uint64_t set_hook_source_storage_generation;
+static uint64_t set_hook_view_generation;
+static uint64_t set_hook_storage_generation;
+
+static void
+set_transition_probe(col_rel_t *rel)
+{
+    wl_columnar_source_access_reader_t reader = { 0 };
+    wl_columnar_source_access_writer_t writer = { 0 };
+
+    if (rel != set_hook_expected)
+        return;
+    set_hook_state_ok = set_hook_owner->columns[0][0]
+        == set_hook_source_value
+        && set_hook_owner->view_generation == set_hook_source_view_generation
+        && set_hook_owner->storage_generation
+        == set_hook_source_storage_generation
+        && rel->storage_owner == set_hook_owner
+        && rel->storage_generation != set_hook_storage_generation
+        && rel->view_generation == set_hook_view_generation
+        && rel->col_shared == NULL
+        && set_hook_owner->storage_alias_borrows == 1;
+    set_hook_reader_rc = col_rel_source_reader_acquire(rel, &reader);
+    if (set_hook_reader_rc == 0)
+        (void)col_rel_source_reader_release(&reader);
+    set_hook_writer_rc = wl_columnar_source_access_writer_acquire(
+        &set_hook_owner->source_access, &writer);
+    if (set_hook_writer_rc == 0)
+        (void)wl_columnar_source_access_writer_release(&writer);
+}
+#endif
+
 static void
 cleanup_relations(void)
 {
@@ -959,6 +999,201 @@ test_canonical_owner_resize_with_live_alias(void)
         && alias->timestamps[alias->nrows - 1u].multiplicity == 5,
         "canonical-owner append-all growth is blocked transactionally");
     cleanup_relations();
+}
+
+static void
+test_checked_set_source_exclusion(void)
+{
+    col_rel_t *rel = new_relation();
+    wl_columnar_source_access_reader_t reader = { 0 };
+    int64_t initial = 17;
+    int64_t **columns;
+    uint64_t view_generation;
+    uint64_t storage_generation;
+    uint32_t aliases;
+
+    CHECK(rel != NULL, "checked set reader relation");
+    CHECK(col_rel_append_row(rel, &initial) == 0,
+        "checked set reader seed");
+    columns = rel->columns;
+    view_generation = rel->view_generation;
+    storage_generation = rel->storage_generation;
+    aliases = rel->storage_alias_borrows;
+    CHECK(col_rel_source_reader_acquire(rel, &reader) == 0,
+        "checked set reader acquire");
+    CHECK(col_rel_set(rel, 0, 0, 23) == EBUSY
+        && rel->columns == columns
+        && rel->columns[0][0] == initial
+        && rel->view_generation == view_generation
+        && rel->storage_generation == storage_generation
+        && rel->storage_alias_borrows == aliases,
+        "checked set reader denial is transactional");
+    CHECK(col_rel_source_reader_release(&reader) == 0,
+        "checked set reader release");
+    CHECK(col_rel_set(rel, 0, 0, 23) == 0
+        && rel->columns[0][0] == 23
+        && rel->view_generation != view_generation,
+        "checked set succeeds after reader release");
+    cleanup_relations();
+}
+
+static void
+test_checked_set_alias_exclusion_and_cow(void)
+{
+    col_rel_t *source = new_relation();
+    col_rel_t *view = new_relation();
+    wl_columnar_source_access_reader_t reader = { 0 };
+    int64_t initial = 31;
+    int64_t **view_columns;
+    uint64_t source_view;
+    uint64_t source_storage;
+    uint64_t view_view;
+    uint64_t view_storage;
+    uint32_t source_aliases;
+
+    CHECK(source && view, "checked set alias relations");
+    CHECK(col_rel_append_row(source, &initial) == 0
+        && col_rel_install_shared_view(view, source) == 0,
+        "checked set alias setup");
+    view_columns = view->columns;
+    source_view = source->view_generation;
+    source_storage = source->storage_generation;
+    view_view = view->view_generation;
+    view_storage = view->storage_generation;
+    source_aliases = source->storage_alias_borrows;
+
+    CHECK(col_rel_source_reader_acquire(source, &reader) == 0,
+        "checked set source reader acquire");
+    CHECK(col_rel_set(view, 0, 0, 41) == EBUSY
+        && view->columns == view_columns
+        && view->col_shared != NULL
+        && view->columns[0][0] == initial
+        && source->columns[0][0] == initial
+        && source->view_generation == source_view
+        && source->storage_generation == source_storage
+        && view->view_generation == view_view
+        && view->storage_generation == view_storage
+        && source->storage_alias_borrows == source_aliases,
+        "source reader blocks alias set transactionally");
+    CHECK(col_rel_source_reader_release(&reader) == 0,
+        "checked set source reader release");
+
+#ifdef WL_TEST_SET_HOOK
+    set_hook_expected = view;
+    set_hook_owner = source;
+    set_hook_reader_rc = 0;
+    set_hook_writer_rc = 0;
+    set_hook_state_ok = false;
+    set_hook_source_value = initial;
+    set_hook_source_view_generation = source->view_generation;
+    set_hook_source_storage_generation = source->storage_generation;
+    set_hook_view_generation = view->view_generation;
+    set_hook_storage_generation = view->storage_generation;
+    wl_columnar_set_transition_hook = set_transition_probe;
+#endif
+    CHECK(col_rel_set(view, 0, 0, 41) == 0,
+        "checked set alias COW succeeds");
+#ifdef WL_TEST_SET_HOOK
+    wl_columnar_set_transition_hook = NULL;
+    set_hook_expected = NULL;
+    CHECK(set_hook_state_ok && set_hook_reader_rc == EBUSY
+        && set_hook_writer_rc == EBUSY,
+        "checked set keeps reader admission closed through COW");
+#endif
+    CHECK(source->columns[0][0] == initial
+        && source->view_generation == source_view
+        && source->storage_generation == source_storage
+        && view->columns[0][0] == 41
+        && view->col_shared == NULL
+        && view->storage_owner == view
+        && source->storage_alias_borrows == source_aliases - 1u
+        && view->view_generation == view_view + 1u
+        && view->storage_generation == view_storage + 1u,
+        "checked set COW publishes after the write");
+    cleanup_relations();
+}
+
+static void
+test_checked_set_owner_alias_rejection(void)
+{
+    col_rel_t *owner = new_relation();
+    col_rel_t *alias = new_relation();
+    int64_t initial = 53;
+    int64_t **owner_columns;
+    uint64_t owner_view;
+    uint64_t owner_storage;
+    uint32_t owner_aliases;
+
+    CHECK(owner && alias, "checked set owner alias relations");
+    CHECK(col_rel_append_row(owner, &initial) == 0
+        && col_rel_install_shared_view(alias, owner) == 0,
+        "checked set owner alias setup");
+    owner_columns = owner->columns;
+    owner_view = owner->view_generation;
+    owner_storage = owner->storage_generation;
+    owner_aliases = owner->storage_alias_borrows;
+    CHECK(col_rel_set(owner, 0, 0, 59) == EBUSY
+        && owner->columns == owner_columns
+        && owner->columns[0][0] == initial
+        && alias->columns[0][0] == initial
+        && owner->view_generation == owner_view
+        && owner->storage_generation == owner_storage
+        && owner->storage_alias_borrows == owner_aliases
+        && alias->storage_owner == owner,
+        "checked set owner with live alias is transactional");
+    cleanup_relations();
+}
+
+static void
+test_checked_set_allocation_atomicity(void)
+{
+#ifdef WL_TEST_ALLOC_WRAP
+    bool completed = false;
+    for (long fail_at = 0; fail_at < 32 && !completed; fail_at++) {
+        col_rel_t *source = new_relation();
+        col_rel_t *view = new_relation();
+        int64_t initial = 67;
+        int64_t **old_columns;
+        bool *old_shared;
+        uint64_t old_view;
+        uint64_t old_storage;
+        uint32_t old_aliases;
+
+        CHECK(source && view, "checked set OOM relations");
+        CHECK(col_rel_append_row(source, &initial) == 0
+            && col_rel_install_shared_view(view, source) == 0,
+            "checked set OOM setup");
+        old_columns = view->columns;
+        old_shared = view->col_shared;
+        old_view = view->view_generation;
+        old_storage = view->storage_generation;
+        old_aliases = source->storage_alias_borrows;
+        allocation_calls = 0;
+        allocation_fail_at = fail_at;
+        int rc = col_rel_set(view, 0, 0, 71);
+        allocation_fail_at = -1;
+        if (rc == 0) {
+            CHECK(view->columns[0][0] == 71 && view->col_shared == NULL,
+                "checked set OOM sweep success");
+            completed = true;
+        } else {
+            CHECK(rc == ENOMEM
+                && view->columns == old_columns
+                && view->col_shared == old_shared
+                && view->view_generation == old_view
+                && view->storage_generation == old_storage
+                && view->columns[0][0] == initial
+                && source->storage_alias_borrows == old_aliases
+                && source->columns[0][0] == initial,
+                "checked set allocation failure is transactional");
+        }
+        cleanup_relations();
+    }
+    allocation_fail_at = -1;
+    CHECK(completed, "checked set OOM sweep reaches success");
+#else
+    /* The normal build still exercises the successful COW path above. */
+#endif
 }
 
 static void
@@ -1911,6 +2146,10 @@ main(void)
     test_source_reader_blocks_append_row();
     test_source_reader_blocks_append_all();
     test_canonical_owner_resize_with_live_alias();
+    test_checked_set_source_exclusion();
+    test_checked_set_alias_exclusion_and_cow();
+    test_checked_set_owner_alias_rejection();
+    test_checked_set_allocation_atomicity();
     test_copy_and_shared_semantics();
     test_rollback_fresh_generation();
     test_overflow_boundary();

--- a/tests/test_relation_generations.c
+++ b/tests/test_relation_generations.c
@@ -883,6 +883,85 @@ test_source_reader_blocks_append_all(void)
 }
 
 static void
+test_canonical_owner_resize_with_live_alias(void)
+{
+    col_rel_t *owner = new_relation();
+    col_rel_t *alias = new_relation();
+    int64_t extra = 777;
+    int64_t **owner_columns;
+    col_delta_timestamp_t *owner_timestamps;
+    int64_t **alias_columns;
+    uint32_t owner_rows;
+    uint32_t owner_capacity;
+    uint64_t owner_view_generation;
+    uint64_t owner_storage_generation;
+    uint64_t owner_generation;
+    uint32_t owner_aliases;
+    int64_t last_value;
+
+    CHECK(owner && alias, "canonical-owner alias resize relations");
+    CHECK(col_rel_enable_timestamps(owner) == 0,
+        "canonical-owner alias timestamps");
+    for (uint32_t i = 0; i < COL_REL_INIT_CAP; i++) {
+        int64_t value = (int64_t)i;
+        CHECK(col_rel_append_row(owner, &value) == 0,
+            "canonical-owner alias fill");
+    }
+    owner->timestamps[COL_REL_INIT_CAP - 1u].iteration = 37;
+    owner->timestamps[COL_REL_INIT_CAP - 1u].multiplicity = 5;
+    CHECK(col_rel_install_shared_view(alias, owner) == 0,
+        "canonical-owner alias install");
+
+    owner_columns = owner->columns;
+    owner_timestamps = owner->timestamps;
+    alias_columns = alias->columns;
+    owner_rows = owner->nrows;
+    owner_capacity = owner->capacity;
+    owner_view_generation = owner->view_generation;
+    owner_storage_generation = owner->storage_generation;
+    owner_generation = owner->storage_owner_generation;
+    owner_aliases = owner->storage_alias_borrows;
+    last_value = alias->columns[0][alias->nrows - 1u];
+
+    CHECK(col_rel_append_row(owner, &extra) == EBUSY
+        && owner->columns == owner_columns
+        && owner->timestamps == owner_timestamps
+        && owner->nrows == owner_rows
+        && owner->capacity == owner_capacity
+        && owner->view_generation == owner_view_generation
+        && owner->storage_generation == owner_storage_generation
+        && owner->storage_owner == owner
+        && owner->storage_owner_generation == owner_generation
+        && owner->storage_alias_borrows == owner_aliases
+        && alias->columns == alias_columns
+        && alias->storage_owner == owner
+        && alias->nrows == owner_rows
+        && alias->columns[0][alias->nrows - 1u] == last_value
+        && alias->timestamps[alias->nrows - 1u].iteration == 37
+        && alias->timestamps[alias->nrows - 1u].multiplicity == 5,
+        "canonical-owner append-row growth is blocked transactionally");
+
+    CHECK(col_rel_append_all(owner, alias, NULL) == EBUSY
+        && owner->columns == owner_columns
+        && owner->timestamps == owner_timestamps
+        && owner->nrows == owner_rows
+        && owner->capacity == owner_capacity
+        && owner->view_generation == owner_view_generation
+        && owner->storage_generation == owner_storage_generation
+        && owner->storage_owner == owner
+        && owner->storage_owner_generation == owner_generation
+        && owner->storage_alias_borrows == owner_aliases
+        && alias->columns == alias_columns
+        && alias->storage_owner == owner
+        && alias->nrows == owner_rows
+        && alias->columns[0][alias->nrows - 1u] == last_value
+        && alias->timestamps[alias->nrows - 1u].iteration == 37
+        && alias->timestamps[alias->nrows - 1u].multiplicity == 5,
+        "canonical-owner append-all growth is blocked transactionally");
+    cleanup_relations();
+}
+
+static void
 test_rollback_fresh_generation(void)
 {
     col_rel_t *rel = new_relation();
@@ -1831,6 +1910,7 @@ main(void)
     test_source_reader_blocks_direct_append_row();
     test_source_reader_blocks_append_row();
     test_source_reader_blocks_append_all();
+    test_canonical_owner_resize_with_live_alias();
     test_copy_and_shared_semantics();
     test_rollback_fresh_generation();
     test_overflow_boundary();

--- a/tests/test_relation_generations.c
+++ b/tests/test_relation_generations.c
@@ -48,17 +48,21 @@ static size_t owned_relation_count;
 
 #ifdef WL_TEST_APPEND_HOOK
 static col_rel_t *append_hook_expected;
+static col_rel_t *append_hook_owner;
 static col_rel_t *append_hook_source;
 static bool append_hook_called;
 static bool append_hook_state_ok;
 static bool append_hook_expect_growth;
+static bool append_hook_probe_source_writer;
 static uint32_t append_hook_expected_rows;
+static uint32_t append_hook_source_expected_rows;
 static uint32_t append_hook_expected_capacity;
 static int64_t **append_hook_source_columns;
 static uint32_t append_hook_source_aliases;
 static uint64_t append_hook_view_generation;
 static uint64_t append_hook_storage_generation;
 static int append_hook_reader_rc;
+static int append_hook_source_writer_rc;
 
 static void
 append_transition_probe(col_rel_t *rel)
@@ -68,10 +72,10 @@ append_transition_probe(col_rel_t *rel)
     if (rel != append_hook_expected)
         return;
     append_hook_called = true;
-    append_hook_state_ok = rel->storage_owner == append_hook_source
-        && rel->storage_owner_identity == append_hook_source->relation_identity
+    append_hook_state_ok = rel->storage_owner == append_hook_owner
+        && rel->storage_owner_identity == append_hook_owner->relation_identity
         && rel->storage_owner_generation
-        == append_hook_source->storage_generation
+        == append_hook_owner->storage_generation
         && rel->nrows == append_hook_expected_rows
         && (append_hook_expect_growth
             ? rel->capacity > append_hook_expected_capacity
@@ -81,12 +85,20 @@ append_transition_probe(col_rel_t *rel)
         && rel->col_shared == NULL
         && rel->storage_alias_borrows == 0
         && append_hook_source->columns == append_hook_source_columns
-        && append_hook_source->nrows == append_hook_expected_rows
+        && append_hook_source->nrows == append_hook_source_expected_rows
         && append_hook_source->storage_alias_borrows
         == append_hook_source_aliases;
     append_hook_reader_rc = col_rel_source_reader_acquire(rel, &reader);
     if (append_hook_reader_rc == 0)
         (void)col_rel_source_reader_release(&reader);
+    if (append_hook_probe_source_writer) {
+        wl_columnar_source_access_writer_t writer = { 0 };
+        append_hook_source_writer_rc =
+            wl_columnar_source_access_writer_acquire(
+            &append_hook_source->source_access, &writer);
+        if (append_hook_source_writer_rc == 0)
+            (void)wl_columnar_source_access_writer_release(&writer);
+    }
 }
 #endif
 
@@ -457,18 +469,22 @@ test_source_reader_blocks_append_row(void)
     view_reserved = view->retained_reserved_bytes;
     view_aliases = view->storage_alias_borrows;
 #ifdef WL_TEST_APPEND_HOOK
+    append_hook_owner = source;
     append_hook_source = source;
     append_hook_expected = view;
     append_hook_called = false;
     append_hook_state_ok = false;
     append_hook_expect_growth = false;
     append_hook_expected_rows = view_rows;
+    append_hook_source_expected_rows = source_rows;
     append_hook_expected_capacity = view_capacity;
     append_hook_source_columns = source_columns;
     append_hook_source_aliases = source_aliases;
     append_hook_view_generation = view_view;
     append_hook_storage_generation = view_storage;
     append_hook_reader_rc = 0;
+    append_hook_probe_source_writer = false;
+    append_hook_source_writer_rc = 0;
     wl_columnar_append_transition_hook = append_transition_probe;
 #endif
     CHECK(col_rel_append_row(view, &extra) == 0,
@@ -550,18 +566,22 @@ test_source_reader_blocks_append_row(void)
     view_reserved = view->retained_reserved_bytes;
     view_aliases = view->storage_alias_borrows;
 #ifdef WL_TEST_APPEND_HOOK
+    append_hook_owner = source;
     append_hook_source = source;
     append_hook_expected = view;
     append_hook_called = false;
     append_hook_state_ok = false;
     append_hook_expect_growth = true;
     append_hook_expected_rows = view_rows;
+    append_hook_source_expected_rows = source_rows;
     append_hook_expected_capacity = view_capacity;
     append_hook_source_columns = source_columns;
     append_hook_source_aliases = source_aliases;
     append_hook_view_generation = view_view;
     append_hook_storage_generation = view_storage;
     append_hook_reader_rc = 0;
+    append_hook_probe_source_writer = false;
+    append_hook_source_writer_rc = 0;
     wl_columnar_append_transition_hook = append_transition_probe;
 #endif
     CHECK(col_rel_append_row(view, &extra) == 0,
@@ -609,6 +629,256 @@ test_source_reader_blocks_append_row(void)
     CHECK(col_rel_source_reader_acquire(view, &reader) == 0
         && col_rel_source_reader_release(&reader) == 0,
         "view reader succeeds after resize append");
+    cleanup_relations();
+}
+
+static void
+test_source_reader_blocks_append_all(void)
+{
+    col_rel_t *src = new_relation();
+    col_rel_t *dst = new_relation();
+    wl_columnar_source_access_reader_t reader = { 0 };
+    int64_t **old_columns;
+    col_delta_timestamp_t *old_timestamps;
+    uint32_t old_rows;
+    uint32_t old_capacity;
+    uint64_t old_view;
+    uint64_t old_storage;
+    uint64_t old_owner_generation;
+    uint64_t old_reserved;
+    uint32_t old_aliases;
+    int64_t value = 17;
+
+    CHECK(src && dst, "append-all direct reader exclusion relations");
+    CHECK(col_rel_append_row(src, &value) == 0
+        && col_rel_append_row(dst, &value) == 0,
+        "append-all direct spare seed");
+    CHECK(col_rel_enable_timestamps(dst) == 0,
+        "append-all direct spare timestamps");
+    dst->timestamps[0].iteration = 41;
+    dst->timestamps[0].multiplicity = 7;
+    CHECK(col_rel_source_reader_acquire(dst, &reader) == 0,
+        "append-all direct spare reader");
+    old_columns = dst->columns;
+    old_timestamps = dst->timestamps;
+    old_rows = dst->nrows;
+    old_capacity = dst->capacity;
+    old_view = dst->view_generation;
+    old_storage = dst->storage_generation;
+    old_owner_generation = dst->storage_owner_generation;
+    old_reserved = dst->retained_reserved_bytes;
+    old_aliases = dst->storage_alias_borrows;
+    int blocked_rc = col_rel_append_all(dst, src, NULL);
+    int release_rc = col_rel_source_reader_release(&reader);
+    CHECK(blocked_rc == EBUSY && release_rc == 0
+        && dst->columns == old_columns
+        && dst->columns[0][0] == value
+        && dst->timestamps == old_timestamps
+        && dst->timestamps[0].iteration == 41
+        && dst->timestamps[0].multiplicity == 7
+        && dst->nrows == old_rows
+        && dst->capacity == old_capacity
+        && dst->view_generation == old_view
+        && dst->storage_generation == old_storage
+        && dst->storage_owner == dst
+        && dst->storage_owner_generation == old_owner_generation
+        && dst->retained_reserved_bytes == old_reserved
+        && dst->storage_alias_borrows == old_aliases,
+        "append-all spare reader denial is transactional");
+    CHECK(col_rel_append_all(dst, src, NULL) == 0
+        && dst->nrows == old_rows + src->nrows
+        && dst->columns[0][old_rows] == value,
+        "append-all spare retry succeeds after reader release");
+    cleanup_relations();
+
+    src = new_relation();
+    dst = new_relation();
+    CHECK(src && dst, "append-all resize reader exclusion relations");
+    CHECK(col_rel_append_row(src, &value) == 0,
+        "append-all resize source seed");
+    for (uint32_t i = 0; i < COL_REL_INIT_CAP; i++) {
+        int64_t row = (int64_t)i;
+        CHECK(col_rel_append_row(dst, &row) == 0,
+            "append-all resize destination seed");
+    }
+    CHECK(col_rel_enable_timestamps(dst) == 0,
+        "append-all resize timestamps");
+    dst->timestamps[COL_REL_INIT_CAP - 1u].stratum = 9;
+    dst->timestamps[COL_REL_INIT_CAP - 1u].multiplicity = 11;
+    CHECK(col_rel_source_reader_acquire(dst, &reader) == 0,
+        "append-all resize reader");
+    old_columns = dst->columns;
+    old_timestamps = dst->timestamps;
+    old_rows = dst->nrows;
+    old_capacity = dst->capacity;
+    old_view = dst->view_generation;
+    old_storage = dst->storage_generation;
+    old_owner_generation = dst->storage_owner_generation;
+    old_reserved = dst->retained_reserved_bytes;
+    old_aliases = dst->storage_alias_borrows;
+    blocked_rc = col_rel_append_all(dst, src, NULL);
+    release_rc = col_rel_source_reader_release(&reader);
+    CHECK(blocked_rc == EBUSY && release_rc == 0
+        && dst->columns == old_columns
+        && dst->columns[0][COL_REL_INIT_CAP - 1u]
+        == (int64_t)(COL_REL_INIT_CAP - 1u)
+        && dst->timestamps == old_timestamps
+        && dst->timestamps[COL_REL_INIT_CAP - 1u].stratum == 9
+        && dst->timestamps[COL_REL_INIT_CAP - 1u].multiplicity == 11
+        && dst->nrows == old_rows
+        && dst->capacity == old_capacity
+        && dst->view_generation == old_view
+        && dst->storage_generation == old_storage
+        && dst->storage_owner == dst
+        && dst->storage_owner_generation == old_owner_generation
+        && dst->retained_reserved_bytes == old_reserved
+        && dst->storage_alias_borrows == old_aliases,
+        "append-all resize reader denial is transactional");
+    CHECK(col_rel_append_all(dst, src, NULL) == 0
+        && dst->nrows == old_rows + src->nrows
+        && dst->capacity > old_capacity
+        && dst->columns[0][old_rows] == value,
+        "append-all resize retry succeeds after reader release");
+    cleanup_relations();
+
+    src = new_relation();
+    dst = new_relation();
+    CHECK(src && dst, "append-all shared spare relations");
+    CHECK(col_rel_append_row(src, &value) == 0
+        && col_rel_enable_timestamps(src) == 0,
+        "append-all shared spare source");
+    src->timestamps[0].iteration = 23;
+    CHECK(col_rel_install_shared_view(dst, src) == 0,
+        "append-all shared spare view");
+#ifdef WL_TEST_APPEND_HOOK
+    append_hook_owner = src;
+    append_hook_source = src;
+    append_hook_expected = dst;
+    append_hook_called = false;
+    append_hook_state_ok = false;
+    append_hook_expect_growth = false;
+    append_hook_expected_rows = dst->nrows;
+    append_hook_source_expected_rows = src->nrows;
+    append_hook_expected_capacity = dst->capacity;
+    append_hook_source_columns = src->columns;
+    append_hook_source_aliases = src->storage_alias_borrows;
+    append_hook_view_generation = dst->view_generation;
+    append_hook_storage_generation = dst->storage_generation;
+    append_hook_reader_rc = 0;
+    append_hook_probe_source_writer = false;
+    append_hook_source_writer_rc = 0;
+    wl_columnar_append_transition_hook = append_transition_probe;
+#endif
+    CHECK(col_rel_append_all(dst, src, NULL) == 0,
+        "append-all shared spare succeeds");
+#ifdef WL_TEST_APPEND_HOOK
+    wl_columnar_append_transition_hook = NULL;
+    append_hook_expected = NULL;
+    CHECK(append_hook_called && append_hook_state_ok
+        && append_hook_reader_rc == EBUSY,
+        "append-all shared spare keeps reader admission closed");
+#endif
+    CHECK(src->nrows == 1 && src->timestamps[0].iteration == 23
+        && dst->nrows == 2 && dst->columns[0][1] == value
+        && dst->timestamps[1].iteration == 23
+        && dst->storage_owner == dst && dst->col_shared == NULL,
+        "append-all shared spare commits after transition");
+    CHECK(col_rel_source_reader_acquire(dst, &reader) == 0
+        && col_rel_source_reader_release(&reader) == 0,
+        "append-all shared spare reader succeeds after commit");
+    cleanup_relations();
+
+    src = new_relation();
+    dst = new_relation();
+    CHECK(src && dst, "append-all shared resize relations");
+    for (uint32_t i = 0; i < COL_REL_INIT_CAP; i++) {
+        int64_t row = (int64_t)i;
+        CHECK(col_rel_append_row(src, &row) == 0,
+            "append-all shared resize source");
+    }
+    CHECK(col_rel_enable_timestamps(src) == 0,
+        "append-all shared resize timestamps");
+    src->timestamps[COL_REL_INIT_CAP - 1u].stratum = 9;
+    CHECK(col_rel_install_shared_view(dst, src) == 0,
+        "append-all shared resize view");
+#ifdef WL_TEST_APPEND_HOOK
+    append_hook_owner = src;
+    append_hook_source = src;
+    append_hook_expected = dst;
+    append_hook_called = false;
+    append_hook_state_ok = false;
+    append_hook_expect_growth = true;
+    append_hook_expected_rows = dst->nrows;
+    append_hook_source_expected_rows = src->nrows;
+    append_hook_expected_capacity = dst->capacity;
+    append_hook_source_columns = src->columns;
+    append_hook_source_aliases = src->storage_alias_borrows;
+    append_hook_view_generation = dst->view_generation;
+    append_hook_storage_generation = dst->storage_generation;
+    append_hook_reader_rc = 0;
+    append_hook_probe_source_writer = false;
+    append_hook_source_writer_rc = 0;
+    wl_columnar_append_transition_hook = append_transition_probe;
+#endif
+    CHECK(col_rel_append_all(dst, src, NULL) == 0,
+        "append-all shared resize succeeds");
+#ifdef WL_TEST_APPEND_HOOK
+    wl_columnar_append_transition_hook = NULL;
+    append_hook_expected = NULL;
+    CHECK(append_hook_called && append_hook_state_ok
+        && append_hook_reader_rc == EBUSY,
+        "append-all shared resize keeps reader admission closed");
+#endif
+    CHECK(src->nrows == COL_REL_INIT_CAP
+        && src->timestamps[COL_REL_INIT_CAP - 1u].stratum == 9
+        && dst->nrows == COL_REL_INIT_CAP * 2u
+        && dst->capacity > COL_REL_INIT_CAP
+        && dst->columns[0][COL_REL_INIT_CAP] == 0
+        && dst->storage_owner == dst && dst->col_shared == NULL,
+        "append-all shared resize commits after transition");
+    cleanup_relations();
+
+    src = new_relation();
+    col_rel_t *destination_owner = new_relation();
+    dst = new_relation();
+    CHECK(src && destination_owner && dst,
+        "append-all different-owner relations");
+    CHECK(col_rel_append_row(src, &value) == 0
+        && col_rel_append_row(destination_owner, &value) == 0
+        && col_rel_install_shared_view(dst, destination_owner) == 0,
+        "append-all different-owner view");
+#ifdef WL_TEST_APPEND_HOOK
+    append_hook_owner = destination_owner;
+    append_hook_source = src;
+    append_hook_expected = dst;
+    append_hook_called = false;
+    append_hook_state_ok = false;
+    append_hook_expect_growth = false;
+    append_hook_expected_rows = dst->nrows;
+    append_hook_source_expected_rows = src->nrows;
+    append_hook_expected_capacity = dst->capacity;
+    append_hook_source_columns = src->columns;
+    append_hook_source_aliases = src->storage_alias_borrows;
+    append_hook_view_generation = dst->view_generation;
+    append_hook_storage_generation = dst->storage_generation;
+    append_hook_reader_rc = 0;
+    append_hook_probe_source_writer = true;
+    append_hook_source_writer_rc = 0;
+    wl_columnar_append_transition_hook = append_transition_probe;
+#endif
+    CHECK(col_rel_append_all(dst, src, NULL) == 0,
+        "append-all different-owner succeeds");
+#ifdef WL_TEST_APPEND_HOOK
+    wl_columnar_append_transition_hook = NULL;
+    append_hook_expected = NULL;
+    CHECK(append_hook_called && append_hook_state_ok
+        && append_hook_reader_rc == EBUSY
+        && append_hook_source_writer_rc == EBUSY,
+        "append-all holds source reader through destination transition");
+#endif
+    CHECK(src->nrows == 1 && destination_owner->nrows == 1
+        && dst->nrows == 2 && dst->storage_owner == dst,
+        "append-all different-owner transaction commits");
     cleanup_relations();
 }
 
@@ -1560,6 +1830,7 @@ main(void)
     test_source_reader_blocks_checked_destroy();
     test_source_reader_blocks_direct_append_row();
     test_source_reader_blocks_append_row();
+    test_source_reader_blocks_append_all();
     test_copy_and_shared_semantics();
     test_rollback_fresh_generation();
     test_overflow_boundary();

--- a/wirelog/columnar/diff.c
+++ b/wirelog/columnar/diff.c
@@ -74,11 +74,12 @@ col_op_consolidate_diff(eval_stack_t *stack, wl_col_session_t *sess)
                 free(e.seg_boundaries);
             return ENOMEM;
         }
-        if (col_rel_append_all(work, in, NULL) != 0) {
+        int append_rc = col_rel_append_all(work, in, NULL);
+        if (append_rc != 0) {
             col_rel_destroy(work);
             if (e.seg_boundaries)
                 free(e.seg_boundaries);
-            return ENOMEM;
+            return append_rc;
         }
         work_owned = true;
     }

--- a/wirelog/columnar/inline.c
+++ b/wirelog/columnar/inline.c
@@ -359,7 +359,9 @@ wl_col_rel_inline_project_column(col_rel_t *dst, uint32_t dst_row,
      * dst is per-worker owned; no cross-worker writes occur here. */
     for (uint32_t k = 0; k < src_width; k++) {
         int64_t v = col_rel_get(src, src_row, src_offset + k);
-        col_rel_set(dst, dst_row, dst_offset + k, v);
+        rc = col_rel_set(dst, dst_row, dst_offset + k, v);
+        if (rc != 0)
+            return rc;
     }
     WL_LOG(WL_LOG_SEC_COMPOUND, WL_LOG_TRACE,
         "event=project path=inline dst=%s src=%s logical_col=%u width=%u "

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -504,6 +504,12 @@ extern wl_columnar_append_transition_hook_t
     wl_columnar_append_transition_hook;
 #endif
 
+#ifdef WL_TEST_SET_HOOK
+/* Test-only seam for the checked-set COW transition window. */
+typedef void (*wl_columnar_set_transition_hook_t)(col_rel_t *);
+extern wl_columnar_set_transition_hook_t wl_columnar_set_transition_hook;
+#endif
+
 /* MSVC in its default C mode neither defines __STDC_VERSION__ >= 201112L
  * nor accepts offsetof() inside _Static_assert (C2059); mirror the guard
  * used by diff_trace.c so the layout contract is still checked everywhere
@@ -703,30 +709,6 @@ static inline int64_t
 col_rel_get(const col_rel_t *r, uint32_t row, uint32_t col)
 {
     return r->columns[col][row];
-}
-
-/** Write a single cell value at (row, col). */
-static inline int
-col_rel_set(col_rel_t *r, uint32_t row, uint32_t col, int64_t val)
-{
-    if (!r || !r->columns || row >= r->capacity || col >= r->ncols
-        || !r->columns[col])
-        return EINVAL;
-    if (r->column_types && r->column_types[col] == WIRELOG_TYPE_FLOAT) {
-        if (!wl_columnar_float_bits_valid(val))
-            return EINVAL;
-        if (wl_columnar_float_bits_zero(val))
-            val = 0;
-    }
-    /* A shared view is a borrowed storage view.  Detach it before the first
-     * write so the source relation and its generations remain untouched.
-     * col_rel_cow_unshare() advances storage_generation once; this logical
-     * cell mutation advances view_generation below. */
-    if (r->col_shared && col_rel_cow_unshare(r, 0) != 0)
-        return ENOMEM;
-    r->columns[col][row] = val;
-    wl_columnar_relation_touch_view(r);
-    return 0;
 }
 
 /** Write a single cell value at (row, col) WITHOUT publishing a generation
@@ -2135,6 +2117,10 @@ int col_rel_storage_owner_destroy_status(const col_rel_t *owner);
 int col_rel_source_reader_acquire(const col_rel_t *,
     wl_columnar_source_access_reader_t *);
 int col_rel_source_reader_release(wl_columnar_source_access_reader_t *);
+
+/* Checked single-cell mutation.  The implementation lives in relation.c so
+ * it can hold canonical-owner source admission across COW and publication. */
+int col_rel_set(col_rel_t *, uint32_t row, uint32_t col, int64_t val);
 
 /* Test seam for the non-wrapping relation identity allocator. */
 int

--- a/wirelog/columnar/merge.c
+++ b/wirelog/columnar/merge.c
@@ -861,11 +861,12 @@ col_op_consolidate(eval_stack_t *stack, wl_col_session_t *sess)
                 free(e.seg_boundaries);
             return ENOMEM;
         }
-        if (col_rel_append_all(work, in, NULL) != 0) {
+        int append_rc = col_rel_append_all(work, in, NULL);
+        if (append_rc != 0) {
             col_rel_destroy(work);
             if (e.seg_boundaries)
                 free(e.seg_boundaries);
-            return ENOMEM;
+            return append_rc;
         }
         work_owned = true;
     }

--- a/wirelog/columnar/ops.c
+++ b/wirelog/columnar/ops.c
@@ -445,6 +445,7 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
         return ENOMEM;
     }
     uint32_t map_mask = map_cap - 1;
+    int set_rc = 0;
 
     /* Index groups by their key so reduction remains linear in the number of
      * input rows rather than scanning every output group. */
@@ -542,7 +543,9 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
             int64_t cur = col_rel_get(out, group_row, agg_index);
             switch (op->agg_fn) {
             case WIRELOG_AGG_COUNT:
-                col_rel_set(out, group_row, agg_index, cur + 1);
+                set_rc = col_rel_set(out, group_row, agg_index, cur + 1);
+                if (set_rc != 0)
+                    goto set_failure;
                 break;
             case WIRELOG_AGG_SUM:
             {
@@ -558,9 +561,11 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                         return ERANGE;
                     }
                     sums[slot] = next_value;
-                    (void)col_rel_set(out, group_row, agg_index,
-                        (int64_t)wl_columnar_float_canonical_bits(
-                            wl_columnar_float_to_bits(next_value)));
+                    set_rc = col_rel_set(out, group_row, agg_index,
+                            (int64_t)wl_columnar_float_canonical_bits(
+                                wl_columnar_float_to_bits(next_value)));
+                    if (set_rc != 0)
+                        goto set_failure;
                     break;
                 }
                 int64_t next;
@@ -577,7 +582,9 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                         col_rel_destroy(in);
                     return ERANGE;
                 }
-                col_rel_set(out, group_row, agg_index, next);
+                set_rc = col_rel_set(out, group_row, agg_index, next);
+                if (set_rc != 0)
+                    goto set_failure;
             }
             break;
             case WIRELOG_AGG_MIN:
@@ -589,11 +596,17 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                     int cmp = wl_columnar_float_compare_bits(agg_val, cur);
                     if ((op->agg_fn == WIRELOG_AGG_MIN && cmp < 0)
                         || (op->agg_fn == WIRELOG_AGG_MAX && cmp > 0))
-                        (void)col_rel_set(out, group_row, agg_index,
-                            (int64_t)wl_columnar_float_canonical_bits(agg_val));
+                        set_rc = col_rel_set(out, group_row, agg_index,
+                                (int64_t)wl_columnar_float_canonical_bits(
+                                    agg_val));
+                    if (set_rc != 0)
+                        goto set_failure;
                 } else if (col_agg_better(op->agg_fn, op->agg_operand_type,
-                    sess->intern, agg_val, cur))
-                    col_rel_set(out, group_row, agg_index, agg_val);
+                    sess->intern, agg_val, cur)) {
+                    set_rc = col_rel_set(out, group_row, agg_index, agg_val);
+                    if (set_rc != 0)
+                        goto set_failure;
+                }
                 break;
             case WIRELOG_AGG_AVG:
                 if (!float_agg)
@@ -608,10 +621,12 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
                     if (e.owned) col_rel_destroy(in);
                     return ERANGE;
                 }
-                (void)col_rel_set(out, group_row, agg_index,
-                    (int64_t)wl_columnar_float_canonical_bits(
-                        wl_columnar_float_to_bits(sums[slot]
-                        / (double)counts[slot])));
+                set_rc = col_rel_set(out, group_row, agg_index,
+                        (int64_t)wl_columnar_float_canonical_bits(
+                            wl_columnar_float_to_bits(sums[slot]
+                            / (double)counts[slot])));
+                if (set_rc != 0)
+                    goto set_failure;
                 break;
             default:
                 break;
@@ -662,6 +677,18 @@ col_op_reduce(const wl_plan_op_t *op, eval_stack_t *stack,
     if (e.owned)
         col_rel_destroy(in);
     return eval_stack_push(stack, out, true);
+
+set_failure:
+    col_row_buf_release(&row_rb);
+    wl_columnar_expr_compiled_free(agg_ce);
+    free(groups);
+    free(sums);
+    free(counts);
+    free(tmp);
+    col_rel_destroy(out);
+    if (e.owned)
+        col_rel_destroy(in);
+    return set_rc;
 }
 
 /* --- REDUCE WEIGHTED (Z-set / Mobius COUNT) ------------------------------ */

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -29,6 +29,10 @@ static wl_atomic_u64 wl_next_relation_identity = 1u;
 wl_columnar_append_transition_hook_t wl_columnar_append_transition_hook;
 #endif
 
+#ifdef WL_TEST_SET_HOOK
+wl_columnar_set_transition_hook_t wl_columnar_set_transition_hook;
+#endif
+
 static int
 col_rel_new_identity(uint64_t *out)
 {
@@ -225,6 +229,64 @@ col_rel_source_writer_acquire(const col_rel_t *rel,
         return rc;
     return wl_columnar_source_access_writer_acquire(
         &owner->source_access, token);
+}
+
+int
+col_rel_set(col_rel_t *r, uint32_t row, uint32_t col, int64_t val)
+{
+    wl_columnar_source_access_writer_t writer = { 0 };
+    bool alias_release_pending = false;
+    col_rel_t *owner = NULL;
+    int rc;
+
+    if (!r || !r->columns || row >= r->capacity || col >= r->ncols
+        || !r->columns[col])
+        return EINVAL;
+    if (r->column_types && r->column_types[col] == WIRELOG_TYPE_FLOAT) {
+        if (!wl_columnar_float_bits_valid(val))
+            return EINVAL;
+        if (wl_columnar_float_bits_zero(val))
+            val = 0;
+    }
+
+    rc = col_rel_storage_owner_resolve(r, &owner);
+    if (rc != 0)
+        return rc;
+    rc = col_rel_source_writer_acquire(r, &writer);
+    if (rc != 0)
+        return rc;
+    if (r == owner && owner->storage_alias_borrows > 0) {
+        rc = EBUSY;
+        goto release_writer;
+    }
+
+    /* Keep the canonical owner writer admission held through the detach,
+     * cell write, and logical generation publication.  The deferred alias
+     * release prevents a new reader from entering through the detached view
+     * before this mutation is complete. */
+    if (r->col_shared) {
+        rc = col_rel_cow_unshare_impl(r, 0, true);
+        if (rc != 0)
+            goto release_writer;
+        alias_release_pending = true;
+    }
+#ifdef WL_TEST_SET_HOOK
+    if (alias_release_pending && wl_columnar_set_transition_hook)
+        wl_columnar_set_transition_hook(r);
+#endif
+    r->columns[col][row] = val;
+    wl_columnar_relation_touch_view(r);
+    rc = 0;
+
+release_writer:
+    if (alias_release_pending) {
+        int alias_rc = col_rel_storage_alias_release(r);
+        if (alias_rc != 0 && rc == 0)
+            rc = alias_rc;
+    }
+    if (wl_columnar_source_access_writer_release(&writer) != 0 && rc == 0)
+        rc = EINVAL;
+    return rc;
 }
 
 /* Prepare a complete private replacement for a relation resize.  This is

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1370,6 +1370,14 @@ col_rel_append_row(col_rel_t *r, const int64_t *row)
 
     bool needs_resize = r->nrows >= r->capacity;
     if (needs_resize) {
+        /* Canonical-owner storage replacement frees the old buffers.  Live
+         * shared views still point at those buffers, so refuse growth until
+         * the aliases are released.  A shared-view destination is allowed
+         * to COW/grow because it replaces its own alias safely. */
+        if (r->storage_owner == r && r->storage_alias_borrows > 0) {
+            rc = EBUSY;
+            goto release_writer;
+        }
         uint64_t ledger_before = col_rel_owned_ledger_bytes(r);
         uint32_t new_cap = r->capacity ? r->capacity * 2 : COL_REL_INIT_CAP;
         if (new_cap <= r->capacity) /* overflow guard */
@@ -1581,6 +1589,15 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
 
     uint32_t dst_base = dst->nrows;
     uint32_t new_nrows = dst->nrows + src->nrows;
+
+    /* Replacing canonical-owner storage frees buffers still referenced by
+     * live aliases.  Keep the raw-pointer alias model safe by refusing only
+     * owner growth; alias destinations may still detach and grow privately. */
+    if (dst == dst_owner && dst_owner->storage_alias_borrows > 0
+        && new_nrows > dst->capacity) {
+        rc = EBUSY;
+        goto cleanup;
+    }
 
     /* Type metadata is part of the append transaction.  Prepare its owned
      * copy and complete Arrow schema before resizing or changing dst. */

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1474,14 +1474,64 @@ release_writer:
 int
 col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
 {
+    col_rel_t *src_owner = NULL;
+    col_rel_t *dst_owner = NULL;
+    wl_columnar_source_access_reader_t source_reader = { 0 };
+    wl_columnar_source_access_writer_t destination_writer = { 0 };
+    bool source_reader_acquired = false;
+    bool destination_writer_acquired = false;
+    bool alias_release_pending = false;
     wirelog_column_type_t *prepared_types = NULL;
     struct ArrowSchema prepared_schema;
     bool prepared_schema_ok = false;
+    int rc;
     (void)arena;
     if (!dst || !src || dst->ncols != src->ncols)
         return EINVAL;
     if (src->nrows == 0)
         return 0;
+
+    /* Preserve the historical zero-initialized, zero-column arithmetic path.
+     * These stack relations have no generation or owner metadata, so owner
+     * resolution would turn a formerly valid row-count operation into EINVAL.
+     * Initialized zero-column relations have an owner and use the normal
+     * source-access gate below. */
+    if (dst->ncols == 0 && src->ncols == 0
+        && !dst->storage_owner && !src->storage_owner) {
+        if (src->nrows > UINT32_MAX - dst->nrows)
+            return EOVERFLOW;
+        dst->nrows += src->nrows;
+        wl_columnar_relation_touch_view(dst);
+        return 0;
+    }
+
+    /* Resolve canonical owners before reading mutable source or destination
+     * state.  A same-owner append uses one writer token: the source reader
+     * and destination writer cannot coexist on one gate. */
+    rc = col_rel_storage_owner_resolve(src, &src_owner);
+    if (rc != 0)
+        return rc;
+    rc = col_rel_storage_owner_resolve(dst, &dst_owner);
+    if (rc != 0)
+        return rc;
+    if (src_owner == dst_owner) {
+        rc = wl_columnar_source_access_writer_acquire(
+            &dst_owner->source_access, &destination_writer);
+        if (rc != 0)
+            return rc;
+        destination_writer_acquired = true;
+    } else {
+        rc = wl_columnar_source_access_reader_acquire(
+            &src_owner->source_access, &source_reader);
+        if (rc != 0)
+            return rc;
+        source_reader_acquired = true;
+        rc = wl_columnar_source_access_writer_acquire(
+            &dst_owner->source_access, &destination_writer);
+        if (rc != 0)
+            goto cleanup;
+        destination_writer_acquired = true;
+    }
 
     /* A typed relation must never receive lanes whose physical meaning is
      * unknown or differs from its own.  Legacy untyped relations are treated
@@ -1499,10 +1549,10 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
             if ((dst_type == WIRELOG_TYPE_FLOAT
                 || src_type == WIRELOG_TYPE_FLOAT)
                 && dst_type != src_type)
-                return EINVAL;
+                goto invalid;
             if (!dst->column_types && src->column_types
                 && src_type == WIRELOG_TYPE_FLOAT && dst->nrows > 0)
-                return EINVAL;
+                goto invalid;
         }
     }
 
@@ -1511,7 +1561,7 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
             for (uint32_t c = 0; c < src->ncols; c++) {
                 if (src->column_types[c] == WIRELOG_TYPE_FLOAT
                     && !wl_columnar_float_bits_valid(src->columns[c][row]))
-                    return EINVAL;
+                    goto invalid;
             }
         }
         if (!dst->column_types) {
@@ -1520,14 +1570,14 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
                     if (src->column_types[c] == WIRELOG_TYPE_FLOAT
                         && !wl_columnar_float_bits_valid(
                             dst->columns[c][row]))
-                        return EINVAL;
+                        goto invalid;
                 }
             }
         }
     }
 
     if (src->nrows > UINT32_MAX - dst->nrows)
-        return EOVERFLOW;
+        goto overflow;
 
     uint32_t dst_base = dst->nrows;
     uint32_t new_nrows = dst->nrows + src->nrows;
@@ -1537,8 +1587,10 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
     if (!dst->column_types && src->column_types) {
         int type_rc = col_rel_prepare_column_types(dst, src->column_types,
                 dst->ncols, &prepared_types, &prepared_schema);
-        if (type_rc != 0)
-            return type_rc;
+        if (type_rc != 0) {
+            rc = type_rc;
+            goto cleanup;
+        }
         prepared_schema_ok = true;
     }
 
@@ -1549,12 +1601,8 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
         uint32_t new_cap = dst->capacity ? dst->capacity * 2 : COL_REL_INIT_CAP;
         while (new_cap < new_nrows) {
             uint32_t next_cap = new_cap * 2;
-            if (next_cap <= new_cap) { /* overflow guard */
-                free(prepared_types);
-                if (prepared_schema_ok)
-                    ArrowSchemaRelease(&prepared_schema);
-                return ENOMEM;
-            }
+            if (next_cap <= new_cap) /* overflow guard */
+                goto overflow;
             new_cap = next_cap;
         }
 
@@ -1567,14 +1615,17 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
             int64_t **new_columns = (int64_t **)calloc(dst->ncols,
                     sizeof(*new_columns));
             col_delta_timestamp_t *new_timestamps = NULL;
-            if (!new_columns)
-                goto fail_prepared;
+            if (!new_columns) {
+                rc = ENOMEM;
+                goto cleanup;
+            }
             for (uint32_t c = 0; c < dst->ncols; c++) {
                 new_columns[c] = (int64_t *)wl_arena_alloc(arena,
                         (size_t)new_cap * sizeof(int64_t));
                 if (!new_columns[c]) {
                     free((void *)new_columns);
-                    goto fail_prepared;
+                    rc = ENOMEM;
+                    goto cleanup;
                 }
                 memcpy(new_columns[c], dst->columns[c],
                     (size_t)dst->nrows * sizeof(int64_t));
@@ -1584,7 +1635,8 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
                     (size_t)new_cap * sizeof(*new_timestamps));
                 if (!new_timestamps) {
                     free((void *)new_columns);
-                    goto fail_prepared;
+                    rc = ENOMEM;
+                    goto cleanup;
                 }
                 memcpy(new_timestamps, dst->timestamps,
                     (size_t)dst->nrows * sizeof(*new_timestamps));
@@ -1602,9 +1654,11 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
             wl_columnar_relation_touch_storage(dst);
             transitioned = true;
         } else if (dst->col_shared || dst->arena_owned) {
-            if (col_rel_grow_owned_transition(dst, new_cap) != 0)
-                goto fail_prepared;
+            rc = col_rel_grow_owned_transition_impl(dst, new_cap, true);
+            if (rc != 0)
+                goto cleanup;
             transitioned = true;
+            alias_release_pending = true;
         } else {
             /* Heap-owned growth: admit (retained relations), prepare, commit,
              * publish -- see col_rel_append_row. */
@@ -1615,20 +1669,22 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
             if (admitted) {
                 pending_rc = col_rel_reserve_retained(dst, new_cap, &pending);
                 if (pending_rc < 0)
-                    goto fail_prepared;
+                    goto allocation_failure;
                 if (!col_rel_retained_bytes(dst->ncols, new_cap,
                     dst->timestamps != NULL, &new_bytes)) {
                     col_rel_reservation_rollback(&pending);
-                    goto fail_prepared;
+                    goto allocation_failure;
                 }
             }
             int64_t **new_cols = NULL;
             col_delta_timestamp_t *new_ts = NULL;
-            if (col_rel_prepare_resize(dst, new_cap, &new_cols, &new_ts)
-                != 0) {
+            int prepare_rc = col_rel_prepare_resize(dst, new_cap,
+                    &new_cols, &new_ts);
+            if (prepare_rc != 0) {
                 if (admitted)
                     col_rel_reservation_rollback(&pending);
-                goto fail_prepared;
+                rc = prepare_rc;
+                goto cleanup;
             }
             if (admitted && pending_rc > 0
                 && col_rel_publish_retained_reservation(dst, &pending,
@@ -1636,7 +1692,7 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
                 col_rel_reservation_rollback(&pending);
                 col_columns_free(new_cols, dst->ncols);
                 free(new_ts);
-                goto fail_prepared;
+                goto allocation_failure;
             }
             col_rel_publish_resize(dst, new_cols, new_ts, new_cap);
             transitioned = false;
@@ -1649,8 +1705,17 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
 
     /* Bulk append also mutates spare capacity, so a shared view must be
      * privatized even when the destination does not grow. */
-    if (dst->col_shared && col_rel_cow_unshare(dst, 0) != 0)
-        goto fail_prepared;
+    if (dst->col_shared) {
+        rc = col_rel_cow_unshare_impl(dst, 0, true);
+        if (rc != 0)
+            goto cleanup;
+        alias_release_pending = true;
+    }
+
+#ifdef WL_TEST_APPEND_HOOK
+    if (alias_release_pending && wl_columnar_append_transition_hook)
+        wl_columnar_append_transition_hook(dst);
+#endif
 
     /* Install the prepared type metadata only after all potentially failing
      * destination growth has completed.  A rejected append therefore cannot
@@ -1663,6 +1728,7 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
         dst->schema = prepared_schema;
         dst->schema_ok = true;
         prepared_types = NULL;
+        prepared_schema_ok = false;
     }
 
     /* Bulk copy all rows per-column.  All fallible preparation is complete. */
@@ -1688,13 +1754,35 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
 
     wl_columnar_relation_touch_view(dst);
 
-    return 0;
+    rc = 0;
+    goto cleanup;
 
-fail_prepared:
+invalid:
+    rc = EINVAL;
+    goto cleanup;
+overflow:
+    rc = EOVERFLOW;
+    goto cleanup;
+allocation_failure:
+    rc = ENOMEM;
+cleanup:
     free(prepared_types);
     if (prepared_schema_ok)
         ArrowSchemaRelease(&prepared_schema);
-    return ENOMEM;
+    if (alias_release_pending) {
+        int alias_rc = col_rel_storage_alias_release(dst);
+        if (alias_rc != 0 && rc == 0)
+            rc = alias_rc;
+    }
+    if (destination_writer_acquired
+        && wl_columnar_source_access_writer_release(&destination_writer) != 0
+        && rc == 0)
+        rc = EINVAL;
+    if (source_reader_acquired
+        && wl_columnar_source_access_reader_release(&source_reader) != 0
+        && rc == 0)
+        rc = EINVAL;
+    return rc;
 }
 
 /* ---- compaction ---------------------------------------------------------- */


### PR DESCRIPTION
## Summary\n\n- add canonical source-owner writer admission to col_rel_append_row\n- return EBUSY before any append mutation while a source reader is active\n- defer shared-view COW/grow alias release until row and generation publication completes\n- add deterministic transition-window tests for spare-capacity COW and full-capacity growth\n- keep the test hook internal and out of the production ABI\n\nThis is one atomic unit of #1495, stacked on #1519. The remaining mutation families stay separate.\n\n## Validation\n\n- normal build: relation_generations, relation_generations_oom, source_access passed\n- ASan/UBSan build: same 3 tests passed\n- normal and sanitizer ABI checks: 7/7 passed each\n- diff and formatting checks passed\n\nAddresses the append-row portion of #1495; it does not close the parent issue.