### PR TITLE
Fix arrangement registry reservation relocation

### DIFF
--- a/tests/test_arrangement_lru_eviction.c
+++ b/tests/test_arrangement_lru_eviction.c
@@ -344,7 +344,83 @@ test_total_bytes_accounting(void)
 }
 
 /* ================================================================
- * Test 5: pinned arrangements defer invalidation until the lease ends
+ * Test 5: registry growth moves live governor reservations
+ * ================================================================ */
+static void
+test_registry_growth_moves_reservations(void)
+{
+    TEST("registry growth preserves reservation identity and accounting");
+
+    const char *src = ".decl edge(a:int32,b:int32,c:int32,d:int32,"
+        "e:int32,f:int32,g:int32,h:int32,i:int32,j:int32)\n"
+        "edge(1,2,3,4,5,6,7,8,9,10).\n"
+        ".decl path(a:int32,b:int32)\n"
+        "path(a,b) :- edge(a,b).\n";
+    wl_session_t *sess = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *prog = NULL;
+    wl_col_session_t *cs;
+    wl_columnar_memory_governor_t *governor;
+    wl_columnar_memory_governor_ref_t *governor_ref;
+    col_rel_t *rel;
+
+    setenv("WIRELOG_MEMORY_BUDGET", "268435456", 1);
+    ASSERT(make_session(src, &sess, &plan, &prog) == 0,
+        "session setup failed");
+    cs = COL_SESSION(sess);
+    governor_ref = cs->memory_governor;
+    wl_columnar_memory_governor_ref_retain(governor_ref);
+    governor = wl_columnar_memory_governor_ref_get(cs->memory_governor);
+    rel = session_find_rel(cs, "edge");
+    ASSERT(rel != NULL, "source relation missing");
+    for (uint32_t key = 0; key < 9; key++) {
+        uint32_t key_col = key;
+        ASSERT(col_session_get_arrangement(sess, "edge", &key_col, 1)
+            != NULL, "arrangement build failed");
+    }
+    ASSERT(cs->arr_cap >= 16 && cs->arr_count == 9,
+        "primary registry did not grow");
+    for (uint32_t i = 0; i < cs->arr_count; i++) {
+        wl_columnar_memory_reservation_t *reservation
+            = &cs->arr_entries[i].arr.reservation;
+        uint64_t state = atomic_load_explicit(&reservation->state,
+                memory_order_acquire);
+        ASSERT(reservation->identity == reservation,
+            "grown entry has stale reservation identity");
+        ASSERT(state == WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED,
+            "grown entry lost committed reservation");
+    }
+    ASSERT(wl_columnar_memory_reserved(governor) > 0,
+        "governor lost arrangement reservation");
+    for (uint32_t key = 0; key < 5; key++) {
+        uint32_t key_col = key;
+        ASSERT(col_session_get_delta_arrangement(cs, "edge", rel,
+            &key_col, 1) != NULL, "delta arrangement build failed");
+        ASSERT(col_session_get_filt_arrangement(cs, "edge", key + 1, rel,
+            &key_col, 1) != NULL, "filtered arrangement build failed");
+    }
+    ASSERT(cs->darr_cap >= 8 && cs->darr_count == 5,
+        "delta registry did not grow");
+    ASSERT(cs->filt_arr_cap >= 8 && cs->filt_arr_count == 5,
+        "filtered registry did not grow");
+    for (uint32_t i = 0; i < cs->darr_count; i++)
+        ASSERT(cs->darr_entries[i].arr.reservation.identity
+            == &cs->darr_entries[i].arr.reservation,
+            "grown delta entry has stale reservation identity");
+    for (uint32_t i = 0; i < cs->filt_arr_count; i++)
+        ASSERT(cs->filt_arr_entries[i].arr.reservation.identity
+            == &cs->filt_arr_entries[i].arr.reservation,
+            "grown filtered entry has stale reservation identity");
+    free_session(sess, plan, prog);
+    ASSERT(wl_columnar_memory_reserved(governor) == 0,
+        "session destruction leaked registry reservations");
+    wl_columnar_memory_governor_ref_release(governor_ref);
+    unsetenv("WIRELOG_MEMORY_BUDGET");
+    PASS();
+}
+
+/* ================================================================
+ * Test 6: pinned arrangements defer invalidation until the lease ends
  * ================================================================ */
 static void
 test_pinned_invalidation(void)
@@ -761,6 +837,7 @@ main(void)
     test_tombstone_reuse_failure(true);
     test_append_failure_rolls_back();
     test_total_bytes_accounting();
+    test_registry_growth_moves_reservations();
     test_pinned_invalidation();
     for (unsigned scenario = 0; scenario < 8; scenario++)
         test_pinned_rebuild(scenario);

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -240,19 +240,167 @@ arr_reserve_bytes(col_arrangement_t *arr, uint64_t bytes,
     return true;
 }
 
-static void
+static bool
 arr_publish_reservation(col_arrangement_t *arr,
     wl_columnar_memory_reservation_t *pending, uint64_t bytes)
 {
     if (!arr || !arr->memory_governor)
-        return;
+        return true;
     if (bytes == arr->reserved_bytes) {
-        (void)wl_columnar_memory_release(pending);
-        return;
+        return wl_columnar_memory_release(pending);
     }
-    (void)wl_columnar_memory_release(&arr->reservation);
-    (void)wl_columnar_memory_reservation_move(&arr->reservation, pending);
+    wl_columnar_memory_reservation_t previous;
+    wl_columnar_memory_reservation_init(&previous);
+    uint64_t old_state = atomic_load_explicit(&arr->reservation.state,
+            memory_order_acquire);
+    bool old_active = old_state == WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+        || old_state == WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED;
+    if (old_active
+        && !wl_columnar_memory_reservation_move(&previous,
+        &arr->reservation)) {
+        (void)wl_columnar_memory_release(pending);
+        return false;
+    }
+    if (!wl_columnar_memory_reservation_move(&arr->reservation, pending)) {
+        (void)wl_columnar_memory_release(pending);
+        if (old_active)
+            (void)wl_columnar_memory_reservation_move(&arr->reservation,
+                &previous);
+        return false;
+    }
+    if (old_active && !wl_columnar_memory_release(&previous)) {
+        wl_columnar_memory_reservation_t replacement;
+        wl_columnar_memory_reservation_init(&replacement);
+        (void)wl_columnar_memory_reservation_move(&replacement,
+            &arr->reservation);
+        (void)wl_columnar_memory_reservation_move(&arr->reservation,
+            &previous);
+        (void)wl_columnar_memory_release(&replacement);
+        return false;
+    }
     arr->reserved_bytes = bytes;
+    return true;
+}
+
+/* Registry entries embed non-copyable reservation tokens.  A flat-array
+ * relocation must move each token deliberately; realloc would leave identity
+ * pointing into the old array and lose accounting. */
+static bool
+arr_entry_relocate(col_arr_entry_t *dst, col_arr_entry_t *src)
+{
+    uint64_t state = atomic_load_explicit(&src->arr.reservation.state,
+            memory_order_acquire);
+    if (src->arr.reservation.identity != &src->arr.reservation)
+        return false;
+    memcpy(dst, src, sizeof(*dst));
+    wl_columnar_memory_reservation_init(&dst->arr.reservation);
+    dst->arr.key_cols = dst->key_cols;
+    if (state == WL_COLUMNAR_MEMORY_RESERVATION_EMPTY
+        || state == WL_COLUMNAR_MEMORY_RESERVATION_RELEASED)
+        return true;
+    if (state != WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+        && state != WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED)
+        return false;
+    if (!wl_columnar_memory_reservation_move(&dst->arr.reservation,
+        &src->arr.reservation))
+        return false;
+    state = atomic_load_explicit(&dst->arr.reservation.state,
+            memory_order_acquire);
+    if ((state == WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+        || state == WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED)
+        && !wl_columnar_memory_transfer(&dst->arr.reservation, &dst->arr)) {
+        (void)wl_columnar_memory_reservation_move(
+            &src->arr.reservation, &dst->arr.reservation);
+        return false;
+    }
+    return true;
+}
+
+static bool
+filt_arr_entry_relocate(col_filt_arr_entry_t *dst, col_filt_arr_entry_t *src)
+{
+    uint64_t state = atomic_load_explicit(&src->arr.reservation.state,
+            memory_order_acquire);
+    if (src->arr.reservation.identity != &src->arr.reservation)
+        return false;
+    memcpy(dst, src, sizeof(*dst));
+    wl_columnar_memory_reservation_init(&dst->arr.reservation);
+    dst->arr.key_cols = dst->key_cols;
+    if (state == WL_COLUMNAR_MEMORY_RESERVATION_EMPTY
+        || state == WL_COLUMNAR_MEMORY_RESERVATION_RELEASED)
+        return true;
+    if (state != WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+        && state != WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED)
+        return false;
+    if (!wl_columnar_memory_reservation_move(&dst->arr.reservation,
+        &src->arr.reservation))
+        return false;
+    state = atomic_load_explicit(&dst->arr.reservation.state,
+            memory_order_acquire);
+    if ((state == WL_COLUMNAR_MEMORY_RESERVATION_RESERVED
+        || state == WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED)
+        && !wl_columnar_memory_transfer(&dst->arr.reservation, &dst->arr)) {
+        (void)wl_columnar_memory_reservation_move(
+            &src->arr.reservation, &dst->arr.reservation);
+        return false;
+    }
+    return true;
+}
+
+static bool
+arr_entries_grow(col_arr_entry_t **entries, uint32_t *capacity,
+    uint32_t count, uint32_t new_capacity)
+{
+    col_arr_entry_t *old = *entries;
+    col_arr_entry_t *grown = (col_arr_entry_t *)calloc(new_capacity,
+            sizeof(*grown));
+    if (!grown)
+        return false;
+    for (uint32_t i = 0; i < count; i++) {
+        if (!arr_entry_relocate(&grown[i], &old[i])) {
+            for (uint32_t j = 0; j < i; j++) {
+                if (wl_columnar_memory_reservation_move(
+                        &old[j].arr.reservation,
+                        &grown[j].arr.reservation))
+                    (void)wl_columnar_memory_transfer(
+                        &old[j].arr.reservation, &old[j].arr);
+            }
+            free(grown);
+            return false;
+        }
+    }
+    free(old);
+    *entries = grown;
+    *capacity = new_capacity;
+    return true;
+}
+
+static bool
+filt_arr_entries_grow(col_filt_arr_entry_t **entries, uint32_t *capacity,
+    uint32_t count, uint32_t new_capacity)
+{
+    col_filt_arr_entry_t *old = *entries;
+    col_filt_arr_entry_t *grown = (col_filt_arr_entry_t *)calloc(new_capacity,
+            sizeof(*grown));
+    if (!grown)
+        return false;
+    for (uint32_t i = 0; i < count; i++) {
+        if (!filt_arr_entry_relocate(&grown[i], &old[i])) {
+            for (uint32_t j = 0; j < i; j++) {
+                if (wl_columnar_memory_reservation_move(
+                        &old[j].arr.reservation,
+                        &grown[j].arr.reservation))
+                    (void)wl_columnar_memory_transfer(
+                        &old[j].arr.reservation, &old[j].arr);
+            }
+            free(grown);
+            return false;
+        }
+    }
+    free(old);
+    *entries = grown;
+    *capacity = new_capacity;
+    return true;
 }
 
 /*
@@ -602,8 +750,11 @@ arr_build_full_impl(col_arrangement_t *arr, const col_rel_t *rel)
         arr->ht_next = new_next;
         arr->ht_cap = new_cap;
     }
-    if (pending_valid)
-        arr_publish_reservation(arr, &pending, prospective_bytes);
+    if (pending_valid
+        && !arr_publish_reservation(arr, &pending, prospective_bytes)) {
+        arr_free_contents(arr);
+        return ENOMEM;
+    }
 
     /* Start a new epoch.  Only wraparound needs a full clear; normal rebuilds
      * lazily replace each bucket head as that bucket receives its first row. */
@@ -697,8 +848,11 @@ arr_update_incremental_impl(col_arrangement_t *arr, const col_rel_t *rel,
         free(arr->ht_next);
         arr->ht_next = nxt;
         arr->ht_cap = new_cap;
-        if (pending_valid)
-            arr_publish_reservation(arr, &pending, target_bytes);
+        if (pending_valid
+            && !arr_publish_reservation(arr, &pending, target_bytes)) {
+            arr_free_contents(arr);
+            return ENOMEM;
+        }
     }
 
     uint32_t nb = arr->nbuckets;
@@ -915,12 +1069,9 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
                 return NULL;
         }
         uint32_t new_cap = cs->arr_cap ? cs->arr_cap * 2u : 8u;
-        col_arr_entry_t *ne = (col_arr_entry_t *)realloc(
-            cs->arr_entries, new_cap * sizeof(col_arr_entry_t));
-        if (!ne)
+        if (!arr_entries_grow(&cs->arr_entries, &cs->arr_cap,
+            cs->arr_count, new_cap))
             return NULL;
-        cs->arr_entries = ne;
-        cs->arr_cap = new_cap;
     }
 
     /* Issue #1515: take every allocation that can fail before disturbing
@@ -1235,12 +1386,9 @@ col_session_get_delta_arrangement(wl_col_session_t *cs, const char *rel_name,
     /* Not found: grow cache and create new entry. */
     if (cs->darr_count >= cs->darr_cap) {
         uint32_t new_cap = cs->darr_cap ? cs->darr_cap * 2u : 4u;
-        col_arr_entry_t *ne = (col_arr_entry_t *)realloc(
-            cs->darr_entries, new_cap * sizeof(col_arr_entry_t));
-        if (!ne)
+        if (!arr_entries_grow(&cs->darr_entries, &cs->darr_cap,
+            cs->darr_count, new_cap))
             return NULL;
-        cs->darr_entries = ne;
-        cs->darr_cap = new_cap;
     }
 
     col_arr_entry_t *e = &cs->darr_entries[cs->darr_count];
@@ -1357,12 +1505,9 @@ col_session_get_filt_arrangement(wl_col_session_t *cs, const char *rel_name,
     /* Not found: grow cache and create new entry. */
     if (cs->filt_arr_count >= cs->filt_arr_cap) {
         uint32_t new_cap = cs->filt_arr_cap ? cs->filt_arr_cap * 2u : 4u;
-        col_filt_arr_entry_t *ne = (col_filt_arr_entry_t *)realloc(
-            cs->filt_arr_entries, new_cap * sizeof(col_filt_arr_entry_t));
-        if (!ne)
+        if (!filt_arr_entries_grow(&cs->filt_arr_entries,
+            &cs->filt_arr_cap, cs->filt_arr_count, new_cap))
             return NULL;
-        cs->filt_arr_entries = ne;
-        cs->filt_arr_cap = new_cap;
     }
 
     col_filt_arr_entry_t *e = &cs->filt_arr_entries[cs->filt_arr_count];


### PR DESCRIPTION
## Summary
- replace reservation-unsafe registry `realloc` growth with explicit entry relocation
- preserve reservation identity, owner, and governor accounting across primary, delta, and filtered registries
- make arrangement reservation publication transactional on replacement failure
- add regression coverage for all three registry growth paths and destruction accounting

Fixes #1524.

## Validation
- `meson test -C builddir-1524 --suite unit --print-errorlogs`
- arrangement-related test suite (10 tests)
- `wirelog:arrangement_lru_eviction` with ASan/UBSan
