### PR TITLE
fix: protect primary JOIN arrangement probes

### DIFF
--- a/tests/test_join_arrangement.c
+++ b/tests/test_join_arrangement.c
@@ -15,6 +15,7 @@
  */
 
 #include "../wirelog/columnar/columnar_nanoarrow.h"
+#include "../wirelog/columnar/internal.h"
 #include "../wirelog/exec_plan_gen.h"
 #include "../wirelog/passes/fusion.h"
 #include "../wirelog/passes/jpp.h"
@@ -24,6 +25,7 @@
 #include "../wirelog/wirelog.h"
 
 #include <inttypes.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -142,6 +144,76 @@ run_program(const char *src, const char *rel, int64_t *out_count,
         wirelog_program_free(prog);
     }
     return 0;
+}
+
+static col_rel_t *
+make_join_left(void)
+{
+    col_rel_t *left = NULL;
+    const char *cols[] = { "x", "payload" };
+    wirelog_column_type_t types[] = {
+        WIRELOG_TYPE_INT32,
+        WIRELOG_TYPE_INT32,
+    };
+    int64_t row1[] = { 1, 10 };
+    int64_t row2[] = { 2, 20 };
+
+    if (col_rel_alloc(&left, "left") != 0)
+        return NULL;
+    if (col_rel_set_schema(left, 2, cols) != 0
+        || col_rel_set_column_types(left, types, 2) != 0
+        || col_rel_append_row(left, row1) != 0
+        || col_rel_append_row(left, row2) != 0) {
+        col_rel_destroy(left);
+        return NULL;
+    }
+    return left;
+}
+
+static int
+run_direct_join(wl_col_session_t *col_session, col_rel_t *left,
+    eval_entry_t *out_entry)
+{
+    wl_plan_op_t op = { 0 };
+    const char *left_keys[] = { "x" };
+    const char *right_keys[] = { "x" };
+    eval_stack_t stack;
+
+    op.op = WL_PLAN_OP_JOIN;
+    op.right_relation = "edge";
+    op.key_count = 1;
+    op.left_keys = left_keys;
+    op.right_keys = right_keys;
+    op.delta_mode = WL_DELTA_FORCE_FULL;
+
+    eval_stack_init(&stack);
+    if (eval_stack_push(&stack, left, false) != 0)
+        return ENOMEM;
+    int rc = col_op_join(&op, &stack, col_session);
+    if (rc != 0) {
+        eval_stack_drain(&stack);
+        return rc;
+    }
+    if (out_entry)
+        *out_entry = eval_stack_pop(&stack);
+    else
+        eval_stack_drain(&stack);
+    return 0;
+}
+
+/* An enforcing governor that admits no arrangement hash table.  Existing
+ * relations stay on their original governor; swapping this into a session
+ * only affects subsequently attached arrangement entries. */
+static wl_columnar_memory_governor_ref_t *
+tight_arrangement_governor(void)
+{
+    wl_columnar_memory_resolution_t resolution = { 0 };
+    resolution.budget_bytes = 1u;
+    resolution.usable_bytes = 1u;
+    resolution.mode = WL_COLUMNAR_MEMORY_MODE_ENFORCING;
+    resolution.source = WL_COLUMNAR_MEMORY_SOURCE_ENV;
+    resolution.status = WL_COLUMNAR_MEMORY_OK;
+    return wl_columnar_memory_governor_ref_create(&resolution);
 }
 
 /* ================================================================
@@ -412,6 +484,159 @@ test_join_arr_large_chain_delta(void)
 }
 
 /* ================================================================
+ * Test 10: Primary full-right JOIN honors exact-source probe leases
+ *
+ * The unfiltered, non-delta primary arrangement path must acquire the exact
+ * right source before any cold build or stale rebuild.  A right writer must
+ * therefore return EBUSY instead of falling back to an ephemeral hash table.
+ * ================================================================ */
+static void
+test_join_arr_primary_probe_writer_retry(void)
+{
+    TEST("Primary arrangement JOIN admits source before build/rebuild");
+
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+                      "edge(1, 100). edge(2, 200).\n";
+    wl_session_t *sess = NULL;
+    int64_t count = 0;
+    int rc = run_program(src, "edge", &count, NULL, &sess);
+    ASSERT(rc == 0, "edge fixture setup failed");
+    ASSERT(sess != NULL, "session kept for direct join");
+
+    wl_col_session_t *col_session = COL_SESSION(sess);
+    col_rel_t *right = session_find_rel(col_session, "edge");
+    ASSERT(right != NULL, "right relation lookup");
+
+    uint32_t key_cols[] = { 0 };
+    ASSERT(col_session->arr_count == 0, "right arrangement starts cold");
+
+    wl_columnar_source_access_writer_t writer = { 0 };
+    ASSERT(wl_columnar_source_access_writer_acquire(&right->source_access,
+        &writer) == 0, "cold right writer acquire");
+
+    col_rel_t *cold_busy_left = make_join_left();
+    ASSERT(cold_busy_left != NULL, "cold busy left fixture");
+    rc = run_direct_join(col_session, cold_busy_left, NULL);
+    col_rel_destroy(cold_busy_left);
+    ASSERT(rc == EBUSY, "cold active right writer must propagate EBUSY");
+    ASSERT(col_session->arr_count == 0,
+        "cold writer must not build arrangement before admission");
+    ASSERT(wl_columnar_source_access_writer_release(&writer) == 0,
+        "cold right writer release");
+
+    col_rel_t *cold_retry_left = make_join_left();
+    eval_entry_t cold_out = { 0 };
+    ASSERT(cold_retry_left != NULL, "cold retry left fixture");
+    rc = run_direct_join(col_session, cold_retry_left, &cold_out);
+    col_rel_destroy(cold_retry_left);
+    ASSERT(rc == 0, "cold join retry after writer release");
+    ASSERT(cold_out.rel != NULL, "cold retry join produces a relation");
+    col_rel_destroy(cold_out.rel);
+
+    col_arrangement_t *arr = col_session_get_arrangement(sess, "edge",
+            key_cols, 1);
+    ASSERT(arr != NULL && arr->indexed_rows == right->nrows,
+           "right arrangement built after admitted retry");
+
+    ASSERT(wl_columnar_source_access_writer_acquire(&right->source_access,
+        &writer) == 0, "prebuilt right writer acquire");
+
+    col_rel_t *busy_left = make_join_left();
+    ASSERT(busy_left != NULL, "busy left fixture");
+    rc = run_direct_join(col_session, busy_left, NULL);
+    col_rel_destroy(busy_left);
+    ASSERT(rc == EBUSY, "prebuilt active right writer must propagate EBUSY");
+    ASSERT(wl_columnar_source_access_writer_release(&writer) == 0,
+        "prebuilt right writer release");
+
+    col_rel_t *retry_left = make_join_left();
+    eval_entry_t out = { 0 };
+    ASSERT(retry_left != NULL, "retry left fixture");
+    rc = run_direct_join(col_session, retry_left, &out);
+    col_rel_destroy(retry_left);
+    ASSERT(rc == 0, "join retry after writer release");
+    ASSERT(out.rel != NULL, "retry join produces a relation");
+    col_rel_destroy(out.rel);
+
+    ASSERT(wl_columnar_source_access_writer_acquire(&right->source_access,
+        &writer) == 0, "right writer reacquire after retry");
+    ASSERT(wl_columnar_source_access_writer_release(&writer) == 0,
+        "right writer release after retry");
+
+    int64_t stale_row[] = { 3, 300 };
+    ASSERT(col_rel_append_row(right, stale_row) == 0,
+        "append makes arrangement stale");
+    ASSERT(wl_columnar_source_access_writer_acquire(&right->source_access,
+        &writer) == 0, "stale right writer acquire");
+
+    col_rel_t *stale_busy_left = make_join_left();
+    ASSERT(stale_busy_left != NULL, "stale busy left fixture");
+    rc = run_direct_join(col_session, stale_busy_left, NULL);
+    col_rel_destroy(stale_busy_left);
+    ASSERT(rc == EBUSY, "stale active right writer must propagate EBUSY");
+    ASSERT(wl_columnar_source_access_writer_release(&writer) == 0,
+        "stale right writer release");
+
+    col_rel_t *stale_retry_left = make_join_left();
+    eval_entry_t stale_out = { 0 };
+    ASSERT(stale_retry_left != NULL, "stale retry left fixture");
+    rc = run_direct_join(col_session, stale_retry_left, &stale_out);
+    col_rel_destroy(stale_retry_left);
+    ASSERT(rc == 0, "stale join retry after writer release");
+    ASSERT(stale_out.rel != NULL, "stale retry join produces a relation");
+    col_rel_destroy(stale_out.rel);
+
+    wl_session_destroy(sess);
+    PASS();
+}
+
+/* ================================================================
+ * Test 11: Primary full-right JOIN propagates arrangement build ENOMEM
+ *
+ * ENOENT is the only primary probe miss that may use the old ephemeral
+ * fallback.  Once the probe has admitted the exact source, allocation failure
+ * during cold build or stale rebuild must remain visible to the caller.
+ * ================================================================ */
+static void
+test_join_arr_primary_probe_enomem_propagates(void)
+{
+    TEST("Primary arrangement JOIN propagates build ENOMEM");
+
+    const char *src = ".decl edge(x: int32, y: int32)\n"
+                      "edge(1, 100). edge(2, 200).\n";
+    wl_session_t *sess = NULL;
+    int64_t count = 0;
+    int rc = run_program(src, "edge", &count, NULL, &sess);
+    ASSERT(rc == 0, "edge fixture setup failed");
+    ASSERT(sess != NULL, "session kept for direct join");
+
+    wl_col_session_t *col_session = COL_SESSION(sess);
+    ASSERT(col_session->arr_count == 0, "right arrangement starts cold");
+
+    wl_columnar_memory_governor_ref_t *tight
+        = tight_arrangement_governor();
+    ASSERT(tight != NULL, "tight arrangement governor allocation failed");
+    wl_columnar_memory_governor_ref_t *orig_governor
+        = col_session->memory_governor;
+    col_session->memory_governor = tight;
+
+    col_rel_t *left = make_join_left();
+    ASSERT(left != NULL, "ENOMEM left fixture");
+    rc = run_direct_join(col_session, left, NULL);
+    col_rel_destroy(left);
+
+    col_session->memory_governor = orig_governor;
+    wl_columnar_memory_governor_ref_release(tight);
+
+    ASSERT(rc == ENOMEM, "primary build ENOMEM must not fall back");
+    ASSERT(col_session->arr_count == 0,
+        "failed primary build must not publish an arrangement");
+
+    wl_session_destroy(sess);
+    PASS();
+}
+
+/* ================================================================
  * main
  * ================================================================ */
 
@@ -430,6 +655,8 @@ main(void)
     test_join_arr_populated_after_join();
     test_join_arr_darr_cleared_after_kfusion();
     test_join_arr_large_chain_delta();
+    test_join_arr_primary_probe_writer_retry();
+    test_join_arr_primary_probe_enomem_propagates();
 
     printf("\nResults: %d/%d passed", pass_count, test_count);
     if (fail_count > 0)

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -974,44 +974,35 @@ col_arr_entry_for_arr(wl_col_session_t *cs, const col_arrangement_t *arr)
 /* Arrangement Accessors (Phase 3C)                                         */
 /* ======================================================================== */
 
-col_arrangement_t *
-col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
+static bool
+col_arr_entry_key_match(const col_arr_entry_t *e, const char *rel_name,
     const uint32_t *key_cols, uint32_t key_count)
 {
-    if (!sess || !rel_name || !key_cols || key_count == 0)
-        return NULL;
-
-    wl_col_session_t *cs = COL_SESSION(sess);
-
-    /* Look up the relation. */
-    col_rel_t *rel = NULL;
-    for (uint32_t i = 0; i < cs->nrels; i++) {
-        if (cs->rels[i] && cs->rels[i]->name
-            && strcmp(cs->rels[i]->name, rel_name) == 0) {
-            rel = cs->rels[i];
-            break;
-        }
+    if (!e || !rel_name || !key_cols || e->key_count != key_count
+        || !e->rel_name || strcmp(e->rel_name, rel_name) != 0)
+        return false;
+    for (uint32_t k = 0; k < key_count; k++) {
+        if (e->key_cols[k] != key_cols[k])
+            return false;
     }
-    if (!rel)
-        return NULL;
+    return true;
+}
+
+static int
+col_session_get_arrangement_for_source(wl_col_session_t *cs, col_rel_t *rel,
+    const char *rel_name, const uint32_t *key_cols, uint32_t key_count,
+    col_arrangement_t **out_arr)
+{
+    if (!cs || !rel || !rel_name || !key_cols || key_count == 0 || !out_arr)
+        return EINVAL;
+    *out_arr = NULL;
     if (!arr_key_cols_valid(rel, key_cols, key_count))
-        return NULL;
+        return ENOENT;
 
     /* Search registry for matching (rel_name, key_cols) entry. */
     for (uint32_t i = 0; i < cs->arr_count; i++) {
         col_arr_entry_t *e = &cs->arr_entries[i];
-        if (e->key_count != key_count)
-            continue;
-        if (!e->rel_name || strcmp(e->rel_name, rel_name) != 0)
-            continue;
-        bool match = true;
-        for (uint32_t k = 0; k < key_count; k++) {
-            if (e->key_cols[k] != key_cols[k]) {
-                match = false;
-                break;
-            }
-        }
-        if (!match)
+        if (!col_arr_entry_key_match(e, rel_name, key_cols, key_count))
             continue;
 
         /* A token mismatch invalidates the complete index. */
@@ -1026,20 +1017,20 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
             && (!snapshot_match || arr_entry_unbuilt(e)
             || e->arr.indexed_rows < rel->nrows || e->rebuild_deferred)) {
             e->rebuild_deferred = true;
-            return NULL;
+            return EBUSY;
         }
         if (!snapshot_match || arr_entry_unbuilt(e)) {
             /* Deduct stale bytes before rebuild; restore on failure. */
             cs->arr_total_bytes -= e->mem_bytes;
             if (arr_build_full(&e->arr, rel) != 0) {
                 cs->arr_total_bytes += e->mem_bytes;
-                return NULL;
+                return ENOMEM;
             }
             if (!arr_memory_bytes(&e->arr, &e->mem_bytes)) {
                 arr_free_contents(&e->arr);
                 arr_entry_mark_unbuilt(e);
                 e->mem_bytes = 0;
-                return NULL;
+                return ENOMEM;
             }
             cs->arr_total_bytes += e->mem_bytes;
             e->source_snapshot = wl_columnar_relation_snapshot(rel);
@@ -1048,20 +1039,21 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
             cs->arr_total_bytes -= e->mem_bytes;
             if (arr_update_incremental(&e->arr, rel, old) != 0) {
                 cs->arr_total_bytes += e->mem_bytes; /* restore on failure */
-                return NULL;
+                return ENOMEM;
             }
             if (!arr_memory_bytes(&e->arr, &e->mem_bytes)) {
                 arr_free_contents(&e->arr);
                 arr_entry_mark_unbuilt(e);
                 e->mem_bytes = 0;
-                return NULL;
+                return ENOMEM;
             }
             cs->arr_total_bytes += e->mem_bytes;
             e->source_snapshot = wl_columnar_relation_snapshot(rel);
         }
         /* Bump LRU clock on every access. */
         e->lru_clock = ++cs->arr_clock;
-        return &e->arr;
+        *out_arr = &e->arr;
+        return 0;
     }
 
     /* Not found: evict if count or byte limits exceeded. */
@@ -1094,12 +1086,12 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
          * arrangement until the lease is released. */
         for (uint32_t i = 0; i < cs->arr_count; i++) {
             if (cs->arr_entries[i].pin_count > 0)
-                return NULL;
+                return EBUSY;
         }
         uint32_t new_cap = cs->arr_cap ? cs->arr_cap * 2u : 8u;
         if (!arr_entries_grow(&cs->arr_entries, &cs->arr_cap,
             cs->arr_count, new_cap))
-            return NULL;
+            return ENOMEM;
     }
 
     /* Issue #1515: take every allocation that can fail before disturbing
@@ -1107,11 +1099,11 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
      * reused tombstone exactly as it was. */
     char *new_name = wl_strdup(rel_name);
     if (!new_name)
-        return NULL;
+        return ENOMEM;
     uint32_t *new_keys = (uint32_t *)malloc(key_count * sizeof(uint32_t));
     if (!new_keys) {
         free(new_name);
-        return NULL;
+        return ENOMEM;
     }
 
     if (appended) {
@@ -1155,12 +1147,41 @@ col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
              * can reuse the slot again. */
             e->source_snapshot = wl_columnar_relation_snapshot(NULL);
         }
-        return NULL;
+        return ENOMEM;
     }
     e->source_snapshot = wl_columnar_relation_snapshot(rel);
     cs->arr_total_bytes += e->mem_bytes;
     e->lru_clock = ++cs->arr_clock;
-    return &e->arr;
+    *out_arr = &e->arr;
+    return 0;
+}
+
+col_arrangement_t *
+col_session_get_arrangement(wl_session_t *sess, const char *rel_name,
+    const uint32_t *key_cols, uint32_t key_count)
+{
+    wl_col_session_t *cs;
+    col_rel_t *rel = NULL;
+    col_arrangement_t *arr = NULL;
+
+    if (!sess || !rel_name || !key_cols || key_count == 0)
+        return NULL;
+
+    cs = COL_SESSION(sess);
+    for (uint32_t i = 0; i < cs->nrels; i++) {
+        if (cs->rels[i] && cs->rels[i]->name
+            && strcmp(cs->rels[i]->name, rel_name) == 0) {
+            rel = cs->rels[i];
+            break;
+        }
+    }
+    if (!rel)
+        return NULL;
+    if (col_session_get_arrangement_for_source(cs, rel, rel_name, key_cols,
+        key_count, &arr)
+        != 0)
+        return NULL;
+    return arr;
 }
 
 static int
@@ -1318,6 +1339,110 @@ col_session_acquire_arrangement_probe(wl_session_t *sess,
     if (probe->arrangement_pin.arr != arr
         || probe->arrangement_pin.entry != entry
         || !col_session_has_exact_relation(session, source, entry->rel_name)
+        || col_arrangement_probe_storage_owner_resolve(source,
+        &post_storage_owner, &post_storage_owner_identity,
+        &post_storage_owner_generation)
+        != 0
+        || post_storage_owner != storage_owner
+        || post_storage_owner_identity != storage_owner_identity
+        || post_storage_owner_generation != storage_owner_generation
+        || !wl_columnar_relation_snapshot_equal(entry->source_snapshot,
+        snapshot)) {
+        col_arrangement_pin_release(&probe->arrangement_pin);
+        rc = col_rel_source_reader_release(&probe->source_reader);
+        return rc == 0 ? EBUSY : rc;
+    }
+
+    probe->arr = arr;
+    probe->source = source;
+    probe->source_snapshot = snapshot;
+    probe->storage_owner = storage_owner;
+    probe->storage_owner_identity = storage_owner_identity;
+    probe->storage_owner_generation = storage_owner_generation;
+    probe->identity = (uintptr_t)probe;
+    probe->active = true;
+    return 0;
+}
+
+int
+col_session_acquire_primary_arrangement_probe(wl_session_t *sess,
+    const col_rel_t *source, const uint32_t *key_cols, uint32_t key_count,
+    col_arrangement_probe_t *probe)
+{
+    col_relation_snapshot_t snapshot;
+    col_arrangement_t *arr = NULL;
+    col_arr_entry_t *entry;
+    col_rel_t *storage_owner = NULL;
+    col_rel_t *post_storage_owner = NULL;
+    wl_col_session_t *session;
+    uint64_t storage_owner_identity = 0;
+    uint64_t storage_owner_generation = 0;
+    uint64_t post_storage_owner_identity = 0;
+    uint64_t post_storage_owner_generation = 0;
+    int rc;
+
+    if (!sess || !source || !source->name || !key_cols || key_count == 0
+        || !probe || probe->active || probe->identity != 0 || probe->arr
+        || probe->source || probe->storage_owner
+        || probe->storage_owner_identity != 0
+        || probe->storage_owner_generation != 0
+        || probe->arrangement_pin.active || probe->source_reader.owner)
+        return EINVAL;
+    session = COL_SESSION(sess);
+    if (!col_session_has_exact_relation(session, source, source->name))
+        return EBUSY;
+
+    rc = col_arrangement_probe_storage_owner_resolve(source, &storage_owner,
+            &storage_owner_identity, &storage_owner_generation);
+    if (rc != 0)
+        return rc;
+
+    rc = col_rel_source_reader_acquire(source, &probe->source_reader);
+    if (rc != 0)
+        return rc;
+
+    snapshot = wl_columnar_relation_snapshot(source);
+    if (!wl_columnar_relation_snapshot_valid(snapshot)
+        || !col_session_has_exact_relation(session, source, source->name)) {
+        rc = col_rel_source_reader_release(&probe->source_reader);
+        return rc == 0 ? EBUSY : rc;
+    }
+
+    rc = col_session_get_arrangement_for_source(session, (col_rel_t *)source,
+            source->name, key_cols, key_count, &arr);
+    if (rc != 0) {
+        int release_rc = col_rel_source_reader_release(&probe->source_reader);
+        return release_rc == 0 ? rc : release_rc;
+    }
+    entry = col_arr_entry_for_arr(session, arr);
+    if (!entry) {
+        rc = col_rel_source_reader_release(&probe->source_reader);
+        return rc == 0 ? EINVAL : rc;
+    }
+    if (col_arrangement_probe_storage_owner_resolve(source,
+        &post_storage_owner, &post_storage_owner_identity,
+        &post_storage_owner_generation)
+        != 0
+        || post_storage_owner != storage_owner
+        || post_storage_owner_identity != storage_owner_identity
+        || post_storage_owner_generation != storage_owner_generation
+        || !col_session_has_exact_relation(session, source, entry->rel_name)
+        || !wl_columnar_relation_snapshot_equal(
+        wl_columnar_relation_snapshot(source), snapshot)
+        || !wl_columnar_relation_snapshot_equal(entry->source_snapshot,
+        snapshot)) {
+        rc = col_rel_source_reader_release(&probe->source_reader);
+        return rc == 0 ? EBUSY : rc;
+    }
+
+    rc = col_arrangement_pin_entry(session, entry, arr,
+            &probe->arrangement_pin);
+    if (rc != 0) {
+        int release_rc = col_rel_source_reader_release(&probe->source_reader);
+        return release_rc == 0 ? rc : release_rc;
+    }
+    if (probe->arrangement_pin.arr != arr
+        || probe->arrangement_pin.entry != entry
         || col_arrangement_probe_storage_owner_resolve(source,
         &post_storage_owner, &post_storage_owner_identity,
         &post_storage_owner_generation)

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1220,9 +1220,9 @@ typedef struct {
 } col_arrangement_pin_t;
 
 /* Allocation-free, address-bound lease for probing one primary arrangement
- * against the exact source relation used to validate it.  This primitive is
- * intentionally not wired into JOIN yet; #1496 activates consumers only
- * after their complete dependency set can be acquired transactionally. */
+ * against the exact source relation used to validate it.  #1496 wires the
+ * primitive into the unfiltered primary JOIN path only; broader consumers
+ * follow after their complete dependency set can be acquired transactionally. */
 typedef struct {
     col_arrangement_pin_t arrangement_pin;
     col_arrangement_t *arr;
@@ -1904,6 +1904,10 @@ col_arrangement_pin_release(col_arrangement_pin_t *pin);
 int
 col_session_acquire_arrangement_probe(wl_session_t *sess,
     col_arrangement_t *arr, const col_rel_t *source,
+    col_arrangement_probe_t *probe);
+int
+col_session_acquire_primary_arrangement_probe(wl_session_t *sess,
+    const col_rel_t *source, const uint32_t *key_cols, uint32_t key_count,
     col_arrangement_probe_t *probe);
 int
 col_arrangement_probe_release(col_arrangement_probe_t *probe);

--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -1222,11 +1222,14 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
             out->nrows);
     } else {
         /* Standard merge-join for non-unary relations. */
-        /* Hash join: use persistent arrangement for the full right relation;
-         * fall back to an ephemeral hash table for delta substitution or when
-         * the arrangement cannot be allocated. */
+        /* Hash join: use persistent arrangement for the full right relation.
+         * Delta substitution and true "no arrangement" misses retain the
+         * existing ephemeral hash table path.  Once the protected primary
+         * probe admits the exact source, build/rebuild failures are real
+         * errors and must not silently change execution mode. */
         col_arrangement_t *arr = NULL;
         col_arrangement_pin_t arr_pin = { 0 };
+        col_arrangement_probe_t arr_probe = { 0 };
         uint32_t nbuckets_ep = 0;
         uint32_t *ht_head_ep = NULL;
         uint32_t *ht_next_ep = NULL;
@@ -1237,9 +1240,22 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
 
         if (!used_right_delta && op->right_relation && kc > 0) {
             if (op->right_filter_expr.size == 0) {
-                if (col_session_pin_arrangement(&sess->base,
-                    op->right_relation, rk, kc, &arr_pin) == 0)
-                    arr = arr_pin.arr;
+                int probe_rc = col_session_acquire_primary_arrangement_probe(
+                    &sess->base, right, rk, kc, &arr_probe);
+                if (probe_rc == 0) {
+                    right = (col_rel_t *)arr_probe.source;
+                    arr = arr_probe.arr;
+                } else if (probe_rc != ENOENT) {
+                    free(tmp);
+                    col_rel_destroy(out);
+                    free(lk);
+                    free(rk);
+                    if (right_filtered)
+                        col_rel_destroy(right_filtered);
+                    if (left_e.owned)
+                        col_rel_destroy(left);
+                    return probe_rc;
+                }
             } else {
                 /* Issue #433: filtered right arrangement cache.
                  * `right` is the cached filtered relation from filt_cache;
@@ -1316,6 +1332,9 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
             key_row = (int64_t *)malloc(
                 sizeof(int64_t) * (right->ncols > 0 ? right->ncols : 1));
             if (!key_row) {
+                int release_rc = 0;
+                if (arr_probe.active)
+                    release_rc = col_arrangement_probe_release(&arr_probe);
                 col_arrangement_pin_release(&arr_pin);
                 free(ht_head_ep);
                 free(ht_next_ep);
@@ -1325,7 +1344,7 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
                 free(rk);
                 if (left_e.owned)
                     col_rel_destroy(left);
-                return ENOMEM;
+                return release_rc != 0 ? release_rc : ENOMEM;
             }
         }
 
@@ -1414,6 +1433,7 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
         free(ht_head_ep);
         free(ht_next_ep);
         if (join_rc != 0) {
+            int release_rc = 0;
             WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_DEBUG,
                 "Merge-join failed with rc=%d, out->nrows=%u",
                 join_rc, out->nrows);
@@ -1425,11 +1445,29 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
                 col_rel_destroy(right_filtered);
             if (left_e.owned)
                 col_rel_destroy(left);
+            if (arr_probe.active)
+                release_rc = col_arrangement_probe_release(&arr_probe);
             col_arrangement_pin_release(&arr_pin);
+            if (release_rc != 0)
+                return release_rc;
             return join_rc;
         }
         WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_DEBUG, "Merge-join succeeded");
+        int release_rc = 0;
+        if (arr_probe.active)
+            release_rc = col_arrangement_probe_release(&arr_probe);
         col_arrangement_pin_release(&arr_pin);
+        if (release_rc != 0) {
+            free(tmp);
+            col_rel_destroy(out);
+            free(lk);
+            free(rk);
+            if (right_filtered)
+                col_rel_destroy(right_filtered);
+            if (left_e.owned)
+                col_rel_destroy(left);
+            return release_rc;
+        }
     }
 
     free(tmp);


### PR DESCRIPTION
## Summary
- bind the unfiltered primary JOIN arrangement path to the exact source/storage-owner probe lease
- admit the source reader before any cold or stale arrangement build/rebuild
- propagate EBUSY and ENOMEM instead of hiding protected-source conflicts in ephemeral fallback; retain fallback only for ENOENT
- add cold, prebuilt, stale-writer retry, and allocation-failure regression coverage

Part of #1496

## Validation
- `meson test -C builddir-1496-join join_arrangement arrangement_probe --print-errorlogs`
- `meson test -C builddir-1496-join-san join_arrangement arrangement_probe --print-errorlogs`
- `git diff --check`

Scope is intentionally limited to unfiltered, non-delta primary JOIN. Filtered/delta/differential paths, compound dependencies, and operation-scope registration remain subsequent #1496 units.
