### PR TITLE
fix: make coordinator IDB reset and restore transactional

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5161,7 +5161,7 @@ test_tdd_recursive_exe = executable(
   include_directories: [wirelog_inc, wirelog_src_inc],
   dependencies: [nanoarrow_dep, threads_dep, xxhash_dep, mbedtls_dep, math_dep],
   c_args: ['-DWL_TEST_BDX_SEED=1', '-DWL_TEST_TDD_MERGE=1',
-    '-DWL_TEST_ALLOC_WRAP=1'],
+    '-DWL_TEST_TDD_RESET_RESTORE=1', '-DWL_TEST_ALLOC_WRAP=1'],
   link_args: [
     '-Wl,--wrap=malloc', '-Wl,--wrap=calloc', '-Wl,--wrap=realloc',
   ],

--- a/tests/test_relation_generations.c
+++ b/tests/test_relation_generations.c
@@ -540,6 +540,7 @@ test_copy_and_shared_semantics(void)
     uint64_t old_view;
     uint64_t old_storage;
     CHECK(col_rel_append_row(src, &row) == 0, "copy seed");
+    src->declared_ncols = 7u;
     source_view = src->view_generation;
     source_storage = src->storage_generation;
     old_view = view->view_generation;
@@ -548,6 +549,8 @@ test_copy_and_shared_semantics(void)
     track_relation(copy);
     CHECK(copy->relation_identity != src->relation_identity,
         "deep copy receives a fresh identity");
+    CHECK(copy->declared_ncols == src->declared_ncols,
+        "deep copy preserves the declared column count");
     CHECK(copy->view_generation == src->view_generation
         && copy->storage_generation == src->storage_generation,
         "deep copy preserves the source snapshot generations");
@@ -2487,6 +2490,7 @@ test_staged_replacement_contract(void)
     int64_t *old_columns;
     char *old_name;
     col_rel_replacement_t replacement;
+    wl_columnar_source_access_writer_t writer = { 0 };
 
     CHECK(dst && candidate, "replacement setup");
     CHECK(col_rel_append_row(dst, &old_value) == 0
@@ -2509,8 +2513,12 @@ test_staged_replacement_contract(void)
         && dst->storage_generation == storage_before
         && dst->retained_reserved_bytes == reserved_before,
         "replacement preparation leaves destination unchanged");
-    CHECK(col_rel_commit_replacement_locked(dst, &replacement) == 0,
-        "replacement commit succeeds");
+    col_rel_commit_replacement_locked(dst, &replacement);
+    CHECK(wl_columnar_source_access_writer_acquire(
+            &dst->source_access, &writer) == 0,
+        "replacement commit releases its writer");
+    CHECK(wl_columnar_source_access_writer_release(&writer) == 0,
+        "replacement commit writer can be released");
     CHECK(dst->relation_identity == identity && dst->name == old_name
         && strcmp(dst->name, "generation_test") == 0
         && dst->columns[0] != old_columns
@@ -2542,9 +2550,9 @@ test_staged_replacement_contract(void)
             && col_rel_append_row(dst, &old_value) == 0
             && col_rel_append_row(candidate, &new_value) == 0,
             "replacement admission rows");
-        CHECK(col_rel_prepare_replacement(dst, candidate, &replacement) == 0
-            && col_rel_commit_replacement_locked(dst, &replacement) == 0,
-            "replacement admission commit");
+        CHECK(col_rel_prepare_replacement(dst, candidate, &replacement) == 0,
+            "replacement admission prepare");
+        col_rel_commit_replacement_locked(dst, &replacement);
         reserved_after = col_rel_transport_bytes(dst);
         CHECK(dst->retained_reserved_bytes == reserved_after
             && wl_columnar_memory_reserved(
@@ -2576,9 +2584,9 @@ test_staged_replacement_contract(void)
         "replacement reader denial preserves state");
     CHECK(col_rel_source_reader_release(&reader) == 0,
         "replacement reader release");
-    CHECK(col_rel_prepare_replacement(dst, candidate, &replacement) == 0
-        && col_rel_commit_replacement_locked(dst, &replacement) == 0,
-        "replacement retries after reader release");
+    CHECK(col_rel_prepare_replacement(dst, candidate, &replacement) == 0,
+        "replacement retries after reader release prepare");
+    col_rel_commit_replacement_locked(dst, &replacement);
     cleanup_relations();
 
     dst = new_relation();

--- a/tests/test_tdd_recursive.c
+++ b/tests/test_tdd_recursive.c
@@ -1216,6 +1216,351 @@ test_bdx_seed_success_preserves_timestamps(void)
     return 0;
 }
 
+#ifdef WL_TEST_TDD_RESET_RESTORE
+static int
+test_tdd_reset_restore_transaction(void)
+{
+    TEST("TDD coordinator reset/restore preserves state transactionally");
+
+    const int64_t rows[] = { 7, 8, 9, 10 };
+    col_rel_t *rel = make_seed_relation("r", rows, 2, 2);
+    col_rel_t *alias = NULL;
+    wl_columnar_source_access_reader_t reader = { 0 };
+    wl_col_session_t coord = { 0 };
+    wl_plan_relation_t plan_rel = { 0 };
+    wl_plan_stratum_t stratum = { 0 };
+    col_rel_t **saved = NULL;
+    uint64_t *saved_dedup = NULL;
+    int64_t first0;
+    int64_t first1;
+    uint64_t generation;
+    int rc;
+
+    if (!rel || col_rel_enable_timestamps(rel) != 0) {
+        col_rel_destroy(rel);
+        FAIL("reset/restore setup");
+        return 1;
+    }
+    rel->timestamps[0].iteration = 12;
+    rel->timestamps[0].multiplicity = -3;
+    rel->compound_kind = WIRELOG_COMPOUND_KIND_INLINE;
+    rel->compound_count = 1;
+    rel->compound_arity_map = (uint32_t *)calloc(2,
+            sizeof(*rel->compound_arity_map));
+    if (!rel->compound_arity_map) {
+        col_rel_destroy(rel);
+        FAIL("compound metadata setup");
+        return 1;
+    }
+    rel->compound_arity_map[0] = 1;
+    rel->compound_arity_map[1] = 1;
+    rel->dedup_slots = (uint64_t *)calloc(4, sizeof(*rel->dedup_slots));
+    if (!rel->dedup_slots) {
+        col_rel_destroy(rel);
+        FAIL("dedup setup");
+        return 1;
+    }
+    rel->dedup_cap = 4;
+    rel->dedup_count = 1;
+    rel->dedup_slots[1] = 0xfeed;
+    first0 = rel->columns[0][0];
+    first1 = rel->columns[1][0];
+    generation = rel->view_generation;
+
+    rc = col_rel_source_reader_acquire(rel, &reader);
+    if (rc != 0 || wl_columnar_eval_test_tdd_reset(rel) != EBUSY
+        || rel->nrows != 2 || rel->columns[0][0] != first0
+        || rel->columns[1][0] != first1
+        || rel->view_generation != generation
+        || col_rel_source_reader_release(&reader) != 0) {
+        col_rel_destroy(rel);
+        FAIL("reader denial changed coordinator relation");
+        return 1;
+    }
+
+    alias = col_rel_new_auto("alias", 2);
+    if (!alias || col_rel_install_shared_view(alias, rel) != 0
+        || wl_columnar_eval_test_tdd_reset(rel) != EBUSY
+        || rel->nrows != 2 || rel->columns[0][0] != first0
+        || col_rel_storage_alias_release(alias) != 0) {
+        if (alias)
+            col_rel_storage_alias_release(alias);
+        col_rel_destroy(alias);
+        col_rel_destroy(rel);
+        FAIL("live alias denial changed coordinator relation");
+        return 1;
+    }
+    col_rel_destroy(alias);
+
+    rc = wl_columnar_eval_test_tdd_reset(rel);
+    if (rc != 0 || rel->nrows != 0 || rel->ncols != 2
+        || rel->compound_kind != WIRELOG_COMPOUND_KIND_INLINE
+        || rel->timestamps != NULL || rel->dedup_slots != NULL) {
+        col_rel_destroy(rel);
+        FAIL("successful reset did not preserve schema and clear rows");
+        return 1;
+    }
+
+#ifdef WL_TEST_ALLOC_WRAP
+    {
+        bool observed_failure = false;
+        for (long fail_at = 0; fail_at < 64 && !observed_failure;
+            fail_at++) {
+            col_rel_t *candidate = make_seed_relation("r", rows, 2, 2);
+            bdx_seed_snapshot_t snapshot;
+            if (!candidate) {
+                FAIL("reset allocation setup");
+                return 1;
+            }
+            capture_bdx_seed_snapshot(candidate, &snapshot);
+            allocation_calls = 0;
+            allocation_fail_at = fail_at;
+            rc = wl_columnar_eval_test_tdd_reset(candidate);
+            allocation_fail_at = -1;
+            if (rc == ENOMEM) {
+                observed_failure = true;
+                if (!bdx_seed_snapshot_unchanged(candidate, &snapshot)) {
+                    col_rel_destroy(candidate);
+                    FAIL("reset allocation failure changed relation");
+                    return 1;
+                }
+            } else if (rc != 0) {
+                col_rel_destroy(candidate);
+                FAIL("unexpected reset allocation result");
+                return 1;
+            }
+            col_rel_destroy(candidate);
+        }
+        if (!observed_failure) {
+            FAIL("reset allocation failure seam was not exercised");
+            return 1;
+        }
+    }
+#endif
+
+    {
+        col_rel_t *overflow = make_seed_relation("overflow", rows, 2, 2);
+        bdx_seed_snapshot_t snapshot;
+        if (!overflow) {
+            FAIL("reset overflow setup");
+            return 1;
+        }
+        overflow->view_generation = WL_COLUMNAR_REL_GENERATION_INVALID - 1u;
+        capture_bdx_seed_snapshot(overflow, &snapshot);
+        rc = wl_columnar_eval_test_tdd_reset(overflow);
+        if (rc != EOVERFLOW || !bdx_seed_snapshot_unchanged(overflow,
+            &snapshot)) {
+            col_rel_destroy(overflow);
+            FAIL("reset overflow was not transactional");
+            return 1;
+        }
+        col_rel_destroy(overflow);
+    }
+
+    if (session_add_rel(&coord, rel) != 0) {
+        col_rel_destroy(rel);
+        FAIL("restore session registration");
+        return 1;
+    }
+    plan_rel.name = "r";
+    stratum.relations = &plan_rel;
+    stratum.relation_count = 1;
+    saved_dedup = (uint64_t *)calloc(4, sizeof(*saved_dedup));
+    if (!saved_dedup) {
+        session_remove_rel(&coord, "r");
+        free(coord.rels);
+        FAIL("restore dedup setup");
+        return 1;
+    }
+    /* Restore starts from a published relation with its own metadata. */
+    rel = session_find_rel(&coord, "r");
+    rel->nrows = 0;
+    rel->dedup_slots = saved_dedup;
+    rel->dedup_cap = 4;
+    rel->dedup_count = 1;
+    rel->dedup_slots[2] = 0xbeef;
+
+    {
+        col_rel_t *bad = col_rel_new_auto("r", 2);
+        col_rel_t *bad_saved[1] = { bad };
+        uint64_t before_generation = rel->view_generation;
+        if (!bad) {
+            session_remove_rel(&coord, "r");
+            free(coord.rels);
+            FAIL("restore schema setup");
+            return 1;
+        }
+        bad->compound_kind = WIRELOG_COMPOUND_KIND_INLINE;
+        bad->compound_count = 1;
+        bad->compound_arity_map = (uint32_t *)calloc(2,
+                sizeof(*bad->compound_arity_map));
+        if (!bad->compound_arity_map) {
+            col_rel_destroy(bad);
+            session_remove_rel(&coord, "r");
+            free(coord.rels);
+            FAIL("restore schema metadata setup");
+            return 1;
+        }
+        bad->compound_arity_map[0] = 0;
+        bad->compound_arity_map[1] = 1;
+        if (wl_columnar_eval_test_tdd_restore(&stratum, &coord,
+            bad_saved) != EINVAL
+            || rel->view_generation != before_generation
+            || rel->nrows != 0) {
+            col_rel_destroy(bad);
+            session_remove_rel(&coord, "r");
+            free(coord.rels);
+            FAIL("restore schema failure changed relation");
+            return 1;
+        }
+        col_rel_destroy(bad);
+    }
+
+    if (col_rel_enable_timestamps(rel) != 0
+        || wl_columnar_eval_test_tdd_save(&stratum, &coord, &saved) != 0) {
+        session_remove_rel(&coord, "r");
+        free(coord.rels);
+        FAIL("lossless snapshot setup");
+        return 1;
+    }
+
+    rel = session_find_rel(&coord, "r");
+    rel->nrows = 0;
+    if (col_rel_source_reader_acquire(rel, &reader) != 0
+        || wl_columnar_eval_test_tdd_restore(&stratum, &coord, saved)
+        != EBUSY
+        || rel->nrows != 0
+        || col_rel_source_reader_release(&reader) != 0
+        || wl_columnar_eval_test_tdd_restore(&stratum, &coord, saved) != 0) {
+        wl_columnar_eval_test_tdd_free_saved(&stratum, saved);
+        session_remove_rel(&coord, "r");
+        free(coord.rels);
+        FAIL("restore reader denial or retry");
+        return 1;
+    }
+    rel = session_find_rel(&coord, "r");
+    if (!rel || rel->nrows != 0 || !rel->timestamps
+        || rel->dedup_cap != 4 || rel->dedup_count != 1
+        || rel->dedup_slots[2] != 0xbeef
+        || rel->compound_kind != WIRELOG_COMPOUND_KIND_INLINE) {
+        wl_columnar_eval_test_tdd_free_saved(&stratum, saved);
+        session_remove_rel(&coord, "r");
+        free(coord.rels);
+        FAIL("restore did not preserve relation metadata");
+        return 1;
+    }
+    wl_columnar_eval_test_tdd_free_saved(&stratum, saved);
+    session_remove_rel(&coord, "r");
+    session_rel_free_hash(&coord);
+    free(coord.rels);
+
+    /* Admission covers the complete relation set before publication.  A
+     * reader on the second relation must not leave the first relation
+     * restored while the second remains untouched. */
+    {
+        wl_col_session_t multi = { 0 };
+        wl_plan_relation_t multi_plan[2] = { { 0 }, { 0 } };
+        wl_plan_stratum_t multi_stratum = { 0 };
+        col_rel_t *a = make_seed_relation("a", rows, 2, 2);
+        const int64_t rows_b[] = { 11, 12, 13, 14 };
+        col_rel_t *b = make_seed_relation("b", rows_b, 2, 2);
+        col_rel_t **multi_saved = NULL;
+        wl_columnar_source_access_reader_t b_reader = { 0 };
+
+        if (!a || !b || session_add_rel(&multi, a) != 0
+            || session_add_rel(&multi, b) != 0) {
+            col_rel_destroy(a);
+            col_rel_destroy(b);
+            session_rel_free_hash(&multi);
+            free(multi.rels);
+            FAIL("multi-relation restore setup");
+            return 1;
+        }
+        multi_plan[0].name = "a";
+        multi_plan[1].name = "b";
+        multi_stratum.relations = multi_plan;
+        multi_stratum.relation_count = 2;
+        if (wl_columnar_eval_test_tdd_save(&multi_stratum, &multi,
+            &multi_saved) != 0) {
+            session_remove_rel(&multi, "a");
+            session_remove_rel(&multi, "b");
+            session_rel_free_hash(&multi);
+            free(multi.rels);
+            FAIL("multi-relation snapshot setup");
+            return 1;
+        }
+        session_find_rel(&multi, "a")->nrows = 0;
+        session_find_rel(&multi, "b")->nrows = 0;
+        if (col_rel_source_reader_acquire(session_find_rel(&multi, "b"),
+            &b_reader) != 0
+            || wl_columnar_eval_test_tdd_restore(&multi_stratum, &multi,
+            multi_saved) != EBUSY
+            || session_find_rel(&multi, "a")->nrows != 0
+            || session_find_rel(&multi, "b")->nrows != 0
+            || col_rel_source_reader_release(&b_reader) != 0
+            || wl_columnar_eval_test_tdd_restore(&multi_stratum, &multi,
+            multi_saved) != 0
+            || session_find_rel(&multi, "a")->nrows != 2
+            || session_find_rel(&multi, "b")->nrows != 2) {
+            col_rel_source_reader_release(&b_reader);
+            wl_columnar_eval_test_tdd_free_saved(&multi_stratum, multi_saved);
+            session_remove_rel(&multi, "a");
+            session_remove_rel(&multi, "b");
+            session_rel_free_hash(&multi);
+            free(multi.rels);
+            FAIL("multi-relation reader admission or retry");
+            return 1;
+        }
+        wl_columnar_eval_test_tdd_free_saved(&multi_stratum, multi_saved);
+        session_remove_rel(&multi, "a");
+        session_remove_rel(&multi, "b");
+        session_rel_free_hash(&multi);
+        free(multi.rels);
+    }
+
+    /* A malformed candidate for an absent relation must fail before any
+     * candidate is registered, leaving the session registry unchanged. */
+    {
+        wl_col_session_t fresh = { 0 };
+        wl_plan_relation_t fresh_plan[2] = { { 0 }, { 0 } };
+        wl_plan_stratum_t fresh_stratum = { 0 };
+        col_rel_t *bad = col_rel_new_auto("missing", 2);
+        col_rel_t *bad_saved[2] = { bad, NULL };
+
+        fresh_plan[0].name = "missing";
+        fresh_plan[1].name = "also_missing";
+        fresh_stratum.relations = fresh_plan;
+        fresh_stratum.relation_count = 2;
+        bad->compound_kind = WIRELOG_COMPOUND_KIND_INLINE;
+        bad->compound_count = 1;
+        bad->compound_arity_map = (uint32_t *)calloc(2,
+                sizeof(*bad->compound_arity_map));
+        if (!bad->compound_arity_map) {
+            col_rel_destroy(bad);
+            FAIL("new-relation cleanup setup");
+            return 1;
+        }
+        bad->compound_arity_map[0] = 0;
+        bad->compound_arity_map[1] = 1;
+        if (wl_columnar_eval_test_tdd_restore(&fresh_stratum, &fresh,
+            bad_saved) != EINVAL || fresh.nrels != 0
+            || session_find_rel(&fresh, "missing")
+            || session_find_rel(&fresh, "also_missing")) {
+            col_rel_destroy(bad);
+            session_rel_free_hash(&fresh);
+            free(fresh.rels);
+            FAIL("failed restore left a new relation registered");
+            return 1;
+        }
+        col_rel_destroy(bad);
+        session_rel_free_hash(&fresh);
+        free(fresh.rels);
+    }
+    PASS();
+    return 0;
+}
+#endif
+
 #ifdef WL_TEST_TDD_MERGE
 static int
 test_tdd_merge_transactional_publication(void)
@@ -1724,6 +2069,9 @@ main(void)
     test_bdx_seed_sort_failure_is_atomic();
     test_bdx_seed_allocation_failure_is_atomic();
     test_bdx_seed_success_preserves_timestamps();
+#ifdef WL_TEST_TDD_RESET_RESTORE
+    test_tdd_reset_restore_transaction();
+#endif
 #ifdef WL_TEST_TDD_MERGE
     test_tdd_merge_transactional_publication();
     test_tdd_merge_schema_mismatch_rollback();

--- a/wirelog/columnar/eval.c
+++ b/wirelog/columnar/eval.c
@@ -2019,8 +2019,10 @@ tdd_seed_bdx_coordinator_idb(col_rel_t *cidb, col_rel_t *const *worker_idbs,
 
     memset(&replacement, 0, sizeof(replacement));
     rc = col_rel_prepare_replacement(cidb, candidate, &replacement);
-    if (rc == 0)
-        rc = col_rel_commit_replacement_locked(cidb, &replacement);
+    if (rc == 0) {
+        col_rel_commit_replacement_locked(cidb, &replacement);
+        rc = 0;
+    }
     if (rc != 0)
         col_rel_discard_replacement(&replacement);
 
@@ -2260,8 +2262,10 @@ tdd_merge_relation_results(col_rel_t **target_io, const char *rel_name,
 
     memset(&replacement, 0, sizeof(replacement));
     rc = col_rel_prepare_replacement(target, candidate, &replacement);
-    if (rc == 0)
-        rc = col_rel_commit_replacement_locked(target, &replacement);
+    if (rc == 0) {
+        col_rel_commit_replacement_locked(target, &replacement);
+        rc = 0;
+    }
     if (rc != 0)
         col_rel_discard_replacement(&replacement);
 
@@ -3764,6 +3768,111 @@ tdd_clear_relation_dedup_set(col_rel_t *r)
     r->dedup_count = 0;
 }
 
+/* Snapshot a published relation without carrying over its session-owned
+ * accounting or source-storage leases.  col_rel_deep_copy deliberately
+ * treats the dedup table as a rebuildable cache; coordinator fallback needs a
+ * lossless snapshot instead, so copy it explicitly and reject any metadata
+ * degradation from the deep-copy helper. */
+static int
+tdd_snapshot_relation(const col_rel_t *source, col_rel_t **out)
+{
+    col_rel_t *snapshot = NULL;
+    uint32_t compound_entries = 0;
+    int rc;
+
+    if (!source || !out)
+        return EINVAL;
+    *out = NULL;
+    rc = col_rel_deep_copy(source, &snapshot, NULL);
+    if (rc != 0)
+        return rc;
+    if (snapshot->compound_kind != source->compound_kind
+        || snapshot->compound_count != source->compound_count
+        || snapshot->inline_physical_offset
+        != source->inline_physical_offset
+        || snapshot->declared_ncols != source->declared_ncols
+        || snapshot->has_graph_column != source->has_graph_column
+        || snapshot->graph_col_idx != source->graph_col_idx) {
+        col_rel_destroy(snapshot);
+        return EINVAL;
+    }
+    if (source->compound_arity_map) {
+        if (!tdd_compound_map_entries(source, &compound_entries)
+            || !snapshot->compound_arity_map
+            || memcmp(snapshot->compound_arity_map,
+            source->compound_arity_map,
+            (size_t)compound_entries * sizeof(uint32_t)) != 0) {
+            col_rel_destroy(snapshot);
+            return EINVAL;
+        }
+    }
+    if (source->dedup_cap > 0) {
+        if (!source->dedup_slots)
+            goto invalid;
+        snapshot->dedup_slots = (uint64_t *)malloc(
+            (size_t)source->dedup_cap * sizeof(*snapshot->dedup_slots));
+        if (!snapshot->dedup_slots) {
+            col_rel_destroy(snapshot);
+            return ENOMEM;
+        }
+        memcpy(snapshot->dedup_slots, source->dedup_slots,
+            (size_t)source->dedup_cap * sizeof(*snapshot->dedup_slots));
+        snapshot->dedup_cap = source->dedup_cap;
+        snapshot->dedup_count = source->dedup_count;
+    }
+    *out = snapshot;
+    return 0;
+
+invalid:
+    col_rel_destroy(snapshot);
+    return EINVAL;
+}
+
+static int
+tdd_empty_relation_candidate(const col_rel_t *source, col_rel_t **out)
+{
+    int rc = tdd_snapshot_relation(source, out);
+    col_rel_t *candidate;
+
+    if (rc != 0)
+        return rc;
+    candidate = *out;
+    candidate->nrows = 0;
+    candidate->sorted_nrows = 0;
+    candidate->base_nrows = 0;
+    candidate->run_count = 0;
+    memset(candidate->run_ends, 0, sizeof(candidate->run_ends));
+    free(candidate->timestamps);
+    candidate->timestamps = NULL;
+    candidate->ledger_ts_bytes = 0;
+    tdd_clear_relation_dedup_set(candidate);
+    return 0;
+}
+
+static int
+tdd_reset_coord_relation(col_rel_t *relation)
+{
+    col_rel_t *candidate = NULL;
+    col_rel_replacement_t replacement;
+    int rc;
+
+    if (!relation)
+        return EINVAL;
+    rc = tdd_empty_relation_candidate(relation, &candidate);
+    if (rc != 0)
+        return rc;
+    memset(&replacement, 0, sizeof(replacement));
+    rc = col_rel_prepare_replacement(relation, candidate, &replacement);
+    if (rc == 0) {
+        col_rel_commit_replacement_locked(relation, &replacement);
+        rc = 0;
+    }
+    if (rc != 0)
+        col_rel_discard_replacement(&replacement);
+    col_rel_destroy(candidate);
+    return rc;
+}
+
 static int
 tdd_save_coord_idb(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
     col_rel_t ***out_saved)
@@ -3777,16 +3886,15 @@ tdd_save_coord_idb(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
         return EOVERFLOW;
     col_rel_t **saved = (col_rel_t **)calloc(
         sp->relation_count, sizeof(col_rel_t *));
+    int rc = 0;
     if (!saved)
         return ENOMEM;
     for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
         col_rel_t *r = session_find_rel(coord, sp->relations[ri].name);
         if (!r || r->ncols == 0)
             continue;
-        saved[ri] = col_rel_new_auto(r->name, r->ncols);
-        if (!saved[ri])
-            goto fail;
-        if (r->nrows > 0 && col_rel_append_all(saved[ri], r, NULL) != 0)
+        rc = tdd_snapshot_relation(r, &saved[ri]);
+        if (rc != 0)
             goto fail;
     }
     *out_saved = saved;
@@ -3796,50 +3904,198 @@ fail:
     for (uint32_t ri = 0; ri < sp->relation_count; ri++)
         col_rel_destroy(saved[ri]);
     free((void *)saved);
-    return ENOMEM;
+    return rc;
+}
+
+typedef struct {
+    const char *name;
+    col_rel_t *relation;
+    col_rel_t *owner;
+    col_rel_t *saved;
+    col_rel_t *candidate;
+    col_rel_replacement_t replacement;
+    bool replacement_prepared;
+    bool registered;
+} tdd_restore_entry_t;
+
+static int
+tdd_restore_entry_compare(const void *left, const void *right)
+{
+    const tdd_restore_entry_t *a = (const tdd_restore_entry_t *)left;
+    const tdd_restore_entry_t *b = (const tdd_restore_entry_t *)right;
+
+    if (!a->owner && !b->owner)
+        return strcmp(a->name, b->name);
+    if (!a->owner)
+        return 1;
+    if (!b->owner)
+        return -1;
+    if (a->owner->relation_identity < b->owner->relation_identity)
+        return -1;
+    if (a->owner->relation_identity > b->owner->relation_identity)
+        return 1;
+    return strcmp(a->name, b->name);
+}
+
+static void
+tdd_restore_entries_discard(wl_col_session_t *coord,
+    tdd_restore_entry_t *entries, uint32_t count, uint32_t initial_nrels)
+{
+    if (!entries)
+        return;
+    for (uint32_t i = count; i-- > 0; ) {
+        if (entries[i].registered) {
+            for (uint32_t ri = 0; ri < coord->nrels; ri++) {
+                if (coord->rels[ri]
+                    && strcmp(coord->rels[ri]->name, entries[i].name) == 0) {
+                    col_rel_destroy(coord->rels[ri]);
+                    coord->rels[ri] = NULL;
+                    break;
+                }
+            }
+            entries[i].registered = false;
+            entries[i].candidate = NULL;
+        }
+    }
+    coord->nrels = initial_nrels;
+    (void)session_rel_build_hash(coord);
+    for (uint32_t i = 0; i < count; i++) {
+        if (entries[i].replacement_prepared
+            || entries[i].replacement.writer_acquired)
+            col_rel_discard_replacement(&entries[i].replacement);
+        if (entries[i].candidate)
+            col_rel_destroy(entries[i].candidate);
+    }
+    free(entries);
 }
 
 static int
 tdd_restore_coord_idb(const wl_plan_stratum_t *sp, wl_col_session_t *coord,
     col_rel_t **saved)
 {
+    tdd_restore_entry_t *entries = NULL;
+    size_t entry_bytes;
+    uint32_t count;
+    uint32_t initial_nrels;
+    int rc = 0;
+
     if (!saved)
         return 0;
-    for (uint32_t ri = 0; ri < sp->relation_count; ri++) {
-        const char *name = sp->relations[ri].name;
-        col_rel_t *r = session_find_rel(coord, name);
-        if (!r) {
-            int alloc_rc = col_rel_alloc(&r, name);
-            if (alloc_rc != 0)
-                return alloc_rc;
-            alloc_rc = session_add_rel(coord, r);
-            if (alloc_rc != 0) {
-                col_rel_destroy(r);
-                return alloc_rc;
-            }
-        }
-        r->nrows = 0;
-        r->sorted_nrows = 0;
-        r->run_count = 0;
-        memset(r->run_ends, 0, sizeof(r->run_ends));
-        free(r->timestamps);
-        r->timestamps = NULL;
-        wl_columnar_relation_touch_replacement(r);
-        tdd_clear_relation_dedup_set(r);
-        if (saved[ri] && saved[ri]->ncols > 0) {
-            if (r->ncols == 0) {
-                int rc = col_rel_set_schema(r, saved[ri]->ncols,
-                        (const char *const *)saved[ri]->col_names);
-                if (rc != 0)
-                    return rc;
-            }
-            int rc = col_rel_append_all(r, saved[ri], NULL);
+    initial_nrels = coord->nrels;
+    count = sp->relation_count;
+    if (wl_columnar_eval_checked_size_mul(count, sizeof(*entries),
+        &entry_bytes) != 0)
+        return EOVERFLOW;
+    entries = (tdd_restore_entry_t *)calloc(1, entry_bytes);
+    if (!entries && count > 0)
+        return ENOMEM;
+
+    /* Build every private candidate before touching a published relation or
+     * the session registry.  This includes candidates for relations that are
+     * absent from the registry; registration is delayed until all existing
+     * owners have passed admission. */
+    for (uint32_t ri = 0; ri < count; ri++) {
+        tdd_restore_entry_t *entry = &entries[ri];
+        entry->name = sp->relations[ri].name;
+        entry->relation = session_find_rel(coord, entry->name);
+        entry->saved = saved[ri];
+        if (entry->relation) {
+            rc = col_rel_storage_owner_resolve(entry->relation,
+                    &entry->owner);
             if (rc != 0)
-                return rc;
+                goto fail;
+            if (entry->owner != entry->relation
+                || entry->owner->storage_alias_borrows > 0) {
+                rc = EBUSY;
+                goto fail;
+            }
         }
-        col_session_invalidate_arrangements(&coord->base, name);
+        if (entry->saved)
+            rc = tdd_snapshot_relation(entry->saved, &entry->candidate);
+        else if (entry->relation)
+            rc = tdd_empty_relation_candidate(entry->relation,
+                    &entry->candidate);
+        else
+            rc = col_rel_alloc(&entry->candidate, entry->name);
+        if (rc != 0)
+            goto fail;
     }
+
+    /* Acquire every canonical writer in a deterministic order.  Rejecting a
+     * later reader/alias therefore happens before any relation is changed. */
+    qsort(entries, count, sizeof(*entries), tdd_restore_entry_compare);
+    for (uint32_t i = 0; i < count; i++) {
+        tdd_restore_entry_t *entry = &entries[i];
+        if (!entry->relation)
+            continue;
+        if (i > 0 && entries[i - 1].owner == entry->owner) {
+            rc = EBUSY;
+            goto fail;
+        }
+        memset(&entry->replacement, 0, sizeof(entry->replacement));
+        wl_columnar_memory_reservation_init(
+            &entry->replacement.reservation);
+        rc = wl_columnar_source_access_writer_acquire(
+            &entry->owner->source_access, &entry->replacement.writer);
+        if (rc != 0)
+            goto fail;
+        entry->replacement.writer_acquired = true;
+    }
+
+    /* Prepare all replacements while all writers remain held.  Preparation
+     * may allocate or fail, but publication has not begun and cleanup can
+     * release every admission without changing a destination. */
+    for (uint32_t i = 0; i < count; i++) {
+        tdd_restore_entry_t *entry = &entries[i];
+        if (!entry->relation)
+            continue;
+        rc = col_rel_prepare_replacement_locked(entry->relation,
+                entry->candidate, &entry->replacement);
+        if (rc != 0)
+            goto fail;
+        entry->replacement_prepared = true;
+        col_rel_destroy(entry->candidate);
+        entry->candidate = NULL;
+    }
+
+    /* Register new relations only after all fallible replacement preparation
+     * has completed.  If registration fails, remove only the registrations
+     * made by this transaction; no existing relation has been published. */
+    for (uint32_t i = 0; i < count; i++) {
+        tdd_restore_entry_t *entry = &entries[i];
+        if (entry->relation)
+            continue;
+        rc = session_add_rel(coord, entry->candidate);
+        if (rc != 0) {
+            if (session_find_rel(coord, entry->name) == entry->candidate)
+                (void)session_remove_rel(coord, entry->name);
+            else
+                col_rel_destroy(entry->candidate);
+            entry->candidate = NULL;
+            goto fail;
+        }
+        entry->registered = true;
+        entry->candidate = NULL;
+    }
+
+    /* Commit is deliberately last.  The replacement primitive guarantees
+     * that this phase performs no allocation, schema construction, or
+     * admission; every possible failure was handled above. */
+    for (uint32_t i = 0; i < count; i++) {
+        tdd_restore_entry_t *entry = &entries[i];
+        if (!entry->relation)
+            continue;
+        col_rel_commit_replacement_locked(entry->relation,
+            &entry->replacement);
+        entry->replacement_prepared = false;
+        col_session_invalidate_arrangements(&coord->base, entry->name);
+    }
+    free(entries);
     return 0;
+
+fail:
+    tdd_restore_entries_discard(coord, entries, count, initial_nrels);
+    return rc;
 }
 
 static void
@@ -3851,6 +4107,35 @@ tdd_free_saved_coord_idb(const wl_plan_stratum_t *sp, col_rel_t **saved)
         col_rel_destroy(saved[ri]);
     free((void *)saved);
 }
+
+#ifdef WL_TEST_TDD_RESET_RESTORE
+int
+wl_columnar_eval_test_tdd_reset(col_rel_t *relation)
+{
+    return tdd_reset_coord_relation(relation);
+}
+
+int
+wl_columnar_eval_test_tdd_save(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord, col_rel_t ***out_saved)
+{
+    return tdd_save_coord_idb(sp, coord, out_saved);
+}
+
+int
+wl_columnar_eval_test_tdd_restore(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord, col_rel_t **saved)
+{
+    return tdd_restore_coord_idb(sp, coord, saved);
+}
+
+void
+wl_columnar_eval_test_tdd_free_saved(const wl_plan_stratum_t *sp,
+    col_rel_t **saved)
+{
+    tdd_free_saved_coord_idb(sp, saved);
+}
+#endif
 
 /*
  * tdd_bdx_exchange_deltas:
@@ -4556,8 +4841,11 @@ col_eval_stratum_tdd_recursive(const wl_plan_stratum_t *sp,
         for (uint32_t ri = 0; ri < nrels; ri++) {
             col_rel_t *r = session_find_rel(coord, sp->relations[ri].name);
             if (r && r->nrows > 0) {
-                r->nrows = 0;
-                wl_columnar_relation_touch_view(r);
+                rc = tdd_reset_coord_relation(r);
+                if (rc != 0) {
+                    coord->tdd_total_ns += now_ns() - tdd_total_t0;
+                    return rc;
+                }
                 col_session_invalidate_arrangements(&coord->base,
                     sp->relations[ri].name);
             }

--- a/wirelog/columnar/internal.h
+++ b/wirelog/columnar/internal.h
@@ -1925,9 +1925,18 @@ col_rel_destroy_checked(col_rel_t *r);
 int
 col_rel_prepare_replacement(col_rel_t *dst, const col_rel_t *candidate,
     col_rel_replacement_t *replacement);
-/* Publish a prepared replacement while its canonical writer is held.  This
-* path performs no allocation, schema construction, or memory admission. */
+/* Prepare a replacement after the caller has already admitted the
+ * destination's canonical writer into replacement->writer.  This is used by
+ * multi-relation transactions so all writers can be acquired before any
+ * candidate is prepared or published. */
 int
+col_rel_prepare_replacement_locked(col_rel_t *dst,
+    const col_rel_t *candidate, col_rel_replacement_t *replacement);
+/* Publish a prepared replacement while its canonical writer is held.  The
+ * preparation contract makes this path no-fail: it performs no allocation,
+ * schema construction, or memory admission, and writer release is diagnostic
+ * only because publication has already completed. */
+void
 col_rel_commit_replacement_locked(col_rel_t *dst,
     col_rel_replacement_t *replacement);
 /* Release a prepared replacement and its writer; safe after any prepare error
@@ -2205,6 +2214,19 @@ void
 wl_columnar_eval_test_tdd_merge_fail_sort_once(void);
 void
 wl_columnar_eval_test_tdd_merge_fail_overflow_once(void);
+#endif
+#ifdef WL_TEST_TDD_RESET_RESTORE
+int
+wl_columnar_eval_test_tdd_reset(col_rel_t *relation);
+int
+wl_columnar_eval_test_tdd_save(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord, col_rel_t ***out_saved);
+int
+wl_columnar_eval_test_tdd_restore(const wl_plan_stratum_t *sp,
+    wl_col_session_t *coord, col_rel_t **saved);
+void
+wl_columnar_eval_test_tdd_free_saved(const wl_plan_stratum_t *sp,
+    col_rel_t **saved);
 #endif
 col_rel_t *
 col_rel_pool_new_like(delta_pool_t *pool, const char *name,

--- a/wirelog/columnar/relation.c
+++ b/wirelog/columnar/relation.c
@@ -14,6 +14,7 @@
 
 #include "../wirelog-internal.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -2961,6 +2962,7 @@ col_rel_deep_copy(const col_rel_t *src, col_rel_t **out, wl_arena_t *arena)
     dst->storage_generation = src->storage_generation;
     col_rel_storage_owner_init(dst);
     dst->ncols = src->ncols;
+    dst->declared_ncols = src->declared_ncols;
     dst->nrows = src->nrows;
     dst->capacity = src->capacity;
     dst->sorted_nrows = src->sorted_nrows;
@@ -3268,9 +3270,9 @@ col_rel_replacement_old_reservation_valid(const col_rel_t *dst)
     return state == WL_COLUMNAR_MEMORY_RESERVATION_COMMITTED;
 }
 
-int
-col_rel_prepare_replacement(col_rel_t *dst, const col_rel_t *candidate,
-    col_rel_replacement_t *replacement)
+static int
+col_rel_prepare_replacement_impl(col_rel_t *dst, const col_rel_t *candidate,
+    col_rel_replacement_t *replacement, bool writer_held)
 {
     uint64_t planned_bytes;
     uint64_t staged_bytes;
@@ -3279,8 +3281,6 @@ col_rel_prepare_replacement(col_rel_t *dst, const col_rel_t *candidate,
 
     if (!dst || !candidate || !replacement || dst == candidate)
         return EINVAL;
-    memset(replacement, 0, sizeof(*replacement));
-    wl_columnar_memory_reservation_init(&replacement->reservation);
 
     rc = col_rel_replacement_validate_candidate(candidate);
     if (rc != 0)
@@ -3294,10 +3294,22 @@ col_rel_prepare_replacement(col_rel_t *dst, const col_rel_t *candidate,
         candidate->timestamps != NULL, &planned_bytes))
         return EOVERFLOW;
 
-    rc = col_rel_published_writer_acquire(dst, &replacement->writer);
-    if (rc != 0)
-        return rc;
-    replacement->writer_acquired = true;
+    if (writer_held) {
+        col_rel_t *owner = NULL;
+        if (!replacement->writer_acquired
+            || col_rel_storage_owner_resolve(dst, &owner) != 0
+            || replacement->writer.owner != &owner->source_access
+            || !wl_columnar_source_access_writer_thread_equal(
+                &replacement->writer)) {
+            rc = EINVAL;
+            goto fail;
+        }
+    } else {
+        rc = col_rel_published_writer_acquire(dst, &replacement->writer);
+        if (rc != 0)
+            return rc;
+        replacement->writer_acquired = true;
+    }
 
     /* Reserve the complete private shape before deep_copy allocates it.  The
      * candidate may borrow arena/shared storage, but publication always owns
@@ -3321,7 +3333,6 @@ col_rel_prepare_replacement(col_rel_t *dst, const col_rel_t *candidate,
     rc = col_rel_deep_copy(candidate, &replacement->staged, NULL);
     if (rc != 0)
         goto fail;
-    replacement->staged->declared_ncols = candidate->declared_ncols;
     /* col_rel_deep_copy historically degrades malformed compound metadata to
      * NONE.  A publication primitive must reject that loss instead of
      * silently publishing a different schema. */
@@ -3338,6 +3349,20 @@ col_rel_prepare_replacement(col_rel_t *dst, const col_rel_t *candidate,
             candidate->compound_arity_map,
             (size_t)compound_entries * sizeof(uint32_t)) != 0)
             goto invalid;
+    }
+    if (candidate->dedup_cap > 0) {
+        if (!candidate->dedup_slots)
+            goto invalid;
+        replacement->staged->dedup_slots = (uint64_t *)malloc(
+            (size_t)candidate->dedup_cap
+            * sizeof(*replacement->staged->dedup_slots));
+        if (!replacement->staged->dedup_slots)
+            goto allocation_failure;
+        memcpy(replacement->staged->dedup_slots, candidate->dedup_slots,
+            (size_t)candidate->dedup_cap
+            * sizeof(*replacement->staged->dedup_slots));
+        replacement->staged->dedup_cap = candidate->dedup_cap;
+        replacement->staged->dedup_count = candidate->dedup_count;
     }
 
     staged_bytes = col_rel_transport_bytes(replacement->staged);
@@ -3359,6 +3384,32 @@ fail:
 }
 
 int
+col_rel_prepare_replacement(col_rel_t *dst, const col_rel_t *candidate,
+    col_rel_replacement_t *replacement)
+{
+    if (!dst || !candidate || !replacement)
+        return EINVAL;
+    memset(replacement, 0, sizeof(*replacement));
+    wl_columnar_memory_reservation_init(&replacement->reservation);
+    return col_rel_prepare_replacement_impl(dst, candidate, replacement,
+               false);
+}
+
+int
+col_rel_prepare_replacement_locked(col_rel_t *dst,
+    const col_rel_t *candidate, col_rel_replacement_t *replacement)
+{
+    int rc;
+
+    if (!dst || !candidate || !replacement)
+        return EINVAL;
+    rc = col_rel_prepare_replacement_impl(dst, candidate, replacement, true);
+    if (rc != 0 && replacement->writer_acquired)
+        col_rel_discard_replacement(replacement);
+    return rc;
+}
+
+void
 col_rel_commit_replacement_locked(col_rel_t *dst,
     col_rel_replacement_t *replacement)
 {
@@ -3378,25 +3429,27 @@ col_rel_commit_replacement_locked(col_rel_t *dst,
     bool has_new_reservation;
     int release_rc;
 
-    if (!dst || !replacement || !replacement->staged
-        || !replacement->writer_acquired
-        || replacement->writer.owner != &dst->source_access
-        || !wl_columnar_source_access_writer_thread_equal(
-            &replacement->writer))
-        return EINVAL;
+    /* Preparation establishes all fallible invariants.  Publication is a
+     * no-fail operation: callers must not attempt to roll it back after the
+     * destination has been replaced. */
+    assert(dst && replacement && replacement->staged
+        && replacement->writer_acquired
+        && replacement->writer.owner == &dst->source_access
+        && wl_columnar_source_access_writer_thread_equal(
+            &replacement->writer));
     staged = replacement->staged;
-    if (staged->nrows > staged->capacity
-        || dst->view_generation >= WL_COLUMNAR_REL_GENERATION_INVALID - 1u
-        || dst->storage_generation
-        >= WL_COLUMNAR_REL_GENERATION_INVALID - 1u)
-        return EINVAL;
+    assert(staged->nrows <= staged->capacity
+        && dst->view_generation < WL_COLUMNAR_REL_GENERATION_INVALID - 1u
+        && dst->storage_generation < WL_COLUMNAR_REL_GENERATION_INVALID - 1u);
 
     has_new_reservation = replacement->reservation_active;
     wl_columnar_memory_reservation_init(&new_reservation);
     if (has_new_reservation
         && !wl_columnar_memory_reservation_move(&new_reservation,
-        &replacement->reservation))
-        return EINVAL;
+        &replacement->reservation)) {
+        assert(false && "prepared replacement reservation must be movable");
+        abort();
+    }
 
     old = *dst;
     name = old.name;
@@ -3457,8 +3510,12 @@ col_rel_commit_replacement_locked(col_rel_t *dst,
 
     release_rc = wl_columnar_source_access_writer_release(
         &replacement->writer);
+    /* The token is valid for the whole publication.  A release error can
+     * only indicate an internal contract violation after state was already
+     * published; it is therefore diagnostic, never a commit failure. */
+    assert(release_rc == 0);
+    (void)release_rc;
     replacement->writer_acquired = false;
-    return release_rc == 0 ? 0 : EINVAL;
 }
 
 void


### PR DESCRIPTION
## Summary
- make coordinator IDB snapshots lossless, including schema, declared width, compound metadata, timestamps, and dedup state
- pre-admit all canonical writers and stage all reset/restore candidates before publication
- preserve existing relations and session registry on reader, allocation, schema, overflow, or restore failures
- make incremental coordinator reset use the same writer-admitted transaction contract

## Validation
- `tdd_recursive`
- `tdd_nonrecursive`
- `relation_generations`
- ASan/UBSan `tdd_recursive`
- OOM/reset-focused tests
- uncrustify and `git diff --check`

Depends on #1565. Owner/global-read exchange, worker truncation, retraction, and finalization remain separate units.
