### PR TITLE
feat: add operation-local arrangement probe bundle

### DIFF
--- a/tests/test_arrangement_probe.c
+++ b/tests/test_arrangement_probe.c
@@ -195,7 +195,12 @@ main(void)
     wirelog_program_t *program = NULL;
     col_rel_t *same_name = NULL;
     col_arrangement_probe_t probe = { 0 };
+    col_arrangement_probe_bundle_t bundle = { 0 };
+    col_arrangement_probe_t *bundle_probe = NULL;
+    col_arrangement_probe_t *nested_probe = NULL;
+    col_arrangement_probe_t *second_probe = NULL;
     wl_columnar_source_access_writer_t writer = { 0 };
+    wl_columnar_source_access_writer_t dependency_writer = { 0 };
     struct release_probe_arg release_arg = { &probe, 0 };
     thread_t release_thread;
     uint32_t key_cols[] = { 0 };
@@ -246,6 +251,85 @@ main(void)
     CHECK(col_arrangement_probe_release(&probe) == EINVAL,
         "double release is rejected");
 
+    col_arrangement_t *second_arr = col_session_get_arrangement(session,
+            "edge", (uint32_t[]){ 1 }, 1);
+    CHECK(second_arr != NULL, "second arrangement setup");
+    col_arrangement_probe_bundle_init(&bundle);
+    CHECK(bundle.active, "bundle init activates scope");
+    CHECK(col_arrangement_probe_bundle_acquire(&bundle, session, arr, source,
+        &bundle_probe) == 0 && bundle_probe != NULL,
+        "bundle acquires primary probe");
+    CHECK(col_arrangement_probe_bundle_acquire(&bundle, session, arr, source,
+        &nested_probe) == 0 && nested_probe == bundle_probe
+        && bundle.count == 1 && bundle.slots[0].ref_count == 2,
+        "nested same-source lease is coalesced and counted");
+    if (second_arr)
+        CHECK(col_arrangement_probe_bundle_acquire(&bundle, session,
+            second_arr, source, &second_probe) == 0
+            && second_probe != bundle_probe && bundle.count == 2,
+            "bundle acquires a second arrangement dependency");
+    CHECK(atomic_load_explicit(&source->source_access.state,
+        memory_order_acquire) == 2,
+        "bundle holds one reader per distinct arrangement dependency");
+    CHECK(col_arrangement_probe_bundle_release(&bundle) == 0
+        && !bundle.active && bundle.count == 0
+        && atomic_load_explicit(&source->source_access.state,
+        memory_order_acquire) == 0,
+        "bundle releases dependencies in reverse order");
+
+    col_rel_t *dependency = session_find_rel(col_session, "path");
+    col_arrangement_t *dependency_arr = dependency
+        ? col_session_get_arrangement(session, "path", key_cols, 1) : NULL;
+    CHECK(dependency && dependency_arr, "dependency arrangement setup");
+    col_arrangement_probe_bundle_init(&bundle);
+    CHECK(bundle.active, "partial rollback bundle init activates scope");
+    CHECK(col_arrangement_probe_bundle_acquire(&bundle, session, arr, source,
+        &bundle_probe) == 0, "partial rollback acquires first dependency");
+    if (dependency && dependency_arr) {
+        CHECK(wl_columnar_source_access_writer_acquire(
+            &dependency->source_access, &dependency_writer) == 0,
+            "partial rollback dependency writer setup");
+        CHECK(col_arrangement_probe_bundle_acquire(&bundle, session,
+            dependency_arr, dependency, &second_probe) == EBUSY
+            && bundle.count == 0 && !bundle.slots[0].probe.active
+            && atomic_load_explicit(&source->source_access.state,
+            memory_order_acquire) == 0 && entry->pin_count == 0,
+            "later dependency failure rolls back earlier leases");
+        CHECK(wl_columnar_source_access_writer_release(&dependency_writer)
+            == 0, "partial rollback dependency writer release");
+    }
+    CHECK(col_arrangement_probe_bundle_release(&bundle) == 0,
+        "partial rollback leaves an empty releasable bundle");
+
+    col_arrangement_probe_bundle_init(&bundle);
+    CHECK(col_arrangement_probe_bundle_acquire(&bundle, session, arr, source,
+        &bundle_probe) == 0, "capacity rollback acquires first dependency");
+    if (second_arr) {
+        /* Fill the bounded scope marker to exercise the full-capacity path;
+         * the active slot remains a real lease and must be unwound. */
+        bundle.count = COL_ARRANGEMENT_PROBE_BUNDLE_MAX;
+        CHECK(col_arrangement_probe_bundle_acquire(&bundle, session,
+            second_arr, source, &second_probe) == EOVERFLOW
+            && bundle.count == 0
+            && atomic_load_explicit(&source->source_access.state,
+            memory_order_acquire) == 0 && entry->pin_count == 0,
+            "capacity failure rolls back earlier leases");
+    }
+    CHECK(col_arrangement_probe_bundle_release(&bundle) == 0,
+        "capacity rollback leaves an empty releasable bundle");
+
+    col_arrangement_probe_bundle_init(&bundle);
+    CHECK(bundle.active, "bundle rollback init activates scope");
+    CHECK(wl_columnar_source_access_writer_acquire(&source->source_access,
+        &writer) == 0, "bundle rollback writer setup");
+    CHECK(col_arrangement_probe_bundle_acquire(&bundle, session, arr, source,
+        &bundle_probe) == EBUSY && bundle.count == 0
+        && !bundle_probe, "failed bundle acquire rolls back cleanly");
+    CHECK(wl_columnar_source_access_writer_release(&writer) == 0,
+        "bundle rollback writer release");
+    CHECK(col_arrangement_probe_bundle_release(&bundle) == 0,
+        "empty bundle release");
+
     CHECK(col_rel_alloc(&same_name, "edge") == 0,
         "same-name relation setup");
     CHECK(col_session_acquire_arrangement_probe(session, arr, same_name,
@@ -275,10 +359,14 @@ main(void)
         "source writer release");
 
 cleanup:
+    if (bundle.active)
+        (void)col_arrangement_probe_bundle_release(&bundle);
     if (probe.active)
         (void)col_arrangement_probe_release(&probe);
     if (writer.owner)
         (void)wl_columnar_source_access_writer_release(&writer);
+    if (dependency_writer.owner)
+        (void)wl_columnar_source_access_writer_release(&dependency_writer);
     if (same_name)
         (void)col_rel_destroy_checked(same_name);
     wl_session_destroy(session);

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -1497,14 +1497,32 @@ col_arrangement_pin_release(col_arrangement_pin_t *pin)
     }
 }
 
+static int
+col_arrangement_probe_release_ready(const col_arrangement_probe_t *probe);
+
 int
 col_arrangement_probe_release(col_arrangement_probe_t *probe)
 {
-    wl_columnar_source_access_reader_t *reader;
+    int rc;
+
+    rc = col_arrangement_probe_release_ready(probe);
+    if (rc != 0)
+        return rc;
+    col_arrangement_pin_release(&probe->arrangement_pin);
+    rc = col_rel_source_reader_release(&probe->source_reader);
+    if (rc != 0)
+        return rc;
+    memset(probe, 0, sizeof(*probe));
+    return 0;
+}
+
+static int
+col_arrangement_probe_release_ready(const col_arrangement_probe_t *probe)
+{
+    const wl_columnar_source_access_reader_t *reader;
     col_rel_t *storage_owner = NULL;
     uint64_t storage_owner_identity = 0;
     uint64_t storage_owner_generation = 0;
-    int rc;
 
     if (!probe || !probe->active || probe->identity != (uintptr_t)probe
         || !probe->arr || !probe->source || !probe->storage_owner)
@@ -1527,11 +1545,102 @@ col_arrangement_probe_release(col_arrangement_probe_t *probe)
         || (reader->transferable && reader->thread_valid)
         || !wl_columnar_source_access_gate_busy(reader->owner))
         return EINVAL;
-    col_arrangement_pin_release(&probe->arrangement_pin);
-    rc = col_rel_source_reader_release(reader);
-    if (rc != 0)
+    return 0;
+}
+
+void
+col_arrangement_probe_bundle_init(col_arrangement_probe_bundle_t *bundle)
+{
+    if (!bundle)
+        return;
+    memset(bundle, 0, sizeof(*bundle));
+    bundle->identity = (uintptr_t)bundle;
+    bundle->active = true;
+}
+
+int
+col_arrangement_probe_bundle_acquire(col_arrangement_probe_bundle_t *bundle,
+    wl_session_t *sess, col_arrangement_t *arr, const col_rel_t *source,
+    col_arrangement_probe_t **out_probe)
+{
+    col_arrangement_probe_bundle_slot_t *slot;
+    int rc;
+
+    if (out_probe)
+        *out_probe = NULL;
+    if (!bundle || bundle->identity != (uintptr_t)bundle || !bundle->active
+        || !sess || !arr || !source)
+        return EINVAL;
+    for (uint32_t i = 0; i < bundle->count; i++) {
+        slot = &bundle->slots[i];
+        if (slot->probe.active && slot->probe.arr == arr
+            && slot->probe.source == source) {
+            if (slot->ref_count == UINT32_MAX)
+                return EOVERFLOW;
+            slot->ref_count++;
+            if (out_probe)
+                *out_probe = &slot->probe;
+            return 0;
+        }
+    }
+    if (bundle->count >= COL_ARRANGEMENT_PROBE_BUNDLE_MAX) {
+        int rollback_rc = col_arrangement_probe_bundle_release(bundle);
+        if (rollback_rc != 0)
+            return rollback_rc;
+        col_arrangement_probe_bundle_init(bundle);
+        return EOVERFLOW;
+    }
+
+    slot = &bundle->slots[bundle->count];
+    memset(slot, 0, sizeof(*slot));
+    rc = col_session_acquire_arrangement_probe(sess, arr, source,
+            &slot->probe);
+    if (rc != 0) {
+        if (slot->probe.active)
+            (void)col_arrangement_probe_release(&slot->probe);
+        memset(slot, 0, sizeof(*slot));
+        /* Bundle acquisition is transactional: a later dependency failure
+         * must not leave earlier operation leases live. */
+        if (bundle->count > 0) {
+            int rollback_rc = col_arrangement_probe_bundle_release(bundle);
+            if (rollback_rc != 0)
+                return rollback_rc;
+            col_arrangement_probe_bundle_init(bundle);
+        }
         return rc;
-    memset(probe, 0, sizeof(*probe));
+    }
+    slot->ref_count = 1;
+    bundle->count++;
+    if (out_probe)
+        *out_probe = &slot->probe;
+    return 0;
+}
+
+int
+col_arrangement_probe_bundle_release(col_arrangement_probe_bundle_t *bundle)
+{
+    int rc;
+
+    if (!bundle || bundle->identity != (uintptr_t)bundle || !bundle->active)
+        return EINVAL;
+    for (uint32_t i = bundle->count; i > 0; i--) {
+        col_arrangement_probe_bundle_slot_t *slot = &bundle->slots[i - 1u];
+        if (slot->ref_count == 0 || !slot->probe.active)
+            continue;
+        rc = col_arrangement_probe_release_ready(&slot->probe);
+        if (rc != 0)
+            return rc;
+    }
+    for (uint32_t i = bundle->count; i > 0; i--) {
+        col_arrangement_probe_bundle_slot_t *slot = &bundle->slots[i - 1u];
+        if (slot->ref_count == 0 || !slot->probe.active)
+            continue;
+        rc = col_arrangement_probe_release(&slot->probe);
+        if (rc != 0)
+            return rc;
+        memset(slot, 0, sizeof(*slot));
+    }
+    memset(bundle, 0, sizeof(*bundle));
     return 0;
 }
 

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1236,6 +1236,21 @@ typedef struct {
     bool active;
 } col_arrangement_probe_t;
 
+#define COL_ARRANGEMENT_PROBE_BUNDLE_MAX 4u
+
+typedef struct {
+    col_arrangement_probe_t probe;
+    uint32_t ref_count;
+} col_arrangement_probe_bundle_slot_t;
+
+typedef struct {
+    col_arrangement_probe_bundle_slot_t
+        slots[COL_ARRANGEMENT_PROBE_BUNDLE_MAX];
+    uint32_t count;
+    uintptr_t identity;
+    bool active;
+} col_arrangement_probe_bundle_t;
+
 /*
  * col_sorted_arr_t: cached sorted copy of a relation by a single key column.
  *
@@ -1911,6 +1926,14 @@ col_session_acquire_primary_arrangement_probe(wl_session_t *sess,
     col_arrangement_probe_t *probe);
 int
 col_arrangement_probe_release(col_arrangement_probe_t *probe);
+void
+col_arrangement_probe_bundle_init(col_arrangement_probe_bundle_t *bundle);
+int
+col_arrangement_probe_bundle_acquire(col_arrangement_probe_bundle_t *bundle,
+    wl_session_t *sess, col_arrangement_t *arr, const col_rel_t *source,
+    col_arrangement_probe_t **out_probe);
+int
+col_arrangement_probe_bundle_release(col_arrangement_probe_bundle_t *bundle);
 int
 col_rel_alloc(col_rel_t **out, const char *name);
 int


### PR DESCRIPTION
## Summary
- add an operation-local transactional bundle for exact arrangement probe leases
- coalesce nested identical source/arrangement leases and release distinct leases in reverse order
- roll back all earlier leases on later EBUSY or capacity failure
- add normal and sanitizer regression coverage for nested, rollback, capacity, and release behavior

Part of #1496

## Validation
- `meson test -C builddir-bundle arrangement_probe --print-errorlogs`
- `meson test -C builddir-bundle-san arrangement_probe --print-errorlogs`
- `git diff --check`

This unit intentionally does not activate JOIN, compound, filtered, delta, differential, or broad session-lifecycle paths. Those remain subsequent #1496 units.
