### PR TITLE
Detach empty shared fallback relations

### DIFF
--- a/tests/test_relation_generations.c
+++ b/tests/test_relation_generations.c
@@ -2135,6 +2135,34 @@ test_shared_view_relation_metadata(void)
     cleanup_relations();
 }
 
+static void
+test_empty_append_detaches_shared_destination(void)
+{
+    col_rel_t *src = new_relation();
+    col_rel_t *dst = new_relation();
+
+    CHECK(src != NULL, "empty source allocation");
+    CHECK(dst != NULL, "empty destination allocation");
+    CHECK(col_rel_install_shared_view(dst, src) == 0,
+        "empty source shared view");
+    CHECK(src->nrows == 0 && src->storage_alias_borrows == 1
+        && dst->col_shared != NULL,
+        "empty source installs shared destination");
+    CHECK(col_rel_destroy_checked(src) == EBUSY,
+        "shared empty destination blocks source destroy");
+    CHECK(col_rel_append_all(dst, src, NULL) == 0,
+        "empty append detaches shared destination");
+    CHECK(dst->storage_owner == dst && dst->col_shared == NULL
+        && src->storage_alias_borrows == 0,
+        "empty append retires old shared ownership");
+    CHECK(col_rel_destroy_checked(src) == 0,
+        "source destroy succeeds after empty detach");
+    src = NULL;
+    col_rel_destroy(dst);
+    dst = NULL;
+    owned_relation_count = 0;
+}
+
 int
 main(void)
 {
@@ -2163,6 +2191,7 @@ main(void)
     test_failure_atomicity();
     test_resize_failure_atomicity();
     test_shared_view_relation_metadata();
+    test_empty_append_detaches_shared_destination();
     test_identity_exhaustion();
     if (failures != 0)
         return EXIT_FAILURE;

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -367,6 +367,8 @@ tdd_shared_view_deep_copy_fallback(wl_col_session_t *sess, col_rel_t *dst,
     const col_rel_t *src, int shared_view_rc)
 {
     wl_columnar_source_access_reader_t reader = { 0 };
+    col_rel_t *source_owner = NULL;
+    col_rel_t *destination_owner = NULL;
     int rc;
 
     /* EBUSY can mean terminal source destruction already claimed the gate.
@@ -374,23 +376,41 @@ tdd_shared_view_deep_copy_fallback(wl_col_session_t *sess, col_rel_t *dst,
     if (shared_view_rc != ENOMEM && shared_view_rc != EINVAL
         && shared_view_rc != EOVERFLOW)
         return shared_view_rc;
+    rc = col_rel_storage_owner_resolve(src, &source_owner);
+    if (rc != 0)
+        return rc;
+    rc = col_rel_storage_owner_resolve(dst, &destination_owner);
+    if (rc != 0)
+        return rc;
     rc = col_rel_source_reader_acquire(src, &reader);
     if (rc != 0)
         return rc;
+    bool reader_acquired = true;
+    /* An empty source has no mutable column data to read.  When the source
+     * and reused destination share one gate, release the reader before COW
+     * so the destination writer cannot self-conflict.  The live destination
+     * alias still keeps that owner alive through the transition. */
+    if (src->nrows == 0 && source_owner == destination_owner) {
+        rc = col_rel_source_reader_release(&reader);
+        reader_acquired = false;
+        if (rc != 0)
+            return rc;
+    }
     if (sess) {
         dst->nrows = 0;
         wl_columnar_relation_touch_view(dst);
     }
     rc = col_rel_append_all(dst, src, NULL);
-    int release_rc = col_rel_source_reader_release(&reader);
+    int release_rc = reader_acquired
+        ? col_rel_source_reader_release(&reader) : 0;
     if (rc == 0 && release_rc != 0)
         rc = release_rc;
     if (rc == 0 && sess) {
-        /* append_all COW-detaches a non-empty shared destination before it
-         * returns.  Empty copies may remain aliases and retain their lease. */
+        /* append_all also detaches an empty shared destination before it
+         * returns, so a successful fallback must retire the old lease. */
         int retire_rc
             = wl_columnar_session_retire_source_lease(sess, dst);
-        if (retire_rc != 0 && retire_rc != EBUSY)
+        if (retire_rc != 0)
             rc = retire_rc;
     }
     return rc;

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -1558,8 +1558,24 @@ col_rel_append_all(col_rel_t *dst, const col_rel_t *src, wl_arena_t *arena)
     (void)arena;
     if (!dst || !src || dst->ncols != src->ncols)
         return EINVAL;
-    if (src->nrows == 0)
+    if (src->nrows == 0) {
+        /* An empty source still completes a destination ownership
+         * transition.  In particular, a reused TDD destination may be a
+         * shared view whose old source lease must not survive a successful
+         * fallback merely because there are no rows to copy. */
+        if (dst->col_shared) {
+            wl_columnar_source_access_writer_t writer = { 0 };
+            rc = col_rel_source_writer_acquire(dst, &writer);
+            if (rc != 0)
+                return rc;
+            rc = col_rel_cow_unshare(dst, 0);
+            if (wl_columnar_source_access_writer_release(&writer) != 0
+                && rc == 0)
+                rc = EINVAL;
+            return rc;
+        }
         return 0;
+    }
 
     /* Preserve the historical zero-initialized, zero-column arithmetic path.
      * These stack relations have no generation or owner metadata, so owner


### PR DESCRIPTION
Part of #1496.

When a reused shared destination falls back to deep-copying an empty source, `col_rel_append_all` now completes the ownership transition instead of returning before COW. The fallback keeps source lifetime protected for different owners, avoids same-gate reader/writer self-conflict, and treats failed source-lease retirement as an error. Added regression coverage for empty shared detachment and source destruction.

Validation:
- meson test -C build --suite unit --print-errorlogs
- meson test -C build-asan relation_generations worker_session columnar_teardown --print-errorlogs