### PR TITLE
Drive session-create governor denial through the public API (#1473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ All notable changes to wirelog are documented in this file.
   `arr_count`; a failed reuse of the last slot now keeps that tombstone
   rather than dropping it. Registry lookups, invalidation and worker
   cloning tolerate a slot without a name.
+- **Advanced API reports memory-governor overflow as a memory error**
+  (#1473). `wirelog_session_create()` and
+  `wirelog_session_create_with_snapshot()` now map `EOVERFLOW` from session
+  creation to `WIRELOG_ERR_MEMORY`, as the easy and executor facades already
+  did, instead of `WIRELOG_ERR_EXEC`. Session options carry an injected
+  memory governor so the create-time admission floor and its denial are
+  covered deterministically through the easy, executor and advanced
+  facades, and the overflow verdict through the advanced, eager easy and
+  executor paths.
 
 - **Unfused recursive SCCs no longer terminate with incomplete results**
   (#1376). The forced-delta pre-scan now leaves concatenated rule alternatives

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -83,6 +83,12 @@ the resolved byte limit and provenance in the governor, and never duplicates
 or closes the host handle. Missing, unsupported, or invalid handles clear the
 provider and leave automatic resolution advisory unless another finite source
 is available. `WIRELOG_MEMORY_BUDGET` remains higher precedence.
+Options version 2 (#1473) adds `memory_governor`: a caller-retained governor
+reference the session retains for its own lifetime in place of any resolved
+source, so create-time admission can be driven deterministically from tests;
+`windows_job_handle` and `WIRELOG_MEMORY_BUDGET` are ignored when it is set.
+The program-owned intern table attached at creation keeps its own reference
+until `wirelog_program_free()`, so the governor can outlive the session.
 
 An unlimited cgroup value, an absent optional source, and an unsupported
 platform are different observations. The resolver records which source was

--- a/scripts/ci/check-no-testhook-in-libwirelog.sh
+++ b/scripts/ci/check-no-testhook-in-libwirelog.sh
@@ -70,7 +70,7 @@ nm_defined() {
     nm "$1" 2>/dev/null | awk '$2 != "U" && $2 != "u"'
 }
 
-TESTHOOK_RE='wl_log_test_last|wl_log_test_count|wl_log_testhook|__log_testhook'
+TESTHOOK_RE='wl_log_test_last|wl_log_test_count|wl_log_testhook|__log_testhook|wl_session_testhook'
 
 # Capture once, then match the variable.  `nm_defined "$LIB" | grep -q ...` is
 # not equivalent: grep -q exits at the first match, nm takes SIGPIPE and exits

--- a/scripts/ci/test-check-no-testhook.sh
+++ b/scripts/ci/test-check-no-testhook.sh
@@ -110,6 +110,14 @@ EOF
 expect_status 'a testhook symbol is a leak' 1 run "$leaky" "$clean_syms" --check=leak
 expect_says   'the leak names the symbol' 'wl_log_test_last'
 expect_status 'a clean library passes the leak check' 0 run "$clean_syms" "$clean_syms" --check=leak
+# #1473: the session-options test hook shares the gate with the log hooks.
+leaky_session="$tmp/leaky-session.txt"
+cat > "$leaky_session" <<'EOF'
+0000000000001100 T wl_log_init
+0000000000001190 T wl_session_testhook_default_options
+EOF
+expect_status 'a session testhook symbol is a leak' 1 run "$leaky_session" "$clean_syms" --check=leak
+expect_says   'the session leak names the symbol' 'wl_session_testhook_default_options'
 
 # --- (b) the provenance check ------------------------------------------------
 # The regression itself: with line info present the check must reach a verdict.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3684,6 +3684,7 @@ test_session_exe = executable(
   arena_src,
   thread_src,
   workqueue_src,
+  c_args: ['-DWL_SESSION_TEST_HOOKS=1'],
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
@@ -5508,6 +5509,7 @@ test_wirelog_easy_exe = executable(
   workqueue_src,
   '../wirelog/wirelog-easy.c',
   '../wirelog/api_facade.c',
+  c_args: ['-DWL_SESSION_TEST_HOOKS=1'],
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )
@@ -5568,6 +5570,7 @@ test_wirelog_advanced_exe = executable(
   '../wirelog/wirelog-easy.c',
   '../wirelog/api_facade.c',
   '../wirelog/wirelog_advanced.c',
+  c_args: ['-DWL_SESSION_TEST_HOOKS=1'],
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
 )

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -18,6 +18,8 @@
 #include "../wirelog/passes/sip.h"
 #include "../wirelog/session.h"
 #include "../wirelog/columnar/memory_governor.h"
+#include "../wirelog/arena/compound_arena.h"
+#include "../wirelog/intern.h"
 #include "../wirelog/wirelog-parser.h"
 #include "../wirelog/wirelog.h"
 #include "plan_fixture.h"
@@ -496,6 +498,285 @@ test_session_create_with_options(void)
     }
     wl_session_destroy(session);
     wl_plan_free(ffi);
+    PASS();
+}
+
+/* ======================================================================== */
+/* Issue #1473: injected governor and create-time admission                 */
+/* ======================================================================== */
+
+static wl_columnar_memory_governor_ref_t *
+enforcing_governor(uint64_t usable)
+{
+    wl_columnar_memory_resolution_t resolution = { 0 };
+    resolution.budget_bytes = usable;
+    resolution.usable_bytes = usable;
+    resolution.mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING;
+    resolution.source = WL_COLUMNAR_MEMORY_SOURCE_ENV;
+    resolution.status = WL_COLUMNAR_MEMORY_OK;
+    return wl_columnar_memory_governor_ref_create(&resolution);
+}
+
+static uint64_t
+reserved_on(wl_columnar_memory_governor_ref_t *ref)
+{
+    return wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(ref));
+}
+
+/* Bytes a session admits for the program's intern table when it attaches
+ * the table (#1431), measured with a throwaway governor and detached again
+ * so the table is free for the session under test. */
+static int
+probe_intern_bytes(wl_intern_t *intern, uint64_t *out)
+{
+    wl_columnar_memory_governor_ref_t *probe
+        = enforcing_governor(UINT64_MAX / 4u);
+    int rc;
+    if (!probe)
+        return -1;
+    rc = wl_intern_attach_memory_governor(intern, probe);
+    if (rc == 0) {
+        *out = reserved_on(probe);
+        rc = wl_intern_detach_memory_governor(intern, probe);
+        if (rc == 0 && reserved_on(probe) != 0)
+            rc = -1;
+    }
+    wl_columnar_memory_governor_ref_release(probe);
+    return rc;
+}
+
+/* Bytes the session's fixed compound arena admits at creation, using the
+ * same shape col_session_create_internal builds (seed, default_gen_cap and
+ * the library-default epoch count; like the budget tests this assumes
+ * WIRELOG_COMPOUND_MAX_EPOCHS is unset in the test environment). */
+static int
+probe_compound_bytes(uint64_t *out)
+{
+    wl_columnar_memory_governor_ref_t *probe
+        = enforcing_governor(UINT64_MAX / 4u);
+    wl_compound_arena_t *arena;
+    int rc = 0;
+    if (!probe)
+        return -1;
+    arena = wl_compound_arena_create_managed(0x53455353u, 4096u, 0u,
+            wl_columnar_memory_governor_ref_get(probe));
+    if (!arena) {
+        rc = -1;
+    } else {
+        *out = reserved_on(probe);
+        wl_compound_arena_free(arena);
+        if (reserved_on(probe) != 0)
+            rc = -1;
+    }
+    wl_columnar_memory_governor_ref_release(probe);
+    return rc;
+}
+
+/* A fact-free program: nothing but the create-time floor (intern table plus
+ * fixed compound arena; the delta pool and eval arena degrade to malloc) is
+ * admitted at session creation. */
+static const char *INJECTED_GOVERNOR_SRC
+    = ".decl edge(x: int64, y: int64)\n"
+    ".decl path(x: int64, y: int64)\n"
+    "path(x, y) :- edge(x, y).\n";
+
+static void
+test_session_injected_governor_admission(void)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = NULL;
+    wl_plan_t *plan = NULL;
+    wl_session_t *session = NULL;
+    wl_session_options_t options;
+    wl_columnar_memory_governor_ref_t *ref = NULL;
+    wl_columnar_memory_reservation_t token;
+    wl_mem_ledger_snapshot_t ledger;
+    uint64_t intern_bytes = 0;
+    uint64_t compound_bytes = 0;
+    int rc;
+
+    TEST("session(#1473): injected governor denies below the intern floor");
+    prog = wirelog_parse_string(INJECTED_GOVERNOR_SRC, &err);
+    if (!prog || wl_plan_from_program(prog, &plan) != 0 || !plan) {
+        if (prog)
+            wirelog_program_free(prog);
+        FAIL("plan generation failed");
+        return;
+    }
+    /* The overflow case below needs more than 16 intern bytes so that the
+     * pre-reserved total overflows instead of being merely denied. */
+    if (probe_intern_bytes(plan->intern, &intern_bytes) != 0
+        || intern_bytes <= 16u || probe_compound_bytes(&compound_bytes) != 0
+        || compound_bytes == 0) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("could not measure the create-time floor");
+        return;
+    }
+
+    /* The whole intern table is admitted transactionally; one byte short
+     * fails creation before anything else is charged and leaves the
+     * caller's reference untouched (LSan proves the refcount). */
+    ref = enforcing_governor(intern_bytes - 1u);
+    wl_session_options_init(&options);
+    options.memory_governor = ref;
+    session = NULL;
+    rc = ref ? wl_session_create_with_options(wl_backend_columnar(), plan, 1,
+            &options, &session) : -1;
+    if (!ref || rc != ENOMEM || session != NULL || reserved_on(ref) != 0) {
+        if (session)
+            wl_session_destroy(session);
+        if (ref)
+            wl_columnar_memory_governor_ref_release(ref);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("intern-floor denial did not fail creation with ENOMEM");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+
+    /* The intern table fits but the compound arena does not: creation fails
+     * and the oom path detaches the table it attached. */
+    TEST("session(#1473): injected governor denies below the compound floor");
+    ref = enforcing_governor(intern_bytes + compound_bytes - 1u);
+    options.memory_governor = ref;
+    session = NULL;
+    rc = ref ? wl_session_create_with_options(wl_backend_columnar(), plan, 1,
+            &options, &session) : -1;
+    if (!ref || rc != ENOMEM || session != NULL || reserved_on(ref) != 0) {
+        if (session)
+            wl_session_destroy(session);
+        if (ref)
+            wl_columnar_memory_governor_ref_release(ref);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("compound-floor denial did not fail creation with ENOMEM");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+
+    /* Exact fit: creation succeeds on the injected governor itself, charges
+     * exactly the floor, and destroy releases everything but the
+     * program-owned intern reservation. */
+    TEST("session(#1473): injected governor admits the exact floor");
+    ref = enforcing_governor(intern_bytes + compound_bytes);
+    options.memory_governor = ref;
+    session = NULL;
+    rc = ref ? wl_session_create_with_options(wl_backend_columnar(), plan, 1,
+            &options, &session) : -1;
+    if (rc == 0 && session)
+        wl_mem_ledger_snapshot(&COL_SESSION(session)->mem_ledger, &ledger);
+    if (!ref || rc != 0 || !session
+        || COL_SESSION(session)->memory_governor != ref
+        || wl_session_memory_governor(session)
+        != wl_columnar_memory_governor_ref_get(ref)
+        || reserved_on(ref) != intern_bytes + compound_bytes
+        || ledger.total_budget != intern_bytes + compound_bytes) {
+        if (session)
+            wl_session_destroy(session);
+        if (ref)
+            wl_columnar_memory_governor_ref_release(ref);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("exact-fit creation did not use the injected governor");
+        return;
+    }
+    wl_session_destroy(session);
+    if (reserved_on(ref) != intern_bytes) {
+        wl_columnar_memory_governor_ref_release(ref);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("destroy did not leave exactly the intern reservation");
+        return;
+    }
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
+    prog = NULL;
+    plan = NULL;
+    if (reserved_on(ref) != 0) {
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("program free did not release the intern reservation");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+
+    /* Arithmetic overflow of the governor total is EOVERFLOW, not ENOMEM. */
+    TEST("session(#1473): injected governor overflow fails with EOVERFLOW");
+    prog = wirelog_parse_string(INJECTED_GOVERNOR_SRC, &err);
+    if (!prog || wl_plan_from_program(prog, &plan) != 0 || !plan) {
+        if (prog)
+            wirelog_program_free(prog);
+        FAIL("plan generation failed");
+        return;
+    }
+    ref = enforcing_governor(UINT64_MAX);
+    wl_columnar_memory_reservation_init(&token);
+    if (!ref || wl_columnar_memory_reserve_checked(
+            wl_columnar_memory_governor_ref_get(ref), UINT64_MAX - 16u,
+            &token) != WL_COLUMNAR_MEMORY_ADMISSION_OK) {
+        if (ref)
+            wl_columnar_memory_governor_ref_release(ref);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("overflow fixture setup failed");
+        return;
+    }
+    options.memory_governor = ref;
+    session = NULL;
+    rc = wl_session_create_with_options(wl_backend_columnar(), plan, 1,
+            &options, &session);
+    if (rc != EOVERFLOW || session != NULL
+        || reserved_on(ref) != UINT64_MAX - 16u) {
+        if (session)
+            wl_session_destroy(session);
+        (void)wl_columnar_memory_release(&token);
+        wl_columnar_memory_governor_ref_release(ref);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("governor overflow did not fail creation with EOVERFLOW");
+        return;
+    }
+    (void)wl_columnar_memory_release(&token);
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+
+    /* The test-only per-thread default stands in for options on the
+     * option-less creators used by the public facades. */
+    TEST("session(#1473): thread default options reach option-less create");
+    ref = enforcing_governor(intern_bytes - 1u);
+    options.memory_governor = ref;
+    wl_session_testhook_set_default_options(&options);
+    session = NULL;
+    rc = ref ? wl_session_create(wl_backend_columnar(), plan, 1, &session)
+        : -1;
+    wl_session_testhook_set_default_options(NULL);
+    if (!ref || rc != ENOMEM || session != NULL || reserved_on(ref) != 0
+        || wl_session_testhook_default_options() != NULL) {
+        if (session)
+            wl_session_destroy(session);
+        if (ref)
+            wl_columnar_memory_governor_ref_release(ref);
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("thread default options were not applied");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    session = NULL;
+    rc = wl_session_create(wl_backend_columnar(), plan, 1, &session);
+    if (rc != 0 || !session) {
+        wl_plan_free(plan);
+        wirelog_program_free(prog);
+        FAIL("clearing the thread default did not restore resolution");
+        return;
+    }
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    wirelog_program_free(prog);
     PASS();
 }
 
@@ -1317,6 +1598,7 @@ main(void)
     test_session_create_destroy();
     test_session_create_destroy_columnar();
     test_session_create_with_options();
+    test_session_injected_governor_admission();
 #ifdef _WIN32
     test_session_windows_job_options();
 #endif

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -2394,9 +2394,10 @@ reserved_on(wl_columnar_memory_governor_ref_t *ref)
 /* The create-time floor of a fact-free program: the bytes its intern table
  * admits when a session attaches it (#1431) plus the session's fixed
  * compound arena (probed with the library-default epoch count, so like the
- * budget tests this assumes WIRELOG_COMPOUND_MAX_EPOCHS is unset); the delta pool and eval arena degrade to malloc when
- * denied.  Plan generation is run once first so the table measured is the
- * one the facade's own plan generation will attach. */
+ * budget tests this assumes WIRELOG_COMPOUND_MAX_EPOCHS is unset); the delta
+ * pool and eval arena degrade to malloc when denied.  Plan generation is run
+ * once first so the table measured is the one the facade's own plan
+ * generation will attach. */
 static int
 measure_create_floor(wirelog_program_t *prog, uint64_t *intern_bytes,
     uint64_t *compound_bytes)
@@ -2526,6 +2527,68 @@ out:
     return rc;
 }
 
+/* Governor arithmetic overflow is EOVERFLOW at the session layer; the
+ * advanced facade must report it as the memory verdict, not ERR_EXEC. */
+static int
+test_injected_governor_overflow_maps_to_memory(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T-1473-overflow");
+    wirelog_session_t *session = NULL;
+    wl_session_options_t options;
+    wl_columnar_memory_governor_ref_t *ref = NULL;
+    wl_columnar_memory_reservation_t token;
+    wirelog_error_t error;
+    int rc = 1;
+
+    if (!prog)
+        return 1;
+    /* Leave 16 bytes of headroom: the fixture's intern table holds more,
+     * so attaching it overflows the governor total instead of being
+     * denied within the budget. */
+    wl_columnar_memory_reservation_init(&token);
+    ref = enforcing_governor(UINT64_MAX);
+    if (!ref || wl_columnar_memory_reserve_checked(
+            wl_columnar_memory_governor_ref_get(ref), UINT64_MAX - 16u,
+            &token) != WL_COLUMNAR_MEMORY_ADMISSION_OK) {
+        fprintf(stderr, "T-1473-overflow: fixture setup failed\n");
+        wirelog_program_free(prog);
+        if (ref)
+            wl_columnar_memory_governor_ref_release(ref);
+        return 1;
+    }
+    wl_session_options_init(&options);
+    options.memory_governor = ref;
+    wl_session_testhook_set_default_options(&options);
+    error = wirelog_session_create(prog, WIRELOG_BACKEND_COLUMNAR, 1,
+            &session);
+    wl_session_testhook_set_default_options(NULL);
+    if (error != WIRELOG_ERR_MEMORY || session != NULL
+        || reserved_on(ref) != UINT64_MAX - 16u) {
+        fprintf(stderr, "T-1473-overflow: create err=%d s=%p\n", error,
+            (void *)session);
+        goto out;
+    }
+    wl_session_testhook_set_default_options(&options);
+    error = wirelog_session_create_with_snapshot(prog,
+            WIRELOG_BACKEND_COLUMNAR, 1, NULL, &session);
+    wl_session_testhook_set_default_options(NULL);
+    if (error != WIRELOG_ERR_MEMORY || session != NULL
+        || reserved_on(ref) != UINT64_MAX - 16u) {
+        fprintf(stderr, "T-1473-overflow: create_with_snapshot err=%d s=%p\n",
+            error, (void *)session);
+        goto out;
+    }
+    rc = 0;
+
+out:
+    if (session)
+        wirelog_session_destroy(session);
+    (void)wl_columnar_memory_release(&token);
+    wl_columnar_memory_governor_ref_release(ref);
+    wirelog_program_free(prog);
+    return rc;
+}
+
 static int
 test_invalid_memory_budget(void)
 {
@@ -2593,6 +2656,7 @@ main(void)
     failures += test_issue_665_partial_conjunction_multi_worker();
     failures += test_invalid_memory_budget();
     failures += test_injected_governor_denial_maps_to_memory();
+    failures += test_injected_governor_overflow_maps_to_memory();
     failures += test_typed_float_ingress();
     if (failures == 0)
         printf("test_wirelog_advanced: OK\n");

--- a/tests/test_wirelog_advanced.c
+++ b/tests/test_wirelog_advanced.c
@@ -18,6 +18,10 @@
 #include "wirelog/wirelog-extension.h"
 #include "wirelog/wirelog.h"
 #include "wirelog/intern.h"
+#include "wirelog/arena/compound_arena.h"
+#include "wirelog/columnar/memory_governor.h"
+#include "wirelog/exec_plan_gen.h"
+#include "wirelog/session.h"
 #include "wirelog/passes/fusion.h"
 #include "wirelog/passes/jpp.h"
 #include "wirelog/passes/sip.h"
@@ -2364,6 +2368,164 @@ test_issue_665_partial_conjunction_multi_worker(void)
     return run_issue_665_partial_conjunction(4, "issue 665 multi-worker");
 }
 
+/* ======================================================================== */
+/* Issue #1473: create-time governor denial maps to WIRELOG_ERR_MEMORY      */
+/* ======================================================================== */
+
+static wl_columnar_memory_governor_ref_t *
+enforcing_governor(uint64_t usable)
+{
+    wl_columnar_memory_resolution_t resolution = { 0 };
+    resolution.budget_bytes = usable;
+    resolution.usable_bytes = usable;
+    resolution.mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING;
+    resolution.source = WL_COLUMNAR_MEMORY_SOURCE_ENV;
+    resolution.status = WL_COLUMNAR_MEMORY_OK;
+    return wl_columnar_memory_governor_ref_create(&resolution);
+}
+
+static uint64_t
+reserved_on(wl_columnar_memory_governor_ref_t *ref)
+{
+    return wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(ref));
+}
+
+/* The create-time floor of a fact-free program: the bytes its intern table
+ * admits when a session attaches it (#1431) plus the session's fixed
+ * compound arena (probed with the library-default epoch count, so like the
+ * budget tests this assumes WIRELOG_COMPOUND_MAX_EPOCHS is unset); the delta pool and eval arena degrade to malloc when
+ * denied.  Plan generation is run once first so the table measured is the
+ * one the facade's own plan generation will attach. */
+static int
+measure_create_floor(wirelog_program_t *prog, uint64_t *intern_bytes,
+    uint64_t *compound_bytes)
+{
+    wl_columnar_memory_governor_ref_t *probe
+        = enforcing_governor(UINT64_MAX / 4u);
+    wl_compound_arena_t *arena = NULL;
+    wl_plan_t *warm = NULL;
+    /* The public accessor is read-only; the probe attaches and detaches
+     * the program-owned table exactly as session creation does. */
+    wl_intern_t *intern = (wl_intern_t *)wirelog_program_get_intern(prog);
+    int ok = 0;
+
+    if (!probe || !intern)
+        goto out;
+    if (wl_plan_from_program(prog, &warm) != 0 || !warm)
+        goto out;
+    wl_plan_free(warm);
+    if (wl_intern_attach_memory_governor(intern, probe) != 0)
+        goto out;
+    *intern_bytes = reserved_on(probe);
+    if (wl_intern_detach_memory_governor(intern, probe) != 0
+        || reserved_on(probe) != 0)
+        goto out;
+    arena = wl_compound_arena_create_managed(0x53455353u, 4096u, 0u,
+            wl_columnar_memory_governor_ref_get(probe));
+    if (!arena)
+        goto out;
+    *compound_bytes = reserved_on(probe);
+    wl_compound_arena_free(arena);
+    ok = reserved_on(probe) == 0 && *intern_bytes > 0
+        && *compound_bytes > 0;
+out:
+    if (probe)
+        wl_columnar_memory_governor_ref_release(probe);
+    return ok ? 0 : -1;
+}
+
+static int
+test_injected_governor_denial_maps_to_memory(void)
+{
+    wirelog_program_t *prog = parse_or_die(PROG_SRC, "T-1473");
+    wirelog_session_t *session = NULL;
+    wl_session_options_t options;
+    wl_columnar_memory_governor_ref_t *ref = NULL;
+    wirelog_error_t error;
+    uint64_t intern_bytes = 0;
+    uint64_t compound_bytes = 0;
+    int rc = 1;
+
+    if (!prog)
+        return 1;
+    if (measure_create_floor(prog, &intern_bytes, &compound_bytes) != 0) {
+        fprintf(stderr, "T-1473: could not measure the create-time floor\n");
+        goto out;
+    }
+    wl_session_options_init(&options);
+
+    /* One byte short of the intern table: creation is denied at attach
+     * time and both public creators report the memory verdict. */
+    ref = enforcing_governor(intern_bytes - 1u);
+    if (!ref)
+        goto out;
+    options.memory_governor = ref;
+    wl_session_testhook_set_default_options(&options);
+    error = wirelog_session_create(prog, WIRELOG_BACKEND_COLUMNAR, 1,
+            &session);
+    wl_session_testhook_set_default_options(NULL);
+    if (error != WIRELOG_ERR_MEMORY || session != NULL
+        || reserved_on(ref) != 0) {
+        fprintf(stderr, "T-1473: create denial err=%d s=%p\n", error,
+            (void *)session);
+        goto out;
+    }
+    wl_session_testhook_set_default_options(&options);
+    error = wirelog_session_create_with_snapshot(prog,
+            WIRELOG_BACKEND_COLUMNAR, 1, NULL, &session);
+    wl_session_testhook_set_default_options(NULL);
+    if (error != WIRELOG_ERR_MEMORY || session != NULL
+        || reserved_on(ref) != 0) {
+        fprintf(stderr, "T-1473: create_with_snapshot denial err=%d s=%p\n",
+            error, (void *)session);
+        goto out;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+
+    /* Exact floor: creation succeeds, destroy leaves the program-owned
+     * intern reservation, and freeing the program releases it. */
+    ref = enforcing_governor(intern_bytes + compound_bytes);
+    if (!ref)
+        goto out;
+    options.memory_governor = ref;
+    wl_session_testhook_set_default_options(&options);
+    error = wirelog_session_create(prog, WIRELOG_BACKEND_COLUMNAR, 1,
+            &session);
+    wl_session_testhook_set_default_options(NULL);
+    if (error != WIRELOG_OK || !session
+        || reserved_on(ref) != intern_bytes + compound_bytes) {
+        fprintf(stderr, "T-1473: exact-fit create err=%d reserved=%llu\n",
+            error, (unsigned long long)reserved_on(ref));
+        goto out;
+    }
+    wirelog_session_destroy(session);
+    session = NULL;
+    if (reserved_on(ref) != intern_bytes) {
+        fprintf(stderr, "T-1473: destroy left %llu bytes, expected %llu\n",
+            (unsigned long long)reserved_on(ref),
+            (unsigned long long)intern_bytes);
+        goto out;
+    }
+    wirelog_program_free(prog);
+    prog = NULL;
+    if (reserved_on(ref) != 0) {
+        fprintf(stderr, "T-1473: program free left %llu bytes\n",
+            (unsigned long long)reserved_on(ref));
+        goto out;
+    }
+    rc = 0;
+
+out:
+    if (session)
+        wirelog_session_destroy(session);
+    if (prog)
+        wirelog_program_free(prog);
+    if (ref)
+        wl_columnar_memory_governor_ref_release(ref);
+    return rc;
+}
+
 static int
 test_invalid_memory_budget(void)
 {
@@ -2430,6 +2592,7 @@ main(void)
     failures += test_issue_665_partial_conjunction_default_workers();
     failures += test_issue_665_partial_conjunction_multi_worker();
     failures += test_invalid_memory_budget();
+    failures += test_injected_governor_denial_maps_to_memory();
     failures += test_typed_float_ingress();
     if (failures == 0)
         printf("test_wirelog_advanced: OK\n");

--- a/tests/test_wirelog_easy.c
+++ b/tests/test_wirelog_easy.c
@@ -2529,8 +2529,9 @@ reserved_on(wl_columnar_memory_governor_ref_t *ref)
 /* The create-time floor of a fact-free program: the bytes its intern table
  * admits when a session attaches it (#1431) plus the session's fixed
  * compound arena (probed with the library-default epoch count, so like the
- * budget tests this assumes WIRELOG_COMPOUND_MAX_EPOCHS is unset).  The delta pool and eval arena degrade to malloc when
- * denied, so an exact-fit budget admits precisely these two. */
+ * budget tests this assumes WIRELOG_COMPOUND_MAX_EPOCHS is unset).  The
+ * delta pool and eval arena degrade to malloc when denied, so an exact-fit
+ * budget admits precisely these two. */
 static int
 measure_create_floor(wirelog_program_t *prog, uint64_t *intern_bytes,
     uint64_t *compound_bytes)
@@ -2733,8 +2734,8 @@ test_injected_governor_easy_lazy(void)
 
 /* The batch executor builds its session from the caller's program, so the
  * floor is measured on that very intern table. */
-/* PARITY: the batch executor (api_facade.c) is compiled into this binary
- * only; the advanced facade has no executor. */
+/* PARITY: the batch executor (api_facade.c) has no advanced-facade
+ * counterpart; the advanced session API exposes no executor. */
 static void
 test_injected_governor_executor(void)
 {
@@ -2822,6 +2823,70 @@ test_injected_governor_executor(void)
     PASS();
 }
 
+/* Governor arithmetic overflow is EOVERFLOW at the session layer; every
+ * facade reports it as the memory verdict. */
+static void
+test_injected_governor_overflow_maps_to_memory(void)
+{
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
+    wirelog_easy_session_t *session = NULL;
+    wirelog_executor_t *executor = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_session_options_t options;
+    wl_columnar_memory_governor_ref_t *ref;
+    wl_columnar_memory_reservation_t token;
+    wirelog_error_t err;
+
+    TEST("#1473 easy/executor: governor overflow maps to WIRELOG_ERR_MEMORY");
+    /* Leave 16 bytes of headroom: the fixture's intern table holds more,
+     * so attaching it overflows the governor total instead of being
+     * denied within the budget. */
+    wl_columnar_memory_reservation_init(&token);
+    ref = enforcing_governor(UINT64_MAX);
+    if (!ref || wl_columnar_memory_reserve_checked(
+            wl_columnar_memory_governor_ref_get(ref), UINT64_MAX - 16u,
+            &token) != WL_COLUMNAR_MEMORY_ADMISSION_OK) {
+        if (ref)
+            wl_columnar_memory_governor_ref_release(ref);
+        FAIL("overflow fixture setup failed");
+        return;
+    }
+    wl_session_options_init(&options);
+    options.memory_governor = ref;
+    opts.eager_build = true;
+    wl_session_testhook_set_default_options(&options);
+    err = wirelog_easy_open_opts(RELATION_NAME_LIFETIME_SRC, &opts,
+            &session);
+    wl_session_testhook_set_default_options(NULL);
+    if (err != WIRELOG_ERR_MEMORY || session != NULL
+        || reserved_on(ref) != UINT64_MAX - 16u) {
+        wirelog_easy_close(session);
+        (void)wl_columnar_memory_release(&token);
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("easy eager overflow did not map to WIRELOG_ERR_MEMORY");
+        return;
+    }
+    prog = wirelog_parse_string(RELATION_NAME_LIFETIME_SRC, &err);
+    if (!prog) {
+        (void)wl_columnar_memory_release(&token);
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("could not parse the fixture");
+        return;
+    }
+    wl_session_testhook_set_default_options(&options);
+    err = WIRELOG_OK;
+    executor = wirelog_executor_create(prog, &err);
+    wl_session_testhook_set_default_options(NULL);
+    wirelog_executor_free(executor);
+    wirelog_program_free(prog);
+    (void)wl_columnar_memory_release(&token);
+    wl_columnar_memory_governor_ref_release(ref);
+    if (executor || err != WIRELOG_ERR_MEMORY)
+        FAIL("executor overflow did not map to WIRELOG_ERR_MEMORY");
+    else
+        PASS();
+}
+
 /* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
@@ -2865,6 +2930,7 @@ main(void)
     test_injected_governor_easy_eager();
     test_injected_governor_easy_lazy();
     test_injected_governor_executor();
+    test_injected_governor_overflow_maps_to_memory();
 
     test_open_close_null_safe();
     test_open_parse_error();

--- a/tests/test_wirelog_easy.c
+++ b/tests/test_wirelog_easy.c
@@ -11,6 +11,11 @@
 #include "../wirelog/wirelog-easy.h"
 #include "../wirelog/wirelog-extension.h"
 #include "../wirelog/util/log.h"
+#include "../wirelog/arena/compound_arena.h"
+#include "../wirelog/columnar/memory_governor.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/intern.h"
+#include "../wirelog/session.h"
 
 #include <fcntl.h>
 #include <stddef.h>
@@ -2499,6 +2504,325 @@ test_snapshot_rebuilds_idb_after_query_mode_input_changes(void)
 }
 
 /* ======================================================================== */
+/* Issue #1473: create-time governor denial maps to WIRELOG_ERR_MEMORY      */
+/* ======================================================================== */
+
+static wl_columnar_memory_governor_ref_t *
+enforcing_governor(uint64_t usable)
+{
+    wl_columnar_memory_resolution_t resolution = { 0 };
+    resolution.budget_bytes = usable;
+    resolution.usable_bytes = usable;
+    resolution.mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING;
+    resolution.source = WL_COLUMNAR_MEMORY_SOURCE_ENV;
+    resolution.status = WL_COLUMNAR_MEMORY_OK;
+    return wl_columnar_memory_governor_ref_create(&resolution);
+}
+
+static uint64_t
+reserved_on(wl_columnar_memory_governor_ref_t *ref)
+{
+    return wl_columnar_memory_reserved(
+        wl_columnar_memory_governor_ref_get(ref));
+}
+
+/* The create-time floor of a fact-free program: the bytes its intern table
+ * admits when a session attaches it (#1431) plus the session's fixed
+ * compound arena (probed with the library-default epoch count, so like the
+ * budget tests this assumes WIRELOG_COMPOUND_MAX_EPOCHS is unset).  The delta pool and eval arena degrade to malloc when
+ * denied, so an exact-fit budget admits precisely these two. */
+static int
+measure_create_floor(wirelog_program_t *prog, uint64_t *intern_bytes,
+    uint64_t *compound_bytes)
+{
+    wl_columnar_memory_governor_ref_t *probe
+        = enforcing_governor(UINT64_MAX / 4u);
+    wl_compound_arena_t *arena = NULL;
+    /* The public accessor is read-only; the probe attaches and detaches
+     * the program-owned table exactly as session creation does. */
+    wl_intern_t *intern = (wl_intern_t *)wirelog_program_get_intern(prog);
+    int ok = 0;
+
+    if (!probe || !intern)
+        goto out;
+    if (wl_intern_attach_memory_governor(intern, probe) != 0)
+        goto out;
+    *intern_bytes = reserved_on(probe);
+    if (wl_intern_detach_memory_governor(intern, probe) != 0
+        || reserved_on(probe) != 0)
+        goto out;
+    arena = wl_compound_arena_create_managed(0x53455353u, 4096u, 0u,
+            wl_columnar_memory_governor_ref_get(probe));
+    if (!arena)
+        goto out;
+    *compound_bytes = reserved_on(probe);
+    wl_compound_arena_free(arena);
+    ok = reserved_on(probe) == 0 && *intern_bytes > 0
+        && *compound_bytes > 0;
+out:
+    if (probe)
+        wl_columnar_memory_governor_ref_release(probe);
+    return ok ? 0 : -1;
+}
+
+/* Parse and plan the source the way the easy facade does, so the intern
+ * table measured here matches the one the facade's session will attach. */
+static int
+measure_easy_floor(const char *src, uint64_t *intern_bytes,
+    uint64_t *compound_bytes)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog = wirelog_parse_string(src, &err);
+    wl_plan_t *plan = NULL;
+    int rc = -1;
+    if (!prog)
+        return -1;
+    if (wirelog_optimize(prog, &err)
+        && wl_plan_from_program(prog, &plan) == 0 && plan)
+        rc = measure_create_floor(prog, intern_bytes, compound_bytes);
+    if (plan)
+        wl_plan_free(plan);
+    wirelog_program_free(prog);
+    return rc;
+}
+
+/* PARITY: the advanced facade has no eager/lazy split; both easy paths and
+ * the executor pair with test_injected_governor_denial_maps_to_memory. */
+static void
+test_injected_governor_easy_eager(void)
+{
+    wirelog_easy_open_opts_t opts = WIRELOG_EASY_OPEN_OPTS_INIT;
+    wirelog_easy_session_t *session = NULL;
+    wl_session_options_t options;
+    wl_columnar_memory_governor_ref_t *ref = NULL;
+    wirelog_error_t error;
+    uint64_t intern_bytes = 0;
+    uint64_t compound_bytes = 0;
+
+    TEST("#1473 easy eager: governor denial maps to WIRELOG_ERR_MEMORY");
+    if (measure_easy_floor(RELATION_NAME_LIFETIME_SRC, &intern_bytes,
+        &compound_bytes) != 0) {
+        FAIL("could not measure the create-time floor");
+        return;
+    }
+    opts.eager_build = true;
+    wl_session_options_init(&options);
+
+    ref = enforcing_governor(intern_bytes - 1u);
+    if (!ref) {
+        FAIL("governor allocation failed");
+        return;
+    }
+    options.memory_governor = ref;
+    wl_session_testhook_set_default_options(&options);
+    error = wirelog_easy_open_opts(RELATION_NAME_LIFETIME_SRC, &opts,
+            &session);
+    wl_session_testhook_set_default_options(NULL);
+    if (error != WIRELOG_ERR_MEMORY || session != NULL
+        || reserved_on(ref) != 0) {
+        wirelog_easy_close(session);
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("eager denial did not map to WIRELOG_ERR_MEMORY");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+
+    TEST("#1473 easy eager: exact floor budget opens and is released");
+    ref = enforcing_governor(intern_bytes + compound_bytes);
+    if (!ref) {
+        FAIL("governor allocation failed");
+        return;
+    }
+    options.memory_governor = ref;
+    wl_session_testhook_set_default_options(&options);
+    error = wirelog_easy_open_opts(RELATION_NAME_LIFETIME_SRC, &opts,
+            &session);
+    wl_session_testhook_set_default_options(NULL);
+    if (error != WIRELOG_OK || !session
+        || reserved_on(ref) != intern_bytes + compound_bytes) {
+        wirelog_easy_close(session);
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("exact-fit eager open did not admit the floor");
+        return;
+    }
+    /* Close frees the session and the program, so the intern reservation
+     * goes with it. */
+    wirelog_easy_close(session);
+    if (reserved_on(ref) != 0) {
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("close did not release the create-time floor");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+}
+
+/* PARITY: lazy build is an easy-facade-only surface; see the eager test. */
+static void
+test_injected_governor_easy_lazy(void)
+{
+    wirelog_easy_session_t *session = NULL;
+    wl_session_options_t options;
+    wl_columnar_memory_governor_ref_t *ref = NULL;
+    wirelog_error_t error;
+    uint64_t intern_bytes = 0;
+    uint64_t compound_bytes = 0;
+
+    TEST("#1473 easy lazy: governor denial maps to WIRELOG_ERR_MEMORY");
+    if (measure_easy_floor(RELATION_NAME_LIFETIME_SRC, &intern_bytes,
+        &compound_bytes) != 0) {
+        FAIL("could not measure the create-time floor");
+        return;
+    }
+    if (wirelog_easy_open(RELATION_NAME_LIFETIME_SRC, &session)
+        != WIRELOG_OK || !session) {
+        FAIL("lazy open failed");
+        return;
+    }
+    wl_session_options_init(&options);
+    ref = enforcing_governor(intern_bytes - 1u);
+    if (!ref) {
+        wirelog_easy_close(session);
+        FAIL("governor allocation failed");
+        return;
+    }
+    options.memory_governor = ref;
+    wl_session_testhook_set_default_options(&options);
+    error = wirelog_easy_step(session);
+    wl_session_testhook_set_default_options(NULL);
+    if (error != WIRELOG_ERR_MEMORY || reserved_on(ref) != 0) {
+        wirelog_easy_close(session);
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("lazy denial did not map to WIRELOG_ERR_MEMORY");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+
+    /* The same handle retries its build; the exact floor admits it.  The
+     * delta-callback registration builds the session without stepping, so
+     * only creation is measured. */
+    TEST("#1473 easy lazy: exact floor budget builds on retry");
+    ref = enforcing_governor(intern_bytes + compound_bytes);
+    if (!ref) {
+        wirelog_easy_close(session);
+        FAIL("governor allocation failed");
+        return;
+    }
+    options.memory_governor = ref;
+    wl_session_testhook_set_default_options(&options);
+    error = wirelog_easy_set_delta_cb(session, NULL, NULL);
+    wl_session_testhook_set_default_options(NULL);
+    if (error != WIRELOG_OK
+        || reserved_on(ref) != intern_bytes + compound_bytes) {
+        wirelog_easy_close(session);
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("exact-fit lazy build did not admit the floor");
+        return;
+    }
+    wirelog_easy_close(session);
+    if (reserved_on(ref) != 0) {
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("close did not release the create-time floor");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+}
+
+/* The batch executor builds its session from the caller's program, so the
+ * floor is measured on that very intern table. */
+/* PARITY: the batch executor (api_facade.c) is compiled into this binary
+ * only; the advanced facade has no executor. */
+static void
+test_injected_governor_executor(void)
+{
+    wirelog_error_t err;
+    wirelog_program_t *prog;
+    wirelog_executor_t *executor = NULL;
+    wl_session_options_t options;
+    wl_columnar_memory_governor_ref_t *ref = NULL;
+    wl_plan_t *warm = NULL;
+    uint64_t intern_bytes = 0;
+    uint64_t compound_bytes = 0;
+
+    TEST("#1473 executor: governor denial maps to WIRELOG_ERR_MEMORY");
+    prog = wirelog_parse_string(RELATION_NAME_LIFETIME_SRC, &err);
+    /* Plan generation may intern; run it once so the measurement sees the
+     * table the executor's own plan generation will attach. */
+    if (!prog || wl_plan_from_program(prog, &warm) != 0 || !warm) {
+        if (prog)
+            wirelog_program_free(prog);
+        FAIL("could not parse the fixture");
+        return;
+    }
+    wl_plan_free(warm);
+    if (measure_create_floor(prog, &intern_bytes, &compound_bytes) != 0) {
+        wirelog_program_free(prog);
+        FAIL("could not measure the create-time floor");
+        return;
+    }
+    wl_session_options_init(&options);
+    ref = enforcing_governor(intern_bytes - 1u);
+    if (!ref) {
+        wirelog_program_free(prog);
+        FAIL("governor allocation failed");
+        return;
+    }
+    options.memory_governor = ref;
+    wl_session_testhook_set_default_options(&options);
+    err = WIRELOG_OK;
+    executor = wirelog_executor_create(prog, &err);
+    wl_session_testhook_set_default_options(NULL);
+    if (executor || err != WIRELOG_ERR_MEMORY || reserved_on(ref) != 0) {
+        wirelog_executor_free(executor);
+        wl_columnar_memory_governor_ref_release(ref);
+        wirelog_program_free(prog);
+        FAIL("executor denial did not map to WIRELOG_ERR_MEMORY");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+
+    TEST("#1473 executor: exact floor budget creates and is released");
+    ref = enforcing_governor(intern_bytes + compound_bytes);
+    if (!ref) {
+        wirelog_program_free(prog);
+        FAIL("governor allocation failed");
+        return;
+    }
+    options.memory_governor = ref;
+    wl_session_testhook_set_default_options(&options);
+    err = WIRELOG_OK;
+    executor = wirelog_executor_create(prog, &err);
+    wl_session_testhook_set_default_options(NULL);
+    if (!executor || err != WIRELOG_OK
+        || reserved_on(ref) != intern_bytes + compound_bytes) {
+        wirelog_executor_free(executor);
+        wl_columnar_memory_governor_ref_release(ref);
+        wirelog_program_free(prog);
+        FAIL("exact-fit executor create did not admit the floor");
+        return;
+    }
+    wirelog_executor_free(executor);
+    if (reserved_on(ref) != intern_bytes) {
+        wl_columnar_memory_governor_ref_release(ref);
+        wirelog_program_free(prog);
+        FAIL("executor free did not leave exactly the intern reservation");
+        return;
+    }
+    wirelog_program_free(prog);
+    if (reserved_on(ref) != 0) {
+        wl_columnar_memory_governor_ref_release(ref);
+        FAIL("program free did not release the intern reservation");
+        return;
+    }
+    wl_columnar_memory_governor_ref_release(ref);
+    PASS();
+}
+
+/* ======================================================================== */
 /* Main                                                                     */
 /* ======================================================================== */
 
@@ -2538,6 +2862,9 @@ main(void)
     printf("==========================\n\n");
 
     test_invalid_memory_budget();
+    test_injected_governor_easy_eager();
+    test_injected_governor_easy_lazy();
+    test_injected_governor_executor();
 
     test_open_close_null_safe();
     test_open_parse_error();

--- a/tests/test_wirelog_public_api.c
+++ b/tests/test_wirelog_public_api.c
@@ -5,12 +5,36 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+/* setenv/unsetenv for the invalid-budget case (#1473). */
+#define _POSIX_C_SOURCE 200809L
+
 #include "wirelog/wirelog.h"
 
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+/* MSVC's CRT lacks POSIX setenv / unsetenv; route through _putenv_s, as
+ * tests/test_wirelog_easy.c and tests/test_wirelog_advanced.c do. */
+static int
+wl_test_setenv_(const char *name, const char *value, int overwrite)
+{
+    (void)overwrite;
+    return _putenv_s(name, (value && *value) ? value : "1");
+}
+
+static int
+wl_test_unsetenv_(const char *name)
+{
+    return _putenv_s(name, "");
+}
+
+#  define setenv   wl_test_setenv_
+#  define unsetenv wl_test_unsetenv_
+#endif
 
 static int metadata_probe_reads;
 
@@ -361,6 +385,38 @@ test_result_outlives_executor(void)
     return 0;
 }
 
+/* Issue #1473: an invalid WIRELOG_MEMORY_BUDGET is a configuration error
+ * (EINVAL at session creation), reported by the executor facade as
+ * WIRELOG_ERR_EXEC rather than the memory verdict, matching the easy and
+ * advanced facades. */
+static int
+test_executor_invalid_memory_budget_is_exec_error(void)
+{
+    const char *src =
+        ".decl edge(x:int32,y:int32)\n"
+        ".decl path(x:int32,y:int32)\n"
+        "path(X,Y) :- edge(X,Y).\n";
+    wirelog_error_t err = WIRELOG_OK;
+    wirelog_program_t *program = wirelog_parse_string(src, &err);
+    wirelog_executor_t *executor;
+    if (!program || err != WIRELOG_OK) {
+        fprintf(stderr, "invalid budget: parse failed err=%d\n", err);
+        return 1;
+    }
+    setenv("WIRELOG_MEMORY_BUDGET", "0", 1);
+    executor = wirelog_executor_create(program, &err);
+    unsetenv("WIRELOG_MEMORY_BUDGET");
+    wirelog_executor_free(executor);
+    wirelog_program_free(program);
+    if (executor || err != WIRELOG_ERR_EXEC) {
+        fprintf(stderr,
+            "invalid budget: expected NULL executor and ERR_EXEC, got %p err=%d\n",
+            (void *)executor, err);
+        return 1;
+    }
+    return 0;
+}
+
 int
 main(void)
 {
@@ -372,6 +428,7 @@ main(void)
     failures += test_bound_query_without_seed_preserves_answers();
     failures += test_executor_result_api();
     failures += test_result_outlives_executor();
+    failures += test_executor_invalid_memory_budget_is_exec_error();
     if (failures == 0)
         printf("test_wirelog_public_api: OK\n");
     return failures == 0 ? 0 : 1;

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1011,6 +1011,8 @@ col_compute_worker_cap(uint64_t ram_bytes)
  *   5. Set *out = &sess->base  (session.c:38 then sets base.backend)
  *
  * @return 0 on success, EINVAL if plan/out is NULL, ENOMEM on alloc failure
+ *         or governor denial, EOVERFLOW when admitting the intern table would
+ *         overflow the governor total (#1431)
  *
  * @see wl_session_create in session.c for vtable dispatch context
  * @see wl_col_session_t memory layout documentation above

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -1019,27 +1019,38 @@ static int
 col_session_create_internal(const wl_plan_t *plan, uint32_t num_workers,
     const wl_session_options_t *options, wl_session_t **out)
 {
-    wl_columnar_memory_resolution_t memory_resolution;
-    wl_columnar_memory_sources_t memory_sources;
     wl_columnar_memory_governor_ref_t *memory_governor;
+    const wl_columnar_memory_governor_t *governor;
     bool intern_attached_here = false;
-    const char *memory_budget = getenv("WIRELOG_MEMORY_BUDGET");
 
     if (!plan || !out)
         return EINVAL;
-    if (wl_columnar_memory_probe_sources(&memory_sources) != 0)
-        return EINVAL;
-    if (options && options->windows_job_handle)
-        (void)wl_columnar_memory_probe_windows_job(
-            options->windows_job_handle, &memory_sources);
-    if (wl_columnar_memory_resolve(memory_budget, &memory_sources,
-        &memory_resolution)
-        != WL_COLUMNAR_MEMORY_OK)
-        return EINVAL;
-    memory_governor = wl_columnar_memory_governor_ref_create(
-        &memory_resolution);
-    if (!memory_governor)
-        return ENOMEM;
+    if (options && options->memory_governor) {
+        /* #1473: an injected governor replaces environment and host
+         * resolution.  The session holds its own reference; the caller's
+         * reference stays with the caller. */
+        memory_governor = options->memory_governor;
+        wl_columnar_memory_governor_ref_retain(memory_governor);
+    } else {
+        wl_columnar_memory_resolution_t memory_resolution;
+        wl_columnar_memory_sources_t memory_sources;
+        const char *memory_budget = getenv("WIRELOG_MEMORY_BUDGET");
+
+        if (wl_columnar_memory_probe_sources(&memory_sources) != 0)
+            return EINVAL;
+        if (options && options->windows_job_handle)
+            (void)wl_columnar_memory_probe_windows_job(
+                options->windows_job_handle, &memory_sources);
+        if (wl_columnar_memory_resolve(memory_budget, &memory_sources,
+            &memory_resolution)
+            != WL_COLUMNAR_MEMORY_OK)
+            return EINVAL;
+        memory_governor = wl_columnar_memory_governor_ref_create(
+            &memory_resolution);
+        if (!memory_governor)
+            return ENOMEM;
+    }
+    governor = wl_columnar_memory_governor_ref_get(memory_governor);
 
     wl_col_session_t *sess
         = (wl_col_session_t *)calloc(1, sizeof(wl_col_session_t));
@@ -1285,8 +1296,8 @@ col_session_create_internal(const wl_plan_t *plan, uint32_t num_workers,
     /* The ledger remains attribution-only. The shared governor owns admission
      * policy; workers must not receive divided ledger budgets. */
     wl_mem_ledger_init(&sess->mem_ledger,
-        memory_resolution.mode == WL_COLUMNAR_MEMORY_MODE_ENFORCING
-            ? memory_resolution.budget_bytes : 0);
+        governor->mode == WL_COLUMNAR_MEMORY_MODE_ENFORCING
+            ? governor->budget_bytes : 0);
 
     /* Issue #1380: memory instrumentation wiring.  The delta pool and eval
      * arena above were created before the ledger existed, so charge their

--- a/wirelog/session.c
+++ b/wirelog/session.c
@@ -32,7 +32,34 @@ wl_session_options_init(wl_session_options_t *options)
     options->size = (uint32_t)sizeof(*options);
     options->version = WL_SESSION_OPTIONS_VERSION;
     options->windows_job_handle = NULL;
+    options->memory_governor = NULL;
 }
+
+#ifdef WL_SESSION_TEST_HOOKS
+/* Only compiled into direct-source test executables (never libwirelog):
+ * a per-thread default substituted when a creator passes no options, so
+ * facade paths without an options parameter can run under an injected
+ * governor. */
+#if defined(_MSC_VER)
+#define WL_SESSION_THREAD_LOCAL __declspec(thread)
+#else
+#define WL_SESSION_THREAD_LOCAL _Thread_local
+#endif
+static WL_SESSION_THREAD_LOCAL const wl_session_options_t *testhook_options;
+#undef WL_SESSION_THREAD_LOCAL
+
+void
+wl_session_testhook_set_default_options(const wl_session_options_t *options)
+{
+    testhook_options = options;
+}
+
+const wl_session_options_t *
+wl_session_testhook_default_options(void)
+{
+    return testhook_options;
+}
+#endif
 
 static int
 wl_session_options_valid(const wl_session_options_t *options)
@@ -76,6 +103,10 @@ wl_session_create_with_snapshot_options(const wl_compute_backend_t *backend,
     const wl_session_options_t *options, wl_session_t **out)
 {
     int rc;
+#ifdef WL_SESSION_TEST_HOOKS
+    if (!options)
+        options = testhook_options;
+#endif
     if (!backend || !backend->session_create || !out
         || !wl_session_options_valid(options))
         return -1;

--- a/wirelog/session.h
+++ b/wirelog/session.h
@@ -99,6 +99,16 @@ wl_session_create_with_snapshot_options(const wl_compute_backend_t *backend,
     wirelog_extension_snapshot_t *snapshot,
     const wl_session_options_t *options, wl_session_t **out);
 
+#ifdef WL_SESSION_TEST_HOOKS
+/* Test-only, per-thread default options substituted when a creator passes
+ * NULL options.  Borrowed for as long as it stays installed; install NULL
+ * to clear.  Never compiled into libwirelog. */
+void
+wl_session_testhook_set_default_options(const wl_session_options_t *options);
+const wl_session_options_t *
+wl_session_testhook_default_options(void);
+#endif
+
 /**
  * wl_session_destroy:
  * @session:  The session to destroy (NULL-safe).

--- a/wirelog/session_options.h
+++ b/wirelog/session_options.h
@@ -12,18 +12,31 @@
 
 #include <stdint.h>
 
-#define WL_SESSION_OPTIONS_VERSION UINT32_C(1)
+typedef struct wl_columnar_memory_governor_ref
+    wl_columnar_memory_governor_ref_t;
+
+#define WL_SESSION_OPTIONS_VERSION UINT32_C(2)
 
 /*
  * Options are valid only for the duration of session creation.  The Windows
  * Job Object handle is borrowed by the backend, queried synchronously, and
  * never stored or closed by Wirelog.  A void pointer keeps this header
  * portable and prevents windows.h from reaching installed headers.
+ *
+ * Version 2 (#1473) adds @memory_governor: a caller-retained admission
+ * governor the session uses instead of resolving one from the environment
+ * and host limits.  The session retains its own reference and releases it
+ * on destroy; the caller keeps ownership of the reference it passed.  The
+ * program-owned intern table attached at creation (#1431) also retains the
+ * reference until the program is freed, so the governor can outlive the
+ * session.  When it is set, @windows_job_handle and WIRELOG_MEMORY_BUDGET
+ * are ignored.
  */
 typedef struct {
     uint32_t size;
     uint32_t version;
     void *windows_job_handle;
+    wl_columnar_memory_governor_ref_t *memory_governor;
 } wl_session_options_t;
 
 void

--- a/wirelog/wirelog_advanced.c
+++ b/wirelog/wirelog_advanced.c
@@ -455,7 +455,12 @@ wirelog_session_create_impl(wirelog_program_t *program,
             num_workers > 0 ? num_workers : 1, snapshot, &inner);
     if (rc != 0 || !inner) {
         wl_plan_free(plan);
-        return (rc == ENOMEM) ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_EXEC;
+        /* ENOMEM is an allocation failure; EOVERFLOW is the memory
+         * governor refusing to admit the program's intern table (#1431).
+         * Both are memory verdicts under the docs/MEMORY.md contract, as
+         * the easy and executor facades already report (#1473). */
+        return (rc == ENOMEM || rc == EOVERFLOW)
+            ? WIRELOG_ERR_MEMORY : WIRELOG_ERR_EXEC;
     }
 
     /* Issue #718 contract: inline `.dl` facts must be observable in


### PR DESCRIPTION
Closes #1473. Based on `main` (`ec48d48d`), two commits.

## What

1. `feat(#1473): accept an injected memory governor in session options`: the internal `wl_session_options_t` (version 2) carries a caller-retained memory governor reference. When set, columnar session creation retains it instead of resolving a budget from the environment or host limits, and the attribution ledger takes its budget from that governor. `wirelog/session.c` gains a per-thread default options pointer compiled only under `WL_SESSION_TEST_HOOKS` (set on the three direct-source test binaries only; the no-testhook gate now rejects the `wl_session_testhook` prefix in `libwirelog`), so the option-less public facades can be driven under an injected governor. Tests measure the create-time floor (intern table plus the fixed compound arena) and check denial one byte below each floor, the exact fit, arithmetic overflow, and release after destroy and program free, at the session layer and through the easy (eager and lazy), executor and advanced facades.
2. `fix(#1473): map EOVERFLOW from session creation to WIRELOG_ERR_MEMORY in the advanced API`: `wirelog_session_create()` and `wirelog_session_create_with_snapshot()` reported `WIRELOG_ERR_EXEC` for `EOVERFLOW` while the easy and executor facades reported `WIRELOG_ERR_MEMORY`; all three now agree. Overflow tests cover the advanced, eager easy and executor paths; the hook-free public API suite checks that an invalid `WIRELOG_MEMORY_BUDGET` fails executor creation with `WIRELOG_ERR_EXEC`. Includes a CHANGELOG entry and the unit 1 review follow-ups.

## Acceptance criteria

- Session-level and public-API tests fail one byte below the intern footprint and pass at the footprint: `test_session` (intern floor, compound floor, exact fit), `test_wirelog_easy` (eager, lazy, executor), `test_wirelog_advanced` (create, create_with_snapshot).
- No hook symbol in the library: `WL_SESSION_TEST_HOOKS` is defined only in `tests/meson.build`; the abi-suite gate and its self-test cover the new prefix.
- `session`, `wirelog_easy`, `wirelog_advanced`, `wirelog_public_api` clean under ASan/UBSan with leak detection; `session`, `wirelog_easy`, `wirelog_advanced` clean under TSan.

## Evidence

- Focused: `test_session` 18/18, `test_wirelog_easy` 54/54, `test_wirelog_advanced` OK, `test_wirelog_public_api` OK, `test_memory_admission_intern`, `test_memory_governor`, `test_worker_session` OK.
- Red checks: the new session tests fail with the columnar change reverted; the advanced overflow test fails with `WIRELOG_ERR_EXEC` with the mapping reverted.
- abi suite 60 OK / 0 failed / 2 skipped (no-testhook, parity, changelog gates); full suite 353 OK / 0 failed / 14 skipped with the clang-tidy ratchet OK; `.text` delta within budget; uncrustify clean.

## Review

Reviewer, Architect and Critic approved each commit's tree (unit 1 `7c448523`, unit 2 `c884d711`).
