### PR TITLE
Use probe bundles in primary joins

### DIFF
--- a/tests/test_arrangement_probe.c
+++ b/tests/test_arrangement_probe.c
@@ -256,9 +256,9 @@ main(void)
     CHECK(second_arr != NULL, "second arrangement setup");
     col_arrangement_probe_bundle_init(&bundle);
     CHECK(bundle.active, "bundle init activates scope");
-    CHECK(col_arrangement_probe_bundle_acquire(&bundle, session, arr, source,
-        &bundle_probe) == 0 && bundle_probe != NULL,
-        "bundle acquires primary probe");
+    CHECK(col_arrangement_probe_bundle_acquire_primary(&bundle, session,
+        source, key_cols, 1, &bundle_probe) == 0 && bundle_probe != NULL,
+        "bundle acquires primary probe through operation helper");
     CHECK(col_arrangement_probe_bundle_acquire(&bundle, session, arr, source,
         &nested_probe) == 0 && nested_probe == bundle_probe
         && bundle.count == 1 && bundle.slots[0].ref_count == 2,

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -1559,6 +1559,46 @@ col_arrangement_probe_bundle_init(col_arrangement_probe_bundle_t *bundle)
 }
 
 int
+col_arrangement_probe_bundle_acquire_primary(
+    col_arrangement_probe_bundle_t *bundle, wl_session_t *sess,
+    const col_rel_t *source, const uint32_t *key_cols, uint32_t key_count,
+    col_arrangement_probe_t **out_probe)
+{
+    col_arrangement_probe_t acquired = { 0 };
+    col_arrangement_probe_bundle_slot_t *slot;
+    int rc;
+
+    if (!bundle || !sess || !source || !key_cols || key_count == 0
+        || !out_probe || bundle->identity != (uintptr_t)bundle
+        || !bundle->active)
+        return EINVAL;
+    *out_probe = NULL;
+    if (bundle->count >= COL_ARRANGEMENT_PROBE_BUNDLE_MAX) {
+        rc = col_arrangement_probe_bundle_release(bundle);
+        if (rc != 0)
+            return rc;
+        col_arrangement_probe_bundle_init(bundle);
+        return EOVERFLOW;
+    }
+    rc = col_session_acquire_primary_arrangement_probe(sess, source,
+        key_cols, key_count, &acquired);
+    if (rc != 0)
+        return rc;
+    slot = &bundle->slots[bundle->count];
+    slot->probe = acquired;
+    /* The primary helper binds address-sensitive tokens to its caller's
+     * stack object. Rebase both identities after moving the lease into the
+     * operation-owned bundle slot. */
+    slot->probe.identity = (uintptr_t)&slot->probe;
+    slot->probe.source_reader.identity
+        = (uintptr_t)&slot->probe.source_reader;
+    slot->ref_count = 1;
+    bundle->count++;
+    *out_probe = &slot->probe;
+    return 0;
+}
+
+int
 col_arrangement_probe_bundle_acquire(col_arrangement_probe_bundle_t *bundle,
     wl_session_t *sess, col_arrangement_t *arr, const col_rel_t *source,
     col_arrangement_probe_t **out_probe)

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1942,6 +1942,11 @@ col_arrangement_probe_release(col_arrangement_probe_t *probe);
 void
 col_arrangement_probe_bundle_init(col_arrangement_probe_bundle_t *bundle);
 int
+col_arrangement_probe_bundle_acquire_primary(
+    col_arrangement_probe_bundle_t *bundle, wl_session_t *sess,
+    const col_rel_t *source, const uint32_t *key_cols, uint32_t key_count,
+    col_arrangement_probe_t **out_probe);
+int
 col_arrangement_probe_bundle_acquire(col_arrangement_probe_bundle_t *bundle,
     wl_session_t *sess, col_arrangement_t *arr, const col_rel_t *source,
     col_arrangement_probe_t **out_probe);

--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -1229,7 +1229,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
          * errors and must not silently change execution mode. */
         col_arrangement_t *arr = NULL;
         col_arrangement_pin_t arr_pin = { 0 };
-        col_arrangement_probe_t arr_probe = { 0 };
+        col_arrangement_probe_bundle_t arr_bundle = { 0 };
+        col_arrangement_probe_t *arr_probe = NULL;
         uint32_t nbuckets_ep = 0;
         uint32_t *ht_head_ep = NULL;
         uint32_t *ht_next_ep = NULL;
@@ -1240,11 +1241,12 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
 
         if (!used_right_delta && op->right_relation && kc > 0) {
             if (op->right_filter_expr.size == 0) {
-                int probe_rc = col_session_acquire_primary_arrangement_probe(
-                    &sess->base, right, rk, kc, &arr_probe);
+                col_arrangement_probe_bundle_init(&arr_bundle);
+                int probe_rc = col_arrangement_probe_bundle_acquire_primary(
+                    &arr_bundle, &sess->base, right, rk, kc, &arr_probe);
                 if (probe_rc == 0) {
-                    right = (col_rel_t *)arr_probe.source;
-                    arr = arr_probe.arr;
+                    right = (col_rel_t *)arr_probe->source;
+                    arr = arr_probe->arr;
                 } else if (probe_rc != ENOENT) {
                     free(tmp);
                     col_rel_destroy(out);
@@ -1333,8 +1335,9 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
                 sizeof(int64_t) * (right->ncols > 0 ? right->ncols : 1));
             if (!key_row) {
                 int release_rc = 0;
-                if (arr_probe.active)
-                    release_rc = col_arrangement_probe_release(&arr_probe);
+                if (arr_bundle.active)
+                    release_rc = col_arrangement_probe_bundle_release(
+                        &arr_bundle);
                 col_arrangement_pin_release(&arr_pin);
                 free(ht_head_ep);
                 free(ht_next_ep);
@@ -1445,8 +1448,9 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
                 col_rel_destroy(right_filtered);
             if (left_e.owned)
                 col_rel_destroy(left);
-            if (arr_probe.active)
-                release_rc = col_arrangement_probe_release(&arr_probe);
+            if (arr_bundle.active)
+                release_rc = col_arrangement_probe_bundle_release(
+                    &arr_bundle);
             col_arrangement_pin_release(&arr_pin);
             if (release_rc != 0)
                 return release_rc;
@@ -1454,8 +1458,8 @@ wl_columnar_join_op(const wl_plan_op_t *op, eval_stack_t *stack,
         }
         WL_LOG(WL_LOG_SEC_JOIN, WL_LOG_DEBUG, "Merge-join succeeded");
         int release_rc = 0;
-        if (arr_probe.active)
-            release_rc = col_arrangement_probe_release(&arr_probe);
+        if (arr_bundle.active)
+            release_rc = col_arrangement_probe_bundle_release(&arr_bundle);
         col_arrangement_pin_release(&arr_pin);
         if (release_rc != 0) {
             free(tmp);


### PR DESCRIPTION
## Summary
- connect the operation-local probe bundle to the production primary-arrangement JOIN path;
- preserve address-bound probe and source-reader identities when moving a probe into the bundle;
- retain transactional bundle release on JOIN success and error paths;
- cover the operation helper through arrangement-probe and JOIN integration tests.

Stacked on PR #1540 and part of #1496. Retarget to `main` after #1540 merges.

## Validation
- `meson test -C builddir-next5 arrangement_probe join_arrangement --print-errorlogs`
- `meson test -C builddir-next5-san arrangement_probe join_arrangement --print-errorlogs`
