### PR TITLE
test: qualify evaluation error cleanup

### DIFF
--- a/tests/test_arrangement_source_lifetime_tsan.c
+++ b/tests/test_arrangement_source_lifetime_tsan.c
@@ -1,6 +1,7 @@
 /* Public source-reader lifetime qualification (Issue #1497). */
 
 #include "wirelog/wirelog-advanced.h"
+#include "wirelog/wirelog-extension.h"
 #include "wirelog/wirelog.h"
 
 #include <stdint.h>
@@ -12,7 +13,7 @@ static const char *SOURCE =
     ".decl event(id: int64, payload: metadata/2 side)\n"
     ".decl reach(x: int64, y: int64)\n"
     ".decl seen(id: int64)\n"
-    "reach(x, y) :- edge(x, y).\n"
+    "reach(x, y) :- edge(x, y), @call(\"test.lifetime\", x).\n"
     "reach(x, z) :- reach(x, y), edge(y, z).\n"
     "seen(id) :- event(id, _).\n";
 
@@ -20,6 +21,23 @@ typedef struct {
     uint32_t reach_rows;
     uint32_t seen_rows;
 } snapshot_counts_t;
+
+static int evaluation_should_fail;
+
+static int
+lifetime_extension_invoke(const wirelog_extension_value_t *args,
+    uint32_t nargs, wirelog_extension_value_t *result, void *user_data)
+{
+    (void)args;
+    (void)nargs;
+    (void)user_data;
+    if (evaluation_should_fail)
+        return 1;
+    result->type = WIRELOG_EXTENSION_VALUE_BOOL;
+    result->size = sizeof(uint8_t);
+    result->as.bool_value = 1;
+    return 0;
+}
 
 static void
 count_rows(const char *relation, const int64_t *row, uint32_t ncols,
@@ -42,6 +60,8 @@ main(void)
     wirelog_error_t error;
     wirelog_program_t *program = wirelog_parse_string(SOURCE, &error);
     wirelog_session_t *session = NULL;
+    wirelog_extension_registry_t *registry = NULL;
+    wirelog_extension_snapshot_t *extension_snapshot = NULL;
     wirelog_compound_arg_t args[2] = {
         { WIRELOG_TYPE_INT64, 7 },
         { WIRELOG_TYPE_INT64, 11 },
@@ -56,12 +76,34 @@ main(void)
         fprintf(stderr, "parse failed: %s\n", wirelog_error_string(error));
         return 1;
     }
-    if (wirelog_session_create(program, WIRELOG_BACKEND_COLUMNAR, 2,
-            &session) != WIRELOG_OK || !session) {
+    const uint32_t argument_types[] = { WIRELOG_EXTENSION_VALUE_INT64 };
+    wirelog_extension_descriptor_t descriptor = {
+        WIRELOG_EXTENSION_ABI_VERSION, sizeof(descriptor),
+        "test.lifetime", 1, argument_types,
+        WIRELOG_EXTENSION_VALUE_BOOL, lifetime_extension_invoke, NULL, NULL
+    };
+    registry = wirelog_extension_registry_create();
+    if (!registry || wirelog_extension_register(registry, &descriptor) != 0) {
+        fprintf(stderr, "extension setup failed\n");
+        wirelog_program_free(program);
+        if (registry)
+            wirelog_extension_registry_destroy(registry);
+        return 1;
+    }
+    extension_snapshot = wirelog_extension_snapshot_acquire(registry);
+    if (!extension_snapshot
+        || wirelog_session_create_with_snapshot(program,
+            WIRELOG_BACKEND_COLUMNAR, 2, extension_snapshot, &session)
+            != WIRELOG_OK || !session) {
         fprintf(stderr, "public session creation failed\n");
+        wirelog_extension_snapshot_release(extension_snapshot);
+        wirelog_extension_registry_destroy(registry);
         wirelog_program_free(program);
         return 1;
     }
+    wirelog_extension_snapshot_release(extension_snapshot);
+    extension_snapshot = NULL;
+    wirelog_extension_unregister(registry, descriptor.name);
 
     if (wirelog_session_make_compound(session, "metadata", 2, args,
             &handle) != WIRELOG_OK
@@ -79,16 +121,19 @@ main(void)
         failures++;
     }
 
-    /* Exercise a public input-error boundary before evaluating the real
-     * arrangement and side-compound sources.  The full active-reader error
-     * matrix remains covered by the internal bundle tests. */
-    if (wirelog_session_insert(session, "missing", edge_rows, 1, 2)
+    /* Fail inside the public evaluation after arrangement/worker setup, then
+     * retry the same session successfully.  This is the operation-boundary
+     * error cleanup qualification; the internal bundle tests cover rollback
+     * counters and exact lease slots. */
+    evaluation_should_fail = 1;
+    if (wirelog_session_snapshot(session, count_rows, &snapshot)
             != WIRELOG_ERR_EXEC) {
-        fprintf(stderr, "invalid relation did not report WIRELOG_ERR_EXEC\n");
+        fprintf(stderr, "evaluation failure did not report WIRELOG_ERR_EXEC\n");
         failures++;
     }
-    if (wirelog_session_step(session) != WIRELOG_OK
-        || wirelog_session_snapshot(session, count_rows, &snapshot)
+    evaluation_should_fail = 0;
+    snapshot = (snapshot_counts_t){ 0 };
+    if (wirelog_session_snapshot(session, count_rows, &snapshot)
             != WIRELOG_OK
         || snapshot.reach_rows != 3 || snapshot.seen_rows != 1) {
         fprintf(stderr, "post-error evaluation failed (reach=%u seen=%u)\n",
@@ -100,5 +145,7 @@ main(void)
     /* This ordering is the public lifetime contract: destroy is synchronous,
      * so the borrowed program can be freed immediately afterwards. */
     wirelog_program_free(program);
+    if (wirelog_extension_registry_destroy(registry) != 0)
+        failures++;
     return failures != 0;
 }

--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -1730,6 +1730,7 @@ test_worker_alias_chain_checked_teardown(void)
         fprintf(stderr,
             "alias chain: source destroy with live aliases returned %d\n",
             destroy_with_both);
+        FAIL("checked destroy unexpectedly freed a live source");
         return 1;
     }
     ok = worker_a_rel != NULL && worker_b_rel != NULL
@@ -1745,6 +1746,7 @@ test_worker_alias_chain_checked_teardown(void)
         fprintf(stderr,
             "alias chain: source destroy with worker A returned %d\n",
             destroy_with_a);
+        FAIL("checked destroy unexpectedly freed an aliased source");
         return 1;
     }
     ok = ok && source->storage_alias_borrows == 1


### PR DESCRIPTION
## Summary
- make the public lifetime qualification fail inside recursive arrangement evaluation via an extension callback
- verify the same two-worker session retries successfully with exact `reach=3` and `seen=1` results
- ensure unexpected checked-destroy success is recorded by the worker-session test harness instead of being a false pass

## Validation
- `meson test -C build worker_session arrangement_source_lifetime_tsan --print-errorlogs`
- `meson test -C build-asan worker_session arrangement_source_lifetime_tsan --print-errorlogs`
- `git diff --check`

This is the operation-boundary error-cleanup unit for #1497. It does not claim every internal rollback slot or the full cancellation matrix, and excludes delegated #1435/#1507.
