### PR TITLE
fix: prewarm intern benchmark tails

### DIFF
--- a/bench/bench_intern.c
+++ b/bench/bench_intern.c
@@ -443,6 +443,7 @@ main(int argc, char **argv)
     int writers_list[3];
     int nwriters = 0;
     bool run_unique, run_dup, run_off, run_on;
+    bool full_size_warmup_done = false;
     wl_perf_ns_t clock_ns;
 
     bench_argv_state_t st = BENCH_ARGV_INIT;
@@ -510,6 +511,15 @@ main(int argc, char **argv)
                 uint32_t warm = iters / 10u;
                 if ((governed && !run_on) || (!governed && !run_off))
                     continue;
+                /* Pre-fault a full-size throwaway table before the first
+                 * reported row.  Later scenarios retain the lightweight
+                 * warm-up so their setup cost stays bounded. */
+                if (!full_size_warmup_done) {
+                    if (run_scenario(mode, writers_list[wi], governed, iters,
+                        false, clock_ns) != 0)
+                        return 1;
+                    full_size_warmup_done = true;
+                }
                 if (warm > 0
                     && run_scenario(mode, writers_list[wi], governed, warm,
                     false, clock_ns) != 0)

--- a/docs/INTERN_PERF.md
+++ b/docs/INTERN_PERF.md
@@ -1,6 +1,6 @@
 # Intern Write-Path Performance
 
-**Last Updated:** 2026-09-10
+**Last Updated:** 2026-09-11
 **Baseline SHA:** `ec48d48d` (main at the time of measurement)
 **Issue:** #1472 (benchmark and baseline); measures the write path from #958,
 #961 and #1431
@@ -73,7 +73,10 @@ be mistaken for a fast one. Timing values are never asserted.
 The host was not pinned or isolated; the numbers carry run-to-run noise of
 a few percent on the single-writer rows and more on the contended rows. The
 bench deliberately does not call `bench_stability_prep()`: on Windows that
-helper pins the process to one CPU, which would serialize the writers.
+helper pins the process to one CPU, which would serialize the writers. Before
+the first reported row, the bench now runs one full-size untimed scenario to
+pre-fault the allocator path; subsequent scenarios retain their tenth-size
+untimed warm-up.
 
 ## Results: default configuration
 
@@ -146,16 +149,11 @@ Clock pair cost (median of the three runs): 23 ns per bracketed put.
   rehash). Small early resizes and segment opens stay below the threshold.
   The share is reported as a share of summed per-put latency, not of wall
   time.
-- **Scenario order.** The grid runs its scenarios in one process, and the
-  first scenario pays the first-touch page faults of the heap the table
-  grows into (the tenth-size warm-up table does not pre-fault it). The p99
-  and `grow_events` of the first row (`unique`, one writer, governor off)
-  are therefore higher than the same scenario shows when it runs later in
-  the grid, and a scenario run alone is itself in first position and pays
-  the same cost. Tail metrics are only comparable between rows measured in
-  the same position: run each side of a comparison alone (`--mode`,
-  `--writers`, `--governor`) so both sit in first position. `grow_share`
-  is stable across positions; `agg_ns_put` moves by under ten percent.
+- **Scenario order.** The first full-size untimed scenario pre-faults the
+  allocator path before any reported row. Tail metrics can still vary with
+  scheduler and allocator state, so compare medians of three runs, but the
+  first-position page-fault penalty is no longer part of the first reported
+  row.
 
 ## Reproducing these results
 


### PR DESCRIPTION
Closes #1526

Stacked after #1531/#1527. The benchmark now runs one full-size untimed scenario before the first reported row, removing first-scenario allocator/page-fault bias from p99 and grow_events. The existing tenth-size warm-up remains for subsequent scenarios, and the smoke token contract is unchanged.

Validation:
- release build of bench_intern
- bench_intern_smoke passed
- three full-grid release runs completed without errors
- isolated first-row versus full-grid comparison showed comparable p99/grow metrics
- git diff --check