### PR TITLE
Make differential arrangement updates transactional

### DIFF
--- a/tests/test_diff_join.c
+++ b/tests/test_diff_join.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <errno.h>
 
 #include "../wirelog/columnar/internal.h"
 
@@ -827,6 +828,188 @@ test_arrangement_incremental(void)
     PASS;
 }
 
+static bool
+diff_arrangement_links_in_bounds(const col_diff_arrangement_t *arr)
+{
+    for (uint32_t bucket = 0; bucket < arr->nbuckets; bucket++) {
+        uint32_t traversed = 0;
+        for (uint32_t entry = arr->ht_head[bucket]; entry != 0;
+            entry = arr->ht_next[entry - 1]) {
+            if (entry > arr->indexed_rows || traversed++ >= arr->indexed_rows)
+                return false;
+        }
+    }
+    return true;
+}
+
+static uint64_t
+diff_arrangement_ledger_bytes(const wl_col_session_t *sess)
+{
+    wl_mem_ledger_snapshot_t snapshot;
+    wl_mem_ledger_snapshot(&sess->mem_ledger, &snapshot);
+    return snapshot.subsys_bytes[WL_MEM_SUBSYS_ARRANGEMENT];
+}
+
+static void
+test_diff_arrangement_txn_ledger_accounting(void)
+{
+    TEST("diff arrangement transaction ledger accounting");
+    wl_col_session_t *sess = make_mock_session();
+    const char *cn[] = {"x"};
+    col_rel_t *right = make_rel("right", 1, cn);
+    int64_t row[] = {1};
+    uint32_t key_col = 0;
+    ASSERT_TRUE(right && col_rel_append_row(right, row) == 0,
+        "right relation allocated");
+    ASSERT_TRUE(session_add_rel(sess, right) == 0, "right registered");
+
+    wl_columnar_arrangement_diff_txn_t txn = {0};
+    ASSERT_TRUE(wl_columnar_arrangement_diff_txn_begin(sess, "right", right,
+        &key_col, 1, &txn) == 0, "pending transaction begins");
+    uint64_t working_bytes = col_diff_arrangement_bytes(txn.working);
+    ASSERT_TRUE(txn.working->ledger == &sess->mem_ledger,
+        "pending working copy is ledger-attached");
+    ASSERT_TRUE(sess->diff_arr_count == 0,
+        "pending arrangement remains unpublished");
+    ASSERT_TRUE(diff_arrangement_ledger_bytes(sess) == working_bytes,
+        "pending working copy is charged");
+    wl_columnar_arrangement_diff_txn_abort(&txn);
+    ASSERT_TRUE(sess->diff_arr_count == 0,
+        "pending abort leaves no cache entry");
+    ASSERT_TRUE(diff_arrangement_ledger_bytes(sess) == 0,
+        "pending abort credits working copy");
+
+    ASSERT_TRUE(wl_columnar_arrangement_diff_txn_begin(sess, "right", right,
+        &key_col, 1, &txn) == 0, "pending transaction restarts");
+    working_bytes = col_diff_arrangement_bytes(txn.working);
+    wl_columnar_arrangement_diff_txn_commit(&txn);
+    ASSERT_TRUE(sess->diff_arr_count == 1, "pending commit publishes entry");
+    ASSERT_TRUE(diff_arrangement_ledger_bytes(sess) == working_bytes,
+        "pending commit does not double-charge");
+
+    uint64_t persistent_bytes = diff_arrangement_ledger_bytes(sess);
+    ASSERT_TRUE(wl_columnar_arrangement_diff_txn_begin(sess, "right", right,
+        &key_col, 1, &txn) == 0, "existing transaction begins");
+    working_bytes = col_diff_arrangement_bytes(txn.working);
+    ASSERT_TRUE(diff_arrangement_ledger_bytes(sess)
+        == persistent_bytes + working_bytes,
+        "existing working copy is additionally charged");
+    wl_columnar_arrangement_diff_txn_abort(&txn);
+    ASSERT_TRUE(diff_arrangement_ledger_bytes(sess) == persistent_bytes,
+        "existing abort credits working copy");
+
+    destroy_mock_session(sess);
+    PASS;
+}
+
+static void
+test_late_abort_does_not_advance_arrangement(void)
+{
+    TEST("late abort preserves persistent diff arrangement");
+    wl_col_session_t *sess = make_mock_session();
+    const char *cn[] = {"x", "y"};
+    col_rel_t *right = make_rel("right", 2, cn);
+    int64_t right1[] = {1, 100};
+    ASSERT_TRUE(right && col_rel_append_row(right, right1) == 0,
+        "initial right row");
+    ASSERT_TRUE(session_add_rel(sess, right) == 0, "right registered");
+
+    wl_plan_op_t op = {0};
+    op.op = WL_PLAN_OP_JOIN;
+    op.right_relation = "right";
+    op.key_count = 1;
+    char *lkeys[] = {"x"};
+    char *rkeys[] = {"x"};
+    op.left_keys = (const char *const *)lkeys;
+    op.right_keys = (const char *const *)rkeys;
+    op.delta_mode = WL_DELTA_FORCE_FULL;
+
+    col_rel_t *left1 = make_rel("left1", 2, cn);
+    int64_t left_row1[] = {1, 10};
+    ASSERT_TRUE(left1 && col_rel_append_row(left1, left_row1) == 0,
+        "initial left row");
+    eval_stack_t stack;
+    eval_stack_init(&stack);
+    ASSERT_TRUE(eval_stack_push(&stack, left1, false) == 0,
+        "initial input pushed");
+    ASSERT_TRUE(col_op_join_diff(&op, &stack, sess) == 0,
+        "initial join committed");
+    eval_entry_t first = eval_stack_pop(&stack);
+    ASSERT_TRUE(sess->diff_arr_count == 1, "arrangement created");
+
+    col_diff_arrangement_t *before = sess->diff_arr_entries[0].diff_arr;
+    col_relation_snapshot_t snapshot_before = before->source_snapshot;
+    uint32_t indexed_before = before->indexed_rows;
+    uint32_t current_before = before->current_nrows;
+    uint32_t base_before = before->base_nrows;
+    uint32_t *heads_before = malloc(
+        (size_t)before->nbuckets * sizeof(*heads_before));
+    uint32_t *next_before = malloc(
+        (size_t)before->ht_cap * sizeof(*next_before));
+    ASSERT_TRUE(heads_before && next_before, "arrangement snapshot allocated");
+    memcpy(heads_before, before->ht_head,
+        (size_t)before->nbuckets * sizeof(*heads_before));
+    memcpy(next_before, before->ht_next,
+        (size_t)before->ht_cap * sizeof(*next_before));
+
+    int64_t right2[] = {2, 200};
+    ASSERT_TRUE(col_rel_append_row(right, right2) == 0, "right row appended");
+    col_rel_t *left2 = make_rel("left2", 2, cn);
+    int64_t left_row2[] = {2, 20};
+    ASSERT_TRUE(left2 && col_rel_append_row(left2, left_row2) == 0,
+        "retry left row");
+    sess->join_output_limit = 1;
+    eval_stack_init(&stack);
+    ASSERT_TRUE(eval_stack_push(&stack, left2, false) == 0,
+        "failing input pushed");
+    ASSERT_TRUE(col_op_join_diff(&op, &stack, sess) == EOVERFLOW,
+        "late output-limit abort reported");
+
+    col_diff_arrangement_t *after_abort
+        = sess->diff_arr_entries[0].diff_arr;
+    ASSERT_TRUE(after_abort == before, "persistent arrangement not replaced");
+    ASSERT_TRUE(after_abort->indexed_rows == indexed_before
+        && after_abort->current_nrows == current_before
+        && after_abort->base_nrows == base_before,
+        "persistent index bounds restored");
+    ASSERT_TRUE(wl_columnar_relation_snapshot_equal(
+            after_abort->source_snapshot, snapshot_before),
+        "persistent source snapshot restored");
+    ASSERT_TRUE(memcmp(after_abort->ht_head, heads_before,
+        (size_t)after_abort->nbuckets * sizeof(*heads_before)) == 0
+        && memcmp(after_abort->ht_next, next_before,
+        (size_t)after_abort->ht_cap * sizeof(*next_before)) == 0,
+        "persistent hash chains restored");
+    ASSERT_TRUE(diff_arrangement_links_in_bounds(after_abort),
+        "aborted arrangement links remain in bounds");
+
+    sess->join_output_limit = 0;
+    eval_stack_init(&stack);
+    ASSERT_TRUE(eval_stack_push(&stack, left2, false) == 0,
+        "retry input pushed");
+    ASSERT_TRUE(col_op_join_diff(&op, &stack, sess) == 0, "retry succeeds");
+    eval_entry_t retry = eval_stack_pop(&stack);
+    ASSERT_TRUE(retry.rel->nrows == 1, "retry returns appended match");
+    col_diff_arrangement_t *committed = sess->diff_arr_entries[0].diff_arr;
+    ASSERT_TRUE(committed->indexed_rows == right->nrows
+        && committed->current_nrows == right->nrows,
+        "retry commits complete index bounds");
+    ASSERT_TRUE(wl_columnar_relation_snapshot_equal(
+            committed->source_snapshot, wl_columnar_relation_snapshot(right)),
+        "retry commits current source snapshot");
+    ASSERT_TRUE(diff_arrangement_links_in_bounds(committed),
+        "committed arrangement links remain in bounds");
+
+    free(heads_before);
+    free(next_before);
+    eval_entry_dispose(&first);
+    eval_entry_dispose(&retry);
+    col_rel_destroy(left1);
+    col_rel_destroy(left2);
+    destroy_mock_session(sess);
+    PASS;
+}
+
 static void
 test_result_is_delta_flag(void)
 {
@@ -1427,6 +1610,8 @@ main(void)
     test_single_key_column();
     test_arrangement_reuse();
     test_arrangement_incremental();
+    test_diff_arrangement_txn_ledger_accounting();
+    test_late_abort_does_not_advance_arrangement();
     test_result_is_delta_flag();
     test_large_dataset();
     test_diff_operators_active_flag();

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -2443,6 +2443,134 @@ col_session_get_diff_arrangement(wl_col_session_t *cs, const char *rel_name,
     return e->diff_arr;
 }
 
+int
+wl_columnar_arrangement_diff_txn_begin(wl_col_session_t *cs,
+    const char *rel_name, const col_rel_t *source_rel,
+    const uint32_t *key_cols, uint32_t key_count,
+    wl_columnar_arrangement_diff_txn_t *txn)
+{
+    col_diff_arrangement_t **slot = NULL;
+
+    if (!cs || !rel_name || !source_rel || !key_cols || key_count == 0
+        || !txn)
+        return EINVAL;
+    memset(txn, 0, sizeof(*txn));
+
+    for (uint32_t i = 0; i < cs->diff_arr_count; i++) {
+        col_diff_arr_entry_t *entry = &cs->diff_arr_entries[i];
+        if (entry->key_count != key_count
+            || strcmp(entry->rel_name, rel_name) != 0)
+            continue;
+        bool match = true;
+        for (uint32_t k = 0; k < key_count; k++) {
+            if (entry->key_cols[k] != key_cols[k]) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            slot = &entry->diff_arr;
+            break;
+        }
+    }
+
+    if (!slot) {
+        if (cs->diff_arr_count >= cs->diff_arr_cap) {
+            uint32_t new_cap = cs->diff_arr_cap ? cs->diff_arr_cap * 2u : 4u;
+            col_diff_arr_entry_t *entries = (col_diff_arr_entry_t *)realloc(
+                cs->diff_arr_entries, new_cap * sizeof(*entries));
+            if (!entries)
+                return ENOMEM;
+            cs->diff_arr_entries = entries;
+            cs->diff_arr_cap = new_cap;
+        }
+        col_diff_arr_entry_t *entry
+            = &cs->diff_arr_entries[cs->diff_arr_count];
+        memset(entry, 0, sizeof(*entry));
+        entry->rel_name = wl_strdup(rel_name);
+        entry->key_cols = (uint32_t *)malloc(
+            (size_t)key_count * sizeof(*entry->key_cols));
+        if (!entry->rel_name || !entry->key_cols) {
+            free(entry->rel_name);
+            free(entry->key_cols);
+            memset(entry, 0, sizeof(*entry));
+            return ENOMEM;
+        }
+        memcpy(entry->key_cols, key_cols,
+            (size_t)key_count * sizeof(*entry->key_cols));
+        entry->key_count = key_count;
+        entry->diff_arr = col_diff_arrangement_create(key_cols, key_count, 0);
+        if (!entry->diff_arr) {
+            free(entry->rel_name);
+            free(entry->key_cols);
+            memset(entry, 0, sizeof(*entry));
+            return ENOMEM;
+        }
+        txn->entry = entry;
+        txn->pending_entry = true;
+        slot = &entry->diff_arr;
+    }
+
+    txn->session = cs;
+    txn->persistent = *slot;
+    txn->working = col_diff_arrangement_deep_copy(txn->persistent);
+    if (!txn->working) {
+        if (txn->pending_entry) {
+            free(txn->entry->rel_name);
+            free(txn->entry->key_cols);
+            col_diff_arrangement_destroy(txn->persistent);
+            memset(txn->entry, 0, sizeof(*txn->entry));
+        }
+        memset(txn, 0, sizeof(*txn));
+        return ENOMEM;
+    }
+    col_diff_arrangement_attach_ledger(txn->working,
+        txn->pending_entry ? &cs->mem_ledger : txn->persistent->ledger);
+    txn->slot = slot;
+
+    if (!wl_columnar_relation_snapshot_equal(txn->working->source_snapshot,
+        wl_columnar_relation_snapshot(source_rel))) {
+        memset(txn->working->ht_head, 0,
+            (size_t)txn->working->nbuckets * sizeof(*txn->working->ht_head));
+        memset(txn->working->ht_next, 0,
+            (size_t)txn->working->ht_cap * sizeof(*txn->working->ht_next));
+        txn->working->base_nrows = 0;
+        txn->working->current_nrows = 0;
+        txn->working->indexed_rows = 0;
+        txn->working->source_snapshot = (col_relation_snapshot_t){ 0, 0, 0 };
+    }
+    return 0;
+}
+
+void
+wl_columnar_arrangement_diff_txn_commit(
+    wl_columnar_arrangement_diff_txn_t *txn)
+{
+    if (!txn || !txn->slot || !txn->persistent || !txn->working)
+        return;
+    *txn->slot = txn->working;
+    col_diff_arrangement_destroy(txn->persistent);
+    if (txn->pending_entry)
+        txn->session->diff_arr_count++;
+    memset(txn, 0, sizeof(*txn));
+}
+
+void
+wl_columnar_arrangement_diff_txn_abort(
+    wl_columnar_arrangement_diff_txn_t *txn)
+{
+    if (!txn)
+        return;
+    col_diff_arrangement_destroy(txn->working);
+    if (txn->pending_entry && txn->entry) {
+        free(txn->entry->rel_name);
+        free(txn->entry->key_cols);
+        col_diff_arrangement_destroy(txn->persistent);
+        memset(txn->entry, 0, sizeof(*txn->entry));
+    }
+    memset(txn, 0, sizeof(*txn));
+}
+
 /*
  * col_session_free_diff_arrangements:
  *

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -2386,10 +2386,30 @@ void
 col_session_free_filt_arrangements(wl_col_session_t *cs);
 
 /* Differential arrangement registry (Issue #263) */
+typedef struct wl_columnar_arrangement_diff_txn {
+    wl_col_session_t *session;
+    col_diff_arr_entry_t *entry;
+    col_diff_arrangement_t **slot;
+    col_diff_arrangement_t *persistent;
+    col_diff_arrangement_t *working;
+    bool pending_entry;
+} wl_columnar_arrangement_diff_txn_t;
+
 col_diff_arrangement_t *
 col_session_get_diff_arrangement(wl_col_session_t *cs, const char *rel_name,
     const col_rel_t *source_rel,
     const uint32_t *key_cols, uint32_t key_count);
+int
+wl_columnar_arrangement_diff_txn_begin(wl_col_session_t *cs,
+    const char *rel_name, const col_rel_t *source_rel,
+    const uint32_t *key_cols, uint32_t key_count,
+    wl_columnar_arrangement_diff_txn_t *txn);
+void
+wl_columnar_arrangement_diff_txn_commit(
+    wl_columnar_arrangement_diff_txn_t *txn);
+void
+wl_columnar_arrangement_diff_txn_abort(
+    wl_columnar_arrangement_diff_txn_t *txn);
 void
 col_session_free_diff_arrangements(wl_col_session_t *cs);
 /* Issue #260: Deep-copy arrangement entries for K-fusion worker isolation. */

--- a/wirelog/columnar/join.c
+++ b/wirelog/columnar/join.c
@@ -2226,6 +2226,7 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
 
     int join_rc = 0;
     col_arrangement_probe_bundle_t diff_bundle = { 0 };
+    wl_columnar_arrangement_diff_txn_t diff_txn = { 0 };
 
     /* DIFFERENTIAL PATH: persistent diff_arrangement for non-delta right.
      * The arrangement persists across iterations, only indexing new rows. */
@@ -2247,14 +2248,17 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
             (void)col_arrangement_probe_bundle_release(&diff_bundle);
             return dependency_rc;
         }
-        darr = col_session_get_diff_arrangement(sess, op->right_relation,
-                right, rk, kc);
-        if (!darr)
+        int txn_rc = wl_columnar_arrangement_diff_txn_begin(sess,
+                op->right_relation, right, rk, kc, &diff_txn);
+        if (txn_rc == 0)
+            darr = diff_txn.working;
+        else
             (void)col_arrangement_probe_bundle_release(&diff_bundle);
     }
 
     if (darr
         && col_diff_arrangement_ensure_ht_capacity(darr, right->nrows) != 0) {
+        wl_columnar_arrangement_diff_txn_abort(&diff_txn);
         darr = NULL; /* capacity grow failed; fall through to ephemeral */
         (void)col_arrangement_probe_bundle_release(&diff_bundle);
     }
@@ -2289,6 +2293,7 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
                     col_rel_destroy(right_filtered);
                 if (left_e.owned)
                     col_rel_destroy(left);
+                wl_columnar_arrangement_diff_txn_abort(&diff_txn);
                 (void)col_arrangement_probe_bundle_release(&diff_bundle);
                 return ensure_rc;
             }
@@ -2310,6 +2315,7 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
                     col_rel_destroy(right_filtered);
                 if (left_e.owned)
                     col_rel_destroy(left);
+                wl_columnar_arrangement_diff_txn_abort(&diff_txn);
                 (void)col_arrangement_probe_bundle_release(&diff_bundle);
                 return ENOMEM;
             }
@@ -2425,6 +2431,7 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
                     col_rel_destroy(right_filtered);
                 if (left_e.owned)
                     col_rel_destroy(left);
+                wl_columnar_arrangement_diff_txn_abort(&diff_txn);
                 (void)col_arrangement_probe_bundle_release(&diff_bundle);
                 return prc;
             }
@@ -2465,10 +2472,14 @@ wl_columnar_join_diff_op(const wl_plan_op_t *op, eval_stack_t *stack,
                 col_rel_destroy(right_filtered);
             if (left_e.owned)
                 col_rel_destroy(left);
+            wl_columnar_arrangement_diff_txn_abort(&diff_txn);
             (void)col_arrangement_probe_bundle_release(&diff_bundle);
             return join_rc;
         }
     } else {
+        /* Every fallback owns no transaction state, including capacity and
+         * preparation failures that arrived here after an explicit abort. */
+        wl_columnar_arrangement_diff_txn_abort(&diff_txn);
         /* Ephemeral hash table fallback (same as col_op_join) */
         uint32_t nbuckets_ep;
         if (col_join_bucket_count(right->nrows, &nbuckets_ep) != 0) {
@@ -2559,22 +2570,39 @@ join_success:
                 col_rel_destroy(left);
             if (right_filtered)
                 col_rel_destroy(right_filtered);
+            int push_rc = eval_stack_push_delta(stack, out, true,
+                    result_is_delta);
+            if (push_rc == 0)
+                wl_columnar_arrangement_diff_txn_commit(&diff_txn);
+            else {
+                wl_columnar_arrangement_diff_txn_abort(&diff_txn);
+                col_rel_destroy(out);
+            }
             (void)col_arrangement_probe_bundle_release(&diff_bundle);
-            return eval_stack_push_delta(stack, out, true, result_is_delta);
+            return push_rc;
         }
         int cache_rc = col_mat_cache_insert(&sess->mat_cache, left, right, out);
         if (left_e.owned)
             col_rel_destroy(left);
         if (right_filtered)
             col_rel_destroy(right_filtered);
+        int push_rc;
         if (cache_rc != 0) {
             col_rel_destroy(copy);
-            (void)col_arrangement_probe_bundle_release(&diff_bundle);
-            return eval_stack_push_delta(stack, out, true, result_is_delta);
+            push_rc = eval_stack_push_delta(stack, out, true,
+                    result_is_delta);
+            if (push_rc != 0)
+                col_rel_destroy(out);
+        } else {
+            push_rc = eval_stack_push_delta(stack, copy, true,
+                    result_is_delta);
+            if (push_rc != 0)
+                col_rel_destroy(copy);
         }
-        int push_rc = eval_stack_push_delta(stack, copy, true, result_is_delta);
-        if (push_rc != 0)
-            col_rel_destroy(copy);
+        if (push_rc == 0)
+            wl_columnar_arrangement_diff_txn_commit(&diff_txn);
+        else
+            wl_columnar_arrangement_diff_txn_abort(&diff_txn);
         (void)col_arrangement_probe_bundle_release(&diff_bundle);
         return push_rc;
     }
@@ -2582,8 +2610,15 @@ join_success:
         col_rel_destroy(left);
     if (right_filtered)
         col_rel_destroy(right_filtered);
+    int push_rc = eval_stack_push_delta(stack, out, true, result_is_delta);
+    if (push_rc == 0)
+        wl_columnar_arrangement_diff_txn_commit(&diff_txn);
+    else {
+        wl_columnar_arrangement_diff_txn_abort(&diff_txn);
+        col_rel_destroy(out);
+    }
     (void)col_arrangement_probe_bundle_release(&diff_bundle);
-    return eval_stack_push_delta(stack, out, true, result_is_delta);
+    return push_rc;
 }
 
 /* Compatibility entry points used by internal test fixtures and downstream


### PR DESCRIPTION
Part of #1496.

Differential JOIN now mutates a ledger-attached working arrangement and publishes it only after a successful result push. Abort paths leave persistent index bounds, hash chains, snapshots, and pending registry entries unchanged. Added late-abort rollback and transaction ledger-accounting regression tests.

Validation:
- meson test -C build diff_join arrangement_probe join_arrangement --print-errorlogs
- meson test -C build-asan diff_join arrangement_probe join_arrangement --print-errorlogs