### PR TITLE
feat: add exact-source arrangement probe lease

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2608,6 +2608,24 @@ test_arrangement_lru_eviction_exe = executable(
 
 test('arrangement_lru_eviction', test_arrangement_lru_eviction_exe)
 
+# Bound primary-arrangement probe lease (Issue #1496, atomic unit 1)
+test_arrangement_probe_exe = executable(
+  'test_arrangement_probe',
+  files('test_arrangement_probe.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('arrangement_probe', test_arrangement_probe_exe)
+
 # ============================================================================
 # Pin-safe Materialization Cache Reclaimer Tests (Issue #1371)
 # ============================================================================

--- a/tests/test_arrangement_probe.c
+++ b/tests/test_arrangement_probe.c
@@ -1,0 +1,195 @@
+/* Bound primary-arrangement probe lease contract tests (Issue #1496). */
+
+#include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/columnar/internal.h"
+#include "../wirelog/exec_plan_gen.h"
+#include "../wirelog/passes/fusion.h"
+#include "../wirelog/passes/jpp.h"
+#include "../wirelog/passes/sip.h"
+#include "../wirelog/session.h"
+#include "../wirelog/session_facts.h"
+#include "../wirelog/thread.h"
+#include "../wirelog/wirelog.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int failures;
+
+#define CHECK(condition, message) do { \
+            if (!(condition)) { \
+                fprintf(stderr, "FAIL: %s\n", (message)); \
+                failures++; \
+            } \
+} while (0)
+
+static void
+noop_cb(const char *relation, const int64_t *row, uint32_t ncols, void *user)
+{
+    (void)relation;
+    (void)row;
+    (void)ncols;
+    (void)user;
+}
+
+static int
+make_session(wl_session_t **out_session, wl_plan_t **out_plan,
+    wirelog_program_t **out_program)
+{
+    static const char source[] =
+        ".decl edge(x: int32, y: int32)\n"
+        "edge(1, 2). edge(3, 4).\n"
+        ".decl path(x: int32, y: int32)\n"
+        "path(x, y) :- edge(x, y).\n";
+    wirelog_error_t error;
+    wirelog_program_t *program = wirelog_parse_string(source, &error);
+    wl_plan_t *plan = NULL;
+    wl_session_t *session = NULL;
+
+    if (!program)
+        return EINVAL;
+    wl_fusion_apply(program, NULL);
+    wl_jpp_apply(program, NULL);
+    wl_sip_apply(program, NULL);
+    if (wl_plan_from_program(program, &plan) != 0
+        || wl_session_create(wl_backend_columnar(), plan, 1, &session) != 0
+        || wl_session_load_facts(session, program) != 0
+        || wl_session_snapshot(session, noop_cb, NULL) != 0) {
+        if (session)
+            wl_session_destroy(session);
+        if (plan)
+            wl_plan_free(plan);
+        wirelog_program_free(program);
+        return EINVAL;
+    }
+    *out_session = session;
+    *out_plan = plan;
+    *out_program = program;
+    return 0;
+}
+
+static col_arr_entry_t *
+find_entry(wl_col_session_t *session, const col_arrangement_t *arr)
+{
+    for (uint32_t i = 0; i < session->arr_count; i++) {
+        if (&session->arr_entries[i].arr == arr)
+            return &session->arr_entries[i];
+    }
+    return NULL;
+}
+
+struct release_probe_arg {
+    col_arrangement_probe_t *probe;
+    int rc;
+};
+
+static void *
+release_probe_from_other_thread(void *opaque)
+{
+    struct release_probe_arg *arg = opaque;
+    arg->rc = col_arrangement_probe_release(arg->probe);
+    return NULL;
+}
+
+int
+main(void)
+{
+    wl_session_t *session = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *program = NULL;
+    col_rel_t *same_name = NULL;
+    col_arrangement_probe_t probe = { 0 };
+    wl_columnar_source_access_writer_t writer = { 0 };
+    struct release_probe_arg release_arg = { &probe, 0 };
+    thread_t release_thread;
+    uint32_t key_cols[] = { 0 };
+
+    CHECK(make_session(&session, &plan, &program) == 0,
+        "session setup");
+    if (!session)
+        return 1;
+
+    wl_col_session_t *col_session = COL_SESSION(session);
+    col_rel_t *source = session_find_rel(col_session, "edge");
+    col_arrangement_t *arr = col_session_get_arrangement(session, "edge",
+            key_cols, 1);
+    col_arr_entry_t *entry = find_entry(col_session, arr);
+    CHECK(source && arr && entry, "source arrangement setup");
+    if (!source || !arr || !entry)
+        goto cleanup;
+
+    uint64_t acquire_clock = entry->lru_clock;
+    CHECK(col_session_acquire_arrangement_probe(session, arr, source,
+        &probe) == 0, "successful probe acquire");
+    CHECK(probe.active && probe.identity == (uintptr_t)&probe
+        && probe.arr == arr && probe.source == source
+        && probe.arrangement_pin.active && entry->pin_count == 1
+        && wl_columnar_relation_snapshot_equal(probe.source_snapshot,
+        wl_columnar_relation_snapshot(source)),
+        "probe binds exact arrangement, source, and generation");
+    CHECK(entry->lru_clock == acquire_clock,
+        "exact-entry acquire does not re-enter name-based getter");
+    CHECK(atomic_load_explicit(&source->source_access.state,
+        memory_order_acquire) == 1, "probe holds one source reader");
+    CHECK(thread_create(&release_thread, release_probe_from_other_thread,
+        &release_arg) == 0, "wrong-thread release setup");
+    CHECK(thread_join(&release_thread) == 0 && release_arg.rc == EINVAL,
+        "wrong-thread release is rejected");
+    CHECK(probe.active && probe.arrangement_pin.active
+        && entry->pin_count == 1
+        && atomic_load_explicit(&source->source_access.state,
+        memory_order_acquire) == 1,
+        "wrong-thread release retains both leases");
+    CHECK(col_arrangement_probe_release(&probe) == 0,
+        "successful probe release");
+    CHECK(!probe.active && entry->pin_count == 0
+        && atomic_load_explicit(&source->source_access.state,
+        memory_order_acquire) == 0, "release balances both leases");
+    CHECK(col_arrangement_probe_release(&probe) == EINVAL,
+        "double release is rejected");
+
+    CHECK(col_rel_alloc(&same_name, "edge") == 0,
+        "same-name relation setup");
+    CHECK(col_session_acquire_arrangement_probe(session, arr, same_name,
+        &probe) == EBUSY, "same-name relation cannot replace exact source");
+    CHECK(!probe.active && entry->pin_count == 0
+        && atomic_load_explicit(&same_name->source_access.state,
+        memory_order_acquire) == 0,
+        "identity rejection leaves both sources unleased");
+
+    col_arrangement_t saved_arr = *arr;
+    col_relation_snapshot_t saved_snapshot = entry->source_snapshot;
+    uint64_t saved_clock = entry->lru_clock;
+    CHECK(wl_columnar_source_access_writer_acquire(&source->source_access,
+        &writer) == 0, "source writer setup");
+    CHECK(col_session_acquire_arrangement_probe(session, arr, source,
+        &probe) == EBUSY, "source writer EBUSY is propagated");
+    CHECK(!probe.active && entry->pin_count == 0
+        && entry->lru_clock == saved_clock
+        && arr->ht_head == saved_arr.ht_head
+        && arr->ht_next == saved_arr.ht_next
+        && arr->nbuckets == saved_arr.nbuckets
+        && arr->indexed_rows == saved_arr.indexed_rows
+        && arr->generation == saved_arr.generation
+        && wl_columnar_relation_snapshot_equal(entry->source_snapshot,
+        saved_snapshot), "EBUSY preserves arrangement and lease state");
+    CHECK(wl_columnar_source_access_writer_release(&writer) == 0,
+        "source writer release");
+
+cleanup:
+    if (probe.active)
+        (void)col_arrangement_probe_release(&probe);
+    if (writer.owner)
+        (void)wl_columnar_source_access_writer_release(&writer);
+    if (same_name)
+        (void)col_rel_destroy_checked(same_name);
+    wl_session_destroy(session);
+    wl_plan_free(plan);
+    wirelog_program_free(program);
+    if (failures != 0)
+        return 1;
+    puts("arrangement_probe: OK");
+    return 0;
+}

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -1163,6 +1163,23 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
     return &e->arr;
 }
 
+static int
+col_arrangement_pin_entry(wl_col_session_t *session, col_arr_entry_t *entry,
+    col_arrangement_t *arr, col_arrangement_pin_t *pin)
+{
+    if (!session || !entry || !arr || !pin || &entry->arr != arr)
+        return EINVAL;
+    memset(pin, 0, sizeof(*pin));
+    if (entry->pin_count == UINT32_MAX)
+        return EOVERFLOW;
+    entry->pin_count++;
+    pin->entry = entry;
+    pin->arr = arr;
+    pin->session = session;
+    pin->active = true;
+    return 0;
+}
+
 int
 col_session_pin_arrangement(wl_session_t *sess, const char *rel_name,
     const uint32_t *key_cols, uint32_t key_count, col_arrangement_pin_t *pin)
@@ -1179,11 +1196,92 @@ col_session_pin_arrangement(wl_session_t *sess, const char *rel_name,
     entry = col_arr_entry_for_arr(COL_SESSION(sess), arr);
     if (!entry)
         return EINVAL;
-    entry->pin_count++;
-    pin->entry = entry;
-    pin->arr = arr;
-    pin->session = COL_SESSION(sess);
-    pin->active = true;
+    return col_arrangement_pin_entry(COL_SESSION(sess), entry, arr, pin);
+}
+
+static bool
+col_session_has_exact_relation(const wl_col_session_t *session,
+    const col_rel_t *source, const char *name)
+{
+    if (!session || !source || !name)
+        return false;
+    for (uint32_t i = 0; i < session->nrels; i++) {
+        const col_rel_t *candidate = session->rels[i];
+        if (candidate && candidate->name
+            && strcmp(candidate->name, name) == 0)
+            return candidate == source;
+    }
+    return false;
+}
+
+int
+col_session_acquire_arrangement_probe(wl_session_t *sess,
+    col_arrangement_t *arr, const col_rel_t *source,
+    col_arrangement_probe_t *probe)
+{
+    col_relation_snapshot_t snapshot;
+    col_arr_entry_t *entry;
+    wl_col_session_t *session;
+    int rc;
+
+    if (!sess || !arr || !source || !probe || probe->active
+        || probe->identity != 0 || probe->arr || probe->source
+        || probe->arrangement_pin.active || probe->source_reader.owner)
+        return EINVAL;
+    session = COL_SESSION(sess);
+    entry = col_arr_entry_for_arr(session, arr);
+    snapshot = wl_columnar_relation_snapshot(source);
+    if (!entry || !source->name || !entry->rel_name
+        || strcmp(entry->rel_name, source->name) != 0)
+        return EINVAL;
+    if (!col_session_has_exact_relation(session, source, entry->rel_name)
+        || !wl_columnar_relation_snapshot_valid(snapshot)
+        || !wl_columnar_relation_snapshot_equal(entry->source_snapshot,
+        snapshot) || arr_entry_unbuilt(entry) || entry->rebuild_deferred)
+        return EBUSY;
+
+    rc = col_rel_source_reader_acquire(source, &probe->source_reader);
+    if (rc != 0)
+        return rc;
+
+    /* Admission freezes source storage, but identity and registry membership
+     * are checked again so a future concurrent session registry cannot turn
+     * this exact-source API back into a name-only lookup. */
+    if (!col_session_has_exact_relation(session, source, entry->rel_name)
+        || col_arr_entry_for_arr(session, arr) != entry
+        || !wl_columnar_relation_snapshot_equal(
+            wl_columnar_relation_snapshot(source), snapshot)
+        || !wl_columnar_relation_snapshot_equal(entry->source_snapshot,
+        snapshot)) {
+        rc = col_rel_source_reader_release(&probe->source_reader);
+        return rc == 0 ? EBUSY : rc;
+    }
+
+    /* Pin the exact entry already validated under source admission.  Calling
+     * the name-based getter here could rebuild, relocate, or otherwise mutate
+     * registry state before a replacement race is rejected. */
+    rc = col_arrangement_pin_entry(session, entry, arr,
+            &probe->arrangement_pin);
+    if (rc != 0) {
+        int release_rc
+            = col_rel_source_reader_release(&probe->source_reader);
+        return release_rc == 0 ? rc : release_rc;
+    }
+    if (probe->arrangement_pin.arr != arr
+        || probe->arrangement_pin.entry != entry
+        || !col_session_has_exact_relation(session, source, entry->rel_name)
+        || !wl_columnar_relation_snapshot_equal(entry->source_snapshot,
+        snapshot)) {
+        col_arrangement_pin_release(&probe->arrangement_pin);
+        rc = col_rel_source_reader_release(&probe->source_reader);
+        return rc == 0 ? EBUSY : rc;
+    }
+
+    probe->arr = arr;
+    probe->source = source;
+    probe->source_snapshot = snapshot;
+    probe->identity = (uintptr_t)probe;
+    probe->active = true;
     return 0;
 }
 
@@ -1214,6 +1312,34 @@ col_arrangement_pin_release(col_arrangement_pin_t *pin)
         size_t target = (cs->arr_cache_limit_bytes / 4u) * 3u;
         col_arr_cache_evict_lru(cs, target);
     }
+}
+
+int
+col_arrangement_probe_release(col_arrangement_probe_t *probe)
+{
+    wl_columnar_source_access_reader_t *reader;
+    int rc;
+
+    if (!probe || !probe->active || probe->identity != (uintptr_t)probe
+        || !probe->arr || !probe->source)
+        return EINVAL;
+    reader = &probe->source_reader;
+    /* Validate every source-reader precondition before changing the index
+     * pin.  The reader itself keeps the gate nonzero between this check and
+     * release, so a successful precheck makes the two releases atomic with
+     * respect to all supported token states. */
+    if (reader->identity != (uintptr_t)reader || !reader->owner
+        || (!reader->transferable
+        && !wl_columnar_source_access_reader_thread_equal(reader))
+        || (reader->transferable && reader->thread_valid)
+        || !wl_columnar_source_access_gate_busy(reader->owner))
+        return EINVAL;
+    col_arrangement_pin_release(&probe->arrangement_pin);
+    rc = col_rel_source_reader_release(reader);
+    if (rc != 0)
+        return rc;
+    memset(probe, 0, sizeof(*probe));
+    return 0;
 }
 
 uint32_t

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1219,6 +1219,20 @@ typedef struct {
     bool active;
 } col_arrangement_pin_t;
 
+/* Allocation-free, address-bound lease for probing one primary arrangement
+ * against the exact source relation used to validate it.  This primitive is
+ * intentionally not wired into JOIN yet; #1496 activates consumers only
+ * after their complete dependency set can be acquired transactionally. */
+typedef struct {
+    col_arrangement_pin_t arrangement_pin;
+    col_arrangement_t *arr;
+    const col_rel_t *source;
+    col_relation_snapshot_t source_snapshot;
+    wl_columnar_source_access_reader_t source_reader;
+    uintptr_t identity;
+    bool active;
+} col_arrangement_probe_t;
+
 /*
  * col_sorted_arr_t: cached sorted copy of a relation by a single key column.
  *
@@ -1881,6 +1895,15 @@ col_session_pin_arrangement(wl_session_t *sess, const char *rel_name,
     col_arrangement_pin_t *pin);
 void
 col_arrangement_pin_release(col_arrangement_pin_t *pin);
+/* Bind an already-built primary arrangement to its exact current source.
+ * EBUSY means the source is write-locked, replaced, or generation-stale;
+ * callers may retry after the conflicting operation finishes. */
+int
+col_session_acquire_arrangement_probe(wl_session_t *sess,
+    col_arrangement_t *arr, const col_rel_t *source,
+    col_arrangement_probe_t *probe);
+int
+col_arrangement_probe_release(col_arrangement_probe_t *probe);
 int
 col_rel_alloc(col_rel_t **out, const char *name);
 int


### PR DESCRIPTION
## Summary
- add an allocation-free arrangement probe lease bound to the exact source relation and arrangement entry
- acquire and release source-reader and arrangement pins transactionally, including wrong-thread release retention
- add focused normal and sanitizer contract tests without changing JOIN activation

Part of #1496

## Validation
- `meson test -C builddir arrangement_probe --print-errorlogs`
- `meson test -C builddir-san arrangement_probe --print-errorlogs`

This is the first atomic unit for #1496. JOIN integration, compound dependencies, worker aliases, and operation-scope registration remain subsequent units; the parent issue stays open until its full acceptance criteria are met.
