### PR TITLE
Avoid copying cold worker arrangement indexes

### DIFF
--- a/tests/test_generation_cache.c
+++ b/tests/test_generation_cache.c
@@ -197,6 +197,10 @@ test_generation_consumers(void)
     uint32_t arr_clone_cap = 0;
     col_diff_arr_entry_t *diff_clone = NULL;
     uint32_t diff_clone_cap = 0;
+    col_rel_t *worker_rel = NULL;
+    wl_mem_ledger_t worker_ledger;
+    wl_mem_ledger_init(&worker_ledger, 0);
+    wl_columnar_arrangement_diff_txn_t worker_txn = { 0 };
     int result = 0;
     CHECK(make_session(&session, &plan, &program) == 0,
         "session creation failed");
@@ -291,15 +295,58 @@ test_generation_consumers(void)
         &arr_clone, &arr_clone_cap, NULL) == 0 && arr_clone_cap > 0,
         "primary arrangement worker clone failed");
     CHECK(arr_clone[0].source_snapshot.relation_identity == 0
-        && arr_clone[0].arr.indexed_rows == 0,
+        && arr_clone[0].arr.indexed_rows == 0
+        && arr_clone[0].arr.ht_head == NULL
+        && arr_clone[0].arr.ht_next == NULL
+        && arr_clone[0].mem_bytes == 0
+        && arr_clone[0].arr.reserved_bytes == 0,
         "worker clone reused coordinator primary snapshot");
 
     CHECK(col_diff_arr_entries_clone(cs->diff_arr_entries, cs->diff_arr_count,
         &diff_clone, &diff_clone_cap) == 0 && diff_clone_cap > 0,
         "differential arrangement worker clone failed");
     CHECK(diff_clone[0].diff_arr->source_snapshot.relation_identity == 0
-        && diff_clone[0].diff_arr->indexed_rows == 0,
+        && diff_clone[0].diff_arr->indexed_rows == 0
+        && diff_clone[0].diff_arr->ht_head == NULL
+        && diff_clone[0].diff_arr->ht_next == NULL
+        && diff_clone[0].diff_arr->ht_cap == 0
+        && diff_clone[0].diff_arr->nbuckets == 0
+        && diff_clone[0].diff_arr->ledger == NULL,
         "worker clone reused coordinator differential snapshot");
+    CHECK(col_rel_deep_copy(rel, &worker_rel, NULL) == 0,
+        "worker relation copy failed");
+    CHECK(col_rel_set(worker_rel, 0, key_col, 123456) == 0,
+        "worker relation mutation failed");
+    wl_col_session_t worker = { 0 };
+    worker.diff_arr_entries = diff_clone;
+    worker.diff_arr_count = cs->diff_arr_count;
+    worker.diff_arr_cap = diff_clone_cap;
+    col_diff_arrangement_attach_ledger(diff_clone[0].diff_arr, &worker_ledger);
+    CHECK(atomic_load_explicit(&worker_ledger.current_bytes,
+        memory_order_relaxed)
+        == sizeof(col_diff_arrangement_t) + sizeof(uint32_t),
+        "cold differential clone charged copied hash storage");
+    col_diff_arrangement_t *worker_diff = col_session_get_diff_arrangement(
+        &worker, "edge", worker_rel, &key_col, 1);
+    CHECK(worker_diff && wl_columnar_arrangement_diff_txn_begin(&worker,
+        "edge", worker_rel, &key_col, 1, &worker_txn) == 0,
+        "cold differential transaction failed");
+    worker_diff = worker_txn.working;
+    CHECK(index_diff_arrangement(worker_diff, worker_rel,
+        &key_col, 1) == 0, "cold differential first access failed");
+    worker_diff->source_snapshot = wl_columnar_relation_snapshot(worker_rel);
+    wl_columnar_arrangement_diff_txn_commit(&worker_txn);
+    CHECK(worker_diff->ledger == &worker_ledger
+        && atomic_load_explicit(&worker_ledger.current_bytes,
+        memory_order_relaxed)
+        == col_diff_arrangement_bytes(worker_diff),
+        "private differential rebuild ledger mismatch");
+    CHECK(worker_diff->ht_head != diff->ht_head
+        && worker_diff->ht_next != diff->ht_next
+        && diff_contains_key(worker_diff, worker_rel, key_col, 123456)
+        && !diff_contains_key(diff, rel, key_col, 123456)
+        && diff->indexed_rows == rel->nrows,
+        "differential worker rebuild changed coordinator");
     arr_clone[0].arr.indexed_rows = 7;
     diff_clone[0].diff_arr->indexed_rows = 7;
     CHECK(cs->arr_entries[0].arr.indexed_rows != 7
@@ -309,8 +356,18 @@ test_generation_consumers(void)
     result = 1;
 
 cleanup:
+    wl_columnar_arrangement_diff_txn_abort(&worker_txn);
+    if (worker_rel)
+        col_rel_destroy(worker_rel);
     free_arrangement_clones(arr_clone, arr_clone_cap);
     free_diff_clones(diff_clone, diff_clone_cap);
+    if (atomic_load_explicit(&worker_ledger.current_bytes,
+        memory_order_relaxed) != 0) {
+        fprintf(stderr,
+            "FAIL: differential clone cleanup leaked ledger bytes\n");
+        failures++;
+        result = 0;
+    }
     free(filter.data);
     if (session)
         destroy_session(session, plan, program);

--- a/tests/test_worker_session.c
+++ b/tests/test_worker_session.c
@@ -562,7 +562,7 @@ test_mat_cache_empty(void)
 static int
 test_arrangement_clone_ownership(void)
 {
-    TEST("worker arrangement clone owns arrays and preserves metadata");
+    TEST("worker arrangement clone starts cold and rebuilds privately");
 
     wl_plan_t *plan = NULL;
     wirelog_program_t *prog = NULL;
@@ -624,23 +624,53 @@ test_arrangement_clone_ownership(void)
         && dst->arr.key_cols == dst->key_cols
         && dst->arr.key_cols != src->arr.key_cols
         && dst->arr.key_count == src->arr.key_count
-        /* Issue #1438: a clone is a cold entry -- the buckets are copied
-        * but the freshness token and indexed_rows are reset so the first
-        * lookup rebuilds against the worker's own partition relation. */
+        /* Cold clones own key metadata, but no coordinator index storage. */
         && dst->arr.indexed_rows == 0
         && dst->source_snapshot.relation_identity == 0
-        && dst->arr.content_hash == src->arr.content_hash
-        && dst->arr.nbuckets == src->arr.nbuckets
-        && dst->arr.ht_cap == src->arr.ht_cap
-        && dst->arr.generation == src->arr.generation
-        && dst->arr.ht_head != src->arr.ht_head
-        && dst->arr.ht_next != src->arr.ht_next
-        && memcmp(dst->arr.ht_head, src->arr.ht_head, head_bytes) == 0
-        && memcmp(dst->arr.ht_next, src->arr.ht_next, next_bytes) == 0
+        && dst->arr.content_hash == 0
+        && dst->arr.nbuckets == 0
+        && dst->arr.ht_cap == 0
+        && dst->arr.generation == 0
+        && dst->arr.ht_head == NULL
+        && dst->arr.ht_next == NULL
         && dst->lru_clock == src->lru_clock
-        && dst->mem_bytes == src->mem_bytes
+        && dst->mem_bytes == 0
+        && worker.arr_total_bytes == 0
         && dst->arr.memory_governor == worker.memory_governor
-        && dst->arr.reserved_bytes == src->mem_bytes;
+        && dst->arr.reserved_bytes == 0;
+
+    uint64_t *saved_head = malloc(head_bytes);
+    if (!ok)
+        fprintf(stderr, "cold clone metadata/storage check failed\n");
+    uint32_t *saved_next = malloc(next_bytes);
+    if (saved_head && saved_next) {
+        memcpy(saved_head, src->arr.ht_head, head_bytes);
+        memcpy(saved_next, src->arr.ht_next, next_bytes);
+        col_rel_t *worker_rel = session_find_rel(&worker, "edge");
+        int set_rc = worker_rel ? col_rel_set(worker_rel, 0, 0, 99) : EINVAL;
+        if (set_rc != 0) {
+            fprintf(stderr, "worker mutation failed: %d\n", set_rc);
+            ok = 0;
+        }
+        col_arrangement_t *rebuilt = col_session_get_arrangement(
+            &worker.base, "edge", key_cols, 1);
+        int64_t key = 99;
+        ok = ok && rebuilt && rebuilt->ht_head != src->arr.ht_head
+            && rebuilt->ht_next != src->arr.ht_next
+            && rebuilt->indexed_rows == worker_rel->nrows
+            && dst->mem_bytes > 0 && dst->arr.reserved_bytes == dst->mem_bytes
+            && dst->source_snapshot.relation_identity ==
+            worker_rel->relation_identity
+            && col_arrangement_find_first_typed(rebuilt, worker_rel,
+                &key) != UINT32_MAX
+            && memcmp(saved_head, src->arr.ht_head, head_bytes) == 0
+            && memcmp(saved_next, src->arr.ht_next, next_bytes) == 0
+            && session_find_rel(coord, "edge")->columns[0][0] == 1;
+    } else {
+        ok = 0;
+    }
+    free(saved_head);
+    free(saved_next);
 
     col_worker_session_destroy(&worker);
     cleanup_coordinator(coord, plan, prog);

--- a/wirelog/columnar/arrangement.c
+++ b/wirelog/columnar/arrangement.c
@@ -498,8 +498,8 @@ arr_entry_mark_unbuilt(col_arr_entry_t *e)
 /**
  * col_arr_entry_clone - Deep-copy one arrangement registry entry (#260).
  *
- * All owned memory (rel_name, key_cols, ht_head, ht_next) is freshly
- * allocated.  arr.key_cols is set to the new entry's key_cols (shared alias,
+ * Only rel_name and key_cols are copied; hash storage is built lazily.
+ * arr.key_cols is set to the new entry's key_cols (shared alias,
  * not a separate allocation — matches arrangement.c creation convention).
  * Returns 0 on success; dst is memset-zeroed before returning on failure.
  */
@@ -507,9 +507,6 @@ static int
 col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst,
     wl_columnar_memory_governor_ref_t *memory_governor)
 {
-    size_t head_bytes = 0;
-    size_t next_bytes = 0;
-
     memset(dst, 0, sizeof(*dst));
 
     /* A registry slot may carry no name or keys (defence in depth, #1515);
@@ -533,72 +530,12 @@ col_arr_entry_clone(const col_arr_entry_t *src, col_arr_entry_t *dst,
     * Mirrors the convention in col_session_get_arrangement (arrangement.c). */
     dst->arr.key_cols = dst->key_cols;
     dst->arr.key_count = src->arr.key_count;
-    dst->arr.indexed_rows = src->arr.indexed_rows;
-    dst->arr.content_hash = src->arr.content_hash;
-    dst->arr.nbuckets = src->arr.nbuckets;
-    dst->arr.ht_cap = src->arr.ht_cap;
-    dst->arr.generation = src->arr.generation;
-    /* A worker's relation is a partition with its own identity, and the
-     * differential join walks [indexed_rows, nrows) of its arrangement
-     * directly.  The clone therefore arrives cold: the freshness token is
-     * zeroed so the first lookup rebuilds against the worker's relation
-     * instead of trusting the coordinator's index (Issue #1438). */
-    dst->source_snapshot = (col_relation_snapshot_t){ 0, 0, 0 };
-    dst->arr.indexed_rows = 0;
+    /* Only schema metadata crosses into the worker. Storage, progress,
+     * freshness and byte accounting stay zero until its first rebuild. */
+    wl_columnar_memory_reservation_init(&dst->arr.reservation);
     col_arr_attach_memory_governor(&dst->arr, memory_governor);
-    if (dst->arr.memory_governor && src->mem_bytes > 0) {
-        wl_columnar_memory_governor_t *governor
-            = wl_columnar_memory_governor_ref_get(memory_governor);
-        wl_columnar_memory_reservation_init(&dst->arr.reservation);
-        if (!wl_columnar_memory_reserve(governor, src->mem_bytes,
-            &dst->arr.reservation)
-            || !wl_columnar_memory_commit(&dst->arr.reservation, dst)) {
-            (void)wl_columnar_memory_release(&dst->arr.reservation);
-            col_arr_detach_memory_governor(&dst->arr);
-            free(dst->key_cols);
-            free(dst->rel_name);
-            memset(dst, 0, sizeof(*dst));
-            return ENOMEM;
-        }
-        dst->arr.reserved_bytes = src->mem_bytes;
-    }
-    /* Issue #216: copy LRU metadata so worker clones inherit access state. */
     dst->lru_clock = src->lru_clock;
-    dst->mem_bytes = src->mem_bytes;
-
-    if (src->arr.nbuckets > 0 && src->arr.ht_head) {
-        head_bytes = (size_t)src->arr.nbuckets * sizeof(uint64_t);
-        if (head_bytes / sizeof(uint64_t) != src->arr.nbuckets)
-            goto fail;
-        dst->arr.ht_head
-            = (uint64_t *)malloc(head_bytes);
-        if (!dst->arr.ht_head)
-            goto fail;
-        memcpy(dst->arr.ht_head, src->arr.ht_head,
-            head_bytes);
-    }
-
-    if (src->arr.ht_cap > 0 && src->arr.ht_next) {
-        next_bytes = (size_t)src->arr.ht_cap * sizeof(uint32_t);
-        if (next_bytes / sizeof(uint32_t) != src->arr.ht_cap)
-            goto fail;
-        dst->arr.ht_next
-            = (uint32_t *)malloc(next_bytes);
-        if (!dst->arr.ht_next)
-            goto fail;
-        memcpy(dst->arr.ht_next, src->arr.ht_next,
-            next_bytes);
-    }
-
     return 0;
-
-fail:
-    arr_free_contents(&dst->arr);
-    col_arr_detach_memory_governor(&dst->arr);
-    free(dst->key_cols);
-    free(dst->rel_name);
-    memset(dst, 0, sizeof(*dst));
-    return ENOMEM;
 }
 
 /**
@@ -1428,7 +1365,7 @@ col_session_acquire_primary_arrangement_probe(wl_session_t *sess,
         || post_storage_owner_generation != storage_owner_generation
         || !col_session_has_exact_relation(session, source, entry->rel_name)
         || !wl_columnar_relation_snapshot_equal(
-        wl_columnar_relation_snapshot(source), snapshot)
+            wl_columnar_relation_snapshot(source), snapshot)
         || !wl_columnar_relation_snapshot_equal(entry->source_snapshot,
         snapshot)) {
         rc = col_rel_source_reader_release(&probe->source_reader);
@@ -1581,7 +1518,7 @@ col_arrangement_probe_bundle_acquire_primary(
         return EOVERFLOW;
     }
     rc = col_session_acquire_primary_arrangement_probe(sess, source,
-        key_cols, key_count, &acquired);
+            key_cols, key_count, &acquired);
     if (rc != 0)
         return rc;
     slot = &bundle->slots[bundle->count];
@@ -1667,7 +1604,7 @@ col_arrangement_probe_dependency_release_ready(
         || owner != dependency->storage_owner
         || owner->relation_identity != dependency->storage_owner_identity
         || owner->storage_generation
-            != dependency->storage_owner_generation)
+        != dependency->storage_owner_generation)
         return EINVAL;
     if (dependency->reader.identity != (uintptr_t)&dependency->reader
         || dependency->reader.owner != &owner->source_access
@@ -2390,10 +2327,12 @@ col_session_get_diff_arrangement(wl_col_session_t *cs, const char *rel_name,
             if (!wl_columnar_relation_snapshot_equal(
                     arr->source_snapshot,
                     wl_columnar_relation_snapshot(source_rel))) {
-                memset(arr->ht_head, 0,
-                    (size_t)arr->nbuckets * sizeof(*arr->ht_head));
-                memset(arr->ht_next, 0,
-                    (size_t)arr->ht_cap * sizeof(*arr->ht_next));
+                if (arr->ht_head)
+                    memset(arr->ht_head, 0,
+                        (size_t)arr->nbuckets * sizeof(*arr->ht_head));
+                if (arr->ht_next)
+                    memset(arr->ht_next, 0,
+                        (size_t)arr->ht_cap * sizeof(*arr->ht_next));
                 arr->base_nrows = 0;
                 arr->current_nrows = 0;
                 arr->indexed_rows = 0;
@@ -2530,10 +2469,13 @@ wl_columnar_arrangement_diff_txn_begin(wl_col_session_t *cs,
 
     if (!wl_columnar_relation_snapshot_equal(txn->working->source_snapshot,
         wl_columnar_relation_snapshot(source_rel))) {
-        memset(txn->working->ht_head, 0,
-            (size_t)txn->working->nbuckets * sizeof(*txn->working->ht_head));
-        memset(txn->working->ht_next, 0,
-            (size_t)txn->working->ht_cap * sizeof(*txn->working->ht_next));
+        if (txn->working->ht_head)
+            memset(txn->working->ht_head, 0,
+                (size_t)txn->working->nbuckets *
+                sizeof(*txn->working->ht_head));
+        if (txn->working->ht_next)
+            memset(txn->working->ht_next, 0,
+                (size_t)txn->working->ht_cap * sizeof(*txn->working->ht_next));
         txn->working->base_nrows = 0;
         txn->working->current_nrows = 0;
         txn->working->indexed_rows = 0;
@@ -2626,7 +2568,11 @@ col_diff_arr_entry_clone(const col_diff_arr_entry_t *src,
     dst->key_count = src->key_count;
 
     if (src->diff_arr) {
-        dst->diff_arr = col_diff_arrangement_deep_copy(src->diff_arr);
+        col_diff_arrangement_t cold = { 0 };
+        cold.key_cols = src->diff_arr->key_cols;
+        cold.key_count = src->diff_arr->key_count;
+        cold.worker_id = src->diff_arr->worker_id;
+        dst->diff_arr = col_diff_arrangement_deep_copy(&cold);
         if (!dst->diff_arr) {
             free(dst->key_cols);
             free(dst->rel_name);

--- a/wirelog/columnar/diff_arrangement.c
+++ b/wirelog/columnar/diff_arrangement.c
@@ -141,10 +141,13 @@ col_diff_arrangement_deep_copy(const col_diff_arrangement_t *arr)
         return NULL;
 
     copy->key_cols = malloc(arr->key_count * sizeof(uint32_t));
-    copy->ht_head = malloc(arr->nbuckets * sizeof(uint32_t));
-    copy->ht_next = malloc(arr->ht_cap * sizeof(uint32_t));
+    copy->ht_head = arr->nbuckets
+        ? malloc(arr->nbuckets * sizeof(uint32_t)) : NULL;
+    copy->ht_next = arr->ht_cap
+        ? malloc(arr->ht_cap * sizeof(uint32_t)) : NULL;
 
-    if (!copy->key_cols || !copy->ht_head || !copy->ht_next) {
+    if (!copy->key_cols || (arr->nbuckets && !copy->ht_head)
+        || (arr->ht_cap && !copy->ht_next)) {
         free(copy->key_cols);
         free(copy->ht_head);
         free(copy->ht_next);
@@ -153,8 +156,10 @@ col_diff_arrangement_deep_copy(const col_diff_arrangement_t *arr)
     }
 
     memcpy(copy->key_cols, arr->key_cols, arr->key_count * sizeof(uint32_t));
-    memcpy(copy->ht_head, arr->ht_head, arr->nbuckets * sizeof(uint32_t));
-    memcpy(copy->ht_next, arr->ht_next, arr->ht_cap * sizeof(uint32_t));
+    if (arr->nbuckets)
+        memcpy(copy->ht_head, arr->ht_head, arr->nbuckets * sizeof(uint32_t));
+    if (arr->ht_cap)
+        memcpy(copy->ht_next, arr->ht_next, arr->ht_cap * sizeof(uint32_t));
 
     copy->key_count = arr->key_count;
     copy->base_nrows = arr->base_nrows;
@@ -181,14 +186,16 @@ int
 col_diff_arrangement_ensure_ht_capacity(col_diff_arrangement_t *arr,
     uint32_t nrows)
 {
-    if (nrows <= arr->ht_cap && nrows <= arr->nbuckets * 3 / 4)
+    if (arr->ht_head && arr->ht_next
+        && nrows <= arr->ht_cap && nrows <= arr->nbuckets * 3 / 4)
         return 0;
 
     uint64_t before = arr->ledger ? col_diff_arrangement_bytes(arr) : 0;
 
     /* Grow ht_next capacity if needed */
-    if (nrows > arr->ht_cap) {
-        uint32_t new_cap = arr->ht_cap;
+    if (!arr->ht_next || nrows > arr->ht_cap) {
+        uint32_t new_cap = arr->ht_cap ? arr->ht_cap
+            : DIFF_ARRANGEMENT_INITIAL_BUCKETS;
         while (new_cap < nrows)
             new_cap *= 2;
         uint32_t *new_next = realloc(arr->ht_next,
@@ -202,8 +209,9 @@ col_diff_arrangement_ensure_ht_capacity(col_diff_arrangement_t *arr,
     }
 
     /* Grow bucket array if load factor > 75% */
-    if (nrows > arr->nbuckets * 3 / 4) {
-        uint32_t new_nbuckets = arr->nbuckets;
+    if (!arr->ht_head || nrows > arr->nbuckets * 3 / 4) {
+        uint32_t new_nbuckets = arr->nbuckets ? arr->nbuckets
+            : DIFF_ARRANGEMENT_INITIAL_BUCKETS;
         while (nrows > new_nbuckets * 3 / 4)
             new_nbuckets *= 2;
         uint32_t *new_head = calloc(new_nbuckets, sizeof(uint32_t));

--- a/wirelog/columnar/session.c
+++ b/wirelog/columnar/session.c
@@ -2067,6 +2067,7 @@ col_worker_session_create(wl_col_session_t *coordinator,
     out_worker->arr_entries = NULL;
     out_worker->arr_count = 0;
     out_worker->arr_cap = 0;
+    out_worker->arr_total_bytes = 0; /* cloned registries start without storage */
     out_worker->diff_arr_entries = NULL;
     out_worker->diff_arr_count = 0;
     out_worker->diff_arr_cap = 0;


### PR DESCRIPTION
## Summary

Closes #1466.

Worker arrangement clones are intentionally cold: they copy only relation/key metadata and allocate hash storage on first access against the worker relation. Primary and differential clones no longer copy coordinator hash tables or reserve their footprint during worker initialization.

## Validation

- `meson test -C build worker_session generation_cache k_fusion_memory tdd_multiworker e2e_kfusion_k4_inline --print-errorlogs` — 5/5 passed
- `meson test -C build-asan worker_session generation_cache k_fusion_memory tdd_multiworker e2e_kfusion_k4_inline --print-errorlogs` — 5/5 passed
- `meson test -C build-tsan worker_session generation_cache k_fusion_memory tdd_multiworker e2e_kfusion_k4_inline --print-errorlogs` — 5/5 passed
- `meson test -C build --suite perf --print-errorlogs` — 10 skipped by configured exit 77; no perf result available in this environment
- `git diff --check` — passed

The focused tests verify clone-time storage/accounting is zero, lazy private rebuild, differential ledger reconciliation, coordinator isolation, and cleanup. No public ABI changes.
