### PR TITLE
test: qualify public source lifetime

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -601,10 +601,14 @@ succeeds.
 
 This is an internal coordinator/worker-session contract, not a public API or a
 general concurrent-reader mechanism. Release all leases before session teardown.
-The lease protects index buffers and entry identity, not source column values,
-row positions or compound storage: a reader must not probe an old index against
-a mutated source. Source-reader protection is tracked in #1485; generation
-checks on subsequent lookups are not a substitute for that protection.
-Filtered, differential, sorted and
-materialization-cache lifetimes, plus relation-generation validation, remain
-tracked separately in issue #1435.
+Primary probes, compound/side-relation dependencies, and differential working
+arrangements are acquired as one operation-scoped transactional bundle. The
+bound source reader and ultimate storage-owner generation protect source
+columns, row positions, aliases, metadata, and compound storage for that
+operation. Mutation is denied with `EBUSY` while the bundle is live and may be
+retried after release; aborted differential work leaves the persistent index
+and accounting unchanged.
+
+Checked teardown drains queued work and rejects destruction while a live source
+lease remains. The delegated #1435/#1507 work and non-primary materialization
+cache semantics are not claimed by this contract.

--- a/docs/THREADING.md
+++ b/docs/THREADING.md
@@ -953,7 +953,14 @@ borrower's lifetime. The flat registry refuses `realloc()` while any lease is
 active; callers that cannot obtain a new cache slot must use their ephemeral
 fallback until the lease is released.
 
-The lease is internal and must not be copied or released twice. It does not
-cover filtered/differential/sorted/materialization caches or relation
-generation checks; those extensions are tracked by issue #1435. No claim of
-general multi-threaded access is made by this contract.
+The lease is internal and must not be copied or released twice. The source
+reader is acquired with the arrangement pin in the operation-local bundle and
+is released before the public operation boundary returns. Compound/side
+relations coalesce by ultimate storage owner; dependency failure rolls back
+every earlier pin and reader. Mutation takes the same source gate and returns
+`EBUSY` while a reader is active, so callers retry after release. Worker
+aliases and checked teardown follow the same rule: no queued task or borrowed
+source may outlive the operation/session boundary.
+
+This is not a general concurrent-reader API. Filtered/materialization-cache
+extensions and the delegated #1435/#1507 work remain separate contracts.

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -2626,6 +2626,31 @@ test_arrangement_probe_exe = executable(
 
 test('arrangement_probe', test_arrangement_probe_exe)
 
+# Public source-reader lifetime qualification (Issue #1497).  The test uses
+# the pthread-capable public session path with two workers and is also part of
+# the canonical TSan suite; it does not claim coverage for delegated #1435.
+test_arrangement_source_lifetime_tsan_exe = executable(
+  'test_arrangement_source_lifetime_tsan',
+  files('test_arrangement_source_lifetime_tsan.c'),
+  parser_src,
+  ir_src,
+  optimizer_src,
+  backend_src,
+  io_src,
+  arena_src,
+  thread_src,
+  workqueue_src,
+  '../wirelog/wirelog-easy.c',
+  '../wirelog/api_facade.c',
+  '../wirelog/wirelog_advanced.c',
+  include_directories: [wirelog_inc, wirelog_src_inc],
+  dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
+)
+
+test('arrangement_source_lifetime_tsan',
+     test_arrangement_source_lifetime_tsan_exe,
+     suite: ['unit', 'tsan'], timeout: 60)
+
 # ============================================================================
 # Pin-safe Materialization Cache Reclaimer Tests (Issue #1371)
 # ============================================================================

--- a/tests/test_arrangement_source_lifetime_tsan.c
+++ b/tests/test_arrangement_source_lifetime_tsan.c
@@ -1,0 +1,104 @@
+/* Public source-reader lifetime qualification (Issue #1497). */
+
+#include "wirelog/wirelog-advanced.h"
+#include "wirelog/wirelog.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static const char *SOURCE =
+    ".decl edge(x: int64, y: int64)\n"
+    ".decl event(id: int64, payload: metadata/2 side)\n"
+    ".decl reach(x: int64, y: int64)\n"
+    ".decl seen(id: int64)\n"
+    "reach(x, y) :- edge(x, y).\n"
+    "reach(x, z) :- reach(x, y), edge(y, z).\n"
+    "seen(id) :- event(id, _).\n";
+
+typedef struct {
+    uint32_t reach_rows;
+    uint32_t seen_rows;
+} snapshot_counts_t;
+
+static void
+count_rows(const char *relation, const int64_t *row, uint32_t ncols,
+    void *user_data)
+{
+    snapshot_counts_t *counts = user_data;
+    (void)row;
+    (void)ncols;
+    if (!relation || !counts)
+        return;
+    if (strcmp(relation, "reach") == 0)
+        counts->reach_rows++;
+    else if (strcmp(relation, "seen") == 0)
+        counts->seen_rows++;
+}
+
+int
+main(void)
+{
+    wirelog_error_t error;
+    wirelog_program_t *program = wirelog_parse_string(SOURCE, &error);
+    wirelog_session_t *session = NULL;
+    wirelog_compound_arg_t args[2] = {
+        { WIRELOG_TYPE_INT64, 7 },
+        { WIRELOG_TYPE_INT64, 11 },
+    };
+    uint64_t handle = WIRELOG_COMPOUND_HANDLE_NULL;
+    int64_t event_row[2];
+    int64_t edge_rows[] = { 1, 2, 2, 3 };
+    snapshot_counts_t snapshot = { 0 };
+    int failures = 0;
+
+    if (!program) {
+        fprintf(stderr, "parse failed: %s\n", wirelog_error_string(error));
+        return 1;
+    }
+    if (wirelog_session_create(program, WIRELOG_BACKEND_COLUMNAR, 2,
+            &session) != WIRELOG_OK || !session) {
+        fprintf(stderr, "public session creation failed\n");
+        wirelog_program_free(program);
+        return 1;
+    }
+
+    if (wirelog_session_make_compound(session, "metadata", 2, args,
+            &handle) != WIRELOG_OK
+        || handle == WIRELOG_COMPOUND_HANDLE_NULL) {
+        fprintf(stderr, "side-compound creation failed\n");
+        failures++;
+    }
+    event_row[0] = 1;
+    event_row[1] = (int64_t)handle;
+    if (wirelog_session_insert(session, "event", event_row, 1, 2)
+            != WIRELOG_OK
+        || wirelog_session_insert(session, "edge", edge_rows, 2, 2)
+            != WIRELOG_OK) {
+        fprintf(stderr, "source insertion failed\n");
+        failures++;
+    }
+
+    /* Exercise a public input-error boundary before evaluating the real
+     * arrangement and side-compound sources.  The full active-reader error
+     * matrix remains covered by the internal bundle tests. */
+    if (wirelog_session_insert(session, "missing", edge_rows, 1, 2)
+            != WIRELOG_ERR_EXEC) {
+        fprintf(stderr, "invalid relation did not report WIRELOG_ERR_EXEC\n");
+        failures++;
+    }
+    if (wirelog_session_step(session) != WIRELOG_OK
+        || wirelog_session_snapshot(session, count_rows, &snapshot)
+            != WIRELOG_OK
+        || snapshot.reach_rows != 3 || snapshot.seen_rows != 1) {
+        fprintf(stderr, "post-error evaluation failed (reach=%u seen=%u)\n",
+            snapshot.reach_rows, snapshot.seen_rows);
+        failures++;
+    }
+
+    wirelog_session_destroy(session);
+    /* This ordering is the public lifetime contract: destroy is synchronous,
+     * so the borrowed program can be freed immediately afterwards. */
+    wirelog_program_free(program);
+    return failures != 0;
+}


### PR DESCRIPTION
## Summary
- add a public two-worker source lifetime qualification with inline side-compound data and recursive arrangement evaluation
- verify a public input error does not poison subsequent evaluation and assert exact `reach=3`, `seen=1` results
- register the test for normal and canonical TSan suites
- document the integrated source-reader/arrangement lifetime contract and explicitly exclude delegated #1435/#1507

## Validation
- `meson test -C build arrangement_source_lifetime_tsan --print-errorlogs`
- `meson test -C build-asan arrangement_source_lifetime_tsan --print-errorlogs`
- `git diff --check`

A broader related-test rebuild was attempted but could not complete because the shared `/tmp` filesystem exhausted its temporary-file quota; the focused normal and ASan/UBSan tests passed after cleaning compiler temporaries.

This is an atomic qualification unit for #1497, not a claim that the full issue acceptance is closed.
