### PR TITLE
fix: bind arrangement probes to storage owners

### DIFF
--- a/tests/test_arrangement_probe.c
+++ b/tests/test_arrangement_probe.c
@@ -93,6 +93,100 @@ release_probe_from_other_thread(void *opaque)
     return NULL;
 }
 
+static void
+test_alias_storage_owner_probe(void)
+{
+    wl_session_t *session = NULL;
+    wl_plan_t *plan = NULL;
+    wirelog_program_t *program = NULL;
+    col_rel_t *owner = NULL;
+    col_arrangement_probe_t probe = { 0 };
+    wl_columnar_source_access_writer_t owner_writer = { 0 };
+    uint32_t key_cols[] = { 0 };
+
+    CHECK(make_session(&session, &plan, &program) == 0,
+        "alias session setup");
+    if (!session)
+        goto cleanup;
+
+    wl_col_session_t *col_session = COL_SESSION(session);
+    col_rel_t *source = session_find_rel(col_session, "edge");
+    CHECK(source != NULL, "alias source lookup");
+    if (!source)
+        goto cleanup;
+
+    CHECK(col_rel_deep_copy(source, &owner, NULL) == 0,
+        "alias owner setup");
+    if (!owner)
+        goto cleanup;
+    uint64_t owner_identity = owner->relation_identity;
+    uint64_t owner_generation = owner->storage_owner_generation;
+    CHECK(col_rel_install_shared_view(source, owner) == 0,
+        "install alias shared view");
+    CHECK(source->storage_owner == owner
+        && source->storage_owner_identity == owner_identity
+        && source->storage_owner_generation == owner_generation
+        && owner->storage_alias_borrows == 1,
+        "source is bound to ultimate storage owner");
+
+    col_arrangement_t *arr = col_session_get_arrangement(session, "edge",
+            key_cols, 1);
+    col_arr_entry_t *entry = find_entry(col_session, arr);
+    CHECK(arr && entry, "alias arrangement setup");
+    if (!arr || !entry)
+        goto cleanup;
+
+    CHECK(col_session_acquire_arrangement_probe(session, arr, source,
+        &probe) == 0, "alias probe acquire");
+    CHECK(probe.active && probe.source == source && probe.storage_owner == owner
+        && probe.storage_owner_identity == owner_identity
+        && probe.storage_owner_generation == owner_generation
+        && probe.arrangement_pin.active && entry->pin_count == 1
+        && wl_columnar_relation_snapshot_equal(probe.source_snapshot,
+        wl_columnar_relation_snapshot(source)),
+        "probe captures exact source and ultimate owner generation");
+    CHECK(atomic_load_explicit(&owner->source_access.state,
+        memory_order_acquire) == 1,
+        "alias probe holds owner source reader");
+    CHECK(wl_columnar_source_access_writer_acquire(&owner->source_access,
+        &owner_writer) == EBUSY,
+        "active alias probe blocks owner writer");
+    CHECK(col_rel_destroy_checked(owner) == EBUSY,
+        "active alias probe blocks owner destroy");
+
+    CHECK(col_arrangement_probe_release(&probe) == 0,
+        "alias probe release");
+    CHECK(!probe.active && entry->pin_count == 0
+        && atomic_load_explicit(&owner->source_access.state,
+        memory_order_acquire) == 0,
+        "alias release balances owner reader and arrangement pin");
+    CHECK(wl_columnar_source_access_writer_acquire(&owner->source_access,
+        &owner_writer) == 0,
+        "owner writer succeeds after alias probe release");
+    CHECK(wl_columnar_source_access_writer_release(&owner_writer) == 0,
+        "owner writer release after alias probe release");
+    CHECK(col_rel_destroy_checked(owner) == EBUSY,
+        "source alias still blocks owner destroy after probe release");
+
+    wl_session_destroy(session);
+    session = NULL;
+    CHECK(col_rel_destroy_checked(owner) == 0,
+        "owner destroy succeeds after alias teardown");
+    owner = NULL;
+
+cleanup:
+    if (probe.active)
+        (void)col_arrangement_probe_release(&probe);
+    if (owner_writer.owner)
+        (void)wl_columnar_source_access_writer_release(&owner_writer);
+    if (session)
+        wl_session_destroy(session);
+    if (owner)
+        (void)col_rel_destroy_checked(owner);
+    wl_plan_free(plan);
+    wirelog_program_free(program);
+}
+
 int
 main(void)
 {
@@ -105,6 +199,8 @@ main(void)
     struct release_probe_arg release_arg = { &probe, 0 };
     thread_t release_thread;
     uint32_t key_cols[] = { 0 };
+
+    test_alias_storage_owner_probe();
 
     CHECK(make_session(&session, &plan, &program) == 0,
         "session setup");

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -1214,6 +1214,34 @@ col_session_has_exact_relation(const wl_col_session_t *session,
     return false;
 }
 
+static int
+col_arrangement_probe_storage_owner_resolve(const col_rel_t *source,
+    col_rel_t **out_owner, uint64_t *out_identity, uint64_t *out_generation)
+{
+    col_rel_t *owner = NULL;
+    int rc;
+
+    if (!source || !out_owner || !out_identity || !out_generation)
+        return EINVAL;
+    rc = col_rel_storage_owner_resolve(source, &owner);
+    if (rc != 0)
+        return rc;
+    if (!owner || owner->storage_owner != owner
+        || owner->storage_owner_identity != owner->relation_identity
+        || owner->storage_owner_generation != owner->storage_generation
+        || !wl_columnar_relation_generation_valid(
+            owner->storage_owner_generation))
+        return EINVAL;
+    if (source->storage_owner != owner
+        || source->storage_owner_identity != owner->relation_identity
+        || source->storage_owner_generation != owner->storage_generation)
+        return EBUSY;
+    *out_owner = owner;
+    *out_identity = owner->relation_identity;
+    *out_generation = owner->storage_owner_generation;
+    return 0;
+}
+
 int
 col_session_acquire_arrangement_probe(wl_session_t *sess,
     col_arrangement_t *arr, const col_rel_t *source,
@@ -1221,11 +1249,19 @@ col_session_acquire_arrangement_probe(wl_session_t *sess,
 {
     col_relation_snapshot_t snapshot;
     col_arr_entry_t *entry;
+    col_rel_t *storage_owner = NULL;
+    col_rel_t *post_storage_owner = NULL;
     wl_col_session_t *session;
+    uint64_t storage_owner_identity = 0;
+    uint64_t storage_owner_generation = 0;
+    uint64_t post_storage_owner_identity = 0;
+    uint64_t post_storage_owner_generation = 0;
     int rc;
 
     if (!sess || !arr || !source || !probe || probe->active
         || probe->identity != 0 || probe->arr || probe->source
+        || probe->storage_owner || probe->storage_owner_identity != 0
+        || probe->storage_owner_generation != 0
         || probe->arrangement_pin.active || probe->source_reader.owner)
         return EINVAL;
     session = COL_SESSION(sess);
@@ -1240,6 +1276,11 @@ col_session_acquire_arrangement_probe(wl_session_t *sess,
         snapshot) || arr_entry_unbuilt(entry) || entry->rebuild_deferred)
         return EBUSY;
 
+    rc = col_arrangement_probe_storage_owner_resolve(source, &storage_owner,
+            &storage_owner_identity, &storage_owner_generation);
+    if (rc != 0)
+        return rc;
+
     rc = col_rel_source_reader_acquire(source, &probe->source_reader);
     if (rc != 0)
         return rc;
@@ -1249,6 +1290,13 @@ col_session_acquire_arrangement_probe(wl_session_t *sess,
      * this exact-source API back into a name-only lookup. */
     if (!col_session_has_exact_relation(session, source, entry->rel_name)
         || col_arr_entry_for_arr(session, arr) != entry
+        || col_arrangement_probe_storage_owner_resolve(source,
+        &post_storage_owner, &post_storage_owner_identity,
+        &post_storage_owner_generation)
+        != 0
+        || post_storage_owner != storage_owner
+        || post_storage_owner_identity != storage_owner_identity
+        || post_storage_owner_generation != storage_owner_generation
         || !wl_columnar_relation_snapshot_equal(
             wl_columnar_relation_snapshot(source), snapshot)
         || !wl_columnar_relation_snapshot_equal(entry->source_snapshot,
@@ -1270,6 +1318,13 @@ col_session_acquire_arrangement_probe(wl_session_t *sess,
     if (probe->arrangement_pin.arr != arr
         || probe->arrangement_pin.entry != entry
         || !col_session_has_exact_relation(session, source, entry->rel_name)
+        || col_arrangement_probe_storage_owner_resolve(source,
+        &post_storage_owner, &post_storage_owner_identity,
+        &post_storage_owner_generation)
+        != 0
+        || post_storage_owner != storage_owner
+        || post_storage_owner_identity != storage_owner_identity
+        || post_storage_owner_generation != storage_owner_generation
         || !wl_columnar_relation_snapshot_equal(entry->source_snapshot,
         snapshot)) {
         col_arrangement_pin_release(&probe->arrangement_pin);
@@ -1280,6 +1335,9 @@ col_session_acquire_arrangement_probe(wl_session_t *sess,
     probe->arr = arr;
     probe->source = source;
     probe->source_snapshot = snapshot;
+    probe->storage_owner = storage_owner;
+    probe->storage_owner_identity = storage_owner_identity;
+    probe->storage_owner_generation = storage_owner_generation;
     probe->identity = (uintptr_t)probe;
     probe->active = true;
     return 0;
@@ -1318,17 +1376,27 @@ int
 col_arrangement_probe_release(col_arrangement_probe_t *probe)
 {
     wl_columnar_source_access_reader_t *reader;
+    col_rel_t *storage_owner = NULL;
+    uint64_t storage_owner_identity = 0;
+    uint64_t storage_owner_generation = 0;
     int rc;
 
     if (!probe || !probe->active || probe->identity != (uintptr_t)probe
-        || !probe->arr || !probe->source)
+        || !probe->arr || !probe->source || !probe->storage_owner)
         return EINVAL;
     reader = &probe->source_reader;
     /* Validate every source-reader precondition before changing the index
      * pin.  The reader itself keeps the gate nonzero between this check and
      * release, so a successful precheck makes the two releases atomic with
      * respect to all supported token states. */
-    if (reader->identity != (uintptr_t)reader || !reader->owner
+    if (col_arrangement_probe_storage_owner_resolve(probe->source,
+        &storage_owner, &storage_owner_identity, &storage_owner_generation)
+        != 0
+        || storage_owner != probe->storage_owner
+        || storage_owner_identity != probe->storage_owner_identity
+        || storage_owner_generation != probe->storage_owner_generation
+        || reader->owner != &storage_owner->source_access
+        || reader->identity != (uintptr_t)reader || !reader->owner
         || (!reader->transferable
         && !wl_columnar_source_access_reader_thread_equal(reader))
         || (reader->transferable && reader->thread_valid)

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1228,6 +1228,9 @@ typedef struct {
     col_arrangement_t *arr;
     const col_rel_t *source;
     col_relation_snapshot_t source_snapshot;
+    const col_rel_t *storage_owner;
+    uint64_t storage_owner_identity;
+    uint64_t storage_owner_generation;
     wl_columnar_source_access_reader_t source_reader;
     uintptr_t identity;
     bool active;


### PR DESCRIPTION
## Summary
- bind arrangement probe leases to the ultimate storage owner and its identity/generation
- revalidate owner binding across source-reader admission and exact arrangement pinning
- add shared-view/alias lifetime regression coverage without changing JOIN

Part of #1496

## Validation
- `meson test -C builddir-1496-owner arrangement_probe --print-errorlogs`
- `meson test -C builddir-1496-owner-san arrangement_probe --print-errorlogs`
- `git diff --check`

This is the storage-owner/alias binding unit. JOIN activation, filtered/delta/differential paths, compound dependencies, and operation-scope registration remain subsequent units; #1496 stays open until full acceptance.
