### PR TITLE
fix(#1515): keep the arrangement registry scannable after a failed tombstone reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ All notable changes to wirelog are documented in this file.
 
 ### Fixed
 
+- **Arrangement registry stays scannable after a failed tombstone reuse**
+  (#1515). The name and key allocations for a new `(relation, key columns)`
+  entry now precede any change to the reused slot, and a first build denied
+  by the memory governor leaves a rebuildable tombstone keyed on the new
+  entry (`arr_total_bytes` unchanged) instead of a nameless slot inside
+  `arr_count`; a failed reuse of the last slot now keeps that tombstone
+  rather than dropping it. Registry lookups, invalidation and worker
+  cloning tolerate a slot without a name.
+
 - **Unfused recursive SCCs no longer terminate with incomplete results**
   (#1376). The forced-delta pre-scan now leaves concatenated rule alternatives
   to normal evaluation instead of treating one empty input as an empty union.

--- a/tests/test_arrangement_lru_eviction.c
+++ b/tests/test_arrangement_lru_eviction.c
@@ -556,6 +556,199 @@ cleanup:
 /* ================================================================
  * main
  * ================================================================ */
+/* ================================================================
+ * Issue #1515: a failed tombstone-slot reuse must leave the registry
+ * scannable and the slot a well-formed tombstone.
+ * ================================================================ */
+
+/* An enforcing governor that denies every arrangement build: a 16-bucket
+ * table needs far more than one byte. */
+static wl_columnar_memory_governor_ref_t *
+tight_governor(void)
+{
+    wl_columnar_memory_resolution_t resolution = { 0 };
+    resolution.budget_bytes = 1u;
+    resolution.usable_bytes = 1u;
+    resolution.mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING;
+    resolution.source = WL_COLUMNAR_MEMORY_SOURCE_ENV;
+    resolution.status = WL_COLUMNAR_MEMORY_OK;
+    return wl_columnar_memory_governor_ref_create(&resolution);
+}
+
+static int
+find_entry_index(const wl_col_session_t *cs, const char *rel_name,
+    uint32_t key_col)
+{
+    for (uint32_t i = 0; i < cs->arr_count; i++) {
+        const col_arr_entry_t *e = &cs->arr_entries[i];
+        if (e->rel_name && strcmp(e->rel_name, rel_name) == 0
+            && e->key_count == 1u && e->key_cols[0] == key_col)
+            return (int)i;
+    }
+    return -1;
+}
+
+static const char *REUSE_FAILURE_SRC = ".decl edge(x: int32, y: int32)\n"
+    "edge(10, 1). edge(20, 2). edge(30, 3).\n"
+    ".decl node(x: int32)\n"
+    "node(1). node(2).\n"
+    ".decl pathA(x: int32, y: int32)\n"
+    "pathA(x, y) :- edge(x, y).\n"
+    ".decl n(x: int32)\n"
+    "n(x) :- node(x).\n";
+
+/* @tombstone_last selects where the tombstone sits: index 0 (a following
+ * scan must walk past the failed slot) or the last index (the failure
+ * tail must not mistake a reused last slot for an appended one). */
+static void
+test_tombstone_reuse_failure(bool tombstone_last)
+{
+    TEST(tombstone_last
+        ? "Failed tombstone reuse (last slot) keeps a rebuildable tombstone"
+        : "Failed tombstone reuse (first slot) keeps the registry scannable");
+
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    ASSERT(make_session(REUSE_FAILURE_SRC, &sess, &plan, &prog) == 0,
+        "session creation failed");
+
+    wl_col_session_t *cs = COL_SESSION(sess);
+    uint32_t key0[1] = { 0 };
+    uint32_t key1[1] = { 1 };
+    col_arrangement_t *a_edge = NULL;
+    col_arrangement_t *a_node = NULL;
+    if (tombstone_last) {
+        a_node = col_session_get_arrangement(sess, "node", key0, 1);
+        a_edge = col_session_get_arrangement(sess, "edge", key0, 1);
+    } else {
+        a_edge = col_session_get_arrangement(sess, "edge", key0, 1);
+        a_node = col_session_get_arrangement(sess, "node", key0, 1);
+    }
+    ASSERT(a_edge != NULL && a_node != NULL, "initial builds must succeed");
+    int edge_idx = find_entry_index(cs, "edge", 0);
+    ASSERT(edge_idx == (tombstone_last ? 1 : 0), "unexpected edge slot");
+
+    /* Manufacture an eviction tombstone on the edge entry. */
+    col_arr_entry_t *entry = &cs->arr_entries[edge_idx];
+    cs->arr_total_bytes -= entry->mem_bytes;
+    arr_free_contents(&entry->arr);
+    entry->mem_bytes = 0;
+    uint32_t count_before = cs->arr_count;
+    size_t total_before = cs->arr_total_bytes;
+
+    /* Only later attaches see the swapped session governor; every existing
+     * holder keeps its own retained reference. */
+    wl_columnar_memory_governor_ref_t *tight = tight_governor();
+    ASSERT(tight != NULL, "tight governor allocation failed");
+    wl_columnar_memory_governor_ref_t *orig = cs->memory_governor;
+    cs->memory_governor = tight;
+
+    /* A miss on a new key reuses the tombstone; the build is denied. */
+    ASSERT(col_session_get_arrangement(sess, "edge", key1, 1) == NULL,
+        "denied build must fail the lookup");
+    ASSERT(cs->arr_count == count_before, "failure must not change arr_count");
+    ASSERT(cs->arr_total_bytes == total_before,
+        "failure must not change arr_total_bytes");
+    entry = &cs->arr_entries[edge_idx];
+    /* The registry stays scannable: lookup, pin and invalidation walk past
+     * the failed slot. */
+    ASSERT(col_session_get_arrangement(sess, "node", key0, 1) == a_node,
+        "lookup of another relation must still hit");
+    col_arrangement_pin_t pin;
+    ASSERT(col_session_pin_arrangement(sess, "node", key0, 1, &pin) == 0,
+        "pin of another relation must succeed");
+    col_arrangement_pin_release(&pin);
+    col_session_invalidate_arrangements(sess, "edge");
+
+    ASSERT(entry->rel_name != NULL && strcmp(entry->rel_name, "edge") == 0,
+        "failed slot must keep a name");
+    ASSERT(entry->key_count == 1u && entry->key_cols != NULL
+        && entry->key_cols[0] == 1u, "failed slot must keep the new key");
+    ASSERT(entry->arr.indexed_rows == 0 && entry->mem_bytes == 0
+        && entry->arr.ht_head == NULL && entry->arr.reserved_bytes == 0
+        && entry->pin_count == 0, "failed slot must be a tombstone");
+    ASSERT(entry->arr.memory_governor == tight,
+        "failed slot must keep the governor it attached");
+    col_session_invalidate_arrangements(sess, "edge");
+    ASSERT(entry->arr.indexed_rows == 0, "tombstone stays invalidated");
+    ASSERT(wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(tight)) == 0,
+        "denied build must not leave a reservation");
+
+    /* A same-key retry takes the hit path; the slot's own governor still
+     * denies, and the tombstone is unchanged. */
+    ASSERT(col_session_get_arrangement(sess, "edge", key1, 1) == NULL,
+        "same-key retry must still be denied");
+    ASSERT(cs->arr_count == count_before
+        && cs->arr_total_bytes == total_before
+        && entry->rel_name != NULL && entry->key_cols[0] == 1u
+        && entry->mem_bytes == 0, "denied retry must leave the tombstone");
+
+    /* Restore the session governor; the tombstone keeps its own reference
+     * until it is reused. */
+    cs->memory_governor = orig;
+    wl_columnar_memory_governor_ref_release(tight);
+
+    /* A later miss reuses the failed slot with the session governor. */
+    col_arrangement_t *a_again
+        = col_session_get_arrangement(sess, "edge", key0, 1);
+    ASSERT(a_again != NULL, "reuse after restore must build");
+    ASSERT(a_again->indexed_rows == 3, "rebuilt arrangement must index rows");
+    ASSERT(cs->arr_count == count_before, "reuse must not grow arr_count");
+    entry = &cs->arr_entries[edge_idx];
+    ASSERT(a_again == &entry->arr && entry->key_cols[0] == 0u,
+        "reuse must take the failed slot");
+    ASSERT(entry->arr.memory_governor == orig,
+        "reused slot must attach the session governor");
+    ASSERT(cs->arr_total_bytes == total_before + entry->mem_bytes,
+        "arr_total_bytes must account the rebuilt entry only");
+
+    free_session(sess, plan, prog);
+    PASS();
+}
+
+/* The appended case keeps today's rollback: a denied first build on a
+ * fresh registry leaves nothing behind. */
+static void
+test_append_failure_rolls_back(void)
+{
+    TEST("Denied first build on an appended slot rolls back");
+
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    ASSERT(make_session(REUSE_FAILURE_SRC, &sess, &plan, &prog) == 0,
+        "session creation failed");
+
+    wl_col_session_t *cs = COL_SESSION(sess);
+    uint32_t key0[1] = { 0 };
+    uint32_t count_before = cs->arr_count;
+    size_t total_before = cs->arr_total_bytes;
+    wl_columnar_memory_governor_ref_t *tight = tight_governor();
+    ASSERT(tight != NULL, "tight governor allocation failed");
+    wl_columnar_memory_governor_ref_t *orig = cs->memory_governor;
+    cs->memory_governor = tight;
+
+    ASSERT(col_session_get_arrangement(sess, "edge", key0, 1) == NULL,
+        "denied build must fail the lookup");
+    ASSERT(cs->arr_count == count_before && cs->arr_total_bytes == total_before,
+        "appended failure must roll back");
+    ASSERT(wl_columnar_memory_reserved(
+            wl_columnar_memory_governor_ref_get(tight)) == 0,
+        "denied build must not leave a reservation");
+
+    cs->memory_governor = orig;
+    wl_columnar_memory_governor_ref_release(tight);
+    col_arrangement_t *arr = col_session_get_arrangement(sess, "edge", key0, 1);
+    ASSERT(arr != NULL && arr->indexed_rows == 3,
+        "build after restore must succeed");
+    ASSERT(cs->arr_count == count_before + 1u, "append must add one entry");
+
+    free_session(sess, plan, prog);
+    PASS();
+}
+
 int
 main(void)
 {
@@ -564,6 +757,9 @@ main(void)
     test_lru_clock_and_mem_bytes();
     test_env_var_limit();
     test_tombstone_rebuild();
+    test_tombstone_reuse_failure(false);
+    test_tombstone_reuse_failure(true);
+    test_append_failure_rolls_back();
     test_total_bytes_accounting();
     test_pinned_invalidation();
     for (unsigned scenario = 0; scenario < 8; scenario++)

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -343,11 +343,13 @@ col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst,
 
     memset(dst, 0, sizeof(*dst));
 
-    dst->rel_name = wl_strdup(src->rel_name);
-    if (!dst->rel_name)
+    /* A registry slot may carry no name or keys (defence in depth, #1515);
+     * it clones to an equally empty slot. */
+    dst->rel_name = src->rel_name ? wl_strdup(src->rel_name) : NULL;
+    if (src->rel_name && !dst->rel_name)
         return ENOMEM;
 
-    if (src->key_count > 0) {
+    if (src->key_count > 0 && src->key_cols) {
         dst->key_cols = (uint32_t *)malloc(src->key_count * sizeof(uint32_t));
         if (!dst->key_cols) {
             free(dst->rel_name);
@@ -822,7 +824,7 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
         col_arr_entry_t *e = &cs->arr_entries[i];
         if (e->key_count != key_count)
             continue;
-        if (strcmp(e->rel_name, rel_name) != 0)
+        if (!e->rel_name || strcmp(e->rel_name, rel_name) != 0)
             continue;
         bool match = true;
         for (uint32_t k = 0; k < key_count; k++) {
@@ -901,24 +903,39 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
         }
     }
 
-    if (slot == cs->arr_count) {
-        /* No tombstone available: grow the registry. */
-        if (cs->arr_count >= cs->arr_cap) {
-            /* A lease contains pointers into this flat registry.  Do not
-            * move it underneath an active borrower; callers can fall back
-            * to an ephemeral arrangement until the lease is released. */
-            for (uint32_t i = 0; i < cs->arr_count; i++) {
-                if (cs->arr_entries[i].pin_count > 0)
-                    return NULL;
-            }
-            uint32_t new_cap = cs->arr_cap ? cs->arr_cap * 2u : 8u;
-            col_arr_entry_t *ne = (col_arr_entry_t *)realloc(
-                cs->arr_entries, new_cap * sizeof(col_arr_entry_t));
-            if (!ne)
+    const bool appended = slot == cs->arr_count;
+
+    if (appended && cs->arr_count >= cs->arr_cap) {
+        /* No tombstone available: grow the registry.  A lease contains
+         * pointers into this flat registry.  Do not move it underneath an
+         * active borrower; callers can fall back to an ephemeral
+         * arrangement until the lease is released. */
+        for (uint32_t i = 0; i < cs->arr_count; i++) {
+            if (cs->arr_entries[i].pin_count > 0)
                 return NULL;
-            cs->arr_entries = ne;
-            cs->arr_cap = new_cap;
         }
+        uint32_t new_cap = cs->arr_cap ? cs->arr_cap * 2u : 8u;
+        col_arr_entry_t *ne = (col_arr_entry_t *)realloc(
+            cs->arr_entries, new_cap * sizeof(col_arr_entry_t));
+        if (!ne)
+            return NULL;
+        cs->arr_entries = ne;
+        cs->arr_cap = new_cap;
+    }
+
+    /* Issue #1515: take every allocation that can fail before disturbing
+     * the registry, so a failure leaves an appended count untouched and a
+     * reused tombstone exactly as it was. */
+    char *new_name = wl_strdup(rel_name);
+    if (!new_name)
+        return NULL;
+    uint32_t *new_keys = (uint32_t *)malloc(key_count * sizeof(uint32_t));
+    if (!new_keys) {
+        free(new_name);
+        return NULL;
+    }
+
+    if (appended) {
         cs->arr_count++;
     } else {
         /* Reuse tombstone: free its old ownership before overwriting. */
@@ -930,22 +947,8 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
     col_arr_entry_t *e = &cs->arr_entries[slot];
     memset(e, 0, sizeof(*e));
     wl_columnar_memory_reservation_init(&e->arr.reservation);
-
-    e->rel_name = wl_strdup(rel_name);
-    if (!e->rel_name) {
-        if (slot == cs->arr_count - 1)
-            cs->arr_count--; /* roll back append */
-        return NULL;
-    }
-
-    e->key_cols = (uint32_t *)malloc(key_count * sizeof(uint32_t));
-    if (!e->key_cols) {
-        free(e->rel_name);
-        memset(e, 0, sizeof(*e));
-        if (slot == cs->arr_count - 1)
-            cs->arr_count--;
-        return NULL;
-    }
+    e->rel_name = new_name;
+    e->key_cols = new_keys;
     memcpy(e->key_cols, key_cols, key_count * sizeof(uint32_t));
     e->key_count = key_count;
     e->arr.key_cols = e->key_cols; /* shared view; key_cols owned by entry */
@@ -954,27 +957,28 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
     col_arr_attach_memory_governor(&e->arr, cs->memory_governor);
 
     /* Initial build. */
-    if (arr_build_full(&e->arr, rel) != 0) {
+    if (arr_build_full(&e->arr, rel) != 0
+        || !arr_memory_bytes(&e->arr, &e->mem_bytes)) {
         arr_free_contents(&e->arr);
-        col_arr_detach_memory_governor(&e->arr);
-        free(e->rel_name);
-        free(e->key_cols);
-        memset(e, 0, sizeof(*e));
-        if (slot == cs->arr_count - 1)
-            cs->arr_count--;
+        e->mem_bytes = 0;
+        if (appended) {
+            col_arr_detach_memory_governor(&e->arr);
+            free(e->rel_name);
+            free(e->key_cols);
+            memset(e, 0, sizeof(*e));
+            cs->arr_count--; /* roll back append */
+        } else {
+            /* Issue #1515: a reused slot stays a well-formed tombstone
+             * keyed on the new (rel_name, key_cols), shaped exactly like an
+             * evicted entry: name, keys, ledger and the attached governor
+             * remain, and an invalid token forces a rebuild on the next
+             * hit.  Every registry scan keeps working and the next miss
+             * can reuse the slot again. */
+            e->source_snapshot = wl_columnar_relation_snapshot(NULL);
+        }
         return NULL;
     }
     e->source_snapshot = wl_columnar_relation_snapshot(rel);
-    if (!arr_memory_bytes(&e->arr, &e->mem_bytes)) {
-        arr_free_contents(&e->arr);
-        col_arr_detach_memory_governor(&e->arr);
-        free(e->rel_name);
-        free(e->key_cols);
-        memset(e, 0, sizeof(*e));
-        if (slot == cs->arr_count - 1)
-            cs->arr_count--;
-        return NULL;
-    }
     cs->arr_total_bytes += e->mem_bytes;
     e->lru_clock = ++cs->arr_clock;
     return &e->arr;
@@ -1108,7 +1112,8 @@ col_session_invalidate_arrangements(wl_session_t *sess, const char *rel_name)
         return;
     wl_col_session_t *cs = COL_SESSION(sess);
     for (uint32_t i = 0; i < cs->arr_count; i++) {
-        if (strcmp(cs->arr_entries[i].rel_name, rel_name) == 0) {
+        if (cs->arr_entries[i].rel_name
+            && strcmp(cs->arr_entries[i].rel_name, rel_name) == 0) {
             if (cs->arr_entries[i].pin_count > 0)
                 cs->arr_entries[i].rebuild_deferred = true;
             else


### PR DESCRIPTION
Closes #1515. Based on `main` (`ec48d48d`), one commit.

## What

In `col_session_get_arrangement` the tombstone-slot reuse freed the slot's old name and key columns and detached its governor before allocating the new ones, so a failed allocation, build or accounting left a zeroed slot with a NULL `rel_name` inside `arr_count` (unless it was the appended last slot). `col_session_invalidate_arrangements` compares names with no key-count guard in front and dereferenced the NULL name; the lookup and pin scans only skipped the slot because its key count was zeroed too.

The miss path now takes every allocation that can fail before disturbing the registry (pinned-lease check and growth realloc first, without counting the slot; then the new name and keys; then the commit). A build or accounting failure rolls an appended slot back as before; a reused slot stays a well-formed tombstone keyed on the new `(relation, key columns)`, shaped like an evicted entry with an invalid freshness token, so the next hit rebuilds it in place and the next miss can reuse it. `arr_total_bytes` is untouched on every failure. Behaviour change: a failed reuse of the last slot now keeps the tombstone instead of dropping the slot. The hit scan, invalidation and worker cloning tolerate a nameless slot as defence in depth.

## Tests

`tests/test_arrangement_lru_eviction.c`: an enforcing governor with a one-byte budget is swapped into the session so the reuse build is denied, for a tombstone in the first slot (the unfixed tree segfaults in the following invalidation) and in the last slot (locks the appended-case detection). Assertions cover the failed slot's state (name, new key, no contents, no reservation, governor kept), `arr_count` and `arr_total_bytes` invariants, lookup, pin and invalidation of another relation, a denied same-key retry, and the later reuse under the session governor. A third test checks the appended-case rollback.

## Evidence

- `arrangement_lru_eviction` 16/16; `arrangement_cache_reuse`, `generation_cache`, `post_remap_invalidate`, `worker_session`, `session`, `arrangement` green; red check: library change reverted, tests kept, the binary crashes.
- ASan/UBSan with leak detection clean on the five arrangement suites; TSan clean on `worker_session`, `generation_cache`, `tdd_recursive`.
- abi suite 60 OK / 0 failed / 2 skipped; full suite 353 OK / 0 failed / 14 skipped with the clang-tidy ratchet OK; `.text` delta within budget; uncrustify and changelog format clean.

## Review

Reviewer, Architect and Critic approved tree `8aefbba3`. Follow-up filed from the plan critique: #1524 (registry growth invalidates embedded reservations after realloc).

Note for merging: PR #1516 rewrites the tombstone-selection loop just above this hunk and `test_tombstone_rebuild`; whichever lands second needs a rebase.
