### PR TITLE
Measure PR CI queue time and critical-path duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ subprojects/packagecache/
 # SBOM generation artifacts (timestamped, regenerated per release; only snapshot.txt committed)
 sbom/*.spdx.json
 sbom/*.cdx.json
+
+# Issue #1570: ci-run-telemetry.py writes saved API responses and generated
+# reports here.  Measurement output, never source.
+/ci-telemetry/

--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ external-consumer audit.
 - [docs/INTERNALS.md](docs/INTERNALS.md) -- maintainer map of internal subsystems and public/private boundaries
 - [docs/ERROR_MODEL.md](docs/ERROR_MODEL.md) -- error reporting, logging safety, fork/signal constraints, and restart handoff
 - [docs/MEMORY.md](docs/MEMORY.md) -- memory ledger subsystems, `WL_MEM_REPORT`, measurement overhead, and DOOP/fixture baselines
+- [docs/CI_TELEMETRY.md](docs/CI_TELEMETRY.md) -- PR CI queue delay, per-phase attribution, critical-path measurement, and the measured baseline
 - [CONTRIBUTING.md](CONTRIBUTING.md) -- development workflow, CI/CD, PR requirements
 - [SECURITY.md](SECURITY.md) -- vulnerability disclosure
 - [docs/SIGNING.md](docs/SIGNING.md) -- verifying a release: checksums, Sigstore signatures, and provenance

--- a/docs/CI_TELEMETRY.md
+++ b/docs/CI_TELEMETRY.md
@@ -11,13 +11,22 @@ in CI, registered in `tests/meson.build` under the `abi` suite.
 
 ## What it does not do
 
-It does not change `ci-pr.yml`.  Measurement lands before the changes it
-justifies; #1574, #1571, #1572 and #1573 are where those belong.
+It does not change `ci-pr.yml`.  The changes this measurement informs belong
+to #1574, #1571, #1572 and #1573, the publication path to #1577, and runner
+placement to #1581, which exists because this measurement found the effect.
+Two of those sequence behind this issue: #1574 names it an explicit
+prerequisite, and #1577 ships the publication path second by design.  #1571
+and #1573 say they can start independently, #1572 says only that timing
+telemetry supplies it performance evidence, and #1581's one prerequisite is
+item 17 of #1583 rather than this issue -- or, failing that, naming the single
+table it regenerates -- though it is the issue here that this measurement
+caused.  So "measure first" is the ordering this issue chose rather than one
+all six are waiting on.
 
 It does not read job logs, so it reports no per-test durations and no
 compiler-cache hit rate.  Issue #1570's scope line asks for slow tests and
-cold/warm cache context; that part is **not** delivered here and is carried by
-a follow-up.  See "Known gaps".
+cold/warm cache context; that part is **not** delivered here and is carried
+by #1580.  See "Known gaps".
 
 It never substitutes zero for something it could not measure.  Most of the
 design below follows from that one rule.
@@ -79,9 +88,9 @@ was not observed.
 Each metric under `metrics` carries an `additive` flag saying whether it may be
 summed along a path: `queue_delay`, `job_wall` and `scheduler_release_latency`
 are additive, `upstream_elapsed` is not.  The flag is set in every state, so a
-missing key never has to be interpreted. (Two docstrings in the source call the
-additive one singular.  The flag is right and they are stale; a follow-up
-carries the fix.)
+missing key never has to be interpreted.  (Two docstrings in the source call
+the additive one singular.  The flag is right and they are stale; #1583 carries
+the fix.)
 
 ### Per job
 
@@ -100,9 +109,9 @@ its runner population beside them, eight columns in all.
 
 `upstream_elapsed` and `scheduler_release_latency` have no column in either
 report, so read those from `run-{id}.json`, where `unaccounted` is likewise a
-sibling of `metrics` rather than a key inside it. `upstream_elapsed` is also
-pooled into every aggregate cell without being displayed there; a follow-up
-covers giving it a column.
+sibling of `metrics` rather than a key inside it.  `upstream_elapsed` is also
+pooled into every aggregate cell without being displayed there; #1583 covers
+giving it a column.
 
 Under the per-job table the report lists why any number it printed is not
 final: the status and the reason.  More than three entries sharing one reason
@@ -139,8 +148,9 @@ The two possible mistakes are not symmetric, which is why the rule points this
 way.  An unrecognised conclusion read as executed fabricates a zero that looks
 like a measurement in the artefact, drags an aggregate's sample size with it,
 and is indistinguishable from a real duration.  Read as never run, a job that
-really ran and lost every stamp and every step disappears from the per-job
-table with a sentence saying so, and from the count of jobs that ran.
+really ran and lost every stamp and every step fabricates no per-job number:
+it drops out of the count of jobs that ran, and its row reports `unavailable`
+in all six metric columns.
 
 That second mistake is not free, and the document should not pretend it is.
 `run_wall_clock` and `pr_feedback` are computed over the jobs that ran, and a
@@ -152,17 +162,18 @@ It is still the better direction, because the other one fabricates a number
 where none exists and does so on every job it mistakes; but "this tool may
 under-claim" is the honest summary, not "the worst case is an absence".
 
-A job wrongly judged never-run is visible rather than silent: its row stays in
-the per-job table with `unavailable` in all six metric columns. What is silent
-is its effect on the two run-level totals above.
+What is silent is not the job but its effect on the two run-level totals
+above.
 
 A job that did not run carries `ran: false` and is counted in the run summary
 under its own conclusion -- as a count, not by name: the line reads `jobs: 15
 (10 executed, 5 skipped)`.  It still gets a per-job table row, with
-`unavailable` in all six metric columns and `none` for its population; what it
-is excused from is the explanation block under the table, which would otherwise
-repeat one sentence six times for a job nobody expected a number from.  The
-table row is where such a job is visible by name.
+`unavailable` in all six metric columns, and `none` for its population when it
+never reached a runner -- a job weighed as never-run that did reach one still
+reports the pool it landed on.  What it is excused from is the explanation
+block under the table, which would otherwise repeat one sentence six times for
+a job nobody expected a number from.  The table row is where such a job is
+visible by name.
 
 One metric can survive such a job: `scheduler_release_latency` ends at the
 job's *creation*, which happens whether or not the job then dispatches.  It is
@@ -228,13 +239,14 @@ recorded under `skipped_steps`.  A phase whose every step was skipped reports
 | `first_failure_latency` | run start to the completion of the earliest-completing job that concluded `failure` or `timed_out`; its evidence names the job, its conclusion, and the steps that failed |
 | `total_required_check_completion` | run start to the last *required* check completing, where the required set is knowable |
 
-`total_required_check_completion` is the one metric that is not computed. This
+`total_required_check_completion` is the one metric that is not computed.  This
 repository publishes no `required_status_checks` rule -- rulesets 13129249 and
-13670289 carry none and `branches/main/protection` answers 404 -- so the tool
-emits a fixed `unavailable` naming those three facts, and `required_checks`
-declares `pr_feedback` as the surrogate.  Adding a required-checks rule will
-not change the string: the answer is written into the source, and making it
-react to the repository is a follow-up.
+13670289 carry none, `branches/main/protection` answers 404, and a third
+ruleset, 19420631, is disabled and carries only a Copilot review rule -- so the
+tool emits a fixed `unavailable` naming the first two rulesets and the 404, and
+`required_checks` declares `pr_feedback` as the surrogate.  Adding a
+required-checks rule will not change the string: the answer is written into the
+source, and making it react to the repository is #1582.
 
 `first_failure_latency`'s `failed_steps` list is what tells #1573 whether the
 binary-size gate fired late or early: the job name alone does not say which
@@ -248,7 +260,7 @@ N` -- and divides the run into `executed`, `skipped` and `never_ran`, plus
 `did_not_run_by_conclusion`, a map from GitHub's conclusion to a count.  That
 map is open-ended: expect keys this document does not list.  `skipped` is a
 second spelling of `did_not_run_by_conclusion["skipped"]`, kept so a JSON
-consumer written against the earlier shape still works. In that rendered
+consumer written against the earlier shape still works.  In that rendered
 summary line, every term naming a job that did not run comes from one label
 table, and a conclusion the table has not met names itself; `executed` is the
 one literal.  The per-job reasons come from a second table, which is why adding
@@ -263,8 +275,8 @@ Two, reported side by side.
   job_wall` per hop.  It follows the graph rather than taking the nearest
   earlier finisher, which on real runs picks a macOS matrix build as the
   predecessor of a TSan job that does not depend on it.
-- **`graph`** takes the longest path over the declared graph, weighting
-  each node by `job_wall` and each edge by `scheduler_release_latency`. It
+- **`graph`** takes the longest path over the declared graph, weighting each
+  node by `job_wall` and each edge by `scheduler_release_latency`.  It
   excludes queueing.
 
 Their difference is the part of the wait the scheduler added rather than the
@@ -288,7 +300,7 @@ refuses to step into such a job -- walking through it at zero weight would
 erase the gap it represents -- so the chain **stops there**, and the path is
 `partial` with the reason `walk stopped: X's dependencies did not run`.  The
 graph walk instead routes **through** it at a zero node weight, keeping the
-chain intact and qualifying the total. So a short `observed` chain and a short
+chain intact and qualifying the total.  So a short `observed` chain and a short
 `graph` chain mean opposite things, and the reason string is the only way to
 tell a path that ended from a path that was cut off.  Read the status, not the
 length.
@@ -336,27 +348,26 @@ direction that cannot overstate.
 - Aggregation never pools across runner populations, and a pooled cell
   that still spans more than one self-hosted machine is flagged, because those
   machines are not interchangeable.
-- The aggregate carries no per-cell reason, so feed it completed,
-  first-attempt runs.  Note what that does and does not guard against.  A
-  per-job metric is never `partial`: only `run_wall_clock`, `pr_feedback` and
-  the two critical paths are ever downgraded, and none of those is pooled.
-  Exclusion is per metric rather than per job, which is what makes a live run
-  dangerous to pool.  A job that has started but not finished yields
-  `unavailable` for `job_wall` only: its `queue_delay` and `upstream_elapsed`
-  are `measured` and pool normally.  So a half-done run contributes wall times
-  for its finished jobs alone -- biased fast -- while also contributing the
-  queue delays of the jobs still running, so the two metrics end up pooled over
-  different sets of jobs.  Which way that biases the queue figures depends on
-  where the capture falls, and this baseline cannot say: it contains no
-  half-done run.  Each metric's `n` says how many values it actually pooled --
-  in the JSON for all three, in the markdown for `queue_delay` and `job_wall`,
-  which are the two with columns.  That gives a partial check: a cell whose
-  `queue n` exceeds its `wall n` pooled queue delays from jobs whose wall
-  times it did not, so the two columns are not describing the same jobs.  It
-  is neither necessary nor sufficient for "a live run got in".  A completed
-  run trips it too when a job lost its completion stamp, and it stays silent
-  on a live run whose unfinished jobs have not started, since those have no
-  `queue_delay` either.
+- The aggregate carries no per-cell reason, so feed it completed, first-attempt
+  runs.  Note what that does and does not guard against.  A per-job metric is
+  never `partial`: only `run_wall_clock`, `pr_feedback` and the two critical
+  paths are ever downgraded, and none of those is pooled.  Exclusion is per
+  metric rather than per job, which is what makes a live run dangerous to pool.
+  A job that has started but not finished yields `unavailable` for `job_wall`
+  only: its `queue_delay` and `upstream_elapsed` are `measured` and pool
+  normally.  So a half-done run contributes wall times for its finished jobs
+  alone -- biased fast -- while also contributing the queue delays of the jobs
+  still running, so the two metrics end up pooled over different sets of jobs.
+  Which way that biases the queue figures depends on where the capture falls,
+  and this baseline cannot say: it contains no half-done run.  Each metric's
+  `n` says how many values it actually pooled -- in the JSON for all three, in
+  the markdown for `queue_delay` and `job_wall`, which are the two with
+  columns.  That gives a partial check: a cell whose `queue n` exceeds its
+  `wall n` pooled queue delays from jobs whose wall times it did not, so the
+  two columns are not describing the same jobs.  It is neither necessary nor
+  sufficient for "a live run got in".  A completed run trips it too when a job
+  lost its completion stamp, and it stays silent on a live run whose unfinished
+  jobs have not started, since those have no `queue_delay` either.
 - Half of "completed, first-attempt" the tool enforces itself: a report
   whose `run_attempt` is not 1, or is missing, is dropped into the aggregate's
   `excluded` list with the reason.  Cells are keyed by job name, runner
@@ -366,14 +377,17 @@ direction that cannot overstate.
 
 ## Known limits of the rule above
 
-These follow from the design rather than from missing work, and none of them
-affects the baseline, which was taken from completed successful runs.
+None of them affects the baseline, which was taken from completed successful
+runs, but they are not all alike in whether anything is filed to change them.
+Four have an owner: limits 1, 3 and 6 are items 7, 8 and 9 of #1583, and limit
+5 names #1582 item 15.  Limits 2 and 4 have none, and follow from the design
+rather than from missing work.
 
-1. A job cancelled while it was still queued is reported with no
-   durations at all, including the `created_at` to `started_at` wait it
-   genuinely accrued.  One flag gates all six metrics.  Splitting "ran" from
-   "was queued" would recover a real queue measurement, which is the thing
-   #1570 exists to measure.
+1. A job cancelled while it was still queued is reported with no durations at
+   all, including the `created_at` to `started_at` wait it genuinely accrued.
+   One flag gates all six metrics.  Splitting "ran" from "was queued" would
+   recover a real queue measurement, which is the thing #1570 exists to
+   measure.
 2. `failure` is treated as proof of execution, and a self-hosted job that
    exhausts the queue limit, or whose `runs-on` matches no runner, can reach it
    without dispatching.  Routing `failure` through the evidence instead would
@@ -391,11 +405,19 @@ affects the baseline, which was taken from completed successful runs.
    than the feedback a reviewer actually waits for.  The reader's signal is
    that job's per-job row, which is present and reads `unavailable`; the run
    summary gives a count by conclusion but no name.
-5. `pr_feedback` -- the headline run-level number, and the declared
-   surrogate for the required set -- is scoped by `PINNED_CHECK_PREFIXES`, a
-   hand-maintained literal.  It is not checked against the run and not covered
-   by `graph_drift`, so renaming a job in `ci-pr.yml` silently changes what the
-   number means rather than reporting drift.  #1574 renames jobs.
+5. `pr_feedback` -- the headline run-level number, and the declared surrogate
+   for a required set this repository does not publish -- is scoped by
+   `PINNED_CHECK_PREFIXES`, a hand-maintained tuple matched by prefix against
+   job names.  It is not checked against the run and not covered by
+   `graph_drift`.  Today it matches every job in `ci-pr.yml`, which is why
+   `pr_feedback` equals `run_wall_clock` on this baseline.  A rename changes
+   what the number covers, and so does an *added* job that matches no prefix --
+   the case #1582 item 15 records and no issue has promised against.  Two
+   traces exist and both are weak.  `non_pinned_executed` in the JSON evidence
+   counts the jobs that fell outside the list, but the report mentions it only
+   when it is zero, so a lapse shows up as a caveat disappearing rather than a
+   warning appearing.  And `pr_feedback` diverges from `run_wall_clock` in the
+   run-level table only when the unmatched job is the last to finish.
 6. Adding a conclusion to the tool means touching its reason table, its
    label table and, if it proves execution, the ran list.  Nothing forces an
    author to find all three; the reason and label tables are pinned against
@@ -415,10 +437,16 @@ CI artefacts for the old ones will miss silently.
 
 ## Measured baseline
 
-**Sample.** Seven `CI PR` runs, all `conclusion: success`, all `run_attempt:
+**Sample.**  Seven `CI PR` runs, all `conclusion: success`, all `run_attempt:
 1`, all from 2026-09-10, 126 jobs in total.  Failed runs were excluded on
 purpose: a failure truncates the graph, so its critical path measures a
-different thing.
+different thing.  These seven are not that day's successful runs; by the same
+first-attempt rule the sample itself applies, they are the last seven of
+twenty-eight, and `CI PR` ran sixty-five times in all, sixty-three of them
+first attempts.  The selection is recency, not a random draw, so the sample is
+the day's tail -- which is also where the three clustered runs below sit.
+Unless a figure says otherwise, anything below that counts *other runs* counts
+only these seven.
 
 | start (UTC) | run | head | branch | self-hosted jobs |
 |---|---|---|---|---|
@@ -436,23 +464,30 @@ each other**, and those three are exactly the three that queue heavily.
 Nothing here separates "this pipeline queues" from "three PRs were pushed at
 the same minute".
 
-Nor is there a clean control to compare against.  Taking each run's window as
-its start plus its wall clock, every one of the seven overlaps two or three
-others: the first three overlap each other, and the fourth overlaps the cluster
-it precedes.  That is a loose test: an overlapping run may have nothing
-executing.  Sampling each run's window at one-minute resolution, two of the
-seven spend 45 percent of it with no foreign job running at all, and the mean
-number running ranges from 3.2 to 6.0 across the seven.  So the runs are not
-uniformly contended -- but none is cleanly isolated either.
+Nor is there a clean control to compare against, and the sample cannot see most
+of the contention.  Taking each run's window as its start plus its wall clock,
+every one of the seven overlaps two or three *of the other six*: the first
+three overlap each other, and the fourth overlaps the cluster it precedes.
+Against the day's sixty-five `CI PR` runs the test gives five to sixteen
+overlapping runs each -- the same range whether a retried run is taken as one
+window or attempt by attempt -- so the in-sample count understates real
+concurrency several-fold, and it counts no other workflow at all.  That is also
+a loose test: an overlapping run may have nothing executing.  Sampling each
+run's window at one-minute resolution, two of the seven spend 45 percent of it
+with no job from the other six running, and the mean number of those running
+ranges from 3.2 to 6.0.  Read both as within-sample quantities.  So the runs
+are not uniformly contended -- and none is isolated, in the sample or outside
+it.
 
 What the sample does show is where the long waits sit.  Twelve jobs queued 1000
-s or more; the next longest wait in the sample is 892 s. Here is every one of
-them, with the run it belongs to and the number of runs in flight when it was
-created -- by the same start-plus-wall-clock window as above, but counting the
-job's own run.  This is an instantaneous count at one moment, so it does not
-line up with the whole-window overlaps quoted in the paragraph above:
+s or more; the next longest wait in the sample is 892 s.  Here is every one of
+them, with the run it belongs to and the number of *sampled* runs in flight
+when it was created -- by the same start-plus-wall-clock window as above, but
+counting the job's own run.  This is an instantaneous count at one moment, so
+it does not line up with the whole-window overlaps quoted in the paragraph
+above:
 
-| created | queue | in flight | run | job |
+| created | queue | sampled runs | run | job |
 |---|---|---|---|---|
 | 18:59:50 | 1145 s | 4 | 34514413925 | `Sanitizers / macos-latest / clang` |
 | 18:59:50 | 1202 s | 4 | 34514413925 | `Sanitizers / ubuntu-latest / gcc` |
@@ -467,18 +502,35 @@ line up with the whole-window overlaps quoted in the paragraph above:
 | 20:25:47 | 1645 s | 2 | 34514413925 | `TSan / ubuntu-latest / clang` |
 | 20:25:47 | 1979 s | 2 | 34514413925 | `TSan-native / ubuntu-latest / gcc` |
 
-They fall in an eighty-six minute span, and the in-flight column is printed so
-a reader can see that concurrency was not constant across it.  The table
+They fall in an eighty-six minute span.  The `sampled runs` column counts only
+the sampled seven, and over this span it does not merely undercount, it points
+the wrong way: across all sixty-five `CI PR` runs of the day the count at those
+five creation stamps is 7, 9, 11, 11, 12 against a sampled 4, 4, 3, 3, 2.  A
+run counts while any of its attempts is in flight, each attempt taking its own
+start and end, so a retried run counts during its attempts and not in the gaps
+between them.  That distinction is not academic here: one of the sixty-five was
+retried twice, and treating it as one window opening at its last attempt's
+start loses the two earlier attempts and undercounts the 19:22:00 stamp by one.
+Read the column as a property of the sample, never as concurrency.  The table
 locates the long waits; it does not explain them, and it cannot be pushed into
-explaining them.  Little of it is independent -- twelve rows, but five
-creation stamps and three runs, eight rows from one run -- and it is a
-threshold selection, so the groups it appears to form are shaped by the
-threshold as much as by anything in the pipeline.  Comparing those groups
-against each other supports no conclusion: on the full 126 jobs the same
-comparison points the other way, and that in turn is confounded with the time
-of day these three runs happened to land.  A sample that could apportion any
-of this would space the runs deliberately and record the queue depth at each
-job's creation; this one does neither.
+explaining them.  Little of it is independent -- twelve rows, but five creation
+stamps and three runs, eight rows from one run -- and it is a threshold
+selection, so the groups it appears to form are shaped by the threshold as much
+as by anything in the pipeline.  Comparing those groups against each other
+supports no conclusion: on the full 126 jobs the same comparison points the
+other way -- nearest-rank median queue delay is 384, 13, 10 and 3 s at four,
+three, two and one sampled runs in flight -- a count that sees six other runs
+at most, where the day had sixty-four.  The two ends of that gradient are drawn
+from disjoint sets of runs -- four in flight is only the three simultaneous
+runs, one in flight only the two that spend 45 percent of their window with no
+job from the other six running -- while the middle two groups draw on four and
+five runs each.  Within a run the direction is not even consistent: of the six
+runs that span more than one level, three follow it, one is flat, one inverts,
+and one runs 834, 415 and 1645 s (n = 10, 5 and 3) as its own concurrency
+falls.  So the comparison is confounded with run identity, since branch, head
+commit, self-hosted placement and the time of day all travel with the run.  A
+sample that could apportion any of this would space the runs deliberately and
+record the queue depth at each job's creation; this one does neither.
 
 Two of the seven sit on the same branch.  That matters for the cache argument
 below rather than for the timings: the GitHub Actions cache is branch-scoped,
@@ -489,25 +541,33 @@ are ordinary nearest-rank percentiles; the aggregate's per-cell columns are
 sample maxima instead, since every cell is far under the n = 20 threshold (1 to
 7 across all cells, 1 to 6 in the placement table below).
 
-The sample is not on hosted runners only, which #1570's scope line asks for. 96
-of the 126 jobs ran on GitHub-hosted runners and 30 on four self-hosted
-machines.  The labels in use do not control that split -- both pools answer to
-`ubuntu-latest` and `windows-latest` -- though the workflow could: self-hosted
-runners always carry an implicit `self-hosted` label, so `runs-on:
-[self-hosted, ubuntu-latest]` would pin jobs to that pool today.  Pinning the
-other way needs either a label the self-hosted machines do not answer, or for
-those machines to stop answering the bare labels.  No label in this sample is a
-candidate: the two that only ever reached hosted runners, `ubuntu-24.04-arm`
-and `macos-latest` at 14 of 14 jobs each, select a different OS or
-architecture, so they cannot stand in for `ubuntu-latest` on these jobs.  The
-capture could not settle it anyway -- it records the labels each job requested,
-not what each machine offers.  The split moves a single job's duration by as
-much as 3022 s of median wall time.  Nothing in this baseline ranks that
-against the other effects below.  No measurement compares them; they are not
-even the same kind of quantity -- a per-job median difference, a per-run path
-range, a share of summed execution -- and the placement gap's cause is not
-established at all. Read what follows as four separate measurements, not as a
-league table.
+The sample is not on hosted runners only, which #1570's acceptance asks for,
+and #1570 should not be read as having delivered that.  #1581 carries it:
+controlling the split is its first scope item, and its re-measurement pins one
+arm of each pair to the hosted pool, which is a hosted-only baseline.  It is
+not the same shape as the one published here: #1581 pairs on a single head
+commit where these medians and p95s spread over seven, it covers the eight job
+classes of its own table rather than all eighteen jobs a run carries, and its
+acceptance asks for the variance *after* the change where #1570 asks for a
+before-change baseline.  It answers the placement question rather than
+reproducing this distribution on hosted runners alone.  96 of the 126 jobs ran
+on GitHub-hosted runners and 30 on four self-hosted machines.  The labels in
+use do not control that split -- both pools answer to `ubuntu-latest` and
+`windows-latest` -- though the workflow could: self-hosted runners always carry
+an implicit `self-hosted` label, so `runs-on: [self-hosted, ubuntu-latest]`
+would pin jobs to that pool today.  Pinning the other way needs either a label
+the self-hosted machines do not answer, or for those machines to stop answering
+the bare labels.  No label in this sample is a candidate: the two that only
+ever reached hosted runners, `ubuntu-24.04-arm` and `macos-latest` at 14 of 14
+jobs each, select a different OS or architecture, so they cannot stand in for
+`ubuntu-latest` on these jobs.  The capture could not settle it anyway -- it
+records the labels each job requested, not what each machine offers.  The split
+moves a single job's duration by as much as 3022 s of median wall time.
+Nothing in this baseline ranks that against the other effects below.  No
+measurement compares them; they are not even the same kind of quantity -- a
+per-job median difference, a per-run path range, a share of summed execution --
+and the placement gap's cause is not established at all.  Read what follows as
+four separate measurements, not as a league table.
 
 **How long a PR waits.**
 
@@ -515,13 +575,27 @@ league table.
 |---|---|---|---|
 | `run_wall_clock` | 7 | 7414 s | 10366 s |
 | `pr_feedback` | 7 | 7414 s | 10366 s |
+| `first_failure_latency` | 0 | unavailable | unavailable |
 | `total_required_check_completion` | 0 | unavailable | unavailable |
 
-`total_required_check_completion` is unavailable, not zero: this repository has
-no `required_status_checks` rule, in either ruleset (13129249, 13670289), and
-`branches/main/protection` answers 404.  The report records `pr_feedback` as
-the surrogate and says so.  Any later comparison against a repository that does
-pin required checks must not treat these two as the same measurement.
+Both `unavailable` rows are unavailable rather than zero, for different
+reasons.  `total_required_check_completion`: this repository has no
+`required_status_checks` rule in any of its three rulesets -- 13129249 and
+13670289 are active and carry none, 19420631 is disabled and carries only a
+Copilot review rule -- and `branches/main/protection` answers 404.  The report
+records `pr_feedback` as the surrogate and says so.  Any later comparison
+against a repository that does pin required checks must not treat these two as
+the same measurement.
+
+`first_failure_latency`: all seven runs succeeded, so there is no first failure
+to time.  #1570's acceptance asks for this figure, and #1570 should not be read
+as having delivered it; this sample cannot supply it -- the runs were chosen
+successful on purpose, because a failure truncates the graph and its critical
+path measures a different thing.  Getting it needs a second sample of failed
+runs, read for this metric alone.  Both #1573 and #1574 need this figure for
+their own before-and-after comparisons, so both will produce one.  Neither
+covers publishing it as part of *this* baseline, which is what #1583 item 23
+carries.
 
 **Where the time goes.**  Across all 126 jobs:
 
@@ -567,8 +641,8 @@ but they are not simply the two worst: a run that still terminated at the
 Windows build queued 1855 s.  Heavy queueing does not by itself move where the
 path ends.
 
-**Execution time dominates, and compilation dominates execution.** Phase totals
-summed over all 126 jobs:
+**Execution time dominates, and compilation dominates execution.**  Phase
+totals summed over all 126 jobs:
 
 | phase | seconds | share of `job_wall` |
 |---|---|---|
@@ -588,12 +662,14 @@ run, but on its own that would prove less than it looks: the three
 The 4 seconds is the claim that carries.
 
 **The same job's duration differs by 2.4x to 4.5x between the two runner
-pools.**  Both the GitHub-hosted pool and four self-hosted machines answer to
-the plain `ubuntu-latest` and `windows-latest` labels -- three of the four
-machines to `ubuntu-latest` and one to `windows-latest`, none to both -- so the
-same job lands on either pool from run to run and nothing in the workflow
-chooses.  The eight jobs below are the compile-heavy ones; four shorter jobs go
-the other way and are named after the table.
+pools.**  Both the GitHub-hosted pool and the self-hosted pool of four machines
+answer the plain `ubuntu-latest` and `windows-latest` labels, so the same job
+lands on either pool from run to run and nothing in the workflow chooses.
+Three of the four machines served only `ubuntu-latest` jobs here and one served
+only `windows-latest`, and none served both -- but that is what they were sent,
+not what they offer, and the `windows-latest` machine rests on n = 2.  The
+eight jobs below are the compile-heavy ones; four shorter jobs go the other way
+and are named after the table.
 
 | job | hosted n/median | self-hosted n/median | ratio |
 |---|---|---|---|
@@ -615,19 +691,23 @@ uncrustify check`, `RC changelog freeze gate` and `Detect build-triggering
 changes` are slower self-hosted, which is fixed startup overhead on a job that
 does almost no work.
 
-Four things bound how hard these ratios can be pushed.  Sample sizes per cell
+Five things bound how hard these ratios can be pushed.  Sample sizes per cell
 are 1 to 6 here, though the aggregate's other cells reach 7.  The two sides of
 a cell come from different head commits, and two of the seven runs from one
 branch, since each run contributed whichever placement it happened to get.
-Self-hosted placement is far from uniform: the seven runs took 0, 2, 3, 6, 6, 6
-and 7 of their eighteen jobs self-hosted.  And six of these eight self-hosted
-cells pool more than one machine -- the aggregate flags them for exactly this
-reason, `yes` in its `mixed machines` column and `"mixed_machines": true` in
-its JSON, since those machines are not interchangeable.  Two rows are worse
-than flagged: `Build / ubuntu-latest / clang` and `mbedtls-enabled /
-ubuntu-latest / gcc` each have n = 2 spanning two machines, so each self-hosted
-median is one machine's single sample.  Treat the ratios as an order of
-magnitude, not a calibration.
+Self-hosted placement is far from uniform: the seven runs took 0, 2, 3, 6, 6,
+6 and 7 of their eighteen jobs self-hosted.  And six of these eight
+self-hosted cells pool more than one machine -- the aggregate flags them for
+exactly this reason, `yes` in its `mixed machines` column and
+`"mixed_machines": true` in its JSON, since those machines are not
+interchangeable.  Two rows are worse than flagged: `Build / ubuntu-latest /
+clang` and `mbedtls-enabled / ubuntu-latest / gcc` each have n = 2 spanning
+two machines, so each self-hosted median is one machine's single sample.  And
+every one of the 126 jobs is from a single day, so hosted throughput -- the
+one side of every ratio outside this repository's control -- varies however it
+varied that day, unmeasured and uncontrolled.  #1581's paired same-commit
+design does not remove that bound; it holds it deliberately instead of by
+accident.  Treat the ratios as an order of magnitude, not a calibration.
 
 **The cause is not established, and the obvious mechanism for it is not.**  A
 warm compiler cache would land exactly where this gap is, and nothing here
@@ -637,11 +717,13 @@ workflow level and each compiling job runs a `Setup sccache` step, so both
 pools route through the same GitHub Actions cache backend rather than through
 anything local to a machine.  Nothing in this measurement bounds how much of
 the gap is cache behaviour and how much is machine throughput -- it could be
-all of one.  Deciding needs the per-run cache hit rate, which lives in the job
-log and which this tool does not read. That is gap 1 below, and it is the same
-signal #1571 is chasing.
+all of one.  The per-run cache hit rate would bound it, and it lives in the
+job log this tool does not read -- that is gap 1 below, filed as #1580, and it
+is the same signal #1571 is chasing.  It is not the only route: running one
+commit through both pools would separate them without any log, which is
+what #1581 proposes.
 
-**Clock skew.**  22 `runner_clock_skew` anomalies across the seven runs. The
+**Clock skew.**  22 `runner_clock_skew` anomalies across the seven runs.  The
 split is by machine rather than by pool: 20 of the 22 are the two
 `semantic-reasoning-i401-6*` machines, consistently 8 to 9 seconds behind
 GitHub's clock, and the other two are one hosted runner and one self-hosted
@@ -685,24 +767,25 @@ lever sized against the wrong one is mis-sized.
   reading and the second the optimistic one, and neither is a promise: both
   assume the terminal job stays terminal.
 
-  Three different chains produce those numbers.  Five runs end at `Build /
-  windows-latest / msvc`, which `build-matrix` reaches only after `build-arm`
-  and `build-mbedtls`, both of which need `build-primary`, which needs `lint`,
-  which needs `rc-changelog-freeze` -- four of those runs enter through
-  `build-mbedtls` and one through `build-arm`.  The other two end at `TSan /
-  ubuntu-latest / clang`, where `tsan` needs `sanitizer-matrix` and
-  `sanitizer-matrix` needs `lint`.  Every build and sanitizer job named here
-  also needs `build-scope`; `lint` needs only `rc-changelog-freeze`.  Every
-  observed chain in the baseline starts at `rc-changelog-freeze` because the
-  walk enters through `lint`, and `rc-changelog-freeze` behind it is a root --
-  `build-scope` is a root too, so rootness alone does not pick the branch.
+  Three different chains produce those numbers, as `ci-pr.yml` stands today.
+  Five runs end at `Build / windows-latest / msvc`, which `build-matrix`
+  reaches only after `build-arm` and `build-mbedtls`, both of which need
+  `build-primary`, which needs `lint`, which needs `rc-changelog-freeze` --
+  four of those runs enter through `build-mbedtls` and one through `build-arm`.
+  The other two end at `TSan / ubuntu-latest / clang`, where `tsan` needs
+  `sanitizer-matrix` and `sanitizer-matrix` needs `lint`.  Every build and
+  sanitizer job named here also needs `build-scope`; `lint` needs only
+  `rc-changelog-freeze`.  Every observed chain in the baseline starts at
+  `rc-changelog-freeze` because the walk enters through `lint`, and
+  `rc-changelog-freeze` behind it is a root -- `build-scope` is a root too, so
+  rootness alone does not pick the branch.
 
   The chains do not sort the figures cleanly.  The two TSan runs rank fifth and
   seventh of seven in both series -- a `build-mbedtls` run sits between them in
   each, at a conservative 3566 s and an optimistic 4560 s -- and in the
   conservative series a single Sanitizers job is almost the whole figure for
-  each: 3252 s of 3293, and 3861 s of 3904. The two went through different legs
-  of the matrix, the gcc and the clang sanitizer job respectively.  The
+  each: 3252 s of 3293, and 3861 s of 3904.  The two went through different
+  legs of the matrix, the gcc and the clang sanitizer job respectively.  The
   conservative minimum, 1675 s, is the one run that entered through
   `build-arm`, on a 681 s hop where the four `build-mbedtls` runs carry 1483,
   2268, 2272 and 2434 s.
@@ -725,93 +808,153 @@ lever sized against the wrong one is mis-sized.
   Reordering does not reduce total compile seconds.  It changes how many of
   them are serialized on the path, which is the 50 to 84 percent above, not the
   87.
-- **Runner placement**, which no open issue owned before this
-  measurement: 2.4x to 4.5x on the same job, up to 3022 s of median difference
-  on `Build / windows-latest / msvc`.  Its cause is not established -- see the
-  cache confound above -- so this is a variance worth removing before other
-  measurements are taken, ahead of being a lever worth pulling.
+- **Runner placement**, which no open issue owned before this measurement and
+  which #1581 owns now: 2.4x to 4.5x on the same job, up to 3022 s of median
+  difference on `Build / windows-latest / msvc`.  Its cause is not established
+  -- see the cache confound above -- so this is a variance worth removing
+  before other measurements are taken, ahead of being a lever worth pulling.
 - **Queueing** is a tail, not a median: 12 s on a good run, 4853 s on a
   bad one.  Whether the tail is the pipeline or the three concurrent runs that
   produced it is exactly what this sample cannot say.
-- **#1571 (compiler cache) and #1572 (duplicate test compilation)** act
-  on compile time, which dominates by either denominator: 87 percent of summed
-  execution, a median 72 percent of the observed path.  #1571 is also the issue
-  that would settle the placement question.
+- **#1571 (compiler cache) and #1572 (duplicate test compilation)** act on
+  compile time, which dominates by either denominator: 87 percent of summed
+  execution, a median 72 percent of the observed path.  Neither settles the
+  placement question.  #1580 would supply the per-run hit rate and #1571 a
+  cache-disabled control, but #1571's own controls compare "equivalent
+  SHA/compiler/runner/configuration", holding the runner constant -- the one
+  comparison that cannot separate the two pools.  #1581 owns that question and
+  settles it by running the same commit through both pools, which needs
+  neither of them.
 
   That is a direction for #1572, not a size.  This tool attributes compile
   seconds per job; nothing in the job and step API says *which* translation
-  units a job compiled, so the share of those seconds that is duplicated across
-  jobs cannot be derived from this capture at all. Sizing #1572 needs a
-  build-level instrument.  See gap 2 below.
-- **#1573 (binary-size gate).**  `Check binary size` ran once per run, on
-  `Build / ubuntu-latest / gcc`, and took under a second every time, so the
-  gate costs nothing to run.  Its cost is where it sits: step 12 of 16, entered
-  6 to 21 minutes into its job (391 to 1251 s, median 948 -- a job stamp
-  subtracted from a step stamp, so it crosses the two clocks, immaterial at
-  this size), which is 126 to 277 s after the `Build` step it guards has
-  finished (median 158).  Five steps separate them -- `Test`, then a clang-tidy
-  install and the tidy ratchet gate, then a syft install and the SBOM gate --
-  and the tidy pair, which the size check has nothing to do with, is the larger
-  contributor in four of the seven runs. So moving the gate up would cut about
-  two to four and a half minutes from the wait for a size verdict, not the
-  six-to-twenty-one the job offset suggests; most of that offset is the compile
-  itself -- 55 to 84 percent of it in six of the seven runs, and just under
-  half in the seventh.  On a passing run that buys nothing: the gate takes
-  under a second either way.  What it buys is failure-signal latency on a run
-  where the gate fails, which is what #1573 is about.
+  units a job compiled, so the share of those seconds that is duplicated --
+  which for #1572 is repeated work inside one build, not work repeated across
+  jobs -- cannot be derived from this capture at all.  Sizing #1572 needs a
+  build-level instrument.  See gap 3 below.
+- **#1573 (early size failure, and specialized builds scoped to their
+  contracts).**  The measurement speaks to both halves, in different terms: the
+  first it sizes only in part, the second it only locates.  `Check binary size`
+  ran once per run, on `Build / ubuntu-latest / gcc`, and took under a second
+  every time, so the gate costs nothing to run on a run where everything before
+  it passed -- which all seven were.  What it costs where an earlier gate
+  fails, the case #1573's first half exists for, has no observations here.  Its
+  cost is where it sits: step 12 of 16, entered 6 to 21 minutes into its job
+  (391 to 1251 s, median 948 -- a job stamp subtracted from a step stamp, so it
+  crosses the two clocks, immaterial at this size), which is 126 to 277 s after
+  the `Build` step it guards has finished (median 158).  Five steps separate
+  them -- `Test`, then a clang-tidy install and the tidy ratchet gate, then a
+  syft install and the SBOM gate -- and the tidy pair, which the size check has
+  nothing to do with, is the larger contributor in four of the seven runs.
+  Moving the gate up past those five alone would cut about two to four and a
+  half minutes from the wait for a size verdict.  #1573 proposes more than
+  that: building the production shared-library target first puts the gate ahead
+  of the compile as well, and the compile is 195 to 1042 s of the same offset
+  -- 55 to 84 percent of it in six of the seven runs, and just under half in
+  the seventh.  The sample brackets that larger saving without locating it: the
+  shared-library build is somewhere between nothing and the whole compile, so
+  the saving is at least the gap and at most the gap plus the compile -- 126 to
+  277 s at the low end, 347 to 1222 s at the high end, per run.  Narrowing it
+  needs an observation this sample does not contain, because `Build` here is an
+  unrestricted `meson compile`, the whole default target set, never the
+  shared-library target alone.  On a passing run that buys nothing: the gate
+  takes under a second either way.  What it buys is failure-signal latency on a
+  run where the gate fails, which is the first half of #1573.
   `first_failure_latency` does not measure this interval: it runs from the
   run's start to the failing *job's* completion.  `failed_steps` is what names
   the step.
 
+  The second half -- scoping the mbedTLS and native-TSan builds to their
+  documented contracts -- is what the evidence below speaks to.  That evidence
+  appears under #1574 above as well, only because that is where the critical
+  path is discussed.  `mbedtls-enabled / ubuntu-latest / gcc` sits on the
+  observed chain in four of the seven runs, carrying 1483, 2268, 2272 and 2434
+  s, and it is the 3.7x row of the placement table.  A job that runs the full
+  default build to validate a narrower contract is paying that on the critical
+  path.  `TSan-native / ubuntu-latest / gcc` sits on no observed chain in this
+  baseline, so what the measurement lacks for the native-TSan half is
+  critical-path presence rather than cost: it has a measured wall, median 1320
+  s hosted over n = 4 against 433 s self-hosted over n = 3, and a share of the
+  87 percent.  And it does not show how much of the mbedTLS cost the
+  contract actually needs -- that is a build-level question, the same one gap 3
+  raises for #1572.
+
 ## Known gaps
 
-The first two are things this tool cannot measure: one is a scope line of
-#1570 it does not deliver, the other is a question #1572 will ask that
-the job and step API cannot answer.  The third is a defect: on a run that
-triggers it the tool publishes a wrong number as final, with nothing in the
-artefact saying so.  It does not fire on `ci-pr.yml` as it stands, because no
-two jobs in it share a name, and it is listed rather than fixed here so that
-the fix is reviewed on its own.  The rest are limits that would mislead on some
-run other than the ones the baseline above was taken from.  A follow-up issue
-carries all of them together with the internal ones this list omits.
+The first two entries cover three #1570 scope lines this branch does not meet:
+one is a measurement the job and step API cannot yield at all, the others are
+delivery rather than measurement -- the numbers exist, but not where the issue
+says they should appear.  The third entry is not a #1570 criterion at all; it
+is the question #1572 will ask, which this capture cannot answer either.  One
+of #1570's acceptance bullets also goes unmet in two of its three asks, and
+they are recorded where their numbers are, under "Measured baseline": the
+hosted-only sample and first-failure latency.  Its remaining ask, median and
+p95 with sample-size limitations, is delivered.  A second bullet is short
+rather than absent -- "Reproducing the baseline" below records that six of the
+seven baseline tables are derived by hand -- from the per-run JSON, except the
+long-wait table's `sampled runs` column, which is not in those files either --
+and that the seventh is only partly machine-generated, which #1583 item 17
+carries.  Gap 4 below is where a third bullet, "Failed runs preserve useful
+timing evidence; missing telemetry never silently represents successful
+validation", is half unmet: the first clause holds, but on a run that triggers
+gap 4 the tool publishes a wrong number as final, with nothing in the artefact
+saying so.  It does not fire on `ci-pr.yml` as it stands, because no two jobs
+in it share a name, and it is listed rather than fixed here so that the fix is
+reviewed on its own.  Gaps 5 to 9 are limits that would mislead on some run
+other than the ones the baseline above was taken from.  #1582 carries the
+defect and the two limits that sit in the same walkers, #1583 the remaining
+three.  Internal items this list omits go to both: #1582 takes the two named at
+the `pr_feedback` limit and the required-checks metric, #1583 the rest.  This
+accounting is not claimed to be exhaustive; of everything in this document it
+is the part most likely to be incomplete.
 
 1. **Slow tests and cold/warm cache context are not captured.**  #1570's
    scope asks for them.  Both need job logs, and this tool deliberately reads
    only the job and step API, which bounds its request count and keeps it
-   offline after `fetch`.  Filed as a follow-up; #1570 should not be read as
-   having delivered this.
-2. **Duplicated compilation is not visible.**  Compile seconds are
-   attributed per job, but the API names no translation units, so nothing here
-   separates work done twice from work done once.  #1572 gets a direction from
-   this baseline and no size, and no capture this tool can take will supply
-   one.
-3. **Defect.**  Two jobs with the same name in one run collapse in the
+   offline after `fetch`.  Filed as #1580; #1570 should not be read as having
+   delivered this.
+2. **The report reaches an operator, not the pull request author.**  #1570
+   asks for two things this tool produces but does not deliver:
+   machine-readable timing published with a concise job summary, and reports
+   preserved after failures.  Both exist for someone who runs the script by
+   hand.  Neither reaches a pull request author, because the tool is wired
+   into no workflow.  #1577 carries the `workflow_run` publication path;
+   until it closes, #1570 should not be read as having delivered those two
+   criteria either.
+3. **Duplicated compilation is not visible.**  Compile seconds are attributed
+   per job, but the API names no translation units, so nothing here separates
+   work done twice from work done once.  #1572 gets a direction from this
+   baseline and no size, and no capture this tool can take will supply one.
+4. **Defect.**  Two jobs with the same name in one run collapse in the
    per-name index and produce no drift entry.  This also defeats the run-wide
    rule in "Critical paths" above: an untimed job whose name is shared with a
    timed one is filtered out as though it were on the chain, and the total is
    published as final.
-4. An untimed node weighs zero while the graph walk is *choosing* a
+5. An untimed node weighs zero while the graph walk is *choosing* a
    chain, so the reported chain can be the wrong one.  The tool says so rather
    than fixing it.  The same is true of an unusable edge weight, and only
    on-chain unusable edges are reported.
-5. A per-edge release latency uses the dependent's single value for
+6. A per-edge release latency uses the dependent's single value for
    every incoming edge, which understates when the path enters through an
    earlier-finishing dependency.
-6. An unreadable `--workflow` leaves the critical path reporting "no
+7. An unreadable `--workflow` leaves the critical path reporting "no
    dependency graph was supplied", which is true of what reached the walker but
    not of what the operator passed.  The distinction survives only on stderr.
    Relatedly, a graph that *was* supplied and resolved to no jobs is reported
    correctly by the critical path and incorrectly by each job's release
    latency, because the two derive the fact differently.
-7. `upstream_elapsed` is pooled into every aggregate cell and printed by
+8. `upstream_elapsed` is pooled into every aggregate cell and printed by
    neither report.  It also influences which aggregate rows are suppressed.
-8. The explanation block groups by status and reason across the whole run,
+9. The explanation block groups by status and reason across the whole run,
    not per job, so how it scales depends on the reason.  One confined to a
    single column collapses to a single counted line once more than three
    entries share it, and is itemized below that; one spanning several columns
    is itemized however many there are, because a count there would name
-   neither the job nor the number.  A run where every job is degraded several
-   ways is therefore several lines per job -- bounded and linear, but long.
+   neither the job nor the number.  A run whose reasons span several columns
+   is therefore several lines per job -- bounded and linear, but long.
+   Reasons confined to one column, which is the common case, collapse
+   instead: the baseline's `run-34477686557.md` reports `configure` on five
+   jobs in a single line.
 
 ## Reproducing the baseline
 
@@ -838,15 +981,18 @@ Two things that sequence does not do for you.
 
 `aggregate` pools per-job cells only, over `queue_delay`, `job_wall` and
 `upstream_elapsed`.  It emits no run-level statistics, no phase pooling and no
-`sum` column anywhere.  So of the tables above only the runner-placement one
-falls out of `success-7.md`, and even there the compile ratios beside it do
-not; the sample, run-level, job-lifetime, critical-path and phase tables are
-all derived from the seven `run-{id}.json` files by hand.
+`sum` column anywhere.  So of the seven baseline tables only the runner
+placement one falls out of `success-7.md`, and only its `n` and median columns
+do; the `ratio` column beside them and the compile ratios below it are derived
+by hand.  The other six -- sample, long-wait, run-level, job-lifetime,
+critical-path and phase -- are derived from the seven `run-{id}.json` files by
+hand, and the long-wait table's `sampled runs` column is not in those files
+either: it is cross-run window arithmetic the tool never emits.
 
 `report` reads the dependency graph from the **working tree's** `ci-pr.yml`,
 not from each run's head commit, and the seven runs sit at seven different
 commits.  The numbers above were produced against `ci-pr.yml` as of this
-commit.  Re-running `report` over the same `raw/` after #1574 changes the graph
+commit.  Re-running `report` over the same `raw/` if #1574 changes the graph
 will yield different critical-path figures for the same runs, signalled only by
 `graph_drift` and only where a name actually moved.  Pass `--workflow` with the
 file as of the run's commit to compare like with like.
@@ -859,6 +1005,6 @@ python3 scripts/ci/test-ci-run-telemetry.py          # same tests, directly
 ```
 
 The fixtures under `scripts/ci/ci-telemetry-fixtures/` are trimmed captures of
-real runs -- a success, a skip cascade, a clock-skewed run -- plus hand-written
-queued, missing-data and re-run cases.  The self-test uses no network, no `gh`
-and no build directory.
+real runs -- a success, a skip cascade, which is also the failed-run case, and
+a clock-skewed run -- plus hand-written queued, missing-data and re-run cases.
+The self-test uses no network, no `gh` and no build directory.

--- a/docs/CI_TELEMETRY.md
+++ b/docs/CI_TELEMETRY.md
@@ -1,0 +1,864 @@
+# PR CI Timing Telemetry (Issue #1570)
+
+`scripts/ci/ci-run-telemetry.py` separates the time a PR CI job spends waiting
+for a runner from the time it spends running, attributes the running part to
+named phases, and walks the run's critical path two different ways so that
+scheduling delay can be told apart from work the dependency graph forces.
+
+It is an offline analyzer.  It reads saved GitHub REST responses from disk, is
+wired into no workflow, and needs no build directory.  Only its self-test runs
+in CI, registered in `tests/meson.build` under the `abi` suite.
+
+## What it does not do
+
+It does not change `ci-pr.yml`.  Measurement lands before the changes it
+justifies; #1574, #1571, #1572 and #1573 are where those belong.
+
+It does not read job logs, so it reports no per-test durations and no
+compiler-cache hit rate.  Issue #1570's scope line asks for slow tests and
+cold/warm cache context; that part is **not** delivered here and is carried by
+a follow-up.  See "Known gaps".
+
+It never substitutes zero for something it could not measure.  Most of the
+design below follows from that one rule.
+
+## Running it
+
+Three subcommands, in order.  The first is the only one that touches the
+network, and it does so through `gh api` with a hard request budget -- plus one
+`gh repo view` outside that budget when it has to work out which repository it
+is in.
+
+```
+scripts/ci/ci-run-telemetry.py fetch  --out DIR --run-id ID [--run-id ID ...]
+scripts/ci/ci-run-telemetry.py report --out DIR --run-id ID [--run-id ID ...]
+scripts/ci/ci-run-telemetry.py aggregate --out DIR --label NAME
+```
+
+`fetch` saves the raw `runs/{id}` and `runs/{id}/jobs` responses under
+`DIR/raw/`.  `report` turns each saved pair into `DIR/run-{id}.json` and a
+readable `DIR/run-{id}.md`.  `aggregate` pools the reports already in `DIR`
+into `DIR/{label}.json` and `DIR/{label}.md`.
+
+`report` and `aggregate` are offline, and every figure they derive is
+deterministic, so a saved capture can be re-analyzed after the tool changes
+without spending API requests.  The files are not byte-identical between runs:
+each carries a `generated_at` stamp.
+
+`fetch` stops at `--max-requests` (default 40) including retries, and retries
+only a rate-limit answer or an HTTP 5xx, each retry charged to the same budget.
+
+## Metric definitions
+
+Every metric is an object, never a bare number:
+
+```json
+{"seconds": 863, "status": "measured", "reason": null, "evidence": {...}}
+```
+
+| status | meaning |
+|---|---|
+| `measured` | a real duration, with evidence naming what it was derived from |
+| `partial` | a real but incomplete duration; `reason` says what is missing from it |
+| `unavailable` | not measurable; `seconds` is `null` and `reason` says why |
+| `anomalous` | the arithmetic produced an impossible value; `seconds` is `null` and the raw figure is kept under `raw_seconds` |
+
+There is no separate status for a run still in progress.  `run_wall_clock` and
+`pr_feedback`, taken before the run is known to have ended, are downgraded to
+`partial`, so a lower bound is never read as a final figure.
+`first_failure_latency` is deliberately not downgraded -- a job still running
+can only complete later, so it cannot produce an earlier first failure -- and
+`total_required_check_completion` is a fixed `unavailable` here.  Do not
+generalize the rule to all four.
+
+A `measured` metric cannot be constructed without evidence and cannot be
+negative.  Both rules are enforced in the constructor rather than by
+convention, so a zero can never be published as a measurement of something that
+was not observed.
+
+Each metric under `metrics` carries an `additive` flag saying whether it may be
+summed along a path: `queue_delay`, `job_wall` and `scheduler_release_latency`
+are additive, `upstream_elapsed` is not.  The flag is set in every state, so a
+missing key never has to be interpreted. (Two docstrings in the source call the
+additive one singular.  The flag is right and they are stale; a follow-up
+carries the fix.)
+
+### Per job
+
+| metric | definition |
+|---|---|
+| `queue_delay` | job `created_at` to `started_at`: waiting for a runner. Summable along a path. |
+| `job_wall` | job `started_at` to `completed_at`: executing. |
+| `upstream_elapsed` | run start to job `created_at`: everything upstream, including upstream queueing. Useful for ordering jobs, **not** summable along a path. |
+| `scheduler_release_latency` | the last dependency finishing to this job being created: how long the scheduler took to release the job once it was eligible. |
+| `unaccounted` | `job_wall` minus the phases that were attributed. Closes the job's wall time. |
+
+The markdown report prints six metrics per job -- `queue_delay`, `job_wall` and
+`unaccounted` from the table above, and the `configure`, `compile` and `tests`
+phases from the phase table below -- in a table that carries the job name and
+its runner population beside them, eight columns in all.
+
+`upstream_elapsed` and `scheduler_release_latency` have no column in either
+report, so read those from `run-{id}.json`, where `unaccounted` is likewise a
+sibling of `metrics` rather than a key inside it. `upstream_elapsed` is also
+pooled into every aggregate cell without being displayed there; a follow-up
+covers giving it a column.
+
+Under the per-job table the report lists why any number it printed is not
+final: the status and the reason.  More than three entries sharing one reason
+*and* one column collapse into a single line carrying the count, because one
+sentence repeated once per job buries every line that is not repeated.  Entries
+sharing a reason across different columns stay itemized, since a count there
+would name neither the job nor the number.
+
+### Did the job run
+
+A job that did not run has no durations, and reporting a zero for one would
+read as a job that ran instantly.  Deciding which jobs those are is awkward
+because GitHub's stamps do not answer it.  A job that never ran is stamped as
+starting the moment it was created, with a completion equal to that or one
+second earlier, so neither a start stamp nor a zero span distinguishes it from
+a job cancelled the instant it was picked up.
+
+The rule is therefore closed on the other side.  Two kinds of conclusion skip
+the evidence:
+
+- `skipped`, which never dispatches whatever it is stamped with;
+- an outcome only execution reaches -- `success`, `failure`, `timed_out` --
+  where asking the stamps could only erase real seconds.  A job still going
+  carries no conclusion at all and is treated the same way.
+
+Every other conclusion is weighed, including one GitHub adds after this was
+written, so a new value cannot arrive meaning "ran" by default.  The evidence
+is asked in order: a step of its own that ran is conclusive; the span between
+the job's own stamps settles it next, and only a positive span is work; failing
+that, with no completion to judge by, a start later than the creation is the
+only trace of a dispatch.  With none of the three, the job never ran.
+
+The two possible mistakes are not symmetric, which is why the rule points this
+way.  An unrecognised conclusion read as executed fabricates a zero that looks
+like a measurement in the artefact, drags an aggregate's sample size with it,
+and is indistinguishable from a real duration.  Read as never run, a job that
+really ran and lost every stamp and every step disappears from the per-job
+table with a sentence saying so, and from the count of jobs that ran.
+
+That second mistake is not free, and the document should not pretend it is.
+`run_wall_clock` and `pr_feedback` are computed over the jobs that ran, and a
+job excluded from that set does not downgrade them.  If the wrongly-excluded
+job was the last to finish, both figures come out short and still `measured`.
+So the rule buys a bounded, visible per-job absence at the price of a possible
+silent shortfall in two run-level totals, rather than buying nothing at all.
+It is still the better direction, because the other one fabricates a number
+where none exists and does so on every job it mistakes; but "this tool may
+under-claim" is the honest summary, not "the worst case is an absence".
+
+A job wrongly judged never-run is visible rather than silent: its row stays in
+the per-job table with `unavailable` in all six metric columns. What is silent
+is its effect on the two run-level totals above.
+
+A job that did not run carries `ran: false` and is counted in the run summary
+under its own conclusion -- as a count, not by name: the line reads `jobs: 15
+(10 executed, 5 skipped)`.  It still gets a per-job table row, with
+`unavailable` in all six metric columns and `none` for its population; what it
+is excused from is the explanation block under the table, which would otherwise
+repeat one sentence six times for a job nobody expected a number from.  The
+table row is where such a job is visible by name.
+
+One metric can survive such a job: `scheduler_release_latency` ends at the
+job's *creation*, which happens whether or not the job then dispatches.  It is
+*computed* for a job cancelled, stale or failed to start rather than suppressed
+with the rest, and that is why the per-job table's caption is scoped to the
+table rather than claiming the job has no durations at all.  Computed is not
+measured: it still comes back `unavailable` for a root job (`root job; nothing
+released it` -- 21 of the baseline's 126 values), for a job absent from the
+supplied graph, where no graph was supplied at all, where a named dependency is
+absent from the run, and where either end of the interval has no timestamp.
+
+Two skip rules sit on top of that, and they are separate.  A job that is itself
+skipped gets `unavailable: job skipped; no execution`, suppressed alongside its
+other metrics.  A job that *ran* but whose dependency was skipped gets
+`unavailable: released by skipped dependency; creation batched`.  The reason
+for the second is the reason both exist: GitHub materializes a whole skip
+cascade in one second, so creation stamps inside it carry no ordering.  It is
+also the route by which a graph walk's chain ends up weighted by nodes alone.
+
+### Phases
+
+Step names are mapped to a fixed phase table: `runner_setup`, `checkout`,
+`cache_setup`, `deps_install`, `configure`, `compile`, `tests`, `tidy`, `sbom`,
+`binary_size`, `lint`, `policy`, `post_cleanup`, `other`.  A step whose name
+matches no entry lands in `other`.  It is also named in the run's
+`unmapped_steps`, which is how a step rename is detected rather than absorbed
+-- except for the handful in `KNOWN_UNMAPPED` (`Record bash version`, `Verify
+tool version`, `Publish results`), which are deliberately suppressed because
+they are known to belong nowhere.  An empty `unmapped_steps` therefore means
+"nothing unexpected", not "nothing in `other`".
+
+Two things about that table are load-bearing for anyone editing it.  It has two
+tiers -- an exact-name map consulted first, then a pattern list where the first
+match wins.  The tiers are what keep the specific `Install ...` names out of
+the generic `^Install ` pattern, and that precedence is structural rather than
+positional: they are exact entries, so their order among themselves does not
+matter.
+
+Order inside the pattern list is inert *today*: all six patterns are
+`^`-anchored on prefixes no step name can match twice, so the list could be
+permuted without changing any classification.  What is load-bearing is that
+`^Post ` exists -- delete it and a `Post <name>` step matches none of the rest
+and lands in `other`, so the cleanup time disappears from `post_cleanup` rather
+than merging into the phase it follows.  Order becomes load-bearing the moment
+a pattern is added that can match another pattern's input, which is why the
+list is written as an ordered one.
+
+The table also keys on the step names the **API** reports, which are not the `-
+name:` values in the workflow: the runner injects `Set up job` and `Complete
+job`, an unnamed `- uses:` step becomes `Run <action>`, and an action with a
+post phase adds `Post <name>`.
+
+A step that the workflow's `if:` condition skipped contributes nothing and is
+recorded under `skipped_steps`.  A phase whose every step was skipped reports
+`unavailable`, not `measured 0`.
+
+### Per run
+
+| metric | definition |
+|---|---|
+| `run_wall_clock` | run start to the last job that ran completing |
+| `pr_feedback` | run start to the last *pinned check* completing: what a reviewer waits for |
+| `first_failure_latency` | run start to the completion of the earliest-completing job that concluded `failure` or `timed_out`; its evidence names the job, its conclusion, and the steps that failed |
+| `total_required_check_completion` | run start to the last *required* check completing, where the required set is knowable |
+
+`total_required_check_completion` is the one metric that is not computed. This
+repository publishes no `required_status_checks` rule -- rulesets 13129249 and
+13670289 carry none and `branches/main/protection` answers 404 -- so the tool
+emits a fixed `unavailable` naming those three facts, and `required_checks`
+declares `pr_feedback` as the surrogate.  Adding a required-checks rule will
+not change the string: the answer is written into the source, and making it
+react to the repository is a follow-up.
+
+`first_failure_latency`'s `failed_steps` list is what tells #1573 whether the
+binary-size gate fired late or early: the job name alone does not say which
+step inside it failed.  A job that timed out stamps its steps `cancelled`
+rather than `failure`, so an empty `failed_steps` on a `timed_out` job is
+expected, and the evidence carries the conclusion beside the list so an empty
+one is not read as a job that failed with no failing step.
+
+`job_counts` carries a `total` -- the number the summary line prints as `jobs:
+N` -- and divides the run into `executed`, `skipped` and `never_ran`, plus
+`did_not_run_by_conclusion`, a map from GitHub's conclusion to a count.  That
+map is open-ended: expect keys this document does not list.  `skipped` is a
+second spelling of `did_not_run_by_conclusion["skipped"]`, kept so a JSON
+consumer written against the earlier shape still works. In that rendered
+summary line, every term naming a job that did not run comes from one label
+table, and a conclusion the table has not met names itself; `executed` is the
+one literal.  The per-job reasons come from a second table, which is why adding
+a conclusion means touching both.
+
+### Critical paths
+
+Two, reported side by side.
+
+- **`observed`** walks back from the last job to finish, hop by hop,
+  through that job's actual declared dependencies, and sums `queue_delay +
+  job_wall` per hop.  It follows the graph rather than taking the nearest
+  earlier finisher, which on real runs picks a macOS matrix build as the
+  predecessor of a TSan job that does not depend on it.
+- **`graph`** takes the longest path over the declared graph, weighting
+  each node by `job_wall` and each edge by `scheduler_release_latency`. It
+  excludes queueing.
+
+Their difference is the part of the wait the scheduler added rather than the
+part the dependency graph forces -- exactly so only when both walks pick the
+same chain, which they need not.  Where they diverge, the difference also
+absorbs the chain choice, and subtracts release latencies the observed walk
+never counted.  On the baseline below the two walks selected the identical
+chain on all seven runs, and the graph path's edge weights summed to between 1
+and 3 s, so there the difference is queueing to within those few seconds.
+
+The dependency graph is read out of `.github/workflows/ci-pr.yml` at analysis
+time, not hardcoded, so a job rename shows up as drift in
+`critical_path.graph_drift` instead of a silently stale answer.  The `lint` job
+is a reusable workflow; its caller edges are wired to the callee's roots and
+the caller's dependents to the callee's sinks.  A `needs:` form this parser
+does not read is refused outright rather than read as "this job is a root".
+
+The two walks also treat a job that *did not run* differently, which matters to
+anyone reading these paths to decide what to reorder.  The observed walk
+refuses to step into such a job -- walking through it at zero weight would
+erase the gap it represents -- so the chain **stops there**, and the path is
+`partial` with the reason `walk stopped: X's dependencies did not run`.  The
+graph walk instead routes **through** it at a zero node weight, keeping the
+chain intact and qualifying the total. So a short `observed` chain and a short
+`graph` chain mean opposite things, and the reason string is the only way to
+tell a path that ended from a path that was cut off.  Read the status, not the
+length.
+
+Both walkers refuse to sum a hop they could not time.  Beyond that, if any job
+that ran, or may still run, went untimed -- on the reported chain or not -- the
+path is `partial` and names those jobs.  That is deliberately over-inclusive,
+because either walk can exclude such a job without leaving a trace on the chain
+it reports: the graph walk weighs an untimed node at zero and routes the
+longest path around it, and the observed walk starts at the last job it could
+time and steps over an untimed later finisher.
+
+Whether a job may still move depends on the run as well as the job, and the run
+has three states rather than two.  A run whose status this tool does not
+recognise is neither known to be going nor known to be over, so nothing about a
+job's future in it is settled and the report says that rather than guessing.
+The run-level totals take the opposite default and become lower bounds, because
+an unreadable status might mean the run is unfinished.  Each errs in the
+direction that cannot overstate.
+
+## Provenance and caveats
+
+- Job-level timestamps come from GitHub's server clock; step timestamps
+  come from the runner's clock.  Two of the figures the tool reports subtract
+  across the two.  `clock_offset_estimate` subtracts a server-clock job start
+  from a runner-clock first step, which is how the offset is measured at all.
+  It is on every job in `run-{id}.json`, and it has no column in the markdown,
+  which mentions it only inside a `runner_clock_skew` anomaly line.
+  **`unaccounted` is the one that is printed**, as a column in the per-job
+  table, and it subtracts a sum of runner-clock step spans from a server-clock
+  job window.  Every other reported duration stays inside one clock.
+  `unaccounted` is why `steps_exceed_job_wall` exists as an anomaly kind, and
+  on the baseline its exposure cancels -- see the clock skew paragraph there --
+  but it is the one printed number a reader should not assume is clock-safe on
+  an arbitrary run.  Where a runner's clock differs from the server's, the
+  offset is estimated per job and reported as a `runner_clock_skew` anomaly.
+- `pr_feedback` equals `run_wall_clock` by construction on a run where
+  every job that ran is a pinned check.  They are not two agreeing
+  measurements.
+- `critical_path.observed` is a lower bound on run wall clock: it omits
+  the first job's upstream wait and every scheduler release latency.
+- Percentiles are nearest-rank, so a median is a sample value rather
+  than the midpoint of two.  Where n is under 20, the p95 column is the sample
+  maximum, not a percentile estimate.
+- Aggregation never pools across runner populations, and a pooled cell
+  that still spans more than one self-hosted machine is flagged, because those
+  machines are not interchangeable.
+- The aggregate carries no per-cell reason, so feed it completed,
+  first-attempt runs.  Note what that does and does not guard against.  A
+  per-job metric is never `partial`: only `run_wall_clock`, `pr_feedback` and
+  the two critical paths are ever downgraded, and none of those is pooled.
+  Exclusion is per metric rather than per job, which is what makes a live run
+  dangerous to pool.  A job that has started but not finished yields
+  `unavailable` for `job_wall` only: its `queue_delay` and `upstream_elapsed`
+  are `measured` and pool normally.  So a half-done run contributes wall times
+  for its finished jobs alone -- biased fast -- while also contributing the
+  queue delays of the jobs still running, so the two metrics end up pooled over
+  different sets of jobs.  Which way that biases the queue figures depends on
+  where the capture falls, and this baseline cannot say: it contains no
+  half-done run.  Each metric's `n` says how many values it actually pooled --
+  in the JSON for all three, in the markdown for `queue_delay` and `job_wall`,
+  which are the two with columns.  That gives a partial check: a cell whose
+  `queue n` exceeds its `wall n` pooled queue delays from jobs whose wall
+  times it did not, so the two columns are not describing the same jobs.  It
+  is neither necessary nor sufficient for "a live run got in".  A completed
+  run trips it too when a job lost its completion stamp, and it stays silent
+  on a live run whose unfinished jobs have not started, since those have no
+  `queue_delay` either.
+- Half of "completed, first-attempt" the tool enforces itself: a report
+  whose `run_attempt` is not 1, or is missing, is dropped into the aggregate's
+  `excluded` list with the reason.  Cells are keyed by job name, runner
+  population **and** run conclusion, so a failed run's jobs never pool with a
+  successful run's.  Nothing enforces completeness, which is the half left to
+  the operator.
+
+## Known limits of the rule above
+
+These follow from the design rather than from missing work, and none of them
+affects the baseline, which was taken from completed successful runs.
+
+1. A job cancelled while it was still queued is reported with no
+   durations at all, including the `created_at` to `started_at` wait it
+   genuinely accrued.  One flag gates all six metrics.  Splitting "ran" from
+   "was queued" would recover a real queue measurement, which is the thing
+   #1570 exists to measure.
+2. `failure` is treated as proof of execution, and a self-hosted job that
+   exhausts the queue limit, or whose `runs-on` matches no runner, can reach it
+   without dispatching.  Routing `failure` through the evidence instead would
+   be worse: a job that ran, failed and lost its stamps would become never-run,
+   dropping out of `executed`, out of the wall clock and out of the failure
+   scan, so `first_failure_latency` would report no failure on a run that
+   failed.  That metric is read precisely when things are broken.
+3. An in-flight job counts as executed in `job_counts`, so a run still
+   going reports every job that has not yet concluded without running as
+   executed.  A job that has already concluded `cancelled`, `stale`,
+   `startup_failure` or `action_required` mid-run is weighed by the evidence
+   like any other, so it *can* drop out -- but one cancelled after its own
+   steps ran stays in `executed`, which is correct.
+4. A *required* check that never ran leaves `pr_feedback` measuring less
+   than the feedback a reviewer actually waits for.  The reader's signal is
+   that job's per-job row, which is present and reads `unavailable`; the run
+   summary gives a count by conclusion but no name.
+5. `pr_feedback` -- the headline run-level number, and the declared
+   surrogate for the required set -- is scoped by `PINNED_CHECK_PREFIXES`, a
+   hand-maintained literal.  It is not checked against the run and not covered
+   by `graph_drift`, so renaming a job in `ci-pr.yml` silently changes what the
+   number means rather than reporting drift.  #1574 renames jobs.
+6. Adding a conclusion to the tool means touching its reason table, its
+   label table and, if it proves execution, the ran list.  Nothing forces an
+   author to find all three; the reason and label tables are pinned against
+   each other, and both fall back to naming the conclusion itself, which is
+   always true.
+
+## Changed wording
+
+Strings the reports print changed during development.  A reader grepping saved
+CI artefacts for the old ones will miss silently.
+
+| old | new |
+|---|---|
+| `N finished job(s) ... were not timed` | `N job(s) ... reported no duration` |
+| `job has not completed`, on a job the API called completed | `job reported no completion time` |
+| `job never started`, on a job whose steps ran | `job reported no start stamp; its first step ran at ...` |
+
+## Measured baseline
+
+**Sample.** Seven `CI PR` runs, all `conclusion: success`, all `run_attempt:
+1`, all from 2026-09-10, 126 jobs in total.  Failed runs were excluded on
+purpose: a failure truncates the graph, so its critical path measures a
+different thing.
+
+| start (UTC) | run | head | branch | self-hosted jobs |
+|---|---|---|---|---|
+| 12:36:36 | 34477686557 | 8b893e3f | `issue-1471-program-free-guard` | 3 |
+| 13:41:32 | 34484224868 | b0bc5f1f | `issue-1473-public-denial-mapping` | 2 |
+| 14:08:34 | 34487103833 | d41b4349 | `issue-1515-tombstone-reuse` | 6 |
+| 17:34:10 | 34509006108 | 3544a3c6 | `issue-1528-consolidate-fix` | 0 |
+| 18:23:45 | 34514058197 | f5667e80 | `issue-1473-public-denial-mapping` | 6 |
+| 18:26:50 | 34514377419 | d9e09c80 | `issue-1469-intern-governor-rebind` | 7 |
+| 18:27:11 | 34514413925 | d6b217c2 | `issue-1500-empty-index-lease` | 6 |
+
+The start times are in the table because the queueing figures below cannot be
+read without them.  **The last three runs began within 3 minutes 26 seconds of
+each other**, and those three are exactly the three that queue heavily.
+Nothing here separates "this pipeline queues" from "three PRs were pushed at
+the same minute".
+
+Nor is there a clean control to compare against.  Taking each run's window as
+its start plus its wall clock, every one of the seven overlaps two or three
+others: the first three overlap each other, and the fourth overlaps the cluster
+it precedes.  That is a loose test: an overlapping run may have nothing
+executing.  Sampling each run's window at one-minute resolution, two of the
+seven spend 45 percent of it with no foreign job running at all, and the mean
+number running ranges from 3.2 to 6.0 across the seven.  So the runs are not
+uniformly contended -- but none is cleanly isolated either.
+
+What the sample does show is where the long waits sit.  Twelve jobs queued 1000
+s or more; the next longest wait in the sample is 892 s. Here is every one of
+them, with the run it belongs to and the number of runs in flight when it was
+created -- by the same start-plus-wall-clock window as above, but counting the
+job's own run.  This is an instantaneous count at one moment, so it does not
+line up with the whole-window overlaps quoted in the paragraph above:
+
+| created | queue | in flight | run | job |
+|---|---|---|---|---|
+| 18:59:50 | 1145 s | 4 | 34514413925 | `Sanitizers / macos-latest / clang` |
+| 18:59:50 | 1202 s | 4 | 34514413925 | `Sanitizers / ubuntu-latest / gcc` |
+| 18:59:50 | 1295 s | 4 | 34514413925 | `Sanitizers / ubuntu-latest / clang` |
+| 18:59:50 | 1346 s | 4 | 34514413925 | `Build / ubuntu-latest / gcc` |
+| 19:22:00 | 1142 s | 4 | 34514058197 | `TSan-native / ubuntu-latest / gcc` |
+| 19:22:00 | 1408 s | 4 | 34514058197 | `TSan / ubuntu-latest / gcc` |
+| 19:22:00 | 1599 s | 4 | 34514058197 | `TSan / ubuntu-latest / clang` |
+| 19:54:17 | 1081 s | 3 | 34514377419 | `TSan / ubuntu-latest / gcc` |
+| 19:59:58 | 1868 s | 3 | 34514413925 | `Build / ubuntu-latest / clang` |
+| 20:25:47 | 1629 s | 2 | 34514413925 | `TSan / ubuntu-latest / gcc` |
+| 20:25:47 | 1645 s | 2 | 34514413925 | `TSan / ubuntu-latest / clang` |
+| 20:25:47 | 1979 s | 2 | 34514413925 | `TSan-native / ubuntu-latest / gcc` |
+
+They fall in an eighty-six minute span, and the in-flight column is printed so
+a reader can see that concurrency was not constant across it.  The table
+locates the long waits; it does not explain them, and it cannot be pushed into
+explaining them.  Little of it is independent -- twelve rows, but five
+creation stamps and three runs, eight rows from one run -- and it is a
+threshold selection, so the groups it appears to form are shaped by the
+threshold as much as by anything in the pipeline.  Comparing those groups
+against each other supports no conclusion: on the full 126 jobs the same
+comparison points the other way, and that in turn is confounded with the time
+of day these three runs happened to land.  A sample that could apportion any
+of this would space the runs deliberately and record the queue depth at each
+job's creation; this one does neither.
+
+Two of the seven sit on the same branch.  That matters for the cache argument
+below rather than for the timings: the GitHub Actions cache is branch-scoped,
+so those two are not independent observations of cache warmth.
+
+n = 7 is a small sample.  The two p95 figures below are over 126 jobs, so they
+are ordinary nearest-rank percentiles; the aggregate's per-cell columns are
+sample maxima instead, since every cell is far under the n = 20 threshold (1 to
+7 across all cells, 1 to 6 in the placement table below).
+
+The sample is not on hosted runners only, which #1570's scope line asks for. 96
+of the 126 jobs ran on GitHub-hosted runners and 30 on four self-hosted
+machines.  The labels in use do not control that split -- both pools answer to
+`ubuntu-latest` and `windows-latest` -- though the workflow could: self-hosted
+runners always carry an implicit `self-hosted` label, so `runs-on:
+[self-hosted, ubuntu-latest]` would pin jobs to that pool today.  Pinning the
+other way needs either a label the self-hosted machines do not answer, or for
+those machines to stop answering the bare labels.  No label in this sample is a
+candidate: the two that only ever reached hosted runners, `ubuntu-24.04-arm`
+and `macos-latest` at 14 of 14 jobs each, select a different OS or
+architecture, so they cannot stand in for `ubuntu-latest` on these jobs.  The
+capture could not settle it anyway -- it records the labels each job requested,
+not what each machine offers.  The split moves a single job's duration by as
+much as 3022 s of median wall time.  Nothing in this baseline ranks that
+against the other effects below.  No measurement compares them; they are not
+even the same kind of quantity -- a per-job median difference, a per-run path
+range, a share of summed execution -- and the placement gap's cause is not
+established at all. Read what follows as four separate measurements, not as a
+league table.
+
+**How long a PR waits.**
+
+| metric | n | median | max |
+|---|---|---|---|
+| `run_wall_clock` | 7 | 7414 s | 10366 s |
+| `pr_feedback` | 7 | 7414 s | 10366 s |
+| `total_required_check_completion` | 0 | unavailable | unavailable |
+
+`total_required_check_completion` is unavailable, not zero: this repository has
+no `required_status_checks` rule, in either ruleset (13129249, 13670289), and
+`branches/main/protection` answers 404.  The report records `pr_feedback` as
+the surrogate and says so.  Any later comparison against a repository that does
+pin required checks must not treat these two as the same measurement.
+
+**Where the time goes.**  Across all 126 jobs:
+
+| | n | median | p95 | sum |
+|---|---|---|---|---|
+| `queue_delay` | 126 | 29 s | 1346 s | 32582 s |
+| `job_wall` | 126 | 1083 s | 3605 s | 150623 s |
+
+35 of 126 jobs waited longer than they ran.  Queueing is 18 percent of summed
+job lifetime, counting queue and execution together, but it is concentrated:
+the median job waits half a minute and the worst waits 33 minutes.
+
+**The critical path.**
+
+| | median | min | max |
+|---|---|---|---|
+| observed | 7412 s | 6659 s | 10362 s |
+| graph | 6822 s | 5001 s | 7987 s |
+| queueing on the observed path | 996 s | 12 s | 4853 s |
+
+The path terminates at `Build / windows-latest / msvc` on five of the seven
+runs and at `TSan / ubuntu-latest / clang` on the other two, over five or six
+hops.
+
+Queueing is 11.1 percent of the critical path, taking the median of the seven
+per-run shares.  Dividing the two medians in the table instead, 996/7412, gives
+13.4 percent, but those medians come from different runs and no run had both
+values; the per-run shares are 0.2, 1.0, 1.9, 11.1, 21.4, 26.4 and 46.8
+percent.  The spread is what matters, not either central figure: 12 s of
+queueing on the best run and 4853 s on the worst.
+
+The three runs at the top of that spread are the three that started within
+three and a half minutes of each other, so the spread is at least partly a
+property of this sample rather than of the pipeline.  It is still the right
+shape to plan against -- a queueing figure quoted as a median will understate
+what a PR meets when it arrives alongside others -- but it does not establish
+how often that happens.
+
+The two runs whose path terminates at `TSan / ubuntu-latest / clang` rather
+than the Windows build are the two where the graph path covers least of the
+observed one, at 74 and 53 percent.  Both queue heavily, at 1797 s and 4853 s,
+but they are not simply the two worst: a run that still terminated at the
+Windows build queued 1855 s.  Heavy queueing does not by itself move where the
+path ends.
+
+**Execution time dominates, and compilation dominates execution.** Phase totals
+summed over all 126 jobs:
+
+| phase | seconds | share of `job_wall` |
+|---|---|---|
+| `compile` | 131602 | 87% |
+| `tests` | 13840 | 9% |
+| `configure` | 1582 | 1% |
+| `deps_install` | 1532 | 1% |
+| `tidy` | 674 | <1% |
+| everything else | 819 | <1% |
+| `unaccounted` | 574 | <1% |
+
+Attribution closes to within 0.4 percent of summed job wall time, and the
+`other` catch-all holds 4 seconds across all 126 jobs, so the compile share is
+not an artifact of steps falling into it.  `unmapped_steps` was empty on every
+run, but on its own that would prove less than it looks: the three
+`KNOWN_UNMAPPED` names are suppressed from it while still landing in `other`.
+The 4 seconds is the claim that carries.
+
+**The same job's duration differs by 2.4x to 4.5x between the two runner
+pools.**  Both the GitHub-hosted pool and four self-hosted machines answer to
+the plain `ubuntu-latest` and `windows-latest` labels -- three of the four
+machines to `ubuntu-latest` and one to `windows-latest`, none to both -- so the
+same job lands on either pool from run to run and nothing in the workflow
+chooses.  The eight jobs below are the compile-heavy ones; four shorter jobs go
+the other way and are named after the table.
+
+| job | hosted n/median | self-hosted n/median | ratio |
+|---|---|---|---|
+| `Sanitizers / ubuntu-latest / clang` | 3 / 3861 s | 4 / 849 s | 4.5x |
+| `mbedtls-enabled / ubuntu-latest / gcc` | 5 / 2268 s | 2 / 610 s | 3.7x |
+| `Build / windows-latest / msvc` | 5 / 4399 s | 2 / 1377 s | 3.2x |
+| `TSan-native / ubuntu-latest / gcc` | 4 / 1320 s | 3 / 433 s | 3.05x |
+| `Sanitizers / ubuntu-latest / gcc` | 4 / 3108 s | 3 / 1027 s | 3.03x |
+| `TSan / ubuntu-latest / gcc` | 6 / 1502 s | 1 / 544 s | 2.8x |
+| `Build / ubuntu-latest / clang` | 5 / 1160 s | 2 / 476 s | 2.44x |
+| `Build / ubuntu-latest / gcc` | 4 / 1215 s | 3 / 502 s | 2.42x |
+
+The gap sits in the `compile` phase, in the same direction and of the same
+order: compile ratios for those eight jobs run 2.9x to 4.9x against job ratios
+of 2.4x to 4.5x, close but not equal -- `Build / ubuntu-latest / clang` is 2.4x
+by job and 3.2x by compile.  So it is not a difference in what the job does.
+Four jobs invert, all of them short: `lint / EditorConfig check`, `lint /
+uncrustify check`, `RC changelog freeze gate` and `Detect build-triggering
+changes` are slower self-hosted, which is fixed startup overhead on a job that
+does almost no work.
+
+Four things bound how hard these ratios can be pushed.  Sample sizes per cell
+are 1 to 6 here, though the aggregate's other cells reach 7.  The two sides of
+a cell come from different head commits, and two of the seven runs from one
+branch, since each run contributed whichever placement it happened to get.
+Self-hosted placement is far from uniform: the seven runs took 0, 2, 3, 6, 6, 6
+and 7 of their eighteen jobs self-hosted.  And six of these eight self-hosted
+cells pool more than one machine -- the aggregate flags them for exactly this
+reason, `yes` in its `mixed machines` column and `"mixed_machines": true` in
+its JSON, since those machines are not interchangeable.  Two rows are worse
+than flagged: `Build / ubuntu-latest / clang` and `mbedtls-enabled /
+ubuntu-latest / gcc` each have n = 2 spanning two machines, so each self-hosted
+median is one machine's single sample.  Treat the ratios as an order of
+magnitude, not a calibration.
+
+**The cause is not established, and the obvious mechanism for it is not.**  A
+warm compiler cache would land exactly where this gap is, and nothing here
+rules that out -- what is ruled out is the reflex explanation of *why* one pool
+would be warmer, machine persistence: `ci-pr.yml` sets `SCCACHE_GHA_ENABLED` at
+workflow level and each compiling job runs a `Setup sccache` step, so both
+pools route through the same GitHub Actions cache backend rather than through
+anything local to a machine.  Nothing in this measurement bounds how much of
+the gap is cache behaviour and how much is machine throughput -- it could be
+all of one.  Deciding needs the per-run cache hit rate, which lives in the job
+log and which this tool does not read. That is gap 1 below, and it is the same
+signal #1571 is chasing.
+
+**Clock skew.**  22 `runner_clock_skew` anomalies across the seven runs. The
+split is by machine rather than by pool: 20 of the 22 are the two
+`semantic-reasoning-i401-6*` machines, consistently 8 to 9 seconds behind
+GitHub's clock, and the other two are one hosted runner and one self-hosted
+machine at 3 seconds.  The partition is not clean: the self-hosted machine that
+raised one of those two, `B2A1`, sits at 2 to 3 seconds, inside the hosted
+range of 0 to 3, and so does the one remaining machine, which never raised an
+anomaly at all.  Only the two `i401-6*` machines are separated from the hosted
+pool by their offsets.
+
+It changes no figure above, and the reason is arithmetic rather than avoidance:
+`unaccounted` does cross the two clocks, but a constant offset cancels between
+the head gap and the tail gap of the same job.  On the 20 jobs from those two
+machines the median head gap is -8 s and the median tail gap +17 s, summing to
+a skew-free 9 s, and no job in the sample raised a `steps_exceed_job_wall`
+anomaly -- `runner_clock_skew` is the only anomaly kind the baseline produced
+at all.  The skew is recorded because a future step-level comparison would not
+have that cancellation.
+
+## What this says about the planned work
+
+First, one distinction the numbers above will not survive without.  The 87
+percent compile share is a share of **summed job wall time across 126 jobs** --
+a throughput figure, counting parallel jobs separately.  What a PR waits for is
+the critical path, where the denominator is different: on the observed chain,
+compile is 50, 68, 68, 72, 74, 77 and 84 percent of the path across the seven
+runs, median 72.  Both figures are real and they answer different questions.  A
+lever sized against the wrong one is mis-sized.
+
+- **#1574 (job graph).**  The graph-path share of the observed path --
+  100, 99, 98, 89, 79, 74 and 53 percent -- does *not* measure what reordering
+  can recover, and it is easy to read as though it did.  It measures how much
+  of the wait was queueing rather than chain execution, so it bounds capacity
+  work, not graph work.  A share near 100 percent means the wait *is* the
+  dependency chain, which is an argument for restructuring it, not against.
+
+  What reordering could move is the work sitting on the chain ahead of the
+  terminal job.  Its execution alone is 1675, 2727, 2875, 2987, 3293, 3566 and
+  3904 s across the seven runs, median 2987; counting the queueing those hops
+  would carry off the path with them, the figures are 2738, 3010, 3051, 3336,
+  3491, 4560 and 7112 s, median 3336.  The first series is the conservative
+  reading and the second the optimistic one, and neither is a promise: both
+  assume the terminal job stays terminal.
+
+  Three different chains produce those numbers.  Five runs end at `Build /
+  windows-latest / msvc`, which `build-matrix` reaches only after `build-arm`
+  and `build-mbedtls`, both of which need `build-primary`, which needs `lint`,
+  which needs `rc-changelog-freeze` -- four of those runs enter through
+  `build-mbedtls` and one through `build-arm`.  The other two end at `TSan /
+  ubuntu-latest / clang`, where `tsan` needs `sanitizer-matrix` and
+  `sanitizer-matrix` needs `lint`.  Every build and sanitizer job named here
+  also needs `build-scope`; `lint` needs only `rc-changelog-freeze`.  Every
+  observed chain in the baseline starts at `rc-changelog-freeze` because the
+  walk enters through `lint`, and `rc-changelog-freeze` behind it is a root --
+  `build-scope` is a root too, so rootness alone does not pick the branch.
+
+  The chains do not sort the figures cleanly.  The two TSan runs rank fifth and
+  seventh of seven in both series -- a `build-mbedtls` run sits between them in
+  each, at a conservative 3566 s and an optimistic 4560 s -- and in the
+  conservative series a single Sanitizers job is almost the whole figure for
+  each: 3252 s of 3293, and 3861 s of 3904. The two went through different legs
+  of the matrix, the gcc and the clang sanitizer job respectively.  The
+  conservative minimum, 1675 s, is the one run that entered through
+  `build-arm`, on a 681 s hop where the four `build-mbedtls` runs carry 1483,
+  2268, 2272 and 2434 s.
+
+  That run is worth following, because it shows the two effects are not
+  separable.  Its `mbedtls-enabled / ubuntu-latest / gcc` landed self-hosted
+  and took 619 s against the arm hop's 681 s, so the graph walk, which weighs
+  nodes by wall time, took `build-arm`.  The observed walk agreed by a narrower
+  margin: mbedtls also queued 39 s longer, so the two finished 23 s apart
+  rather than 62.  Either way the longest path went through `build-arm`
+  *because* the mbedtls branch happened to be fast, and that is the same
+  placement effect the table above sizes at 3.7x for that exact job.  For this
+  run's figure, chain choice and machine speed are not competing explanations;
+  they are one.  (This is the low end of the conservative series only -- in the
+  optimistic series the same run is fourth of seven.)  Attacking only the
+  Windows chain would still leave the two TSan runs untouched.  Whether any of
+  these edges is necessary is a question about the build that this measurement
+  does not answer, and it is #1574's actual subject.
+
+  Reordering does not reduce total compile seconds.  It changes how many of
+  them are serialized on the path, which is the 50 to 84 percent above, not the
+  87.
+- **Runner placement**, which no open issue owned before this
+  measurement: 2.4x to 4.5x on the same job, up to 3022 s of median difference
+  on `Build / windows-latest / msvc`.  Its cause is not established -- see the
+  cache confound above -- so this is a variance worth removing before other
+  measurements are taken, ahead of being a lever worth pulling.
+- **Queueing** is a tail, not a median: 12 s on a good run, 4853 s on a
+  bad one.  Whether the tail is the pipeline or the three concurrent runs that
+  produced it is exactly what this sample cannot say.
+- **#1571 (compiler cache) and #1572 (duplicate test compilation)** act
+  on compile time, which dominates by either denominator: 87 percent of summed
+  execution, a median 72 percent of the observed path.  #1571 is also the issue
+  that would settle the placement question.
+
+  That is a direction for #1572, not a size.  This tool attributes compile
+  seconds per job; nothing in the job and step API says *which* translation
+  units a job compiled, so the share of those seconds that is duplicated across
+  jobs cannot be derived from this capture at all. Sizing #1572 needs a
+  build-level instrument.  See gap 2 below.
+- **#1573 (binary-size gate).**  `Check binary size` ran once per run, on
+  `Build / ubuntu-latest / gcc`, and took under a second every time, so the
+  gate costs nothing to run.  Its cost is where it sits: step 12 of 16, entered
+  6 to 21 minutes into its job (391 to 1251 s, median 948 -- a job stamp
+  subtracted from a step stamp, so it crosses the two clocks, immaterial at
+  this size), which is 126 to 277 s after the `Build` step it guards has
+  finished (median 158).  Five steps separate them -- `Test`, then a clang-tidy
+  install and the tidy ratchet gate, then a syft install and the SBOM gate --
+  and the tidy pair, which the size check has nothing to do with, is the larger
+  contributor in four of the seven runs. So moving the gate up would cut about
+  two to four and a half minutes from the wait for a size verdict, not the
+  six-to-twenty-one the job offset suggests; most of that offset is the compile
+  itself -- 55 to 84 percent of it in six of the seven runs, and just under
+  half in the seventh.  On a passing run that buys nothing: the gate takes
+  under a second either way.  What it buys is failure-signal latency on a run
+  where the gate fails, which is what #1573 is about.
+  `first_failure_latency` does not measure this interval: it runs from the
+  run's start to the failing *job's* completion.  `failed_steps` is what names
+  the step.
+
+## Known gaps
+
+The first two are things this tool cannot measure: one is a scope line of
+#1570 it does not deliver, the other is a question #1572 will ask that
+the job and step API cannot answer.  The third is a defect: on a run that
+triggers it the tool publishes a wrong number as final, with nothing in the
+artefact saying so.  It does not fire on `ci-pr.yml` as it stands, because no
+two jobs in it share a name, and it is listed rather than fixed here so that
+the fix is reviewed on its own.  The rest are limits that would mislead on some
+run other than the ones the baseline above was taken from.  A follow-up issue
+carries all of them together with the internal ones this list omits.
+
+1. **Slow tests and cold/warm cache context are not captured.**  #1570's
+   scope asks for them.  Both need job logs, and this tool deliberately reads
+   only the job and step API, which bounds its request count and keeps it
+   offline after `fetch`.  Filed as a follow-up; #1570 should not be read as
+   having delivered this.
+2. **Duplicated compilation is not visible.**  Compile seconds are
+   attributed per job, but the API names no translation units, so nothing here
+   separates work done twice from work done once.  #1572 gets a direction from
+   this baseline and no size, and no capture this tool can take will supply
+   one.
+3. **Defect.**  Two jobs with the same name in one run collapse in the
+   per-name index and produce no drift entry.  This also defeats the run-wide
+   rule in "Critical paths" above: an untimed job whose name is shared with a
+   timed one is filtered out as though it were on the chain, and the total is
+   published as final.
+4. An untimed node weighs zero while the graph walk is *choosing* a
+   chain, so the reported chain can be the wrong one.  The tool says so rather
+   than fixing it.  The same is true of an unusable edge weight, and only
+   on-chain unusable edges are reported.
+5. A per-edge release latency uses the dependent's single value for
+   every incoming edge, which understates when the path enters through an
+   earlier-finishing dependency.
+6. An unreadable `--workflow` leaves the critical path reporting "no
+   dependency graph was supplied", which is true of what reached the walker but
+   not of what the operator passed.  The distinction survives only on stderr.
+   Relatedly, a graph that *was* supplied and resolved to no jobs is reported
+   correctly by the critical path and incorrectly by each job's release
+   latency, because the two derive the fact differently.
+7. `upstream_elapsed` is pooled into every aggregate cell and printed by
+   neither report.  It also influences which aggregate rows are suppressed.
+8. The explanation block groups by status and reason across the whole run,
+   not per job, so how it scales depends on the reason.  One confined to a
+   single column collapses to a single counted line once more than three
+   entries share it, and is itemized below that; one spanning several columns
+   is itemized however many there are, because a count there would name
+   neither the job nor the number.  A run where every job is degraded several
+   ways is therefore several lines per job -- bounded and linear, but long.
+
+## Reproducing the baseline
+
+```
+scripts/ci/ci-run-telemetry.py fetch --out ci-telemetry \
+  --run-id 34477686557 --run-id 34484224868 --run-id 34487103833 \
+  --run-id 34509006108 --run-id 34514058197 --run-id 34514377419 \
+  --run-id 34514413925
+scripts/ci/ci-run-telemetry.py report --out ci-telemetry \
+  --run-id 34477686557 --run-id 34484224868 --run-id 34487103833 \
+  --run-id 34509006108 --run-id 34514058197 --run-id 34514377419 \
+  --run-id 34514413925
+scripts/ci/ci-run-telemetry.py aggregate --out ci-telemetry --label success-7
+```
+
+Fourteen budgeted API requests, two per run.  As printed the sequence also
+spends one unbudgeted `gh repo view` to learn the repository, since it passes
+no `--repo` and assumes no `GITHUB_REPOSITORY`; set either to keep it at
+fourteen.  `ci-telemetry/` is gitignored.  Re-running `report` and `aggregate`
+over the saved `raw/` directory needs no network, so the figures above can be
+recomputed after the tool changes.
+
+Two things that sequence does not do for you.
+
+`aggregate` pools per-job cells only, over `queue_delay`, `job_wall` and
+`upstream_elapsed`.  It emits no run-level statistics, no phase pooling and no
+`sum` column anywhere.  So of the tables above only the runner-placement one
+falls out of `success-7.md`, and even there the compile ratios beside it do
+not; the sample, run-level, job-lifetime, critical-path and phase tables are
+all derived from the seven `run-{id}.json` files by hand.
+
+`report` reads the dependency graph from the **working tree's** `ci-pr.yml`,
+not from each run's head commit, and the seven runs sit at seven different
+commits.  The numbers above were produced against `ci-pr.yml` as of this
+commit.  Re-running `report` over the same `raw/` after #1574 changes the graph
+will yield different critical-path figures for the same runs, signalled only by
+`graph_drift` and only where a name actually moved.  Pass `--workflow` with the
+file as of the run's commit to compare like with like.
+
+## Self-test
+
+```
+meson test -C build --suite abi ci_run_telemetry_selftest
+python3 scripts/ci/test-ci-run-telemetry.py          # same tests, directly
+```
+
+The fixtures under `scripts/ci/ci-telemetry-fixtures/` are trimmed captures of
+real runs -- a success, a skip cascade, a clock-skewed run -- plus hand-written
+queued, missing-data and re-run cases.  The self-test uses no network, no `gh`
+and no build directory.

--- a/scripts/ci/ci-run-telemetry.py
+++ b/scripts/ci/ci-run-telemetry.py
@@ -869,7 +869,8 @@ def match_graph_to_jobs(graph: dict, job_names: list) -> tuple:
     the names the API actually reported.  Returns (edges by job name, drift)."""
     # Most specific first: a matrix node such as `Build / .+ / .+` would
     # otherwise shadow the literal `Build / ubuntu-latest / gcc` whenever it
-    # happened to be declared earlier, and #1574 reorders jobs.
+    # happened to be declared earlier, and the workflow's job order is not
+    # something any issue has promised to hold still.
     # R7: placeholder text adds length without adding specificity, so measure
     # the literal part only.
     ordered = sorted(graph, key=lambda node: (node.count("${{"),
@@ -1196,7 +1197,7 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
 
     jobs_by_name = {j.get("name"): j for j in jobs}
     # Until the run is known to have ended, every run-level figure is a lower
-    # bound: a check that has not reported cannot raise it, and #1574 would
+    # bound: a check that has not reported cannot raise it, and a reader would
     # quote it as final.  A status this tool cannot read counts as not known
     # to have ended, while the walkers treat it as stopped -- each errs in
     # the direction that cannot overstate.

--- a/scripts/ci/ci-run-telemetry.py
+++ b/scripts/ci/ci-run-telemetry.py
@@ -49,6 +49,8 @@ Usage:
   ci-run-telemetry.py fetch  --run-id ID [--run-id ID ...] [--out DIR]
                             [--max-requests N] [--repo OWNER/NAME]
   ci-run-telemetry.py report --run-id ID [--run-id ID ...] [--out DIR]
+                             [--workflow FILE]
+  ci-run-telemetry.py aggregate [--run-id ID ...] [--out DIR] [--label NAME]
 
 `fetch` costs two requests for a run whose jobs fit one page, plus any
 retries, which are charged to the same budget.  `--out` defaults to
@@ -85,10 +87,14 @@ CLOCK_SKEW_TOLERANCE_S = 2
 # same rounding slack when checking that relation.
 RELEASE_TOLERANCE_S = 2
 
-GRAPH_PENDING = ("needs-graph extraction is not implemented in this tool "
-                 "version; see #1570 unit 2")
+GRAPH_NOT_SUPPLIED = ("no dependency graph was supplied, so the critical "
+                      "path cannot be walked")
 
 DEFAULT_OUT_DIR = "ci-telemetry"
+# Resolved from this file, not the working directory: the default has to hold
+# when the tool runs from a build directory or anywhere else.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_WORKFLOW = str(REPO_ROOT / ".github" / "workflows" / "ci-pr.yml")
 JOBS_PER_PAGE = 100
 DEFAULT_MAX_REQUESTS = 40
 RETRY_SLEEPS_S = (1, 2, 4, 8)
@@ -308,14 +314,19 @@ def job_phases(job: dict) -> tuple:
         start = parse_ts(step.get("started_at"))
         end = parse_ts(step.get("completed_at"))
         if start is None or end is None:
-            unusable.append({"step": name, "phase": phase,
-                             "reason": "step has no usable interval"})
+            # A step that has not finished is not a broken step; saying so
+            # would drown the ones that are.
+            reason = ("step has not finished"
+                      if step.get("status") != "completed"
+                      else "step has no usable interval")
+            unusable.append({"step": name, "phase": phase, "reason": reason,
+                             "finished": step.get("status") == "completed"})
             continue
         seconds = math.floor((end - start).total_seconds())
         if seconds < 0:
             unusable.append({"step": name, "phase": phase,
                              "reason": "step ends before it starts",
-                             "raw_seconds": seconds})
+                             "raw_seconds": seconds, "finished": True})
             continue
         totals[phase] = totals.get(phase, 0) + seconds
         evidence.setdefault(phase, []).append(name)
@@ -359,8 +370,8 @@ def analyze_job(job: dict, t0_iso: str, completed_by_name: dict) -> dict:
         reason = "job skipped; no execution"
         entry["metrics"] = {
             "upstream_elapsed": non_additive(unavailable(reason)),
-            "queue_delay": unavailable(reason),
-            "job_wall": unavailable(reason),
+            "queue_delay": additive(unavailable(reason)),
+            "job_wall": additive(unavailable(reason)),
         }
         entry["phases"] = {p: unavailable(reason) for p in PHASES}
         entry["unmapped_steps"] = []
@@ -380,10 +391,13 @@ def analyze_job(job: dict, t0_iso: str, completed_by_name: dict) -> dict:
         "upstream_elapsed": non_additive(
             interval(t0_iso, job.get("created_at"),
                      "run or job creation time missing")),
-        "queue_delay": interval(job.get("created_at"), job.get("started_at"),
-                                "job never started"),
-        "job_wall": interval(job.get("started_at"), job.get("completed_at"),
-                             "job has not completed"),
+        # Summable along a path, and the critical path does sum them.
+        "queue_delay": additive(
+            interval(job.get("created_at"), job.get("started_at"),
+                     "job never started")),
+        "job_wall": additive(
+            interval(job.get("started_at"), job.get("completed_at"),
+                     "job has not completed")),
     }
 
     phases, unmapped, unusable, skipped, accounted = job_phases(job)
@@ -438,7 +452,7 @@ def release_latency(job: dict, jobs_by_name: dict, needs: dict) -> dict:
     the only per-job wait that may be summed along a path."""
     name = job.get("name") or ""
     if not needs:
-        return unavailable("dependency graph not supplied; see #1570 unit 2")
+        return unavailable(GRAPH_NOT_SUPPLIED)
     if name not in needs:
         # Not the same as having no dependencies: the extractor may simply
         # have missed this job, and calling that a root would hide the gap.
@@ -466,6 +480,334 @@ def release_latency(job: dict, jobs_by_name: dict, needs: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Dependency graph
+# ---------------------------------------------------------------------------
+#
+# Read from the workflow files rather than hard-coded: #1574 is going to change
+# this graph, and a copy in here would drift exactly when it matters.  Parsed
+# by pinned regex because the repository has no YAML parser and adding one for
+# a measurement instrument is not worth the dependency.
+
+JOB_KEY_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$", re.MULTILINE)
+NAME_RE = re.compile(r"^    name:\s*(.+?)\s*$", re.MULTILINE)
+NEEDS_LIST_RE = re.compile(r"^    needs:\s*\[(.*?)\]\s*$", re.MULTILINE)
+NEEDS_ONE_RE = re.compile(r"^    needs:\s*([A-Za-z0-9_-]+)\s*$", re.MULTILINE)
+NEEDS_ANY_RE = re.compile(r"^    needs:", re.MULTILINE)
+
+
+class WorkflowParseError(Exception):
+    """A `needs:` this parser cannot read.  Refused rather than returned as an
+    empty list, because an empty list means "root job" and a job wrongly called
+    a root severs an edge without leaving any trace in the drift report."""
+USES_LOCAL_RE = re.compile(r"^    uses:\s*(\./[^\s]+)\s*$", re.MULTILINE)
+EXPRESSION_RE = re.compile(r"\$\{\{.*?\}\}")
+
+
+JOBS_SECTION_RE = re.compile(r"^jobs:\s*$", re.MULTILINE)
+TOP_LEVEL_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+:", re.MULTILINE)
+
+
+def split_jobs(text: str) -> dict:
+    """Map job key to its block, within the `jobs:` section only.  Scoping
+    matters: `on:` also carries two-space keys, and without this `pull_request`
+    and `workflow_call` are read as jobs."""
+    section = JOBS_SECTION_RE.search(text)
+    if not section:
+        return {}
+    start = section.end()
+    following = TOP_LEVEL_KEY_RE.search(text, start)
+    text = text[start:following.start() if following else len(text)]
+    keys = [(m.group(1), m.start()) for m in JOB_KEY_RE.finditer(text)]
+    blocks = {}
+    for index, (key, start) in enumerate(keys):
+        end = keys[index + 1][1] if index + 1 < len(keys) else len(text)
+        blocks[key] = text[start:end]
+    return blocks
+
+
+def parse_needs(block: str, job_key: str = "?") -> list:
+    match = NEEDS_LIST_RE.search(block)
+    if match:
+        return [item.strip() for item in match.group(1).split(",")
+                if item.strip()]
+    match = NEEDS_ONE_RE.search(block)
+    if match:
+        return [match.group(1)]
+    if NEEDS_ANY_RE.search(block):
+        raise WorkflowParseError(
+            f"job {job_key!r} declares needs in a form this parser cannot "
+            f"read (only `needs: a` and `needs: [a, b]` on one line); "
+            f"reading it as a root would sever its edges silently")
+    return []
+
+
+def name_pattern(display_name: str):
+    """A matrix job's display name carries `${{ ... }}` placeholders; the API
+    reports them expanded.  Match on the literal parts around them."""
+    parts = [re.escape(part) for part in EXPRESSION_RE.split(display_name)]
+    return re.compile("^" + ".+".join(parts) + "$")
+
+
+def extract_graph(workflow_path) -> dict:
+    """Nodes keyed by API display name, each mapping to the display names it
+    needs.  A job that calls a reusable workflow is expanded into that
+    workflow's jobs, named `<caller key> / <callee display name>` the way the
+    API reports them: without this the `lint` node matches nothing, its edge is
+    severed, and the graph misses the segment between the freeze gate and every
+    build.  Every job gets an entry -- an empty list for a genuine root -- so a
+    job missing from the result is a gap, never a root."""
+    workflow_path = Path(workflow_path)
+    text = workflow_path.read_text(encoding="utf-8")
+    blocks = split_jobs(text)
+
+    display: dict = {}
+    expansion: dict = {}
+    for key, block in blocks.items():
+        local = USES_LOCAL_RE.search(block)
+        if local:
+            # removeprefix, not lstrip: lstrip takes a character set and
+            # would eat the leading dot of `.github`.
+            relative = local.group(1).removeprefix("./")
+            callee = workflow_path.parent.parent.parent / relative
+            callee_blocks = split_jobs(
+                Path(callee).read_text(encoding="utf-8"))
+            inner = {}
+            for sub_key, sub_block in callee_blocks.items():
+                sub_name = NAME_RE.search(sub_block)
+                inner[sub_key] = (f"{key} / {sub_name.group(1)}"
+                                  if sub_name else f"{key} / {sub_key}")
+            expansion[key] = {
+                "names": inner,
+                "needs": {sub: parse_needs(sub_block, sub)
+                          for sub, sub_block in callee_blocks.items()},
+            }
+            continue
+        name = NAME_RE.search(block)
+        display[key] = name.group(1) if name else key
+
+    graph: dict = {}
+    for key, block in blocks.items():
+        outer_needs = parse_needs(block, key)
+        if key in expansion:
+            inner = expansion[key]
+            for sub, sub_name in inner["names"].items():
+                edges = [inner["names"][dep] for dep in inner["needs"][sub]
+                         if dep in inner["names"]]
+                if not inner["needs"][sub]:
+                    # A callee root inherits the caller's dependencies.
+                    edges = [resolve_edge(dep, display, expansion)
+                             for dep in outer_needs]
+                    edges = [e for group in edges for e in group]
+                graph[sub_name] = edges
+            continue
+        edges = [resolve_edge(dep, display, expansion) for dep in outer_needs]
+        graph[display[key]] = [e for group in edges for e in group]
+    return graph
+
+
+def resolve_edge(dep_key: str, display: dict, expansion: dict) -> list:
+    """An edge onto a reusable-workflow call lands on that workflow's sinks --
+    the jobs nothing inside it depends on."""
+    if dep_key in expansion:
+        inner = expansion[dep_key]
+        depended_on = {d for deps in inner["needs"].values() for d in deps}
+        return [inner["names"][sub] for sub in inner["names"]
+                if sub not in depended_on]
+    return [display[dep_key]] if dep_key in display else []
+
+
+def match_graph_to_jobs(graph: dict, job_names: list) -> tuple:
+    """Resolve graph node names, which may carry matrix placeholders, against
+    the names the API actually reported.  Returns (edges by job name, drift)."""
+    # Most specific first: a matrix node such as `Build / .+ / .+` would
+    # otherwise shadow the literal `Build / ubuntu-latest / gcc` whenever it
+    # happened to be declared earlier, and #1574 reorders jobs.
+    # R7: placeholder text adds length without adding specificity, so measure
+    # the literal part only.
+    ordered = sorted(graph, key=lambda node: (node.count("${{"),
+                                              -len(EXPRESSION_RE.sub("", node))))
+    patterns = [(node, name_pattern(node)) for node in ordered]
+    resolved: dict = {}
+    node_of_job: dict = {}
+    matched_nodes = set()
+    for job_name in job_names:
+        for node, pattern in patterns:
+            if pattern.match(job_name):
+                matched_nodes.add(node)
+                node_of_job[job_name] = node
+                resolved[job_name] = set(graph[node])
+                break
+    # Which jobs each node owns, decided once by the specificity rule above.
+    # Expanding a dependency by re-matching its pattern would let it claim
+    # jobs that resolved to a different node, which can make a job its own
+    # dependency and leave a cycle behind with nothing in the drift report.
+    jobs_of_node: dict = {}
+    for job_name, node in node_of_job.items():
+        jobs_of_node.setdefault(node, []).append(job_name)
+
+    edges: dict = {}
+    for job_name in job_names:
+        if job_name not in resolved:
+            # Deliberately absent, not empty: an empty list is a root, and the
+            # observed walk has to be able to tell the two apart.
+            continue
+        concrete = set()
+        for dep_node in resolved[job_name]:
+            concrete.update(jobs_of_node.get(dep_node, []))
+        concrete.discard(job_name)
+        edges[job_name] = sorted(concrete)
+    drift = {
+        "jobs_without_node": sorted(n for n in job_names if n not in resolved),
+        "nodes_without_job": sorted(set(graph) - matched_nodes),
+    }
+    return edges, drift
+
+
+def _seconds(metric: dict):
+    return metric["seconds"] if metric.get("status") in ("measured",
+                                                         "partial") else None
+
+
+def observed_path(analyzed: list, edges: dict, drift: dict) -> dict:
+    """Walk back from the last job to finish, hop by hop, through its actual
+    dependencies.  Taking the nearest earlier finisher instead would be wrong
+    and quietly so: on a real run it picks a macOS matrix build as the
+    predecessor of a TSan job that does not depend on it.  Where the graph
+    cannot resolve a hop the walk stops and says the path is partial rather
+    than attaching a plausible neighbour."""
+    by_name = {entry["name"]: entry for entry in analyzed}
+    finished = [e for e in analyzed
+                if _seconds(e["metrics"]["job_wall"]) is not None
+                and e.get("completed_at")]
+    if not finished:
+        return unavailable("no job has completed")
+    current = max(finished, key=lambda e: ts_key(e["completed_at"]))
+    chain = [current["name"]]
+    truncated = None
+    seen = {current["name"]}
+    while True:
+        if current["name"] not in edges:
+            truncated = f"{current['name']} is not in the dependency graph"
+            break
+        candidates = [by_name[name] for name in edges[current["name"]]
+                      if name in by_name and name not in seen]
+        # A skipped job has a completion stamp but no duration, and walking
+        # through it at zero weight would drop the very gap it represents.
+        candidates = [c for c in candidates if c.get("completed_at")
+                      and c["conclusion"] != "skipped"]
+        if not candidates:
+            if edges[current["name"]]:
+                truncated = (f"{current['name']}'s dependencies did not run")
+            break
+        current = max(candidates, key=lambda e: ts_key(e["completed_at"]))
+        seen.add(current["name"])
+        chain.append(current["name"])
+    chain.reverse()
+    total = sum(
+        (_seconds(by_name[n]["metrics"]["queue_delay"]) or 0)
+        + (_seconds(by_name[n]["metrics"]["job_wall"]) or 0) for n in chain)
+    hops = [{"job": name,
+             "queue_delay": _seconds(by_name[name]["metrics"]["queue_delay"]),
+             "job_wall": _seconds(by_name[name]["metrics"]["job_wall"])}
+            for name in chain]
+    # A hop the run did not time contributes nothing to the sum, so the total
+    # is short by however long that job actually took.  Name it rather than
+    # letting `or 0` present the shortfall as a measurement.
+    unmeasured = [hop["job"] for hop in hops
+                  if hop["queue_delay"] is None or hop["job_wall"] is None]
+    metric = measured(total, {
+        "chain": chain, "hops": hops,
+        "weights": "queue_delay + job_wall per hop",
+        "note": ("a lower bound on run wall clock: it omits the first job's "
+                 "upstream wait and every scheduler release latency"),
+    })
+    if unmeasured:
+        metric["evidence"]["unmeasured_hops"] = unmeasured
+    reasons = []
+    if unmeasured:
+        reasons.append(f"{len(unmeasured)} hop(s) on this chain were not "
+                       f"timed and contribute nothing to the total")
+    if truncated:
+        reasons.append(f"walk stopped: {truncated}")
+    if drift.get("nodes_without_job"):
+        # The run does not contain jobs the declared graph expects, so this
+        # path may be short because those jobs are absent rather than because
+        # the chain ends here.
+        reasons.append(f"{len(drift['nodes_without_job'])} declared jobs are "
+                       f"absent from this run; see drift")
+    if reasons:
+        metric["status"] = "partial"
+        metric["reason"] = "; ".join(reasons)
+    return metric
+
+
+def graph_path(analyzed: list, edges: dict, drift: dict) -> dict:
+    """Longest path over the declared graph, weighting each node by its wall
+    time and each edge by the wait between the dependency finishing and the
+    dependent being created.  Inside a skip cascade every edge weight is
+    unavailable, so the path falls back to node weights alone and says so
+    rather than disappearing."""
+    by_name = {entry["name"]: entry for entry in analyzed}
+    if not edges:
+        return unavailable(GRAPH_NOT_SUPPLIED)
+    best: dict = {}
+    unusable_edges: set = set()
+
+    def visit(name, stack):
+        if name in best:
+            return best[name]
+        if name in stack:            # a cycle cannot occur in a needs DAG,
+            return 0, [name]         # but never spin if the data says one does
+        stack = stack | {name}
+        entry = by_name.get(name)
+        node_weight = _seconds(entry["metrics"]["job_wall"]) or 0 if entry else 0
+        best_total, best_chain = node_weight, [name]
+        for dep in edges.get(name, []):
+            if dep not in by_name:
+                continue
+            dep_total, dep_chain = visit(dep, stack)
+            edge = by_name[name]["metrics"]["scheduler_release_latency"]
+            edge_weight = _seconds(edge)
+            if edge_weight is None:
+                edge_weight = 0
+            total = dep_total + edge_weight + node_weight
+            if total > best_total:
+                best_total, best_chain = total, dep_chain + [name]
+        best[name] = (best_total, best_chain)
+        return best[name]
+
+    results = [visit(name, frozenset()) for name in by_name]
+    if not results:
+        return unavailable("no job to walk")
+    total, chain = max(results, key=lambda pair: pair[0])
+    unmeasured_nodes = [name for name in chain
+                        if _seconds(by_name[name]["metrics"]["job_wall"])
+                        is None]
+    # Only the edges on the chain being reported can qualify this number.
+    for index, name in enumerate(chain[1:], start=1):
+        if _seconds(by_name[name]["metrics"]["scheduler_release_latency"]) is None:
+            unusable_edges.add(f"{chain[index - 1]} -> {name}")
+    metric = measured(total, {"chain": chain,
+                              "weights": "job_wall per node, "
+                                         "scheduler_release_latency per edge"})
+    reasons = []
+    if unmeasured_nodes:
+        reasons.append(f"{len(unmeasured_nodes)} job(s) on this chain were "
+                       f"not timed and contribute nothing to the total")
+        metric["evidence"]["unmeasured_nodes"] = unmeasured_nodes
+    if unusable_edges:
+        reasons.append("edge weights unavailable on this chain; node weights "
+                       "only (a skip cascade batches job creation)")
+        metric["evidence"]["unusable_edges"] = sorted(unusable_edges)
+    if drift["jobs_without_node"] or drift["nodes_without_job"]:
+        reasons.append("the declared graph and the run disagree; see drift")
+    if reasons:
+        metric["status"] = "partial"
+        metric["reason"] = "; ".join(reasons)
+    return metric
+
+
+# ---------------------------------------------------------------------------
 # Run-level analysis
 # ---------------------------------------------------------------------------
 
@@ -473,7 +815,10 @@ def pinned_check(name: str) -> bool:
     return any(name.startswith(prefix) for prefix in PINNED_CHECK_PREFIXES)
 
 
-def analyze(run: dict, jobs_doc: dict, needs: dict | None = None) -> dict:
+def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
+            drift: dict | None = None) -> dict:
+    """@needs is the resolved per-job dependency map and @drift is where it and
+    the run disagree; both come from match_graph_to_jobs."""
     needs = needs or {}
     jobs = jobs_doc.get("jobs") or []
     t0_iso = run.get("run_started_at") or run.get("created_at")
@@ -580,15 +925,34 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None) -> dict:
                 "reason": residual.get("reason"),
             })
         for item in entry.get("unusable_steps") or []:
+            # Only a finished step with unusable timestamps is anomalous.
+            if not item.get("finished"):
+                continue
             anomalies.append({
                 "kind": "unusable_step", "job": entry["name"],
                 "step": item.get("step"), "reason": item.get("reason"),
             })
 
+    if needs:
+        drift = drift or {"jobs_without_node": [], "nodes_without_job": []}
+        critical_path = {
+            "observed": observed_path(analyzed, needs, drift),
+            "graph": graph_path(analyzed, needs, drift),
+            "graph_drift": drift,
+        }
+    else:
+        critical_path = {
+            "observed": unavailable(GRAPH_NOT_SUPPLIED),
+            "graph": unavailable(GRAPH_NOT_SUPPLIED),
+            # Not [].  An empty value here would read as "compared, no drift".
+            "graph_drift": None,
+        }
+
     unmapped = sorted({name for entry in analyzed
                        for name in entry["unmapped_steps"]})
     unusable = sorted({item["step"] for entry in analyzed
-                       for item in entry.get("unusable_steps") or []})
+                       for item in entry.get("unusable_steps") or []
+                       if item.get("finished")})
 
     return {
         "schema": SCHEMA,
@@ -621,16 +985,156 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None) -> dict:
             "surrogate": "pr_feedback",
             "reason": "the required set is not queryable in this repository",
         },
-        "critical_path": {
-            "observed": unavailable(GRAPH_PENDING),
-            "graph": unavailable(GRAPH_PENDING),
-            # Not [].  An empty list here would read as "compared, no drift".
-            "graph_drift": None,
-        },
+        "critical_path": critical_path,
         "anomalies": anomalies,
         "unmapped_steps": unmapped,
         "unusable_steps": unusable,
     }
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+#
+# Cells are (job name, runner population).  No run in this repository is
+# single-population -- one run spans GitHub-hosted runners and several
+# self-hosted ones, and the same job lands on different ones between runs -- so
+# a run-level population filter would refuse every real input and a pooled
+# median would average two different machines.  "Hosted-runner baseline"
+# therefore means hosted-runner job samples.
+
+AGGREGATED_METRICS = ("queue_delay", "job_wall", "upstream_elapsed")
+
+
+def percentile_nearest_rank(sorted_values: list, fraction: float):
+    """Nearest-rank, pinned so the doc and the tool cannot drift.  With a small
+    sample this returns the maximum, which is why the report says so rather
+    than presenting it as an estimate."""
+    if not sorted_values:
+        return None
+    rank = math.ceil(fraction * len(sorted_values))
+    return sorted_values[max(rank, 1) - 1]
+
+
+def summarize(values: list) -> dict:
+    ordered = sorted(values)
+    return {
+        "n": len(ordered),
+        "median": percentile_nearest_rank(ordered, 0.5),
+        "p95": percentile_nearest_rank(ordered, 0.95),
+        "max": ordered[-1] if ordered else None,
+        "p95_is_sample_max": len(ordered) < 20,
+    }
+
+
+def aggregate_reports(reports: list) -> dict:
+    """Per-(job, population) cells across runs, kept separate by conclusion so
+    a failed run's truncated timings never dilute a successful one's."""
+    cells: dict = {}
+    excluded = []
+    runs = []
+    for report in reports:
+        conclusion = report.get("conclusion") or report.get("status")
+        attempt = report.get("run_attempt")
+        if attempt is None:
+            excluded.append({"run_id": report.get("run_id"),
+                             "reason": "run_attempt unknown"})
+            continue
+        if attempt != 1:
+            excluded.append({"run_id": report.get("run_id"),
+                             "reason": "run_attempt > 1"})
+            continue
+        runs.append({"run_id": report.get("run_id"), "conclusion": conclusion,
+                     "head_sha": report.get("head_sha")})
+        for job in report.get("jobs") or []:
+            key = f"{job['name']}\u0000{job['population']}\u0000{conclusion}"
+            cell = cells.setdefault(key, {
+                "job": job["name"], "population": job["population"],
+                "conclusion": conclusion, "runner_names": set(),
+                "samples": {name: [] for name in AGGREGATED_METRICS},
+            })
+            if job.get("runner_name"):
+                cell["runner_names"].add(job["runner_name"])
+            for name in AGGREGATED_METRICS:
+                value = _seconds(job["metrics"][name])
+                if value is not None:
+                    cell["samples"][name].append(value)
+    summary = []
+    for cell in cells.values():
+        summary.append({
+            "job": cell["job"], "population": cell["population"],
+            "conclusion": cell["conclusion"],
+            # Hosted runners are fungible ephemeral machines; self-hosted ones
+            # are not, so a cell spanning several of them is a mixture and has
+            # to say so rather than hide behind the population label.
+            "runner_names": sorted(cell["runner_names"]),
+            "mixed_machines": len(cell["runner_names"]) > 1
+                              and cell["population"] == "self-hosted",
+            # n is per metric, not per cell: a skipped job contributes to
+            # neither, and a failed run truncates some metrics and not others.
+            "metrics": {name: summarize(values)
+                        for name, values in cell["samples"].items()},
+        })
+    summary.sort(key=lambda c: (c["conclusion"], c["job"], c["population"]))
+    # "none" is the absence of a runner, not a population of one.
+    populations = sorted({c["population"] for c in summary} - {"none"})
+    return {
+        "schema": SCHEMA,
+        "generated_at": now_iso(),
+        "runs": runs,
+        "excluded": excluded,
+        "populations": populations,
+        "pooled": False,
+        "note": ("cells are (job, population, conclusion); populations are "
+                 "never pooled because one run spans several and the same job "
+                 "moves between them.  Within self-hosted, a cell may still "
+                 "span several machines; `mixed_machines` says which do"),
+        "cells": summary,
+    }
+
+
+def render_aggregate_markdown(doc: dict) -> str:
+    lines = [
+        f"# CI telemetry baseline over {len(doc['runs'])} runs",
+        "",
+        f"- populations: {', '.join(doc['populations']) or 'none'}; "
+        f"never pooled",
+        f"- excluded: {len(doc['excluded'])}",
+        "",
+        "Seconds. `n` is per metric: a skipped job contributes to none, and a "
+        "failed run truncates some.",
+        "",
+        "| conclusion | job | population | queue n | queue med | queue p95 | "
+        "wall n | wall med | wall p95 | mixed machines |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    def num(value):
+        # A cell with no samples prints an em dash, not "None" and not 0.
+        return "--" if value is None else str(value)
+
+    for cell in doc["cells"]:
+        q, w = cell["metrics"]["queue_delay"], cell["metrics"]["job_wall"]
+        if all(stats["n"] == 0 for stats in cell["metrics"].values()):
+            # A cell with no samples in any metric is a job that only ever
+            # skipped; it is counted below rather than given a row of dashes.
+            continue
+        lines.append(
+            f"| {cell['conclusion']} | {cell['job']} | {cell['population']} "
+            f"| {q['n']} | {num(q['median'])} | {num(q['p95'])} "
+            f"| {w['n']} | {num(w['median'])} | {num(w['p95'])} "
+            f"| {'yes' if cell['mixed_machines'] else ''} |")
+    empty = sum(1 for c in doc["cells"]
+                if all(stats["n"] == 0 for stats in c["metrics"].values()))
+    if empty:
+        lines += ["", f"{empty} further cells contributed no sample to any "
+                  "metric (jobs that only ever skipped)."]
+    if any(c["metrics"]["queue_delay"]["p95_is_sample_max"]
+           for c in doc["cells"] if c["metrics"]["queue_delay"]["n"]):
+        lines += ["", "Both columns are nearest-rank, so `med` is a sample "
+                  "value rather than the midpoint of two. Where n < 20 the "
+                  "p95 column is the sample maximum, not a percentile "
+                  "estimate."]
+    return "\n".join(lines) + "\n"
 
 
 # ---------------------------------------------------------------------------
@@ -663,6 +1167,41 @@ def render_markdown(report: dict) -> str:
     ]
     for key, metric in report["metrics"].items():
         lines.append(f"| {key} | {cell(metric)} |")
+    path = report["critical_path"]
+    caveats = []
+    feedback = report["metrics"].get("pr_feedback") or {}
+    if (feedback.get("evidence") or {}).get("non_pinned_executed") == 0:
+        caveats.append("`pr_feedback` equals `run_wall_clock` by construction "
+                       "here, not by corroboration: every executed job is a "
+                       "pinned check.")
+    note = (path["observed"].get("evidence") or {}).get("note")
+    if note:
+        caveats.append(f"`critical_path.observed` is {note}.")
+    for key in ("observed", "graph"):
+        metric = path[key]
+        lines.append(f"| critical_path.{key} | {cell(metric)} |")
+    chain = (path["observed"].get("evidence") or {}).get("chain")
+    if chain:
+        hops = {hop["job"]: hop
+                for hop in (path["observed"].get("evidence") or {}).get(
+                    "hops") or []}
+        lines += ["", "Critical path, in order. Seconds are queue then wall:",
+                  ""]
+        for name in chain:
+            hop = hops.get(name) or {}
+            lines.append(f"- {name}"
+                         f" ({hop.get('queue_delay')} / {hop.get('job_wall')})")
+    if caveats:
+        lines += ["", "These are not three independent measurements:", ""]
+        lines += [f"- {text}" for text in caveats]
+    drift = path.get("graph_drift")
+    if drift and (drift.get("jobs_without_node")
+                  or drift.get("nodes_without_job")):
+        lines += ["", "The declared graph and the run disagree:", ""]
+        for name in drift.get("jobs_without_node") or []:
+            lines.append(f"- job with no node: {name}")
+        for name in drift.get("nodes_without_job") or []:
+            lines.append(f"- node with no job: {name}")
     lines += [
         "",
         "Per job, seconds. A skipped job has no durations at all.",
@@ -813,7 +1352,26 @@ def cmd_report(args) -> int:
         if run.get("id") is not None and run.get("id") != run_id:
             return die(f"{run_path} holds run {run.get('id')}, not {run_id}; "
                        f"the saved pair does not belong together")
-        report = analyze(run, json.loads(jobs_path.read_text()))
+        jobs_doc = json.loads(jobs_path.read_text())
+        edges, drift = None, None
+        if args.workflow:
+            try:
+                graph = extract_graph(args.workflow)
+            except (OSError, WorkflowParseError) as exc:
+                # A missing workflow costs the critical path, not the report:
+                # the per-job timings are the bulk of the value and they do
+                # not depend on the graph.
+                print(f"ci-run-telemetry: no dependency graph "
+                      f"({exc}); the critical path will say so",
+                      file=sys.stderr)
+                graph = None
+            if not graph:
+                print("ci-run-telemetry: the workflow declares no jobs; the "
+                      "critical path will say so", file=sys.stderr)
+            else:
+                names = [j.get("name") for j in jobs_doc.get("jobs") or []]
+                edges, drift = match_graph_to_jobs(graph, names)
+        report = analyze(run, jobs_doc, edges, drift)
         (out / f"run-{run_id}.json").write_text(
             json.dumps(report, indent=2, sort_keys=True) + "\n")
         (out / f"run-{run_id}.md").write_text(render_markdown(report))
@@ -821,6 +1379,29 @@ def cmd_report(args) -> int:
         print(f"ci-run-telemetry: run {run_id}: {counts['executed']} executed, "
               f"{counts['skipped']} skipped, "
               f"{len(report['anomalies'])} anomalies")
+    return 0
+
+
+def cmd_aggregate(args) -> int:
+    out = Path(args.out)
+    if args.run_id:
+        paths = [out / f"run-{run_id}.json" for run_id in args.run_id]
+        missing = [str(path) for path in paths if not path.exists()]
+        if missing:
+            return die(f"no report at {', '.join(missing)} (run `report` first)")
+    else:
+        paths = sorted(path for path in out.glob("run-*.json")
+                       if path.name != f"{args.label}.json")
+    if not paths:
+        return die(f"no reports under {out} (run `report` first)")
+    reports = [json.loads(path.read_text()) for path in paths]
+    doc = aggregate_reports(reports)
+    (out / f"{args.label}.json").write_text(
+        json.dumps(doc, indent=2, sort_keys=True) + "\n")
+    (out / f"{args.label}.md").write_text(render_aggregate_markdown(doc))
+    print(f"ci-run-telemetry: {args.label}: {len(doc['runs'])} runs, "
+          f"{len(doc['cells'])} cells, populations "
+          f"{', '.join(doc['populations']) or 'none'}")
     return 0
 
 
@@ -846,7 +1427,22 @@ def main(argv=None) -> int:
                         help="workflow run id; repeat for several runs")
     report.add_argument("--out", default=DEFAULT_OUT_DIR,
                         help=f"output directory (default {DEFAULT_OUT_DIR}/)")
+    report.add_argument("--workflow", default=DEFAULT_WORKFLOW,
+                        help="workflow file the dependency graph is read from "
+                             f"(default {DEFAULT_WORKFLOW}); pass an empty "
+                             "value to skip the critical path")
     report.set_defaults(func=cmd_report)
+
+    aggregate = sub.add_parser(
+        "aggregate", help="combine reports into per-(job, population) cells")
+    aggregate.add_argument("--run-id", type=int, action="append",
+                           help="restrict to these runs; default every report "
+                                "in the output directory")
+    aggregate.add_argument("--out", default=DEFAULT_OUT_DIR,
+                           help=f"output directory (default {DEFAULT_OUT_DIR}/)")
+    aggregate.add_argument("--label", default="baseline",
+                           help="name for the written files (default baseline)")
+    aggregate.set_defaults(func=cmd_aggregate)
 
     args = parser.parse_args(argv)
     if getattr(args, "max_requests", 1) < 1:

--- a/scripts/ci/ci-run-telemetry.py
+++ b/scripts/ci/ci-run-telemetry.py
@@ -343,7 +343,6 @@ def no_run_label(conclusion) -> str:
     return NO_RUN_LABELS.get(conclusion, str(conclusion))
 
 
-
 def did_not_run(job: dict) -> bool:
     """Whether the runner never executed this job, so it has no durations to
     report and anything derived from its stamps would be bookkeeping.
@@ -932,12 +931,12 @@ KNOWN_JOB_STATUSES = IN_FLIGHT_STATUSES + ("completed",)
 KNOWN_RUN_STATUSES = KNOWN_JOB_STATUSES
 
 
-
 def absent_by_design(entry: dict) -> bool:
     """True when this job has none of its own durations because the runner
     never executed it, rather than because the run lost them.  Its release
-    latency is not one of these: that ends at the job's creation.  The table caption excuses
-    exactly these jobs, so this has to mean exactly what the caption says.
+    latency is not one of these: that ends at the job's creation.  The table
+    caption excuses exactly these jobs, so this has to mean exactly what the
+    caption says.
 
     It reads the answer `analyze_job` recorded rather than re-deriving one.
     Every re-derivation tried here was wrong on some reachable job: the
@@ -1649,9 +1648,9 @@ def job_count_phrase(counts: dict) -> str:
     breakdown = counts.get("did_not_run_by_conclusion") or {}
     # Sorted by the term the reader sees, so the phrase neither reorders
     # with the order the API happened to return the jobs in nor lists its
-    # words out of alphabetical order.  Every term, skipped included, is named from
-    # this one table; a second spelling elsewhere would be a second thing to
-    # keep in step.
+    # words out of alphabetical order.  Every term, skipped included, is
+    # named from this one table; a second spelling elsewhere would be a
+    # second thing to keep in step.
     for conclusion, count in sorted(breakdown.items(),
                                     key=lambda item: no_run_label(item[0])):
         parts.append(f"{count} {no_run_label(conclusion)}")

--- a/scripts/ci/ci-run-telemetry.py
+++ b/scripts/ci/ci-run-telemetry.py
@@ -668,6 +668,21 @@ def _seconds(metric: dict):
                                                          "partial") else None
 
 
+def untimed_executed_jobs(analyzed: list) -> list:
+    """Jobs that were not skipped and that the run did not time.  A skipped
+    job's absent duration is correct and is not reported here.
+
+    Both walkers pick a chain by comparing weights, so a job like this can
+    decide which chain wins without ever appearing on the winner: the walk
+    routes around the hole and the survivor carries no trace of it.  Naming
+    them run-wide is deliberately over-inclusive.  A total that may have been
+    routed around missing data says so, rather than being right only when the
+    gap happens to fall on the chain that was reported."""
+    return sorted(entry["name"] for entry in analyzed
+                  if entry.get("conclusion") != "skipped"
+                  and _seconds(entry["metrics"]["job_wall"]) is None)
+
+
 def observed_path(analyzed: list, edges: dict, drift: dict) -> dict:
     """Walk back from the last job to finish, hop by hop, through its actual
     dependencies.  Taking the nearest earlier finisher instead would be wrong
@@ -723,10 +738,21 @@ def observed_path(analyzed: list, edges: dict, drift: dict) -> dict:
     })
     if unmeasured:
         metric["evidence"]["unmeasured_hops"] = unmeasured
+    # The walk starts at the last job to finish that the run actually timed,
+    # so an untimed job that finished later is skipped over silently and the
+    # chain below it is reported as if it were the whole path.
+    off_chain = [name for name in untimed_executed_jobs(analyzed)
+                 if name not in set(chain)]
+    if off_chain:
+        metric["evidence"]["untimed_jobs_off_chain"] = off_chain
     reasons = []
     if unmeasured:
         reasons.append(f"{len(unmeasured)} hop(s) on this chain were not "
                        f"timed and contribute nothing to the total")
+    if off_chain:
+        reasons.append(f"{len(off_chain)} executed job(s) elsewhere in the "
+                       f"run were not timed, so this chain may not be the "
+                       f"longest one")
     if truncated:
         reasons.append(f"walk stopped: {truncated}")
     if drift.get("nodes_without_job"):
@@ -749,6 +775,12 @@ def graph_path(analyzed: list, edges: dict, drift: dict) -> dict:
     rather than disappearing."""
     by_name = {entry["name"]: entry for entry in analyzed}
     if not edges:
+        # A graph that resolved to nothing is not the same as no graph, and
+        # saying the latter hides a rename that matched none of the run.
+        if drift and (drift.get("jobs_without_node")
+                      or drift.get("nodes_without_job")):
+            return unavailable("the declared graph resolved to none of this "
+                               "run's jobs; see drift")
         return unavailable(GRAPH_NOT_SUPPLIED)
     best: dict = {}
     unusable_edges: set = set()
@@ -781,7 +813,8 @@ def graph_path(analyzed: list, edges: dict, drift: dict) -> dict:
         return unavailable("no job to walk")
     total, chain = max(results, key=lambda pair: pair[0])
     unmeasured_nodes = [name for name in chain
-                        if _seconds(by_name[name]["metrics"]["job_wall"])
+                        if name not in by_name
+                        or _seconds(by_name[name]["metrics"]["job_wall"])
                         is None]
     # Only the edges on the chain being reported can qualify this number.
     for index, name in enumerate(chain[1:], start=1):
@@ -795,6 +828,16 @@ def graph_path(analyzed: list, edges: dict, drift: dict) -> dict:
         reasons.append(f"{len(unmeasured_nodes)} job(s) on this chain were "
                        f"not timed and contribute nothing to the total")
         metric["evidence"]["unmeasured_nodes"] = unmeasured_nodes
+    # An untimed node weighs zero during selection, so the longest path can
+    # be routed around it and come back clean.  The hole is off the chain
+    # precisely because it was scored as free.
+    off_chain = [name for name in untimed_executed_jobs(analyzed)
+                 if name not in set(chain)]
+    if off_chain:
+        reasons.append(f"{len(off_chain)} executed job(s) off this chain were "
+                       f"not timed, so the longest path may have been routed "
+                       f"around them")
+        metric["evidence"]["untimed_jobs_off_chain"] = off_chain
     if unusable_edges:
         reasons.append("edge weights unavailable on this chain; node weights "
                        "only (a skip cascade batches job creation)")
@@ -819,6 +862,9 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
             drift: dict | None = None) -> dict:
     """@needs is the resolved per-job dependency map and @drift is where it and
     the run disagree; both come from match_graph_to_jobs."""
+    # None means no graph was offered.  An empty mapping means one was and it
+    # resolved to nothing, which is a finding rather than an absence.
+    graph_supplied = needs is not None
     needs = needs or {}
     jobs = jobs_doc.get("jobs") or []
     t0_iso = run.get("run_started_at") or run.get("created_at")
@@ -933,7 +979,7 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
                 "step": item.get("step"), "reason": item.get("reason"),
             })
 
-    if needs:
+    if graph_supplied:
         drift = drift or {"jobs_without_node": [], "nodes_without_job": []}
         critical_path = {
             "observed": observed_path(analyzed, needs, drift),
@@ -1365,10 +1411,14 @@ def cmd_report(args) -> int:
                       f"({exc}); the critical path will say so",
                       file=sys.stderr)
                 graph = None
-            if not graph:
-                print("ci-run-telemetry: the workflow declares no jobs; the "
-                      "critical path will say so", file=sys.stderr)
             else:
+                if not graph:
+                    # Only reachable when the file parsed: an unreadable
+                    # workflow has already said why, and saying it declares
+                    # no jobs on top of that would be a second, false claim.
+                    print("ci-run-telemetry: the workflow declares no jobs; "
+                          "the critical path will say so", file=sys.stderr)
+            if graph:
                 names = [j.get("name") for j in jobs_doc.get("jobs") or []]
                 edges, drift = match_graph_to_jobs(graph, names)
         report = analyze(run, jobs_doc, edges, drift)

--- a/scripts/ci/ci-run-telemetry.py
+++ b/scripts/ci/ci-run-telemetry.py
@@ -305,6 +305,45 @@ def is_skipped(job: dict) -> bool:
     return job.get("conclusion") == "skipped"
 
 
+# A skipped job never dispatches, whatever it is stamped with.  It is the
+# only conclusion that settles the question on its own.
+NEVER_DISPATCHED = ("skipped",)
+
+# Conclusions only a job that executed can reach.  A job reported successful
+# ran, whatever its stamps say, so the report must not tell the reader it
+# never started.
+CONCLUSIONS_THAT_RAN = ("success", "failure", "timed_out")
+
+# Sentences and labels for the conclusions worth naming precisely.  Both fall
+# back to the conclusion itself, which is always true and is what a
+# conclusion this tool has not met before gets.
+NO_EXECUTION_REASONS = {
+    "skipped": "job skipped; no execution",
+    "cancelled": "job cancelled before it ran; no execution",
+    "stale": "job stale; no execution",
+    "startup_failure": "job failed to start; no execution",
+    "action_required": "job awaiting approval; no execution",
+}
+NO_RUN_LABELS = {
+    "skipped": "skipped",
+    "cancelled": "cancelled before running",
+    "stale": "stale",
+    "startup_failure": "failed to start",
+    "action_required": "awaiting approval",
+}
+
+
+def no_execution_reason(conclusion) -> str:
+    return NO_EXECUTION_REASONS.get(
+        conclusion, f"job concluded {conclusion!r} without running; "
+                    f"no execution")
+
+
+def no_run_label(conclusion) -> str:
+    return NO_RUN_LABELS.get(conclusion, str(conclusion))
+
+
+
 def did_not_run(job: dict) -> bool:
     """Whether the runner never executed this job, so it has no durations to
     report and anything derived from its stamps would be bookkeeping.
@@ -331,14 +370,23 @@ def did_not_run(job: dict) -> bool:
     creation is the only trace of that.  With none of the three, it never
     ran.
 
-    A skip needs no such check.  A skipped job never dispatches, whatever it
-    is stamped with."""
+    Only two kinds of conclusion skip the evidence.  A skipped job never
+    dispatches, whatever it is stamped with.  And an outcome only execution
+    reaches -- success, failure, a timeout -- proves the job ran, so asking
+    the stamps could only erase real seconds from the run's wall clock.
+
+    Everything else goes through the evidence, which is the direction that
+    stays correct as GitHub's vocabulary grows: `cancelled` and
+    `action_required` can land either side of a dispatch, `neutral` can, and
+    a conclusion added after this was written would otherwise mean "ran" by
+    default and publish a zero for a job that never started."""
     conclusion = job.get("conclusion")
-    if conclusion == "skipped":
+    if conclusion in NEVER_DISPATCHED:
         return True
-    if conclusion != "cancelled":
+    if conclusion is None or conclusion in CONCLUSIONS_THAT_RAN:
+        # Still going, or an outcome only execution reaches.
         return False
-    # A cancellation lands either side of the runner picking the job up.
+    # It can have landed either side of the runner picking the job up.
     if first_step_start(job):
         return False                       # a step of its own ran
     created = parse_ts(job.get("created_at"))
@@ -461,6 +509,9 @@ def job_may_still_move(job: dict,
                        run_status: str | None) -> bool:
     """Whether this job could still acquire a start stamp.
 
+    Takes either a raw API job or an analyzed entry; it reads only `status`,
+    which both carry.
+
     A status that means not-done-yet only means that while the run itself is
     still going.  The same status in a run the API calls finished describes a
     job that stopped without saying so, and telling the reader it may still
@@ -539,7 +590,9 @@ def queue_absence_reasons(job: dict,
 
 def analyze_job(job: dict, t0_iso: str, completed_by_name: dict,
                 run_status: str | None) -> dict:
-    """One job's timing.  A job that did not run gets no durations at all:
+    """One job's timing.  A job that did not run gets no durations of its
+    own -- its release latency is added later and survives, because it ends
+    at the job's creation rather than at anything the job did:
     GitHub stamps such a job as though it had started and finished at the
     moment it was created, and a zero there would read as a job that ran
     instantly.  `did_not_run` decides which jobs those are."""
@@ -557,8 +610,7 @@ def analyze_job(job: dict, t0_iso: str, completed_by_name: dict,
     }
 
     if did_not_run(job):
-        reason = ("job skipped; no execution" if is_skipped(job)
-                  else "job cancelled before it ran; no execution")
+        reason = no_execution_reason(job.get("conclusion"))
         entry["metrics"] = {
             "upstream_elapsed": non_additive(unavailable(reason)),
             "queue_delay": additive(unavailable(reason)),
@@ -879,15 +931,12 @@ IN_FLIGHT_STATUSES = ("queued", "in_progress", "waiting", "requested",
 KNOWN_JOB_STATUSES = IN_FLIGHT_STATUSES + ("completed",)
 KNOWN_RUN_STATUSES = KNOWN_JOB_STATUSES
 
-# Conclusions only a job that executed can reach.  A job reported successful
-# ran, whatever its stamps say, so the report must not tell the reader it
-# never started.
-CONCLUSIONS_THAT_RAN = ("success", "failure", "timed_out")
 
 
 def absent_by_design(entry: dict) -> bool:
-    """True when this job has no durations because the runner never executed
-    it, rather than because the run lost them.  The table caption excuses
+    """True when this job has none of its own durations because the runner
+    never executed it, rather than because the run lost them.  Its release
+    latency is not one of these: that ends at the job's creation.  The table caption excuses
     exactly these jobs, so this has to mean exactly what the caption says.
 
     It reads the answer `analyze_job` recorded rather than re-deriving one.
@@ -1156,6 +1205,11 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
     analyzed = [analyze_job(j, t0_iso, jobs_by_name, run_status)
                 for j in jobs]
     for entry, job in zip(analyzed, jobs):
+        # Deliberately `is_skipped`, not `did_not_run`: this metric ends at
+        # the job's *creation*, which happens whether or not the job then
+        # dispatches, so a job that never ran still has one.  The skip carve-
+        # out is different -- GitHub materializes a whole skip cascade in one
+        # second, so its creation stamps carry no ordering at all.
         if is_skipped(job):
             entry["metrics"]["scheduler_release_latency"] = additive(
                 unavailable("job skipped; no execution"))
@@ -1163,8 +1217,20 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
             entry["metrics"]["scheduler_release_latency"] = additive(
                 release_latency(job, jobs_by_name, needs))
 
-    executed = [j for j in jobs if not is_skipped(j)]
+    # The same test the table caption uses, and the one the walkers use to
+    # qualify a total.  Counting a job that did not run as executed put "18
+    # executed" directly above a caption excusing it, and a row of six blanks
+    # directly below.  Note the graph walk still routes *through* such a job,
+    # qualifying the total rather than skipping the node.
+    executed = [j for j in jobs if not did_not_run(j)]
     skipped = [j for j in jobs if is_skipped(j)]
+    never_ran = [j for j in jobs if did_not_run(j) and not is_skipped(j)]
+    by_conclusion: dict = {}
+    for job in jobs:
+        if not did_not_run(job):
+            continue
+        conclusion = job.get("conclusion")
+        by_conclusion[conclusion] = by_conclusion.get(conclusion, 0) + 1
     ends = [j.get("completed_at") for j in executed if j.get("completed_at")]
     if ends:
         last = max(ends, key=ts_key)
@@ -1203,7 +1269,7 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
         first_failure = unavailable(
             f"run status {run_status!r} is not one this tool recognises; "
             f"no failure seen")
-    elif any(j.get("conclusion") == "cancelled" for j in executed):
+    elif any(j.get("conclusion") == "cancelled" for j in jobs):
         first_failure = unavailable(
             "no job failed; cancelled jobs were seen and excluded")
     else:
@@ -1299,7 +1365,9 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
         "t0": t0_iso,
         "t0_source": t0_source,
         "job_counts": {"total": len(jobs), "executed": len(executed),
-                       "skipped": len(skipped)},
+                       "skipped": len(skipped),
+                       "never_ran": len(never_ran),
+                       "did_not_run_by_conclusion": by_conclusion},
         "populations": {k: sorted(v) for k, v in sorted(populations.items())},
         "jobs": analyzed,
         "metrics": {
@@ -1400,8 +1468,9 @@ def aggregate_reports(reports: list) -> dict:
             "runner_names": sorted(cell["runner_names"]),
             "mixed_machines": len(cell["runner_names"]) > 1
                               and cell["population"] == "self-hosted",
-            # n is per metric, not per cell: a skipped job contributes to
-            # neither, and a failed run truncates some metrics and not others.
+            # n is per metric, not per cell: a job that did not run
+            # contributes to none, and a failed run truncates some metrics
+            # and not others.
             "metrics": {name: summarize(values)
                         for name, values in cell["samples"].items()},
         })
@@ -1431,8 +1500,8 @@ def render_aggregate_markdown(doc: dict) -> str:
         f"never pooled",
         f"- excluded: {len(doc['excluded'])}",
         "",
-        "Seconds. `n` is per metric: a job that did not run contributes "
-        "to none, and a "        "failed run truncates some.",
+        "Seconds. `n` is per metric: a job that did not run contributes to "
+        "none, and a failed run truncates some.",
         "",
         "| conclusion | job | population | queue n | queue med | queue p95 | "
         "wall n | wall med | wall p95 | mixed machines |",
@@ -1570,6 +1639,25 @@ def degradation_block(report: dict, path: dict) -> list:
     return lines
 
 
+def job_count_phrase(counts: dict) -> str:
+    """How the run's jobs divide.  A job that did not run is named by what
+    kept it from running, from its own conclusion: skipped, stale, failed to
+    start and cancelled before running are different things to a reader
+    asking whether a gate covered the change, and a term naming the wrong one
+    contradicts the table three rows below it."""
+    parts = [f"{counts.get('executed', 0)} executed"]
+    breakdown = counts.get("did_not_run_by_conclusion") or {}
+    # Sorted by the term the reader sees, so the phrase neither reorders
+    # with the order the API happened to return the jobs in nor lists its
+    # words out of alphabetical order.  Every term, skipped included, is named from
+    # this one table; a second spelling elsewhere would be a second thing to
+    # keep in step.
+    for conclusion, count in sorted(breakdown.items(),
+                                    key=lambda item: no_run_label(item[0])):
+        parts.append(f"{count} {no_run_label(conclusion)}")
+    return ", ".join(parts)
+
+
 def render_markdown(report: dict) -> str:
     counts = report["job_counts"]
     lines = [
@@ -1578,8 +1666,7 @@ def render_markdown(report: dict) -> str:
         f"- head `{report['head_sha']}` on `{report['head_branch']}`, "
         f"attempt {report['run_attempt']}, conclusion `{report['conclusion']}`",
         f"- t0 `{report['t0']}` (from `{report['t0_source']}`)",
-        f"- jobs: {counts['total']} ({counts['executed']} executed, "
-        f"{counts['skipped']} skipped)",
+        f"- jobs: {counts['total']} ({job_count_phrase(counts)})",
         "",
         "Run-level, seconds:",
         "",
@@ -1625,8 +1712,9 @@ def render_markdown(report: dict) -> str:
             lines.append(f"- node with no job: {name}")
     lines += [
         "",
-        "Per job, seconds. A job that was skipped, or cancelled before it "
-        "ran, has no durations at all.",
+        "Per job, seconds. A job that did not run has no durations in this "
+        "table, and the run summary above says what kept each one from "
+        "running.",
         "",
         "| job | population | "
         + " | ".join(heading for _, _, heading in JOB_COLUMNS) + " |",
@@ -1803,8 +1891,8 @@ def cmd_report(args) -> int:
         (out / f"run-{run_id}.md").write_text(render_markdown(report),
                                               encoding="utf-8")
         counts = report["job_counts"]
-        print(f"ci-run-telemetry: run {run_id}: {counts['executed']} executed, "
-              f"{counts['skipped']} skipped, "
+        print(f"ci-run-telemetry: run {run_id}: "
+              f"{job_count_phrase(counts)}, "
               f"{len(report['anomalies'])} anomalies")
     return 0
 

--- a/scripts/ci/ci-run-telemetry.py
+++ b/scripts/ci/ci-run-telemetry.py
@@ -1,0 +1,858 @@
+#!/usr/bin/env python3
+"""Measure PR CI queue time and per-phase duration from run metadata (#1570).
+
+PR #1533 exposed slow feedback that status polling could not explain, because a
+pending check does not say whether its job is waiting for a runner or running.
+This tool separates those two and attributes the rest of a job's wall time to
+named phases, so #1571 (cache), #1572 (duplicate compilation), #1573 (early
+size failure) and #1574 (job graph) argue from measurement, not guesswork.
+
+It reads what the API already records -- `runs/{id}` and `runs/{id}/jobs` --
+and is therefore an *offline analyzer*: nothing is added to a workflow.  A job
+cannot observe its own run's end, so run-level completion and the critical path
+are only computable after the fact; and an added step in every job would change
+the durations being measured.  Publishing the report automatically from a
+`workflow_run` trigger is deliberately out of scope and tracked separately, so
+until that lands these numbers are available to whoever runs this script,
+not to the pull request author.
+
+What it deliberately does NOT do:
+
+  * It is not a gate.  It never exits 77, it is never registered as a test that
+    checks anything, and it never enters a workflow.  Only its self-test is
+    registered with Meson.
+  * It does not measure an individual gate's wall time against its own timeout;
+    that is #1487 and it reads `meson-logs/testlog.json`, not the Actions API.
+  * It does not change the job graph.  It measures the one that exists.
+
+Timestamps come from two clocks.  Job-level `created_at`/`started_at`/
+`completed_at` are GitHub's server clock; step timestamps are the runner's.  On
+a self-hosted runner those disagree -- this repository has one whose steps
+start up to ten seconds before the job the server says they belong to.  Every
+duration here is therefore computed on the server clock alone; the runner
+offset is reported separately and never folded into a duration.
+
+Every metric is an object, never a bare number, and a metric that was not
+measured says so with a reason instead of reporting zero:
+
+    {"seconds": 137, "status": "measured", "reason": null, "evidence": {...}}
+    {"seconds": null, "status": "unavailable", "reason": "job skipped; ..."}
+
+`status: "measured"` requires non-empty evidence, so a phase that matched no
+step reports `unavailable` rather than a zero that looks like a fast phase.
+`partial` carries a value that is real but not final (a run still in flight);
+`unavailable` and `anomalous` never carry one.  `clock_offset_estimate` is the
+one signed quantity here and uses `offset_seconds`, so it is never mistaken for
+a duration.
+
+Usage:
+  ci-run-telemetry.py fetch  --run-id ID [--run-id ID ...] [--out DIR]
+                            [--max-requests N] [--repo OWNER/NAME]
+  ci-run-telemetry.py report --run-id ID [--run-id ID ...] [--out DIR]
+
+`fetch` costs two requests for a run whose jobs fit one page, plus any
+retries, which are charged to the same budget.  `--out` defaults to
+`ci-telemetry/`, which the repository ignores.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCHEMA = "wirelog.ci-telemetry/1"
+TOOL_VERSION = "1"
+
+# A runner GitHub operates is named "GitHub Actions <n>".  Everything else is
+# self-hosted.  Labels are NOT a source of truth: this repository runs a
+# self-hosted runner that carries the `ubuntu-latest` label, so a population
+# split on labels silently pools two different machines.
+HOSTED_RUNNER_RE = re.compile(r"^GitHub Actions \d+$")
+
+# Runner and server clocks may disagree by this much before it is reported as
+# skew rather than ordinary second-granularity rounding.
+CLOCK_SKEW_TOLERANCE_S = 2
+
+# A dependent job is created when the last job it needs completes.  Allow the
+# same rounding slack when checking that relation.
+RELEASE_TOLERANCE_S = 2
+
+GRAPH_PENDING = ("needs-graph extraction is not implemented in this tool "
+                 "version; see #1570 unit 2")
+
+DEFAULT_OUT_DIR = "ci-telemetry"
+JOBS_PER_PAGE = 100
+DEFAULT_MAX_REQUESTS = 40
+RETRY_SLEEPS_S = (1, 2, 4, 8)
+RETRYABLE_RE = re.compile(
+    r"rate limit|secondary rate|abuse detection|HTTP 5\d\d|502|503|504",
+    re.IGNORECASE,
+)
+
+# Phase attribution is by API step name, which is not the same set as the
+# `- name:` values in the workflow files: the runner injects `Set up job` and
+# `Complete job`, an unnamed `- uses:` step becomes `Run <action>`, and every
+# action with a post phase adds `Post <name>`.  The self-test asserts this
+# table against the step names in the committed fixtures, not against the YAML.
+PHASE_EXACT = {
+    "Set up job": "runner_setup",
+    "Complete job": "post_cleanup",
+    "Setup sccache": "cache_setup",
+    # Ahead of the generic Install rule below: these install a specific gate's
+    # tool and belong to that gate's phase, not to dependency installation.
+    "Install clang-tidy (pinned major)": "tidy",
+    "Install syft": "sbom",
+    "Install editorconfig-checker": "lint",
+    "Install uncrustify": "lint",
+    "clang-tidy ratchet gate": "tidy",
+    "SBOM snapshot gate": "sbom",
+    "Check binary size": "binary_size",
+    # tsan-native's only test step; it matches no Test* pattern.
+    "Policy smoke (native threads under TSan)": "tests",
+    "Path A example compile-check": "compile",
+    "Run editorconfig-checker": "lint",
+    "Run uncrustify (hard gate)": "lint",
+    "Detect source and build-definition changes": "policy",
+    "Enforce RC changelog freeze policy": "policy",
+    "Validate support policy": "policy",
+    "Verify enabled compile flag": "policy",
+}
+
+# Ordered: the first match wins, and `Post *` precedes everything so a post
+# phase is never merged into the phase it cleans up after.
+PHASE_PATTERNS = (
+    (re.compile(r"^Post "), "post_cleanup"),
+    (re.compile(r"^Run actions/checkout@"), "checkout"),
+    (re.compile(r"^Install "), "deps_install"),
+    (re.compile(r"^Configure\b"), "configure"),
+    (re.compile(r"^Build\b"), "compile"),
+    (re.compile(r"^Test\b"), "tests"),
+)
+
+# Steps that are real but belong to no phase: sub-second diagnostics and a
+# publication step.  Listed so the coverage self-test stays exhaustive -- a new
+# unmapped step name fails it instead of silently landing in `other`.
+KNOWN_UNMAPPED = frozenset({
+    "Record bash version",
+    "Verify tool version",
+    "Publish results",
+})
+
+PHASES = (
+    "runner_setup", "checkout", "cache_setup", "deps_install", "configure",
+    "compile", "tests", "tidy", "sbom", "binary_size", "lint", "policy",
+    "post_cleanup", "other",
+)
+
+# The checks a pull request waits on.  The required set is not queryable in
+# this repository (see `required_checks` in the report), so this list is the
+# declared surrogate and is reported under its own name.
+PINNED_CHECK_PREFIXES = (
+    "Detect build-triggering changes", "Docs / policy validation",
+    "RC changelog freeze gate", "lint / ", "Build / ", "Sanitizers / ",
+    "mbedtls-enabled / ", "TSan / ", "TSan-native / ",
+)
+
+
+def die(message: str) -> int:
+    print(f"ci-run-telemetry: error: {message}", file=sys.stderr)
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Metric objects
+# ---------------------------------------------------------------------------
+
+def measured(seconds: int, evidence: dict) -> dict:
+    """A value the data supports.  Evidence is mandatory: it is what stops a
+    phase that matched no step from reporting a zero that reads as 'fast'.
+    A negative duration is refused here rather than published, so the rule
+    holds for every caller instead of at each call site."""
+    if not evidence:
+        raise ValueError("measured metric requires evidence")
+    if seconds < 0:
+        raise ValueError("measured metric cannot be negative")
+    return {"seconds": seconds, "status": "measured", "reason": None,
+            "evidence": evidence}
+
+
+def unavailable(reason: str) -> dict:
+    return {"seconds": None, "status": "unavailable", "reason": reason,
+            "evidence": {}}
+
+
+def anomalous(reason: str, raw_seconds: int, evidence: dict) -> dict:
+    """Arithmetic the data contradicts.  The raw value is kept so the
+    contradiction can be inspected, but it is never presented as a duration."""
+    return {"seconds": None, "status": "anomalous", "reason": reason,
+            "evidence": evidence, "raw_seconds": raw_seconds}
+
+
+def parse_ts(value):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def ts_key(value, missing_last: bool = False):
+    """Sort key over ISO timestamps.  An unparseable one sorts first, or last
+    when @missing_last, so it never wins a min()/max() by accident."""
+    parsed = parse_ts(value)
+    if parsed is not None:
+        return parsed
+    bound = datetime.max if missing_last else datetime.min
+    return bound.replace(tzinfo=timezone.utc)
+
+
+def non_additive(metric: dict) -> dict:
+    """Mark a value that must not be summed along a path.  `upstream_elapsed`
+    includes every upstream job's own queueing, so adding it up double-counts;
+    saying so in the object keeps a reader from doing it.  Set in every state,
+    including unavailable, so a missing key never has to be interpreted."""
+    metric["additive"] = False
+    return metric
+
+
+def additive(metric: dict) -> dict:
+    """Mark the one per-job wait that may be summed along a path."""
+    metric["additive"] = True
+    return metric
+
+
+def provisional(metric: dict, in_flight: bool) -> dict:
+    """Downgrade a measurement taken while the run is still going.  The value
+    is real but it is a lower bound, and saying so is the difference between a
+    baseline and a number that quietly understates."""
+    if in_flight and metric["status"] == "measured":
+        metric["status"] = "partial"
+        metric["reason"] = "run still in progress; value is a lower bound"
+    return metric
+
+
+def interval(start_iso, end_iso, missing_reason: str) -> dict:
+    """Seconds between two server-clock timestamps, or why they do not yield
+    one.  A negative interval is reported as anomalous, never clamped to 0."""
+    start, end = parse_ts(start_iso), parse_ts(end_iso)
+    if start is None or end is None:
+        return unavailable(missing_reason)
+    seconds = math.floor((end - start).total_seconds())
+    evidence = {"from": start_iso, "to": end_iso}
+    if seconds < 0:
+        return anomalous("end precedes start", seconds, evidence)
+    return measured(seconds, evidence)
+
+
+# ---------------------------------------------------------------------------
+# Per-job analysis
+# ---------------------------------------------------------------------------
+
+def classify_step(name: str) -> str:
+    if name in PHASE_EXACT:
+        return PHASE_EXACT[name]
+    for pattern, phase in PHASE_PATTERNS:
+        if pattern.search(name):
+            return phase
+    return "other"
+
+
+def population_of(job: dict) -> str:
+    runner = job.get("runner_name")
+    if not runner:
+        return "none"
+    return "hosted" if HOSTED_RUNNER_RE.match(runner) else "self-hosted"
+
+
+def is_skipped(job: dict) -> bool:
+    return job.get("conclusion") == "skipped"
+
+
+def job_phases(job: dict) -> tuple:
+    """Phase totals plus the steps that fed each one.  Returns
+    (phases, unmapped_step_names, unusable_steps, skipped_steps,
+    accounted_seconds)."""
+    totals: dict = {}
+    evidence: dict = {}
+    matched_phases = set()
+    unmapped = []
+    unusable = []
+    skipped = []
+    accounted = 0
+    for step in job.get("steps") or []:
+        name = step.get("name") or ""
+        phase = classify_step(name)
+        if phase == "other" and name not in KNOWN_UNMAPPED:
+            unmapped.append(name)
+        if step.get("conclusion") == "skipped":
+            # A skipped step is stamped started == completed.  Counting it
+            # would add a 0 to the phase and put its name in the evidence, and
+            # a phase whose steps were all skipped would then report a
+            # measured zero -- a phase that never ran, presented as instant.
+            skipped.append({"step": name, "phase": phase})
+            continue
+        matched_phases.add(phase)
+        start = parse_ts(step.get("started_at"))
+        end = parse_ts(step.get("completed_at"))
+        if start is None or end is None:
+            unusable.append({"step": name, "phase": phase,
+                             "reason": "step has no usable interval"})
+            continue
+        seconds = math.floor((end - start).total_seconds())
+        if seconds < 0:
+            unusable.append({"step": name, "phase": phase,
+                             "reason": "step ends before it starts",
+                             "raw_seconds": seconds})
+            continue
+        totals[phase] = totals.get(phase, 0) + seconds
+        evidence.setdefault(phase, []).append(name)
+        accounted += seconds
+    phases = {}
+    for phase in PHASES:
+        if phase in totals:
+            phases[phase] = measured(totals[phase],
+                                     {"matched_steps": evidence[phase]})
+        elif phase in matched_phases:
+            # Steps did match; their timestamps were unusable.  Saying "no step
+            # matched" here would be false and would hide the real problem.
+            phases[phase] = unavailable(
+                f"steps matched phase {phase} but carried no usable interval")
+        elif any(item["phase"] == phase for item in skipped):
+            phases[phase] = unavailable(
+                f"every step matching phase {phase} was skipped")
+        else:
+            phases[phase] = unavailable(f"no step matched phase {phase}")
+    return phases, unmapped, unusable, skipped, accounted
+
+
+def analyze_job(job: dict, t0_iso: str, completed_by_name: dict) -> dict:
+    """One job's timing.  Skipped jobs get no durations at all: GitHub stamps
+    them with a completion one second before their own start, and a zero there
+    would read as a job that ran instantly."""
+    name = job.get("name") or ""
+    entry = {
+        "name": name,
+        "status": job.get("status"),
+        "conclusion": job.get("conclusion"),
+        "population": population_of(job),
+        "runner_name": job.get("runner_name"),
+        "labels": job.get("labels") or [],
+        "created_at": job.get("created_at"),
+        "started_at": job.get("started_at"),
+        "completed_at": job.get("completed_at"),
+    }
+
+    if is_skipped(job):
+        reason = "job skipped; no execution"
+        entry["metrics"] = {
+            "upstream_elapsed": non_additive(unavailable(reason)),
+            "queue_delay": unavailable(reason),
+            "job_wall": unavailable(reason),
+        }
+        entry["phases"] = {p: unavailable(reason) for p in PHASES}
+        entry["unmapped_steps"] = []
+        entry["unusable_steps"] = []
+        entry["skipped_steps"] = []
+        entry["unaccounted"] = unavailable(reason)
+        entry["clock_offset_estimate"] = {
+            "offset_seconds": None, "status": "unavailable", "reason": reason,
+            "evidence": {},
+        }
+        entry["runner_first_step_at"] = None
+        return entry
+
+    entry["metrics"] = {
+        # Everything upstream of this job, including every upstream job's own
+        # queueing.  Useful for ordering jobs, but NOT additive along a path.
+        "upstream_elapsed": non_additive(
+            interval(t0_iso, job.get("created_at"),
+                     "run or job creation time missing")),
+        "queue_delay": interval(job.get("created_at"), job.get("started_at"),
+                                "job never started"),
+        "job_wall": interval(job.get("started_at"), job.get("completed_at"),
+                             "job has not completed"),
+    }
+
+    phases, unmapped, unusable, skipped, accounted = job_phases(job)
+    entry["phases"] = phases
+    entry["unmapped_steps"] = unmapped
+    entry["unusable_steps"] = unusable
+    # Normal, not anomalous: a skipped step is an `if:` doing its job.  Kept
+    # out of anomalies so it cannot dilute the signals that are.
+    entry["skipped_steps"] = skipped
+
+    wall = entry["metrics"]["job_wall"]
+    if wall["status"] != "measured":
+        entry["unaccounted"] = unavailable("job wall time unavailable")
+    elif accounted > wall["seconds"]:
+        # Steps are timed by the runner, the job window by the server.  On a
+        # skewed runner the steps can span more than the window, and the
+        # residual is then evidence of that skew, not a duration.
+        entry["unaccounted"] = anomalous(
+            "accounted step time exceeds the job wall",
+            wall["seconds"] - accounted,
+            {"job_wall": wall["seconds"], "accounted": accounted})
+    else:
+        entry["unaccounted"] = measured(
+            wall["seconds"] - accounted,
+            {"job_wall": wall["seconds"], "accounted": accounted})
+
+    # The runner's own first step cannot precede the runner picking the job up,
+    # so a negative offset is the two clocks disagreeing, not a fast start.
+    starts = [parse_ts(s.get("started_at")) for s in (job.get("steps") or [])]
+    starts = [s for s in starts if s is not None]
+    job_start = parse_ts(job.get("started_at"))
+    if starts and job_start is not None:
+        offset = math.floor((min(starts) - job_start).total_seconds())
+        first_at = min(starts).isoformat().replace("+00:00", "Z")
+        entry["runner_first_step_at"] = first_at
+        entry["clock_offset_estimate"] = {
+            "offset_seconds": offset, "status": "measured", "reason": None,
+            "evidence": {"job_started_at": job.get("started_at"),
+                         "first_step_started_at": first_at},
+        }
+    else:
+        entry["runner_first_step_at"] = None
+        entry["clock_offset_estimate"] = {
+            "offset_seconds": None, "status": "unavailable",
+            "reason": "no step start recorded", "evidence": {},
+        }
+    return entry
+
+
+def release_latency(job: dict, jobs_by_name: dict, needs: dict) -> dict:
+    """How long after its dependencies finished the job was created.  This is
+    the only per-job wait that may be summed along a path."""
+    name = job.get("name") or ""
+    if not needs:
+        return unavailable("dependency graph not supplied; see #1570 unit 2")
+    if name not in needs:
+        # Not the same as having no dependencies: the extractor may simply
+        # have missed this job, and calling that a root would hide the gap.
+        return unavailable("job absent from the supplied dependency graph")
+    predecessors = needs[name]
+    if not predecessors:
+        return unavailable("root job; nothing released it")
+    completions = []
+    for dep in predecessors:
+        dep_job = jobs_by_name.get(dep)
+        if dep_job is None:
+            return unavailable(f"dependency {dep!r} absent from the run")
+        if is_skipped(dep_job):
+            # GitHub materializes a whole skip cascade in one second, so the
+            # timestamps carry no ordering information at all.
+            return unavailable("released by skipped dependency; creation batched")
+        completions.append((dep, dep_job.get("completed_at")))
+    latest_name, latest_iso = max(completions,
+                                  key=lambda pair: ts_key(pair[1]))
+    metric = interval(latest_iso, job.get("created_at"),
+                      "dependency or job creation time missing")
+    if metric["status"] == "measured":
+        metric["evidence"]["released_by"] = latest_name
+    return metric
+
+
+# ---------------------------------------------------------------------------
+# Run-level analysis
+# ---------------------------------------------------------------------------
+
+def pinned_check(name: str) -> bool:
+    return any(name.startswith(prefix) for prefix in PINNED_CHECK_PREFIXES)
+
+
+def analyze(run: dict, jobs_doc: dict, needs: dict | None = None) -> dict:
+    needs = needs or {}
+    jobs = jobs_doc.get("jobs") or []
+    t0_iso = run.get("run_started_at") or run.get("created_at")
+    t0_source = "run_started_at" if run.get("run_started_at") else "created_at"
+
+    jobs_by_name = {j.get("name"): j for j in jobs}
+    analyzed = [analyze_job(j, t0_iso, jobs_by_name) for j in jobs]
+    for entry, job in zip(analyzed, jobs):
+        if is_skipped(job):
+            entry["metrics"]["scheduler_release_latency"] = additive(
+                unavailable("job skipped; no execution"))
+        else:
+            entry["metrics"]["scheduler_release_latency"] = additive(
+                release_latency(job, jobs_by_name, needs))
+
+    executed = [j for j in jobs if not is_skipped(j)]
+    skipped = [j for j in jobs if is_skipped(j)]
+    # Until the run ends, every run-level figure is a lower bound: a check that
+    # has not reported cannot raise it, and #1574 would quote it as final.
+    in_flight = run.get("status") != "completed"
+
+    ends = [j.get("completed_at") for j in executed if j.get("completed_at")]
+    if ends:
+        last = max(ends, key=ts_key)
+        run_wall = provisional(
+            interval(t0_iso, last, "no executed job has completed"), in_flight)
+    else:
+        run_wall = unavailable("no executed job has completed")
+
+    # `cancelled` is deliberately excluded: a run cancelled by concurrency did
+    # not fail, and counting it would put scheduling noise in a failure metric.
+    failures = [j for j in executed
+                if j.get("conclusion") in ("failure", "timed_out")
+                and j.get("completed_at")]
+    if failures:
+        first = min(failures,
+                    key=lambda j: ts_key(j["completed_at"], missing_last=True))
+        # Not downgraded while the run is in flight: a job still running can
+        # only complete later, so it cannot produce an earlier first failure.
+        first_failure = interval(t0_iso, first["completed_at"],
+                                 "failing job has no completion time")
+        if first_failure["status"] == "measured":
+            first_failure["evidence"]["job"] = first.get("name")
+            # Which step failed is what tells #1573 whether the size gate fired
+            # late; the job name alone does not.  A timed-out job stamps its
+            # steps `cancelled`, so an empty list there is expected and is
+            # labelled rather than left looking like a job that failed with no
+            # failing step.
+            first_failure["evidence"]["failed_steps"] = [
+                s.get("name") for s in (first.get("steps") or [])
+                if s.get("conclusion") in ("failure", "timed_out")]
+            first_failure["evidence"]["conclusion"] = first.get("conclusion")
+    elif in_flight:
+        first_failure = unavailable("run still in progress; no failure yet")
+    elif any(j.get("conclusion") == "cancelled" for j in executed):
+        first_failure = unavailable(
+            "no job failed; cancelled jobs were seen and excluded")
+    else:
+        first_failure = unavailable("run has no failed job")
+
+    pinned_ends = [j.get("completed_at") for j in executed
+                   if pinned_check(j.get("name") or "") and j.get("completed_at")]
+    if pinned_ends:
+        last_pinned = max(pinned_ends, key=ts_key)
+        pr_feedback = provisional(
+            interval(t0_iso, last_pinned, "no pinned check completed"),
+            in_flight)
+        if pr_feedback["status"] in ("measured", "partial"):
+            pr_feedback["evidence"]["source"] = "pinned-list"
+            # When every executed job is a pinned check this equals
+            # run_wall_clock by construction, not by corroboration.  Say so, so
+            # the two are not read as independent agreeing measurements.
+            pr_feedback["evidence"]["non_pinned_executed"] = sum(
+                1 for j in executed if not pinned_check(j.get("name") or ""))
+    else:
+        pr_feedback = unavailable("no pinned check completed")
+
+    populations: dict = {}
+    for entry in analyzed:
+        populations.setdefault(entry["population"], []).append(entry["name"])
+
+    anomalies = []
+    for entry in analyzed:
+        offset = entry.get("clock_offset_estimate") or {}
+        if (offset.get("status") == "measured"
+                and abs(offset["offset_seconds"]) > CLOCK_SKEW_TOLERANCE_S):
+            anomalies.append({
+                "kind": "runner_clock_skew", "job": entry["name"],
+                "runner_name": entry["runner_name"],
+                "offset_seconds": offset["offset_seconds"],
+            })
+        for key, metric in entry["metrics"].items():
+            if metric.get("status") == "anomalous":
+                anomalies.append({
+                    "kind": "negative_interval", "job": entry["name"],
+                    "metric": key, "raw_seconds": metric.get("raw_seconds"),
+                    "reason": metric.get("reason"),
+                })
+        residual = entry.get("unaccounted") or {}
+        if residual.get("status") == "anomalous":
+            anomalies.append({
+                "kind": "steps_exceed_job_wall", "job": entry["name"],
+                "raw_seconds": residual.get("raw_seconds"),
+                "reason": residual.get("reason"),
+            })
+        for item in entry.get("unusable_steps") or []:
+            anomalies.append({
+                "kind": "unusable_step", "job": entry["name"],
+                "step": item.get("step"), "reason": item.get("reason"),
+            })
+
+    unmapped = sorted({name for entry in analyzed
+                       for name in entry["unmapped_steps"]})
+    unusable = sorted({item["step"] for entry in analyzed
+                       for item in entry.get("unusable_steps") or []})
+
+    return {
+        "schema": SCHEMA,
+        "tool_version": TOOL_VERSION,
+        "generated_at": now_iso(),
+        "run_id": run.get("id"),
+        "run_attempt": run.get("run_attempt"),
+        "workflow": run.get("name"),
+        "event": run.get("event"),
+        "status": run.get("status"),
+        "conclusion": run.get("conclusion"),
+        "head_sha": run.get("head_sha"),
+        "head_branch": run.get("head_branch"),
+        "t0": t0_iso,
+        "t0_source": t0_source,
+        "job_counts": {"total": len(jobs), "executed": len(executed),
+                       "skipped": len(skipped)},
+        "populations": {k: sorted(v) for k, v in sorted(populations.items())},
+        "jobs": analyzed,
+        "metrics": {
+            "run_wall_clock": run_wall,
+            "first_failure_latency": first_failure,
+            "pr_feedback": pr_feedback,
+            "total_required_check_completion": unavailable(
+                "no required_status_checks rule (rulesets 13129249, 13670289); "
+                "branches/main/protection -> 404"),
+        },
+        "required_checks": {
+            "source": "unavailable",
+            "surrogate": "pr_feedback",
+            "reason": "the required set is not queryable in this repository",
+        },
+        "critical_path": {
+            "observed": unavailable(GRAPH_PENDING),
+            "graph": unavailable(GRAPH_PENDING),
+            # Not [].  An empty list here would read as "compared, no drift".
+            "graph_drift": None,
+        },
+        "anomalies": anomalies,
+        "unmapped_steps": unmapped,
+        "unusable_steps": unusable,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def cell(metric: dict) -> str:
+    if metric.get("status") == "measured":
+        return str(metric["seconds"])
+    if metric.get("status") == "partial":
+        return f"{metric['seconds']} (partial)"
+    return metric.get("status", "unavailable")
+
+
+def render_markdown(report: dict) -> str:
+    counts = report["job_counts"]
+    lines = [
+        f"# CI timing for run {report['run_id']} ({report['workflow']})",
+        "",
+        f"- head `{report['head_sha']}` on `{report['head_branch']}`, "
+        f"attempt {report['run_attempt']}, conclusion `{report['conclusion']}`",
+        f"- t0 `{report['t0']}` (from `{report['t0_source']}`)",
+        f"- jobs: {counts['total']} ({counts['executed']} executed, "
+        f"{counts['skipped']} skipped)",
+        "",
+        "Run-level, seconds:",
+        "",
+        "| metric | value |",
+        "| --- | --- |",
+    ]
+    for key, metric in report["metrics"].items():
+        lines.append(f"| {key} | {cell(metric)} |")
+    lines += [
+        "",
+        "Per job, seconds. A skipped job has no durations at all.",
+        "",
+        "| job | population | queue | wall | configure | compile | tests | "
+        "unaccounted |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for job in report["jobs"]:
+        m, p = job["metrics"], job["phases"]
+        lines.append(
+            f"| {job['name']} | {job['population']} | {cell(m['queue_delay'])} "
+            f"| {cell(m['job_wall'])} | {cell(p['configure'])} "
+            f"| {cell(p['compile'])} | {cell(p['tests'])} "
+            f"| {cell(job['unaccounted'])} |")
+    if report["anomalies"]:
+        lines += ["", "Anomalies:", ""]
+        for item in report["anomalies"]:
+            lines.append(f"- `{item['kind']}` on {item['job']}: "
+                         + json.dumps({k: v for k, v in item.items()
+                                       if k not in ("kind", "job")}))
+    if report["unmapped_steps"]:
+        lines += ["", "Steps matching no phase (their seconds land in `other`):",
+                  ""]
+        for name in report["unmapped_steps"]:
+            lines.append(f"- {name}")
+    if report["unusable_steps"]:
+        lines += ["", "Steps whose own timestamps are unusable (their seconds "
+                  "are in no phase):", ""]
+        for name in report["unusable_steps"]:
+            lines.append(f"- {name}")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Fetching
+# ---------------------------------------------------------------------------
+
+def run_gh(args: list) -> bytes:
+    """The single point where this tool touches the network.  The self-test
+    replaces it, so no test needs `gh`, a token, or a network."""
+    proc = subprocess.run(["gh", *args], capture_output=True)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.decode("utf-8", "replace").strip())
+    return proc.stdout
+
+
+class Budget:
+    """A hard cap on API requests, so a bad argument cannot turn this into a
+    crawler.  Retries are charged too, so one logical request can cost up to
+    five: the cap bounds traffic, not distinct endpoints."""
+
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        self.used = 0
+
+    def spend(self) -> None:
+        if self.used >= self.limit:
+            raise RuntimeError(
+                f"API request budget exhausted after {self.used} requests "
+                f"(--max-requests {self.limit})")
+        self.used += 1
+
+
+def api_get(path: str, budget: Budget, transport=run_gh, sleep=time.sleep) -> dict:
+    last = None
+    for attempt, pause in enumerate((0, *RETRY_SLEEPS_S)):
+        if pause:
+            print(f"ci-run-telemetry: retrying in {pause}s ({last})",
+                  file=sys.stderr)
+            sleep(pause)
+        budget.spend()
+        try:
+            return json.loads(transport(["api", path]))
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"gh is not installed or not on PATH: {exc}")
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"gh returned a body that is not JSON: {exc}")
+        except RuntimeError as exc:
+            last = str(exc)
+            if not RETRYABLE_RE.search(last):
+                raise
+    raise RuntimeError(f"giving up after {len(RETRY_SLEEPS_S)} retries: {last}")
+
+
+def fetch_run(repo: str, run_id: int, budget: Budget, transport=run_gh,
+              sleep=time.sleep) -> tuple:
+    run = api_get(f"repos/{repo}/actions/runs/{run_id}", budget, transport, sleep)
+    jobs: list = []
+    page = 1
+    while True:
+        doc = api_get(
+            f"repos/{repo}/actions/runs/{run_id}/jobs"
+            f"?per_page={JOBS_PER_PAGE}&filter=latest&page={page}",
+            budget, transport, sleep)
+        page_jobs = doc.get("jobs") or []
+        jobs.extend(page_jobs)
+        # A short page is the end of pagination.  total_count is not a safe
+        # stop: under filter=latest it can over-report (it counts earlier
+        # attempts), and trusting it to under-report would truncate the run.
+        if len(page_jobs) < JOBS_PER_PAGE:
+            break
+        page += 1
+    return run, {"total_count": len(jobs), "jobs": jobs}
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def raw_paths(out: Path, run_id) -> tuple:
+    return (out / "raw" / f"run-{run_id}.json",
+            out / "raw" / f"run-{run_id}-jobs.json")
+
+
+def cmd_fetch(args) -> int:
+    out = Path(args.out)
+    (out / "raw").mkdir(parents=True, exist_ok=True)
+    budget = Budget(args.max_requests)
+    repo = args.repo or os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        try:
+            repo = json.loads(run_gh(["repo", "view", "--json", "nameWithOwner"]))[
+                "nameWithOwner"]
+        except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+            return die(f"could not determine the repository: {exc}")
+    for run_id in args.run_id:
+        try:
+            run, jobs = fetch_run(repo, run_id, budget)
+        except (RuntimeError, OSError) as exc:
+            return die(str(exc))
+        run_path, jobs_path = raw_paths(out, run_id)
+        run_path.write_text(json.dumps(run, indent=2, sort_keys=True) + "\n")
+        jobs_path.write_text(json.dumps(jobs, indent=2, sort_keys=True) + "\n")
+        print(f"ci-run-telemetry: saved run {run_id} "
+              f"({jobs['total_count']} jobs, {budget.used} requests so far)")
+    return 0
+
+
+def cmd_report(args) -> int:
+    out = Path(args.out)
+    for run_id in args.run_id:
+        run_path, jobs_path = raw_paths(out, run_id)
+        if not run_path.exists() or not jobs_path.exists():
+            return die(f"no saved responses for run {run_id} under {out}/raw "
+                       f"(run `fetch` first)")
+        run = json.loads(run_path.read_text())
+        if run.get("id") is not None and run.get("id") != run_id:
+            return die(f"{run_path} holds run {run.get('id')}, not {run_id}; "
+                       f"the saved pair does not belong together")
+        report = analyze(run, json.loads(jobs_path.read_text()))
+        (out / f"run-{run_id}.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n")
+        (out / f"run-{run_id}.md").write_text(render_markdown(report))
+        counts = report["job_counts"]
+        print(f"ci-run-telemetry: run {run_id}: {counts['executed']} executed, "
+              f"{counts['skipped']} skipped, "
+              f"{len(report['anomalies'])} anomalies")
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ci-run-telemetry.py",
+        description="Measure PR CI queue time and per-phase duration (#1570).")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    fetch = sub.add_parser("fetch", help="save the API responses for a run")
+    fetch.add_argument("--run-id", type=int, action="append", required=True,
+                       help="workflow run id; repeat for several runs")
+    fetch.add_argument("--out", default=DEFAULT_OUT_DIR,
+                       help=f"output directory (default {DEFAULT_OUT_DIR}/)")
+    fetch.add_argument("--repo", help="OWNER/NAME; defaults to the checkout")
+    fetch.add_argument("--max-requests", type=int, default=DEFAULT_MAX_REQUESTS,
+                       help="hard cap on API requests, retries included "
+                            f"(default {DEFAULT_MAX_REQUESTS})")
+    fetch.set_defaults(func=cmd_fetch)
+
+    report = sub.add_parser("report", help="analyze saved responses")
+    report.add_argument("--run-id", type=int, action="append", required=True,
+                        help="workflow run id; repeat for several runs")
+    report.add_argument("--out", default=DEFAULT_OUT_DIR,
+                        help=f"output directory (default {DEFAULT_OUT_DIR}/)")
+    report.set_defaults(func=cmd_report)
+
+    args = parser.parse_args(argv)
+    if getattr(args, "max_requests", 1) < 1:
+        return die("--max-requests must be at least 1")
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/ci-run-telemetry.py
+++ b/scripts/ci/ci-run-telemetry.py
@@ -240,18 +240,27 @@ def additive(metric: dict) -> dict:
     return metric
 
 
-def provisional(metric: dict, in_flight: bool) -> dict:
-    """Downgrade a measurement taken while the run is still going.  The value
-    is real but it is a lower bound, and saying so is the difference between a
-    baseline and a number that quietly understates."""
-    if in_flight and metric["status"] == "measured":
+def provisional(metric: dict, run_status: str | None) -> dict:
+    """Downgrade a measurement taken before the run is known to have ended.
+    The value is real but it is a lower bound, and saying so is the difference
+    between a baseline and a number that quietly understates.
+
+    A status this tool cannot read is downgraded too, since it might mean the
+    run is unfinished -- but the reason says which of the two it is, because
+    `run_is_running` declines to call such a run going and the report should
+    not claim it two lines later."""
+    if run_status != "completed" and metric["status"] == "measured":
         metric["status"] = "partial"
-        metric["reason"] = "run still in progress; value is a lower bound"
+        metric["reason"] = (
+            "run still in progress; value is a lower bound"
+            if run_is_running(run_status)
+            else f"run status {run_status!r} is not one this tool "
+                 f"recognises; value may not be final")
     return metric
 
 
 def interval(start_iso, end_iso, missing_reason: str,
-             no_start_reason: str = None) -> dict:
+             no_start_reason: str | None = None) -> dict:
     """Seconds between two server-clock timestamps, or why they do not yield
     one.  A negative interval is reported as anomalous, never clamped to 0.
 
@@ -294,6 +303,58 @@ def population_of(job: dict) -> str:
 
 def is_skipped(job: dict) -> bool:
     return job.get("conclusion") == "skipped"
+
+
+def did_not_run(job: dict) -> bool:
+    """Whether the runner never executed this job, so it has no durations to
+    report and anything derived from its stamps would be bookkeeping.
+
+    The stamps cannot answer this.  The skip cascade captured in this repo's
+    own fixtures shows GitHub giving a job that did not run
+    `started_at == created_at`, with a completion either equal to them or one
+    second earlier, so a start stamp is not evidence of work and the zero or
+    negative interval derived from it would read as a job that ran instantly.
+
+    No single stamp settles it, because each one is absent on some job that
+    ran and present on some job that did not.  Steps are missing from a
+    successful sixty-second job in this repo's own `run-missing-data`
+    capture, and present-but-unstamped on a job that never started.  A start
+    stamp proves nothing on its own, since a job that did not run is stamped
+    as starting the moment it was created.  And a span of zero is the
+    bookkeeping shape twice over: a skipped job carries it, and so does a job
+    cancelled while it was still queued.
+
+    So ask in order.  A step of its own that ran is conclusive.  Failing
+    that, a span between the job's own stamps settles it, and only a positive
+    one is work.  Failing that, with no completion to judge by, the question
+    is whether the runner ever picked the job up, and a start later than the
+    creation is the only trace of that.  With none of the three, it never
+    ran.
+
+    A skip needs no such check.  A skipped job never dispatches, whatever it
+    is stamped with."""
+    conclusion = job.get("conclusion")
+    if conclusion == "skipped":
+        return True
+    if conclusion != "cancelled":
+        return False
+    # A cancellation lands either side of the runner picking the job up.
+    if first_step_start(job):
+        return False                       # a step of its own ran
+    created = parse_ts(job.get("created_at"))
+    started = parse_ts(job.get("started_at"))
+    ended = parse_ts(job.get("completed_at"))
+    if started and ended:
+        # Its own span settles it.  Zero or negative is the bookkeeping
+        # shape; a job cancelled while still queued carries start ==
+        # completion, and calling that execution would print a measured zero.
+        return ended <= started
+    if started and created:
+        # No completion to judge by, so the question is whether the runner
+        # ever picked it up.  A job that did not run is stamped as starting
+        # the moment it was created; a later start is a real dispatch.
+        return started <= created
+    return True
 
 
 def job_phases(job: dict) -> tuple:
@@ -358,10 +419,130 @@ def job_phases(job: dict) -> tuple:
     return phases, unmapped, unusable, skipped, accounted
 
 
-def analyze_job(job: dict, t0_iso: str, completed_by_name: dict) -> dict:
-    """One job's timing.  Skipped jobs get no durations at all: GitHub stamps
-    them with a completion one second before their own start, and a zero there
-    would read as a job that ran instantly."""
+def first_step_start(job: dict):
+    """When this job's earliest step that shows signs of running began, or
+    None.  Evidence that the runner picked the job up even where the
+    job-level stamps are gone.
+
+    A start stamp is what proves that, and a completion is not required: a
+    step cancelled or still running mid-flight has none, and that is exactly
+    the case worth catching.  Two kinds are excluded.  A skipped step is
+    stamped `started == completed` and never ran, which is why `job_phases`
+    excludes it too.  And a step whose completion precedes its start has
+    stamps the report already calls unusable, so citing its start as a time
+    would publish a figure the same report disowns."""
+    starts = []
+    for step in job.get("steps") or []:
+        if step.get("conclusion") == "skipped":
+            continue
+        started = parse_ts(step.get("started_at"))
+        if not started:
+            continue
+        ended = parse_ts(step.get("completed_at"))
+        if ended and ended < started:
+            continue
+        starts.append(step.get("started_at"))
+    return min(starts, key=ts_key) if starts else None
+
+
+def run_is_running(run_status: str | None) -> bool:
+    """The run is known to be going.  An unrecognised status is not."""
+    return run_status in IN_FLIGHT_STATUSES
+
+
+def run_is_readable(run_status: str | None) -> bool:
+    """The run's status is one this tool understands.  When it is not, the
+    run is neither known to be going nor known to be over, and no sentence
+    about a job's future in it can be settled."""
+    return run_status in KNOWN_RUN_STATUSES
+
+
+def job_may_still_move(job: dict,
+                       run_status: str | None) -> bool:
+    """Whether this job could still acquire a start stamp.
+
+    A status that means not-done-yet only means that while the run itself is
+    still going.  The same status in a run the API calls finished describes a
+    job that stopped without saying so, and telling the reader it may still
+    start promises a number that is never coming."""
+    return run_is_running(run_status) and job.get("status") in IN_FLIGHT_STATUSES
+
+
+def no_start_reason(job: dict, run_status: str | None) -> str:
+    """Why this job has no start stamp.  `never` is a claim about the future
+    and is only safe once the future is settled -- which needs the run's
+    state as well as the job's, because an unreadable run status leaves the
+    job's future open however the job itself is stamped."""
+    status = job.get("status")
+    if status not in KNOWN_JOB_STATUSES:
+        return f"job status {status!r} is not one this tool recognises"
+    first_step = first_step_start(job)
+    if first_step:
+        # Its steps ran, so it started; the run simply did not record when.
+        return ("job reported no start stamp; its first step ran at "
+                f"{first_step}")
+    conclusion = job.get("conclusion")
+    if conclusion in CONCLUSIONS_THAT_RAN:
+        # Reaching this conclusion took execution, so "never started" would
+        # be refuted by the job's own outcome.
+        return f"job reported no start stamp; it concluded {conclusion!r}"
+    if status == "completed":
+        return "job never started"     # the job itself is settled
+    if job_may_still_move(job, run_status):
+        return "job has not started yet"
+    if run_is_readable(run_status):
+        return "job never started"     # the run is over; so is the question
+    return (f"job has no start stamp, and run status {run_status!r} is not "
+            f"one this tool recognises")
+
+
+def wall_absence_reasons(job: dict,
+                         run_status: str | None) -> tuple:
+    """(no-end reason, no-start reason) for one job's wall time, chosen from
+    the state the job is actually in.
+
+    One sentence cannot serve every state without being false in some of
+    them.  A job still in the queue has not started *yet*; a job that
+    finished without a start stamp never started at all; and a job the API
+    calls completed while giving no completion stamp has not "not completed"
+    -- it completed and did not say when."""
+    missing_start = no_start_reason(job, run_status)
+    status = job.get("status")
+    if status == "completed":
+        return "job reported no completion time", missing_start
+    if status in IN_FLIGHT_STATUSES:
+        if run_is_running(run_status):
+            return "job has not completed", missing_start
+        if run_is_readable(run_status):
+            return ("job stopped without reporting a completion time",
+                    missing_start)
+        # The end is what is absent here, and `interval` reaches this string
+        # only when the start is present, so a sentence about the missing
+        # start would be false beside the stamp that carries it.
+        return (f"job reported no completion time, and run status "
+                f"{run_status!r} is not one this tool recognises",
+                missing_start)
+    # An unreadable job status.  The same sentence serves both ends: it
+    # claims nothing about either stamp.
+    return missing_start, missing_start
+
+
+def queue_absence_reasons(job: dict,
+                          run_status: str | None) -> tuple:
+    """(no-end reason, no-start reason) for one job's queue delay.  The end
+    of that interval is the job starting, so the absent-end sentence is the
+    same one the wall time uses for an absent start.  Saying `never started`
+    beside `has not started yet` for one job, which is what a single fixed
+    sentence here produced, is a contradiction a reader can see."""
+    return no_start_reason(job, run_status), "job has no creation time"
+
+
+def analyze_job(job: dict, t0_iso: str, completed_by_name: dict,
+                run_status: str | None) -> dict:
+    """One job's timing.  A job that did not run gets no durations at all:
+    GitHub stamps such a job as though it had started and finished at the
+    moment it was created, and a zero there would read as a job that ran
+    instantly.  `did_not_run` decides which jobs those are."""
     name = job.get("name") or ""
     entry = {
         "name": name,
@@ -375,8 +556,9 @@ def analyze_job(job: dict, t0_iso: str, completed_by_name: dict) -> dict:
         "completed_at": job.get("completed_at"),
     }
 
-    if is_skipped(job):
-        reason = "job skipped; no execution"
+    if did_not_run(job):
+        reason = ("job skipped; no execution" if is_skipped(job)
+                  else "job cancelled before it ran; no execution")
         entry["metrics"] = {
             "upstream_elapsed": non_additive(unavailable(reason)),
             "queue_delay": additive(unavailable(reason)),
@@ -392,8 +574,10 @@ def analyze_job(job: dict, t0_iso: str, completed_by_name: dict) -> dict:
             "evidence": {},
         }
         entry["runner_first_step_at"] = None
+        entry["ran"] = False
         return entry
 
+    entry["ran"] = True
     entry["metrics"] = {
         # Everything upstream of this job, including every upstream job's own
         # queueing.  Useful for ordering jobs, but NOT additive along a path.
@@ -403,10 +587,10 @@ def analyze_job(job: dict, t0_iso: str, completed_by_name: dict) -> dict:
         # Summable along a path, and the critical path does sum them.
         "queue_delay": additive(
             interval(job.get("created_at"), job.get("started_at"),
-                     "job never started", "job has no creation time")),
+                     *queue_absence_reasons(job, run_status))),
         "job_wall": additive(
             interval(job.get("started_at"), job.get("completed_at"),
-                     "job has not completed", "job never started")),
+                     *wall_absence_reasons(job, run_status))),
     }
 
     phases, unmapped, unusable, skipped, accounted = job_phases(job)
@@ -681,21 +865,49 @@ def _seconds(metric: dict):
                                                          "partial") else None
 
 
-# A job with one of these conclusions has no duration because it did not run,
-# not because the run lost the data.  Reporting it as missing data is the same
-# false alarm as reporting a job that is merely still going.
-NO_DURATION_BY_DESIGN = ("skipped", "cancelled")
-
 # The job statuses that mean the job may still produce a duration.  GitHub
-# uses exactly these two before `completed`.
-IN_FLIGHT_STATUSES = ("queued", "in_progress")
+# documents all of these alongside `completed`; `waiting` in particular is an
+# ordinary job held at an environment protection rule, and calling it missing
+# data would raise a false alarm on every run with an approval gate.  A status
+# outside this list is one this tool cannot read, which is a different thing
+# from a job that is merely not done, so it takes the loud branch.
+IN_FLIGHT_STATUSES = ("queued", "in_progress", "waiting", "requested",
+                      "pending")
+
+# Every status this tool knows how to describe, for a job and for a run.
+# Anything else is data it cannot read, and it says so rather than guessing.
+KNOWN_JOB_STATUSES = IN_FLIGHT_STATUSES + ("completed",)
+KNOWN_RUN_STATUSES = KNOWN_JOB_STATUSES
+
+# Conclusions only a job that executed can reach.  A job reported successful
+# ran, whatever its stamps say, so the report must not tell the reader it
+# never started.
+CONCLUSIONS_THAT_RAN = ("success", "failure", "timed_out")
 
 
-def untimed_executed_jobs(analyzed: list) -> tuple:
+def absent_by_design(entry: dict) -> bool:
+    """True when this job has no durations because the runner never executed
+    it, rather than because the run lost them.  The table caption excuses
+    exactly these jobs, so this has to mean exactly what the caption says.
+
+    It reads the answer `analyze_job` recorded rather than re-deriving one.
+    Every re-derivation tried here was wrong on some reachable job: the
+    conclusion alone excuses a job cancelled after it ran; the absence of a
+    start stamp excuses nothing, because GitHub stamps a job that did not run
+    as though it started when it was created; the wall time alone is equally
+    the signature of a job that ran and lost a stamp; and even "no duration
+    measured anywhere" excuses a job that ran and lost every stamp.  One
+    decision, made once, from the evidence that actually distinguishes the
+    two -- see `did_not_run`."""
+    return entry.get("ran") is False
+
+
+def untimed_executed_jobs(analyzed: list,
+                          run_status: str | None) -> tuple:
     """Jobs that ran, or may still run, and that the run did not time, split
-    into the ones that have not finished and the ones that finished anyway.
-    A job that was skipped or cancelled before it started has no duration by
-    design and is in neither list.
+    into the ones that may still produce one and the ones that will not.  A
+    job that did not run has no duration by design and is in neither list;
+    `absent_by_design` decides which those are.
 
     The split is what the caller needs to say something true.  A job still
     running is ordinary and makes the answer a lower bound; a job that
@@ -713,21 +925,23 @@ def untimed_executed_jobs(analyzed: list) -> tuple:
     chain."""
     running, untimed = [], []
     for entry in analyzed:
-        if entry.get("conclusion") in NO_DURATION_BY_DESIGN:
-            continue
         if _seconds(entry["metrics"]["job_wall"]) is not None:
             continue
-        # Only the two statuses that actually mean "not done yet" take the
-        # quiet branch.  A status this tool does not recognise is data it
-        # cannot read, which belongs with missing data rather than with an
-        # ordinary live job.
-        target = running if entry.get("status") in IN_FLIGHT_STATUSES \
-            else untimed
-        target.append(entry["name"])
+        if absent_by_design(entry):
+            continue
+        # Only a status that actually means "not done yet" takes the quiet
+        # branch, and only while the run is still going.  The same status in
+        # a run the API calls completed describes a job that stopped without
+        # saying so, which is missing data rather than work in progress.  A
+        # status this tool does not recognise is data it cannot read and goes
+        # the same way.
+        still_going = job_may_still_move(entry, run_status)
+        (running if still_going else untimed).append(entry["name"])
     return sorted(running), sorted(untimed)
 
 
-def observed_path(analyzed: list, edges: dict, drift: dict) -> dict:
+def observed_path(analyzed: list, edges: dict, drift: dict,
+                  run_status: str | None) -> dict:
     """Walk back from the last job to finish, hop by hop, through its actual
     dependencies.  Taking the nearest earlier finisher instead would be wrong
     and quietly so: on a real run it picks a macOS matrix build as the
@@ -750,10 +964,11 @@ def observed_path(analyzed: list, edges: dict, drift: dict) -> dict:
             break
         candidates = [by_name[name] for name in edges[current["name"]]
                       if name in by_name and name not in seen]
-        # A skipped job has a completion stamp but no duration, and walking
-        # through it at zero weight would drop the very gap it represents.
-        candidates = [c for c in candidates if c.get("completed_at")
-                      and c["conclusion"] != "skipped"]
+        # A job that never ran has a completion stamp but no duration, and
+        # walking through it at zero weight would drop the very gap it
+        # represents.
+        candidates = [c for c in candidates
+                      if c.get("completed_at") and not absent_by_design(c)]
         if not candidates:
             if edges[current["name"]]:
                 truncated = (f"{current['name']}'s dependencies did not run")
@@ -786,7 +1001,7 @@ def observed_path(analyzed: list, edges: dict, drift: dict) -> dict:
     # so an untimed job that finished later is skipped over silently and the
     # chain below it is reported as if it were the whole path.
     on_chain = set(chain)
-    running, untimed = untimed_executed_jobs(analyzed)
+    running, untimed = untimed_executed_jobs(analyzed, run_status)
     off_running = [name for name in running if name not in on_chain]
     off_untimed = [name for name in untimed if name not in on_chain]
     if off_running:
@@ -802,8 +1017,8 @@ def observed_path(analyzed: list, edges: dict, drift: dict) -> dict:
                        f"not finished, so the walk started below the end of "
                        f"the path and the total is a lower bound")
     if off_untimed:
-        reasons.append(f"{len(off_untimed)} finished job(s) elsewhere in the "
-                       f"run were not timed, so the walk may have started "
+        reasons.append(f"{len(off_untimed)} job(s) elsewhere in the run "
+                       f"reported no duration, so the walk may have started "
                        f"below the true end of the path, or one of them may "
                        f"lie on a longer branch it never entered")
     if truncated:
@@ -820,7 +1035,8 @@ def observed_path(analyzed: list, edges: dict, drift: dict) -> dict:
     return metric
 
 
-def graph_path(analyzed: list, edges: dict, drift: dict) -> dict:
+def graph_path(analyzed: list, edges: dict, drift: dict,
+               run_status: str | None) -> dict:
     """Longest path over the declared graph, weighting each node by its wall
     time and each edge by the wait between the dependency finishing and the
     dependent being created.  Inside a skip cascade every edge weight is
@@ -885,7 +1101,7 @@ def graph_path(analyzed: list, edges: dict, drift: dict) -> dict:
     # be routed around it and come back clean.  The hole is off the chain
     # precisely because it was scored as free.
     on_chain = set(chain)
-    running, untimed = untimed_executed_jobs(analyzed)
+    running, untimed = untimed_executed_jobs(analyzed, run_status)
     off_running = [name for name in running if name not in on_chain]
     off_untimed = [name for name in untimed if name not in on_chain]
     if off_running:
@@ -894,9 +1110,9 @@ def graph_path(analyzed: list, edges: dict, drift: dict) -> dict:
                        f"path may move once they do")
         metric["evidence"]["unfinished_jobs_off_chain"] = off_running
     if off_untimed:
-        reasons.append(f"{len(off_untimed)} finished job(s) off this chain "
-                       f"were not timed, so the longest path may have been "
-                       f"routed around them")
+        reasons.append(f"{len(off_untimed)} job(s) off this chain reported no "
+                       f"duration, so the longest path may have been routed "
+                       f"around them")
         metric["evidence"]["untimed_jobs_off_chain"] = off_untimed
     if unusable_edges:
         reasons.append("edge weights unavailable on this chain; node weights "
@@ -931,7 +1147,14 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
     t0_source = "run_started_at" if run.get("run_started_at") else "created_at"
 
     jobs_by_name = {j.get("name"): j for j in jobs}
-    analyzed = [analyze_job(j, t0_iso, jobs_by_name) for j in jobs]
+    # Until the run is known to have ended, every run-level figure is a lower
+    # bound: a check that has not reported cannot raise it, and #1574 would
+    # quote it as final.  A status this tool cannot read counts as not known
+    # to have ended, while the walkers treat it as stopped -- each errs in
+    # the direction that cannot overstate.
+    run_status = run.get("status")
+    analyzed = [analyze_job(j, t0_iso, jobs_by_name, run_status)
+                for j in jobs]
     for entry, job in zip(analyzed, jobs):
         if is_skipped(job):
             entry["metrics"]["scheduler_release_latency"] = additive(
@@ -942,15 +1165,12 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
 
     executed = [j for j in jobs if not is_skipped(j)]
     skipped = [j for j in jobs if is_skipped(j)]
-    # Until the run ends, every run-level figure is a lower bound: a check that
-    # has not reported cannot raise it, and #1574 would quote it as final.
-    in_flight = run.get("status") != "completed"
-
     ends = [j.get("completed_at") for j in executed if j.get("completed_at")]
     if ends:
         last = max(ends, key=ts_key)
         run_wall = provisional(
-            interval(t0_iso, last, "no executed job has completed"), in_flight)
+            interval(t0_iso, last, "no executed job has completed"),
+            run_status)
     else:
         run_wall = unavailable("no executed job has completed")
 
@@ -977,8 +1197,12 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
                 s.get("name") for s in (first.get("steps") or [])
                 if s.get("conclusion") in ("failure", "timed_out")]
             first_failure["evidence"]["conclusion"] = first.get("conclusion")
-    elif in_flight:
+    elif run_is_running(run_status):
         first_failure = unavailable("run still in progress; no failure yet")
+    elif run_status != "completed":
+        first_failure = unavailable(
+            f"run status {run_status!r} is not one this tool recognises; "
+            f"no failure seen")
     elif any(j.get("conclusion") == "cancelled" for j in executed):
         first_failure = unavailable(
             "no job failed; cancelled jobs were seen and excluded")
@@ -991,7 +1215,7 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
         last_pinned = max(pinned_ends, key=ts_key)
         pr_feedback = provisional(
             interval(t0_iso, last_pinned, "no pinned check completed"),
-            in_flight)
+            run_status)
         if pr_feedback["status"] in ("measured", "partial"):
             pr_feedback["evidence"]["source"] = "pinned-list"
             # When every executed job is a pinned check this equals
@@ -1042,8 +1266,8 @@ def analyze(run: dict, jobs_doc: dict, needs: dict | None = None,
     if graph_supplied:
         drift = drift or {"jobs_without_node": [], "nodes_without_job": []}
         critical_path = {
-            "observed": observed_path(analyzed, needs, drift),
-            "graph": graph_path(analyzed, needs, drift),
+            "observed": observed_path(analyzed, needs, drift, run_status),
+            "graph": graph_path(analyzed, needs, drift, run_status),
             "graph_drift": drift,
         }
     else:
@@ -1207,8 +1431,8 @@ def render_aggregate_markdown(doc: dict) -> str:
         f"never pooled",
         f"- excluded: {len(doc['excluded'])}",
         "",
-        "Seconds. `n` is per metric: a skipped job contributes to none, and a "
-        "failed run truncates some.",
+        "Seconds. `n` is per metric: a job that did not run contributes "
+        "to none, and a "        "failed run truncates some.",
         "",
         "| conclusion | job | population | queue n | queue med | queue p95 | "
         "wall n | wall med | wall p95 | mixed machines |",
@@ -1289,14 +1513,16 @@ def degradation_block(report: dict, path: dict) -> list:
     skip, and the caveat the two walkers raise is worth nothing once that has
     happened.
 
+    A job that did not run is left out, for the same reason the walkers leave
+    it out: its durations are absent by design and the table caption says so
+    once.  `absent_by_design` decides which jobs those are.
+
     Two things would defeat it on their own.  Explaining a metric that has no
     column tells the reader about a number they cannot see while leaving the
     ones they can see bare, so the selection is exactly `cell()`'s output:
     the run-level table, both critical paths, and each job's six columns.  And
     one reason repeated once per job buries every line that is not repeated,
-    so identical reasons collapse into a single line carrying the count.  A
-    skipped job is left out for the same reason: its durations are absent by
-    design and the table header says so once."""
+    so identical reasons collapse into a single line carrying the count."""
     def wanted(metric):
         # Deliberately not `and metric.get("reason")`: a degraded metric that
         # carries no reason is the bare `(partial)` this block exists to
@@ -1308,7 +1534,13 @@ def degradation_block(report: dict, path: dict) -> list:
     qualified += [(f"critical_path.{key}", path[key])
                   for key in ("observed", "graph") if wanted(path[key])]
     for job in report["jobs"]:
-        if job["conclusion"] == "skipped":
+        # The same test the walkers use.  A job that did not run has no
+        # durations by design, the table caption says so once, and six
+        # bullets per such job would be six true sentences crowding out the
+        # ones that are not by design.  A job cancelled after it started is
+        # not one of these: it has real durations, so its degraded cells are
+        # explained like any other job's.
+        if absent_by_design(job):
             continue
         qualified += [(f"{job['name']} / {column}", metric)
                       for column, metric in job_cells(job) if wanted(metric)]
@@ -1393,7 +1625,8 @@ def render_markdown(report: dict) -> str:
             lines.append(f"- node with no job: {name}")
     lines += [
         "",
-        "Per job, seconds. A skipped job has no durations at all.",
+        "Per job, seconds. A job that was skipped, or cancelled before it "
+        "ran, has no durations at all.",
         "",
         "| job | population | "
         + " | ".join(heading for _, _, heading in JOB_COLUMNS) + " |",

--- a/scripts/ci/ci-run-telemetry.py
+++ b/scripts/ci/ci-run-telemetry.py
@@ -250,10 +250,19 @@ def provisional(metric: dict, in_flight: bool) -> dict:
     return metric
 
 
-def interval(start_iso, end_iso, missing_reason: str) -> dict:
+def interval(start_iso, end_iso, missing_reason: str,
+             no_start_reason: str = None) -> dict:
     """Seconds between two server-clock timestamps, or why they do not yield
-    one.  A negative interval is reported as anomalous, never clamped to 0."""
+    one.  A negative interval is reported as anomalous, never clamped to 0.
+
+    @missing_reason names the absent end.  @no_start_reason names the absent
+    start where the two are different facts, and they usually are: a job that
+    completed without a start stamp is not a job that has not completed, and
+    telling the reader the second is worse than telling them nothing, because
+    they can check it and find it false."""
     start, end = parse_ts(start_iso), parse_ts(end_iso)
+    if start is None and no_start_reason:
+        return unavailable(no_start_reason)
     if start is None or end is None:
         return unavailable(missing_reason)
     seconds = math.floor((end - start).total_seconds())
@@ -394,10 +403,10 @@ def analyze_job(job: dict, t0_iso: str, completed_by_name: dict) -> dict:
         # Summable along a path, and the critical path does sum them.
         "queue_delay": additive(
             interval(job.get("created_at"), job.get("started_at"),
-                     "job never started")),
+                     "job never started", "job has no creation time")),
         "job_wall": additive(
             interval(job.get("started_at"), job.get("completed_at"),
-                     "job has not completed")),
+                     "job has not completed", "job never started")),
     }
 
     phases, unmapped, unusable, skipped, accounted = job_phases(job)
@@ -452,7 +461,11 @@ def release_latency(job: dict, jobs_by_name: dict, needs: dict) -> dict:
     the only per-job wait that may be summed along a path."""
     name = job.get("name") or ""
     if not needs:
-        return unavailable(GRAPH_NOT_SUPPLIED)
+        # Not GRAPH_NOT_SUPPLIED: that sentence explains why a critical path
+        # cannot be walked, and read against a job it reverses cause and
+        # effect.  What is missing here is the job's own dependencies.
+        return unavailable("no dependency graph was supplied, so this job's "
+                           "dependencies are unknown")
     if name not in needs:
         # Not the same as having no dependencies: the extractor may simply
         # have missed this job, and calling that a root would hide the gap.
@@ -668,19 +681,50 @@ def _seconds(metric: dict):
                                                          "partial") else None
 
 
-def untimed_executed_jobs(analyzed: list) -> list:
-    """Jobs that were not skipped and that the run did not time.  A skipped
-    job's absent duration is correct and is not reported here.
+# A job with one of these conclusions has no duration because it did not run,
+# not because the run lost the data.  Reporting it as missing data is the same
+# false alarm as reporting a job that is merely still going.
+NO_DURATION_BY_DESIGN = ("skipped", "cancelled")
 
-    Both walkers pick a chain by comparing weights, so a job like this can
-    decide which chain wins without ever appearing on the winner: the walk
-    routes around the hole and the survivor carries no trace of it.  Naming
-    them run-wide is deliberately over-inclusive.  A total that may have been
-    routed around missing data says so, rather than being right only when the
-    gap happens to fall on the chain that was reported."""
-    return sorted(entry["name"] for entry in analyzed
-                  if entry.get("conclusion") != "skipped"
-                  and _seconds(entry["metrics"]["job_wall"]) is None)
+# The job statuses that mean the job may still produce a duration.  GitHub
+# uses exactly these two before `completed`.
+IN_FLIGHT_STATUSES = ("queued", "in_progress")
+
+
+def untimed_executed_jobs(analyzed: list) -> tuple:
+    """Jobs that ran, or may still run, and that the run did not time, split
+    into the ones that have not finished and the ones that finished anyway.
+    A job that was skipped or cancelled before it started has no duration by
+    design and is in neither list.
+
+    The split is what the caller needs to say something true.  A job still
+    running is ordinary and makes the answer a lower bound; a job that
+    finished without a usable duration is missing data.  Calling the first
+    the second turns every live run into an alarm, which is how a caveat
+    stops being read.
+
+    Both walkers can pick a chain that excludes such a job, for different
+    reasons.  The graph walk compares weights and an untimed node weighs
+    zero, so the longest path routes around it.  The observed walk compares
+    completion timestamps and starts at the last job it could time, so an
+    untimed later finisher is stepped over and a hole on an unvisited branch
+    is never seen.  Either way the surviving chain carries no trace of it,
+    which is why both lists are collected run-wide rather than along the
+    chain."""
+    running, untimed = [], []
+    for entry in analyzed:
+        if entry.get("conclusion") in NO_DURATION_BY_DESIGN:
+            continue
+        if _seconds(entry["metrics"]["job_wall"]) is not None:
+            continue
+        # Only the two statuses that actually mean "not done yet" take the
+        # quiet branch.  A status this tool does not recognise is data it
+        # cannot read, which belongs with missing data rather than with an
+        # ordinary live job.
+        target = running if entry.get("status") in IN_FLIGHT_STATUSES \
+            else untimed
+        target.append(entry["name"])
+    return sorted(running), sorted(untimed)
 
 
 def observed_path(analyzed: list, edges: dict, drift: dict) -> dict:
@@ -741,18 +785,27 @@ def observed_path(analyzed: list, edges: dict, drift: dict) -> dict:
     # The walk starts at the last job to finish that the run actually timed,
     # so an untimed job that finished later is skipped over silently and the
     # chain below it is reported as if it were the whole path.
-    off_chain = [name for name in untimed_executed_jobs(analyzed)
-                 if name not in set(chain)]
-    if off_chain:
-        metric["evidence"]["untimed_jobs_off_chain"] = off_chain
+    on_chain = set(chain)
+    running, untimed = untimed_executed_jobs(analyzed)
+    off_running = [name for name in running if name not in on_chain]
+    off_untimed = [name for name in untimed if name not in on_chain]
+    if off_running:
+        metric["evidence"]["unfinished_jobs_off_chain"] = off_running
+    if off_untimed:
+        metric["evidence"]["untimed_jobs_off_chain"] = off_untimed
     reasons = []
     if unmeasured:
         reasons.append(f"{len(unmeasured)} hop(s) on this chain were not "
                        f"timed and contribute nothing to the total")
-    if off_chain:
-        reasons.append(f"{len(off_chain)} executed job(s) elsewhere in the "
-                       f"run were not timed, so this chain may not be the "
-                       f"longest one")
+    if off_running:
+        reasons.append(f"{len(off_running)} job(s) elsewhere in the run have "
+                       f"not finished, so the walk started below the end of "
+                       f"the path and the total is a lower bound")
+    if off_untimed:
+        reasons.append(f"{len(off_untimed)} finished job(s) elsewhere in the "
+                       f"run were not timed, so the walk may have started "
+                       f"below the true end of the path, or one of them may "
+                       f"lie on a longer branch it never entered")
     if truncated:
         reasons.append(f"walk stopped: {truncated}")
     if drift.get("nodes_without_job"):
@@ -791,8 +844,9 @@ def graph_path(analyzed: list, edges: dict, drift: dict) -> dict:
         if name in stack:            # a cycle cannot occur in a needs DAG,
             return 0, [name]         # but never spin if the data says one does
         stack = stack | {name}
-        entry = by_name.get(name)
-        node_weight = _seconds(entry["metrics"]["job_wall"]) or 0 if entry else 0
+        # Every name reaching here is a by_name key: the seeds are its keys
+        # and the recursion below skips a dep that is not one.
+        node_weight = _seconds(by_name[name]["metrics"]["job_wall"]) or 0
         best_total, best_chain = node_weight, [name]
         for dep in edges.get(name, []):
             if dep not in by_name:
@@ -813,8 +867,7 @@ def graph_path(analyzed: list, edges: dict, drift: dict) -> dict:
         return unavailable("no job to walk")
     total, chain = max(results, key=lambda pair: pair[0])
     unmeasured_nodes = [name for name in chain
-                        if name not in by_name
-                        or _seconds(by_name[name]["metrics"]["job_wall"])
+                        if _seconds(by_name[name]["metrics"]["job_wall"])
                         is None]
     # Only the edges on the chain being reported can qualify this number.
     for index, name in enumerate(chain[1:], start=1):
@@ -831,13 +884,20 @@ def graph_path(analyzed: list, edges: dict, drift: dict) -> dict:
     # An untimed node weighs zero during selection, so the longest path can
     # be routed around it and come back clean.  The hole is off the chain
     # precisely because it was scored as free.
-    off_chain = [name for name in untimed_executed_jobs(analyzed)
-                 if name not in set(chain)]
-    if off_chain:
-        reasons.append(f"{len(off_chain)} executed job(s) off this chain were "
-                       f"not timed, so the longest path may have been routed "
-                       f"around them")
-        metric["evidence"]["untimed_jobs_off_chain"] = off_chain
+    on_chain = set(chain)
+    running, untimed = untimed_executed_jobs(analyzed)
+    off_running = [name for name in running if name not in on_chain]
+    off_untimed = [name for name in untimed if name not in on_chain]
+    if off_running:
+        reasons.append(f"{len(off_running)} job(s) off this chain have not "
+                       f"finished, so they weigh nothing yet and the longest "
+                       f"path may move once they do")
+        metric["evidence"]["unfinished_jobs_off_chain"] = off_running
+    if off_untimed:
+        reasons.append(f"{len(off_untimed)} finished job(s) off this chain "
+                       f"were not timed, so the longest path may have been "
+                       f"routed around them")
+        metric["evidence"]["untimed_jobs_off_chain"] = off_untimed
     if unusable_edges:
         reasons.append("edge weights unavailable on this chain; node weights "
                        "only (a skip cascade batches job creation)")
@@ -1195,6 +1255,89 @@ def cell(metric: dict) -> str:
     return metric.get("status", "unavailable")
 
 
+# The per-job table, declared once: (metric name, where it lives on the job
+# entry, column heading).  Both the table and the block that explains it are
+# built from this, because they have to agree.  A reason printed for a metric
+# with no column explains a number the reader cannot see, and a column with no
+# reason is the bare `(partial)` the block exists to defeat; either happens the
+# moment the two lists are written out separately.
+JOB_COLUMNS = (
+    ("queue_delay", "metrics", "queue"),
+    ("job_wall", "metrics", "wall"),
+    ("configure", "phases", "configure"),
+    ("compile", "phases", "compile"),
+    ("tests", "phases", "tests"),
+    ("unaccounted", None, "unaccounted"),
+)
+
+# How many entries sharing one reason are still worth naming one by one.  The
+# threshold keys on group size, so it does nothing on a run with fewer jobs
+# than this, where the block is at its longest relative to its table.
+COLLAPSE_AT = 3
+
+
+def job_cells(job: dict) -> list:
+    """The (column, metric) pairs this job contributes to the per-job table,
+    in the order the table prints them."""
+    return [(name, job[source][name] if source else job[name])
+            for name, source, _ in JOB_COLUMNS]
+
+
+def degradation_block(report: dict, path: dict) -> list:
+    """Why any number printed above is not final.  A cell reading `partial`
+    or `unavailable` with nothing saying why is a flag a reader learns to
+    skip, and the caveat the two walkers raise is worth nothing once that has
+    happened.
+
+    Two things would defeat it on their own.  Explaining a metric that has no
+    column tells the reader about a number they cannot see while leaving the
+    ones they can see bare, so the selection is exactly `cell()`'s output:
+    the run-level table, both critical paths, and each job's six columns.  And
+    one reason repeated once per job buries every line that is not repeated,
+    so identical reasons collapse into a single line carrying the count.  A
+    skipped job is left out for the same reason: its durations are absent by
+    design and the table header says so once."""
+    def wanted(metric):
+        # Deliberately not `and metric.get("reason")`: a degraded metric that
+        # carries no reason is the bare `(partial)` this block exists to
+        # defeat, so it must appear and say that its cause was not recorded.
+        return metric.get("status") != "measured"
+
+    qualified = [(key, metric) for key, metric in report["metrics"].items()
+                 if wanted(metric)]
+    qualified += [(f"critical_path.{key}", path[key])
+                  for key in ("observed", "graph") if wanted(path[key])]
+    for job in report["jobs"]:
+        if job["conclusion"] == "skipped":
+            continue
+        qualified += [(f"{job['name']} / {column}", metric)
+                      for column, metric in job_cells(job) if wanted(metric)]
+    if not qualified:
+        return []
+
+    groups: dict = {}
+    for key, metric in qualified:
+        reason = metric.get("reason") or "no cause was recorded"
+        groups.setdefault((metric["status"], reason), []).append(key)
+    lines = ["", "Why a number above is not final:", ""]
+    for (status, reason), keys in groups.items():
+        # A handful is worth naming individually; a wall of them is not.
+        if len(keys) <= COLLAPSE_AT:
+            lines += [f"- `{key}` is {status}: {reason}" for key in keys]
+            continue
+        # Collapse only what can still be named.  Entries sharing a reason
+        # across different columns have no shared subject, and "4 values are
+        # anomalous" tells the reader neither which jobs nor which numbers,
+        # which is worse than four specific lines.
+        columns = {key.rsplit(" / ", 1)[-1] for key in keys}
+        if len(columns) != 1:
+            lines += [f"- `{key}` is {status}: {reason}" for key in keys]
+            continue
+        lines.append(f"- `{columns.pop()}` on {len(keys)} jobs is "
+                     f"{status}: {reason}")
+    return lines
+
+
 def render_markdown(report: dict) -> str:
     counts = report["job_counts"]
     lines = [
@@ -1252,17 +1395,14 @@ def render_markdown(report: dict) -> str:
         "",
         "Per job, seconds. A skipped job has no durations at all.",
         "",
-        "| job | population | queue | wall | configure | compile | tests | "
-        "unaccounted |",
-        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+        "| job | population | "
+        + " | ".join(heading for _, _, heading in JOB_COLUMNS) + " |",
+        "| --- | --- | " + " | ".join("---" for _ in JOB_COLUMNS) + " |",
     ]
     for job in report["jobs"]:
-        m, p = job["metrics"], job["phases"]
-        lines.append(
-            f"| {job['name']} | {job['population']} | {cell(m['queue_delay'])} "
-            f"| {cell(m['job_wall'])} | {cell(p['configure'])} "
-            f"| {cell(p['compile'])} | {cell(p['tests'])} "
-            f"| {cell(job['unaccounted'])} |")
+        values = " | ".join(cell(metric) for _, metric in job_cells(job))
+        lines.append(f"| {job['name']} | {job['population']} | {values} |")
+    lines += degradation_block(report, path)
     if report["anomalies"]:
         lines += ["", "Anomalies:", ""]
         for item in report["anomalies"]:
@@ -1380,8 +1520,10 @@ def cmd_fetch(args) -> int:
         except (RuntimeError, OSError) as exc:
             return die(str(exc))
         run_path, jobs_path = raw_paths(out, run_id)
-        run_path.write_text(json.dumps(run, indent=2, sort_keys=True) + "\n")
-        jobs_path.write_text(json.dumps(jobs, indent=2, sort_keys=True) + "\n")
+        run_path.write_text(json.dumps(run, indent=2, sort_keys=True) + "\n",
+                            encoding="utf-8")
+        jobs_path.write_text(json.dumps(jobs, indent=2, sort_keys=True)
+                             + "\n", encoding="utf-8")
         print(f"ci-run-telemetry: saved run {run_id} "
               f"({jobs['total_count']} jobs, {budget.used} requests so far)")
     return 0
@@ -1394,11 +1536,11 @@ def cmd_report(args) -> int:
         if not run_path.exists() or not jobs_path.exists():
             return die(f"no saved responses for run {run_id} under {out}/raw "
                        f"(run `fetch` first)")
-        run = json.loads(run_path.read_text())
+        run = json.loads(run_path.read_text(encoding="utf-8"))
         if run.get("id") is not None and run.get("id") != run_id:
             return die(f"{run_path} holds run {run.get('id')}, not {run_id}; "
                        f"the saved pair does not belong together")
-        jobs_doc = json.loads(jobs_path.read_text())
+        jobs_doc = json.loads(jobs_path.read_text(encoding="utf-8"))
         edges, drift = None, None
         if args.workflow:
             try:
@@ -1423,8 +1565,10 @@ def cmd_report(args) -> int:
                 edges, drift = match_graph_to_jobs(graph, names)
         report = analyze(run, jobs_doc, edges, drift)
         (out / f"run-{run_id}.json").write_text(
-            json.dumps(report, indent=2, sort_keys=True) + "\n")
-        (out / f"run-{run_id}.md").write_text(render_markdown(report))
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8")
+        (out / f"run-{run_id}.md").write_text(render_markdown(report),
+                                              encoding="utf-8")
         counts = report["job_counts"]
         print(f"ci-run-telemetry: run {run_id}: {counts['executed']} executed, "
               f"{counts['skipped']} skipped, "
@@ -1444,11 +1588,13 @@ def cmd_aggregate(args) -> int:
                        if path.name != f"{args.label}.json")
     if not paths:
         return die(f"no reports under {out} (run `report` first)")
-    reports = [json.loads(path.read_text()) for path in paths]
+    reports = [json.loads(path.read_text(encoding="utf-8"))
+               for path in paths]
     doc = aggregate_reports(reports)
     (out / f"{args.label}.json").write_text(
-        json.dumps(doc, indent=2, sort_keys=True) + "\n")
-    (out / f"{args.label}.md").write_text(render_aggregate_markdown(doc))
+        json.dumps(doc, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (out / f"{args.label}.md").write_text(render_aggregate_markdown(doc),
+                                          encoding="utf-8")
     print(f"ci-run-telemetry: {args.label}: {len(doc['runs'])} runs, "
           f"{len(doc['cells'])} cells, populations "
           f"{', '.join(doc['populations']) or 'none'}")

--- a/scripts/ci/ci-telemetry-fixtures/run-clock-skew-jobs.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-clock-skew-jobs.json
@@ -1,0 +1,317 @@
+{
+  "jobs": [
+    {
+      "completed_at": "2026-09-11T08:35:14Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T08:33:37Z",
+      "id": 103200409721,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "RC changelog freeze gate",
+      "runner_group_name": "default",
+      "runner_name": "semantic-reasoning-i401-6",
+      "started_at": "2026-09-11T08:35:04Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T08:34:56Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T08:34:54Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:34:58Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T08:34:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:34:58Z",
+          "conclusion": "success",
+          "name": "Enforce RC changelog freeze policy",
+          "number": 3,
+          "started_at": "2026-09-11T08:34:58Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:34:58Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 6,
+          "started_at": "2026-09-11T08:34:58Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:34:58Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 7,
+          "started_at": "2026-09-11T08:34:58Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T08:43:06Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T08:33:37Z",
+      "id": 103200409951,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Detect build-triggering changes",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000055818",
+      "started_at": "2026-09-11T08:43:01Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T08:43:02Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T08:43:02Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:04Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T08:43:02Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:04Z",
+          "conclusion": "success",
+          "name": "Detect source and build-definition changes",
+          "number": 3,
+          "started_at": "2026-09-11T08:43:04Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:04Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 6,
+          "started_at": "2026-09-11T08:43:04Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:04Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 7,
+          "started_at": "2026-09-11T08:43:04Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T08:42:30Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T08:33:37Z",
+      "id": 103200409955,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Docs / policy validation",
+      "runner_group_name": "default",
+      "runner_name": "i406-d2",
+      "started_at": "2026-09-11T08:42:20Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T08:42:23Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T08:42:22Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:42:24Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T08:42:23Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:42:24Z",
+          "conclusion": "success",
+          "name": "Validate support policy",
+          "number": 3,
+          "started_at": "2026-09-11T08:42:24Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:42:24Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 6,
+          "started_at": "2026-09-11T08:42:24Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:42:24Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 7,
+          "started_at": "2026-09-11T08:42:24Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T08:43:10Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T08:35:15Z",
+      "id": 103200838630,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "lint / EditorConfig check",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000055821",
+      "started_at": "2026-09-11T08:43:04Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T08:43:05Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T08:43:04Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:07Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T08:43:05Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:07Z",
+          "conclusion": "success",
+          "name": "Install editorconfig-checker",
+          "number": 3,
+          "started_at": "2026-09-11T08:43:07Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:09Z",
+          "conclusion": "success",
+          "name": "Run editorconfig-checker",
+          "number": 4,
+          "started_at": "2026-09-11T08:43:07Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:09Z",
+          "conclusion": "success",
+          "name": "Publish results",
+          "number": 5,
+          "started_at": "2026-09-11T08:43:09Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:09Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 10,
+          "started_at": "2026-09-11T08:43:09Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:09Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 11,
+          "started_at": "2026-09-11T08:43:09Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": null,
+      "conclusion": null,
+      "created_at": "2026-09-11T08:43:11Z",
+      "id": 103202876645,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "lint / uncrustify check",
+      "runner_group_name": "default",
+      "runner_name": "semantic-reasoning-i401-6-2",
+      "started_at": "2026-09-11T08:43:14Z",
+      "status": "in_progress",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T08:43:06Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T08:43:04Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T08:43:08Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T08:43:06Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": null,
+          "conclusion": null,
+          "name": "Install uncrustify",
+          "number": 3,
+          "started_at": "2026-09-11T08:43:08Z",
+          "status": "in_progress"
+        },
+        {
+          "completed_at": null,
+          "conclusion": null,
+          "name": "Verify tool version",
+          "number": 4,
+          "started_at": null,
+          "status": "pending"
+        },
+        {
+          "completed_at": null,
+          "conclusion": null,
+          "name": "Run uncrustify (hard gate)",
+          "number": 5,
+          "started_at": null,
+          "status": "pending"
+        },
+        {
+          "completed_at": null,
+          "conclusion": null,
+          "name": "Publish results",
+          "number": 6,
+          "started_at": null,
+          "status": "pending"
+        },
+        {
+          "completed_at": null,
+          "conclusion": null,
+          "name": "Post Run actions/checkout@v5",
+          "number": 12,
+          "started_at": null,
+          "status": "pending"
+        }
+      ]
+    }
+  ],
+  "total_count": 5
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-clock-skew.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-clock-skew.json
@@ -1,0 +1,12 @@
+{
+  "conclusion": null,
+  "created_at": "2026-09-11T08:33:36Z",
+  "event": "pull_request",
+  "head_branch": "fix/1531-thread-namespace",
+  "head_sha": "941d1dac0aba4c7d8cdf0c3bdb2789a67d134d56",
+  "id": 34579784069,
+  "name": "CI PR",
+  "run_attempt": 1,
+  "run_started_at": "2026-09-11T08:33:36Z",
+  "status": "in_progress"
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-missing-data-jobs.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-missing-data-jobs.json
@@ -1,0 +1,84 @@
+{
+  "jobs": [
+    {
+      "completed_at": "2026-09-10T10:01:11Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T10:00:01Z",
+      "id": 301,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Detect build-triggering changes",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1",
+      "started_at": "2026-09-10T10:00:11Z",
+      "status": "completed",
+      "steps": []
+    },
+    {
+      "completed_at": "2026-09-10T10:02:00Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T10:00:11Z",
+      "id": 302,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Build / ubuntu-latest / gcc",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1",
+      "started_at": null,
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": null,
+          "conclusion": null,
+          "name": "Set up job",
+          "number": 1,
+          "started_at": null,
+          "status": "queued"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T10:03:00Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T10:02:00Z",
+      "id": 303,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "TSan / ubuntu-latest / gcc",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1",
+      "started_at": "2026-09-10T10:02:05Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T10:02:07Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T10:02:05Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T10:02:58Z",
+          "conclusion": "success",
+          "name": "Test with TSan",
+          "number": 2,
+          "started_at": "2026-09-10T10:02:07Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T10:03:00Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 3,
+          "started_at": "2026-09-10T10:02:58Z",
+          "status": "completed"
+        }
+      ]
+    }
+  ],
+  "total_count": 3
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-missing-data.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-missing-data.json
@@ -1,0 +1,12 @@
+{
+  "conclusion": "success",
+  "created_at": "2026-09-10T10:00:00Z",
+  "event": "pull_request",
+  "head_branch": "topic",
+  "head_sha": "0000000000000000000000000000000000000000",
+  "id": 3,
+  "name": "CI PR",
+  "run_attempt": 1,
+  "run_started_at": null,
+  "status": "completed"
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-queued-jobs.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-queued-jobs.json
@@ -1,0 +1,108 @@
+{
+  "jobs": [
+    {
+      "completed_at": "2026-09-10T10:00:18Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T10:00:01Z",
+      "id": 201,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Detect build-triggering changes",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1",
+      "started_at": "2026-09-10T10:00:11Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T10:00:13Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T10:00:11Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T10:00:16Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T10:00:13Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T10:00:17Z",
+          "conclusion": "success",
+          "name": "Detect source and build-definition changes",
+          "number": 3,
+          "started_at": "2026-09-10T10:00:16Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T10:00:18Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 4,
+          "started_at": "2026-09-10T10:00:17Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": null,
+      "conclusion": null,
+      "created_at": "2026-09-10T10:00:18Z",
+      "id": 202,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Build / ubuntu-latest / gcc",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1",
+      "started_at": "2026-09-10T10:00:30Z",
+      "status": "in_progress",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T10:00:33Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T10:00:30Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T10:00:50Z",
+          "conclusion": "success",
+          "name": "Configure",
+          "number": 2,
+          "started_at": "2026-09-10T10:00:33Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": null,
+          "conclusion": null,
+          "name": "Build",
+          "number": 3,
+          "started_at": "2026-09-10T10:00:50Z",
+          "status": "in_progress"
+        }
+      ]
+    },
+    {
+      "completed_at": null,
+      "conclusion": null,
+      "created_at": "2026-09-10T10:00:18Z",
+      "id": 203,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "TSan / ubuntu-latest / gcc",
+      "runner_group_name": null,
+      "runner_name": null,
+      "started_at": null,
+      "status": "queued",
+      "steps": []
+    }
+  ],
+  "total_count": 3
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-queued.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-queued.json
@@ -1,0 +1,12 @@
+{
+  "conclusion": null,
+  "created_at": "2026-09-10T10:00:00Z",
+  "event": "pull_request",
+  "head_branch": "topic",
+  "head_sha": "0000000000000000000000000000000000000000",
+  "id": 2,
+  "name": "CI PR",
+  "run_attempt": 1,
+  "run_started_at": "2026-09-10T10:00:00Z",
+  "status": "in_progress"
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-rerun-jobs.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-rerun-jobs.json
@@ -1,0 +1,45 @@
+{
+  "jobs": [
+    {
+      "completed_at": "2026-09-10T10:01:11Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T10:00:01Z",
+      "id": 401,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Detect build-triggering changes",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1",
+      "started_at": "2026-09-10T10:00:11Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T10:00:13Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T10:00:11Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T10:01:09Z",
+          "conclusion": "success",
+          "name": "Detect source and build-definition changes",
+          "number": 2,
+          "started_at": "2026-09-10T10:00:13Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T10:01:11Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 3,
+          "started_at": "2026-09-10T10:01:09Z",
+          "status": "completed"
+        }
+      ]
+    }
+  ],
+  "total_count": 1
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-rerun.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-rerun.json
@@ -1,0 +1,12 @@
+{
+  "conclusion": "success",
+  "created_at": "2026-09-10T09:00:00Z",
+  "event": "pull_request",
+  "head_branch": "topic",
+  "head_sha": "0000000000000000000000000000000000000000",
+  "id": 4,
+  "name": "CI PR",
+  "run_attempt": 2,
+  "run_started_at": "2026-09-10T10:00:00Z",
+  "status": "completed"
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-skip-cascade-jobs.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-skip-cascade-jobs.json
@@ -1,0 +1,990 @@
+{
+  "jobs": [
+    {
+      "completed_at": "2026-09-11T06:50:30Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T06:49:48Z",
+      "id": 103174726297,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Detect build-triggering changes",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000055703",
+      "started_at": "2026-09-11T06:50:25Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T06:50:26Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T06:50:26Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:28Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T06:50:26Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:28Z",
+          "conclusion": "success",
+          "name": "Detect source and build-definition changes",
+          "number": 3,
+          "started_at": "2026-09-11T06:50:28Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:28Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 6,
+          "started_at": "2026-09-11T06:50:28Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:28Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 7,
+          "started_at": "2026-09-11T06:50:28Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T06:50:04Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T06:49:48Z",
+      "id": 103174726522,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Docs / policy validation",
+      "runner_group_name": "default",
+      "runner_name": "semantic-reasoning-i401-6-2",
+      "started_at": "2026-09-11T06:49:50Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T06:49:43Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T06:49:41Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:49:47Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T06:49:43Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:49:47Z",
+          "conclusion": "success",
+          "name": "Validate support policy",
+          "number": 3,
+          "started_at": "2026-09-11T06:49:47Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:49:48Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 6,
+          "started_at": "2026-09-11T06:49:47Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:49:48Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 7,
+          "started_at": "2026-09-11T06:49:48Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T06:50:17Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T06:49:48Z",
+      "id": 103174726533,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "RC changelog freeze gate",
+      "runner_group_name": "default",
+      "runner_name": "semantic-reasoning-i401-6-2",
+      "started_at": "2026-09-11T06:50:07Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T06:49:59Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T06:49:57Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:00Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T06:49:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:00Z",
+          "conclusion": "success",
+          "name": "Enforce RC changelog freeze policy",
+          "number": 3,
+          "started_at": "2026-09-11T06:50:00Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:01Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 6,
+          "started_at": "2026-09-11T06:50:00Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:01Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 7,
+          "started_at": "2026-09-11T06:50:01Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T06:50:36Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T06:50:17Z",
+      "id": 103174840940,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "lint / EditorConfig check",
+      "runner_group_name": "default",
+      "runner_name": "semantic-reasoning-i401-6-2",
+      "started_at": "2026-09-11T06:50:20Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T06:50:12Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T06:50:10Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:13Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T06:50:12Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:14Z",
+          "conclusion": "success",
+          "name": "Install editorconfig-checker",
+          "number": 3,
+          "started_at": "2026-09-11T06:50:13Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:19Z",
+          "conclusion": "success",
+          "name": "Run editorconfig-checker",
+          "number": 4,
+          "started_at": "2026-09-11T06:50:14Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:19Z",
+          "conclusion": "success",
+          "name": "Publish results",
+          "number": 5,
+          "started_at": "2026-09-11T06:50:19Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:19Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 10,
+          "started_at": "2026-09-11T06:50:19Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:19Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 11,
+          "started_at": "2026-09-11T06:50:19Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T06:50:52Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T06:50:36Z",
+      "id": 103174910112,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "lint / uncrustify check",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000055704",
+      "started_at": "2026-09-11T06:50:38Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T06:50:39Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T06:50:38Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:41Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T06:50:39Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:50Z",
+          "conclusion": "success",
+          "name": "Install uncrustify",
+          "number": 3,
+          "started_at": "2026-09-11T06:50:41Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:50Z",
+          "conclusion": "success",
+          "name": "Verify tool version",
+          "number": 4,
+          "started_at": "2026-09-11T06:50:50Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:50Z",
+          "conclusion": "success",
+          "name": "Run uncrustify (hard gate)",
+          "number": 5,
+          "started_at": "2026-09-11T06:50:50Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:50Z",
+          "conclusion": "success",
+          "name": "Publish results",
+          "number": 6,
+          "started_at": "2026-09-11T06:50:50Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:50Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 12,
+          "started_at": "2026-09-11T06:50:50Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:50Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 13,
+          "started_at": "2026-09-11T06:50:50Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T07:32:35Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T06:50:52Z",
+      "id": 103174971848,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Sanitizers / ubuntu-latest / clang",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000055705",
+      "started_at": "2026-09-11T06:50:54Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T06:50:56Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T06:50:55Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:58Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T06:50:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:59Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-11T06:50:58Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:29Z",
+          "conclusion": "success",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-11T06:50:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:29Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-11T06:51:29Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:49Z",
+          "conclusion": "success",
+          "name": "Configure with sanitizers",
+          "number": 6,
+          "started_at": "2026-09-11T06:51:29Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:31:22Z",
+          "conclusion": "success",
+          "name": "Build with sanitizers",
+          "number": 7,
+          "started_at": "2026-09-11T06:51:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:31:22Z",
+          "conclusion": "success",
+          "name": "Record bash version",
+          "number": 8,
+          "started_at": "2026-09-11T07:31:22Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:32:33Z",
+          "conclusion": "success",
+          "name": "Test with sanitizers",
+          "number": 9,
+          "started_at": "2026-09-11T07:31:22Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:32:33Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 17,
+          "started_at": "2026-09-11T07:32:33Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:32:33Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 18,
+          "started_at": "2026-09-11T07:32:33Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:32:33Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 19,
+          "started_at": "2026-09-11T07:32:33Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T07:14:46Z",
+      "conclusion": "failure",
+      "created_at": "2026-09-11T06:50:52Z",
+      "id": 103174971875,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Build / ubuntu-latest / gcc",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000055706",
+      "started_at": "2026-09-11T06:50:55Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T06:50:57Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T06:50:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:59Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T06:50:57Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:00Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-11T06:50:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:11Z",
+          "conclusion": "success",
+          "name": "Install dependencies",
+          "number": 4,
+          "started_at": "2026-09-11T06:51:00Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:23Z",
+          "conclusion": "success",
+          "name": "Configure",
+          "number": 5,
+          "started_at": "2026-09-11T06:51:11Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:11:36Z",
+          "conclusion": "success",
+          "name": "Build",
+          "number": 6,
+          "started_at": "2026-09-11T06:51:23Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:12:32Z",
+          "conclusion": "success",
+          "name": "Test",
+          "number": 7,
+          "started_at": "2026-09-11T07:11:36Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:12:48Z",
+          "conclusion": "success",
+          "name": "Install clang-tidy (pinned major)",
+          "number": 8,
+          "started_at": "2026-09-11T07:12:32Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:14:39Z",
+          "conclusion": "success",
+          "name": "clang-tidy ratchet gate",
+          "number": 9,
+          "started_at": "2026-09-11T07:12:48Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:14:40Z",
+          "conclusion": "success",
+          "name": "Install syft",
+          "number": 10,
+          "started_at": "2026-09-11T07:14:39Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:14:42Z",
+          "conclusion": "success",
+          "name": "SBOM snapshot gate",
+          "number": 11,
+          "started_at": "2026-09-11T07:14:40Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:14:42Z",
+          "conclusion": "failure",
+          "name": "Check binary size",
+          "number": 12,
+          "started_at": "2026-09-11T07:14:42Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:14:42Z",
+          "conclusion": "skipped",
+          "name": "Path A example compile-check",
+          "number": 13,
+          "started_at": "2026-09-11T07:14:42Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:14:42Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 25,
+          "started_at": "2026-09-11T07:14:42Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:14:42Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 26,
+          "started_at": "2026-09-11T07:14:42Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:14:43Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 27,
+          "started_at": "2026-09-11T07:14:42Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T07:34:51Z",
+      "conclusion": "failure",
+      "created_at": "2026-09-11T06:50:52Z",
+      "id": 103174971879,
+      "labels": [
+        "ubuntu-24.04-arm"
+      ],
+      "name": "Sanitizers / ubuntu-24.04-arm / gcc",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000055708",
+      "started_at": "2026-09-11T06:50:57Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T06:50:59Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T06:50:58Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:01Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T06:50:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:02Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-11T06:51:01Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:17Z",
+          "conclusion": "success",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-11T06:51:02Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:17Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-11T06:51:17Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:35Z",
+          "conclusion": "success",
+          "name": "Configure with sanitizers",
+          "number": 6,
+          "started_at": "2026-09-11T06:51:17Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:23:43Z",
+          "conclusion": "success",
+          "name": "Build with sanitizers",
+          "number": 7,
+          "started_at": "2026-09-11T06:51:35Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:23:43Z",
+          "conclusion": "success",
+          "name": "Record bash version",
+          "number": 8,
+          "started_at": "2026-09-11T07:23:43Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:34:48Z",
+          "conclusion": "failure",
+          "name": "Test with sanitizers",
+          "number": 9,
+          "started_at": "2026-09-11T07:23:43Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:34:48Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 17,
+          "started_at": "2026-09-11T07:34:48Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:34:48Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 18,
+          "started_at": "2026-09-11T07:34:48Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:34:48Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 19,
+          "started_at": "2026-09-11T07:34:48Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T07:31:52Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T06:50:52Z",
+      "id": 103174971902,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Sanitizers / ubuntu-latest / gcc",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000055707",
+      "started_at": "2026-09-11T06:50:55Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T06:50:56Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T06:50:55Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:58Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T06:50:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:50:59Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-11T06:50:58Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:52:42Z",
+          "conclusion": "success",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-11T06:50:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:52:42Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-11T06:52:42Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:52:56Z",
+          "conclusion": "success",
+          "name": "Configure with sanitizers",
+          "number": 6,
+          "started_at": "2026-09-11T06:52:42Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:30:37Z",
+          "conclusion": "success",
+          "name": "Build with sanitizers",
+          "number": 7,
+          "started_at": "2026-09-11T06:52:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:30:37Z",
+          "conclusion": "success",
+          "name": "Record bash version",
+          "number": 8,
+          "started_at": "2026-09-11T07:30:37Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:31:49Z",
+          "conclusion": "success",
+          "name": "Test with sanitizers",
+          "number": 9,
+          "started_at": "2026-09-11T07:30:37Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:31:49Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 17,
+          "started_at": "2026-09-11T07:31:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:31:49Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 18,
+          "started_at": "2026-09-11T07:31:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:31:49Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 19,
+          "started_at": "2026-09-11T07:31:49Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T07:25:36Z",
+      "conclusion": "success",
+      "created_at": "2026-09-11T06:50:53Z",
+      "id": 103174971951,
+      "labels": [
+        "macos-latest"
+      ],
+      "name": "Sanitizers / macos-latest / clang",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000055709",
+      "started_at": "2026-09-11T06:50:58Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-11T06:51:00Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-11T06:50:58Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:02Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-11T06:51:00Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:03Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-11T06:51:02Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:03Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-11T06:51:03Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:07Z",
+          "conclusion": "success",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-11T06:51:03Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T06:51:19Z",
+          "conclusion": "success",
+          "name": "Configure with sanitizers",
+          "number": 6,
+          "started_at": "2026-09-11T06:51:07Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:24:05Z",
+          "conclusion": "success",
+          "name": "Build with sanitizers",
+          "number": 7,
+          "started_at": "2026-09-11T06:51:19Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:24:06Z",
+          "conclusion": "success",
+          "name": "Record bash version",
+          "number": 8,
+          "started_at": "2026-09-11T07:24:05Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:25:32Z",
+          "conclusion": "success",
+          "name": "Test with sanitizers",
+          "number": 9,
+          "started_at": "2026-09-11T07:24:06Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:25:32Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 17,
+          "started_at": "2026-09-11T07:25:32Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:25:33Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 18,
+          "started_at": "2026-09-11T07:25:32Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-11T07:25:35Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 19,
+          "started_at": "2026-09-11T07:25:33Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-11T07:14:46Z",
+      "conclusion": "skipped",
+      "created_at": "2026-09-11T07:14:47Z",
+      "id": 103180567746,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "mbedtls-enabled / ubuntu-latest / gcc",
+      "runner_group_name": null,
+      "runner_name": null,
+      "started_at": "2026-09-11T07:14:47Z",
+      "status": "completed",
+      "steps": []
+    },
+    {
+      "completed_at": "2026-09-11T07:14:46Z",
+      "conclusion": "skipped",
+      "created_at": "2026-09-11T07:14:47Z",
+      "id": 103180567967,
+      "labels": [
+        "ubuntu-24.04-arm"
+      ],
+      "name": "Build / ubuntu-24.04-arm / gcc",
+      "runner_group_name": null,
+      "runner_name": null,
+      "started_at": "2026-09-11T07:14:47Z",
+      "status": "completed",
+      "steps": []
+    },
+    {
+      "completed_at": "2026-09-11T07:14:46Z",
+      "conclusion": "skipped",
+      "created_at": "2026-09-11T07:14:47Z",
+      "id": 103180568034,
+      "labels": [],
+      "name": "Build / ${{ matrix.os }} / ${{ matrix.compiler }}",
+      "runner_group_name": null,
+      "runner_name": null,
+      "started_at": "2026-09-11T07:14:47Z",
+      "status": "completed",
+      "steps": []
+    },
+    {
+      "completed_at": "2026-09-11T07:34:52Z",
+      "conclusion": "skipped",
+      "created_at": "2026-09-11T07:34:52Z",
+      "id": 103185485539,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "TSan / ubuntu-latest / ${{ matrix.compiler }}",
+      "runner_group_name": null,
+      "runner_name": null,
+      "started_at": "2026-09-11T07:34:52Z",
+      "status": "completed",
+      "steps": []
+    },
+    {
+      "completed_at": "2026-09-11T07:34:52Z",
+      "conclusion": "skipped",
+      "created_at": "2026-09-11T07:34:52Z",
+      "id": 103185485852,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "TSan-native / ubuntu-latest / gcc",
+      "runner_group_name": null,
+      "runner_name": null,
+      "started_at": "2026-09-11T07:34:52Z",
+      "status": "completed",
+      "steps": []
+    }
+  ],
+  "total_count": 15
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-skip-cascade.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-skip-cascade.json
@@ -1,0 +1,12 @@
+{
+  "conclusion": "failure",
+  "created_at": "2026-09-11T06:49:47Z",
+  "event": "pull_request",
+  "head_branch": "fix/1531-thread-namespace",
+  "head_sha": "e822778023d469de2ca423d76d332f00044c6e54",
+  "id": 34571608167,
+  "name": "CI PR",
+  "run_attempt": 1,
+  "run_started_at": "2026-09-11T06:49:47Z",
+  "status": "completed"
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-success-jobs.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-success-jobs.json
@@ -1,0 +1,1845 @@
+{
+  "jobs": [
+    {
+      "completed_at": "2026-09-10T18:35:28Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T18:27:12Z",
+      "id": 102996159107,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Detect build-triggering changes",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054606",
+      "started_at": "2026-09-10T18:35:21Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T18:35:23Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T18:35:22Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:35:25Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T18:35:23Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:35:25Z",
+          "conclusion": "success",
+          "name": "Detect source and build-definition changes",
+          "number": 3,
+          "started_at": "2026-09-10T18:35:25Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:35:25Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 6,
+          "started_at": "2026-09-10T18:35:25Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:35:25Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 7,
+          "started_at": "2026-09-10T18:35:25Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T18:36:39Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T18:27:12Z",
+      "id": 102996159417,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "RC changelog freeze gate",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054608",
+      "started_at": "2026-09-10T18:36:33Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T18:36:34Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T18:36:34Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:36:36Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T18:36:34Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:36:36Z",
+          "conclusion": "success",
+          "name": "Enforce RC changelog freeze policy",
+          "number": 3,
+          "started_at": "2026-09-10T18:36:36Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:36:37Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 6,
+          "started_at": "2026-09-10T18:36:36Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:36:37Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 7,
+          "started_at": "2026-09-10T18:36:37Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T18:37:39Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T18:27:12Z",
+      "id": 102996159476,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Docs / policy validation",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054614",
+      "started_at": "2026-09-10T18:37:32Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T18:37:34Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T18:37:33Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:37:37Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T18:37:34Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:37:37Z",
+          "conclusion": "success",
+          "name": "Validate support policy",
+          "number": 3,
+          "started_at": "2026-09-10T18:37:37Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:37:37Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 6,
+          "started_at": "2026-09-10T18:37:37Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:37:37Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 7,
+          "started_at": "2026-09-10T18:37:37Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T18:50:56Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T18:36:40Z",
+      "id": 102999400767,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "lint / EditorConfig check",
+      "runner_group_name": "default",
+      "runner_name": "semantic-reasoning-i401-6-2",
+      "started_at": "2026-09-10T18:50:34Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T18:50:32Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T18:50:25Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:50:33Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T18:50:32Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:50:34Z",
+          "conclusion": "success",
+          "name": "Install editorconfig-checker",
+          "number": 3,
+          "started_at": "2026-09-10T18:50:33Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:50:39Z",
+          "conclusion": "success",
+          "name": "Run editorconfig-checker",
+          "number": 4,
+          "started_at": "2026-09-10T18:50:34Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:50:39Z",
+          "conclusion": "success",
+          "name": "Publish results",
+          "number": 5,
+          "started_at": "2026-09-10T18:50:39Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:50:40Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 10,
+          "started_at": "2026-09-10T18:50:39Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:50:40Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 11,
+          "started_at": "2026-09-10T18:50:40Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T18:59:49Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T18:50:56Z",
+      "id": 103004228926,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "lint / uncrustify check",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054660",
+      "started_at": "2026-09-10T18:59:34Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T18:59:35Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T18:59:35Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:59:37Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T18:59:35Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:59:47Z",
+          "conclusion": "success",
+          "name": "Install uncrustify",
+          "number": 3,
+          "started_at": "2026-09-10T18:59:37Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:59:47Z",
+          "conclusion": "success",
+          "name": "Verify tool version",
+          "number": 4,
+          "started_at": "2026-09-10T18:59:47Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:59:47Z",
+          "conclusion": "success",
+          "name": "Run uncrustify (hard gate)",
+          "number": 5,
+          "started_at": "2026-09-10T18:59:47Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:59:47Z",
+          "conclusion": "success",
+          "name": "Publish results",
+          "number": 6,
+          "started_at": "2026-09-10T18:59:47Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:59:47Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 12,
+          "started_at": "2026-09-10T18:59:47Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T18:59:47Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 13,
+          "started_at": "2026-09-10T18:59:47Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T19:42:53Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T18:59:50Z",
+      "id": 103007248983,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Build / ubuntu-latest / gcc",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054702",
+      "started_at": "2026-09-10T19:22:16Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T19:22:18Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T19:22:17Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:22:22Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T19:22:18Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:22:23Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T19:22:22Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:22:42Z",
+          "conclusion": "success",
+          "name": "Install dependencies",
+          "number": 4,
+          "started_at": "2026-09-10T19:22:23Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:22:54Z",
+          "conclusion": "success",
+          "name": "Configure",
+          "number": 5,
+          "started_at": "2026-09-10T19:22:42Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:40:11Z",
+          "conclusion": "success",
+          "name": "Build",
+          "number": 6,
+          "started_at": "2026-09-10T19:22:54Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:41:01Z",
+          "conclusion": "success",
+          "name": "Test",
+          "number": 7,
+          "started_at": "2026-09-10T19:40:11Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:41:23Z",
+          "conclusion": "success",
+          "name": "Install clang-tidy (pinned major)",
+          "number": 8,
+          "started_at": "2026-09-10T19:41:01Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:42:46Z",
+          "conclusion": "success",
+          "name": "clang-tidy ratchet gate",
+          "number": 9,
+          "started_at": "2026-09-10T19:41:23Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:42:47Z",
+          "conclusion": "success",
+          "name": "Install syft",
+          "number": 10,
+          "started_at": "2026-09-10T19:42:46Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:42:49Z",
+          "conclusion": "success",
+          "name": "SBOM snapshot gate",
+          "number": 11,
+          "started_at": "2026-09-10T19:42:47Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:42:49Z",
+          "conclusion": "success",
+          "name": "Check binary size",
+          "number": 12,
+          "started_at": "2026-09-10T19:42:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:42:50Z",
+          "conclusion": "success",
+          "name": "Path A example compile-check",
+          "number": 13,
+          "started_at": "2026-09-10T19:42:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:42:50Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 25,
+          "started_at": "2026-09-10T19:42:50Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:42:50Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 26,
+          "started_at": "2026-09-10T19:42:50Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:42:51Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 27,
+          "started_at": "2026-09-10T19:42:50Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T19:36:59Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T18:59:50Z",
+      "id": 103007249006,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Sanitizers / ubuntu-latest / gcc",
+      "runner_group_name": "default",
+      "runner_name": "i406-d2",
+      "started_at": "2026-09-10T19:19:52Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T19:19:55Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T19:19:53Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:19:56Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T19:19:55Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:19:56Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T19:19:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:19:59Z",
+          "conclusion": "success",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-10T19:19:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:19:59Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-10T19:19:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:20:10Z",
+          "conclusion": "success",
+          "name": "Configure with sanitizers",
+          "number": 6,
+          "started_at": "2026-09-10T19:19:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:35:56Z",
+          "conclusion": "success",
+          "name": "Build with sanitizers",
+          "number": 7,
+          "started_at": "2026-09-10T19:20:10Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:35:56Z",
+          "conclusion": "success",
+          "name": "Record bash version",
+          "number": 8,
+          "started_at": "2026-09-10T19:35:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:36:51Z",
+          "conclusion": "success",
+          "name": "Test with sanitizers",
+          "number": 9,
+          "started_at": "2026-09-10T19:35:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:36:51Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 17,
+          "started_at": "2026-09-10T19:36:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:36:51Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 18,
+          "started_at": "2026-09-10T19:36:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:36:51Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 19,
+          "started_at": "2026-09-10T19:36:51Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T19:51:34Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T18:59:50Z",
+      "id": 103007249042,
+      "labels": [
+        "ubuntu-24.04-arm"
+      ],
+      "name": "Sanitizers / ubuntu-24.04-arm / gcc",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054683",
+      "started_at": "2026-09-10T19:14:42Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T19:14:43Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T19:14:42Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:14:45Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T19:14:43Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:14:46Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T19:14:45Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:15:01Z",
+          "conclusion": "success",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-10T19:14:46Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:15:01Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-10T19:15:01Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:15:18Z",
+          "conclusion": "success",
+          "name": "Configure with sanitizers",
+          "number": 6,
+          "started_at": "2026-09-10T19:15:01Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:46:05Z",
+          "conclusion": "success",
+          "name": "Build with sanitizers",
+          "number": 7,
+          "started_at": "2026-09-10T19:15:18Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:46:05Z",
+          "conclusion": "success",
+          "name": "Record bash version",
+          "number": 8,
+          "started_at": "2026-09-10T19:46:05Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:51:31Z",
+          "conclusion": "success",
+          "name": "Test with sanitizers",
+          "number": 9,
+          "started_at": "2026-09-10T19:46:05Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:51:32Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 17,
+          "started_at": "2026-09-10T19:51:31Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:51:32Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 18,
+          "started_at": "2026-09-10T19:51:32Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:51:32Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 19,
+          "started_at": "2026-09-10T19:51:32Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T20:05:15Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T18:59:50Z",
+      "id": 103007249058,
+      "labels": [
+        "macos-latest"
+      ],
+      "name": "Sanitizers / macos-latest / clang",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054690",
+      "started_at": "2026-09-10T19:18:55Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T19:18:56Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T19:18:55Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:18:58Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T19:18:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:18:59Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T19:18:58Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:18:59Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-10T19:18:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:19:04Z",
+          "conclusion": "success",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-10T19:18:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:19:17Z",
+          "conclusion": "success",
+          "name": "Configure with sanitizers",
+          "number": 6,
+          "started_at": "2026-09-10T19:19:04Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:03:21Z",
+          "conclusion": "success",
+          "name": "Build with sanitizers",
+          "number": 7,
+          "started_at": "2026-09-10T19:19:17Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:03:22Z",
+          "conclusion": "success",
+          "name": "Record bash version",
+          "number": 8,
+          "started_at": "2026-09-10T20:03:21Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:05:08Z",
+          "conclusion": "success",
+          "name": "Test with sanitizers",
+          "number": 9,
+          "started_at": "2026-09-10T20:03:22Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:05:08Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 17,
+          "started_at": "2026-09-10T20:05:08Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:05:09Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 18,
+          "started_at": "2026-09-10T20:05:08Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:05:12Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 19,
+          "started_at": "2026-09-10T20:05:09Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T20:25:46Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T18:59:50Z",
+      "id": 103007249070,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Sanitizers / ubuntu-latest / clang",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054699",
+      "started_at": "2026-09-10T19:21:25Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T19:21:27Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T19:21:26Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:21:28Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T19:21:27Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:21:29Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T19:21:28Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:21:43Z",
+          "conclusion": "success",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-10T19:21:29Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:21:43Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-10T19:21:43Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:22:07Z",
+          "conclusion": "success",
+          "name": "Configure with sanitizers",
+          "number": 6,
+          "started_at": "2026-09-10T19:21:43Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:24:19Z",
+          "conclusion": "success",
+          "name": "Build with sanitizers",
+          "number": 7,
+          "started_at": "2026-09-10T19:22:07Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:24:19Z",
+          "conclusion": "success",
+          "name": "Record bash version",
+          "number": 8,
+          "started_at": "2026-09-10T20:24:19Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:25:44Z",
+          "conclusion": "success",
+          "name": "Test with sanitizers",
+          "number": 9,
+          "started_at": "2026-09-10T20:24:19Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:25:44Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 17,
+          "started_at": "2026-09-10T20:25:44Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:25:44Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 18,
+          "started_at": "2026-09-10T20:25:44Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:25:44Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 19,
+          "started_at": "2026-09-10T20:25:44Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T19:56:53Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T19:42:53Z",
+      "id": 103021643946,
+      "labels": [
+        "ubuntu-24.04-arm"
+      ],
+      "name": "Build / ubuntu-24.04-arm / gcc",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054763",
+      "started_at": "2026-09-10T19:45:59Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T19:46:01Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T19:46:00Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:46:02Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T19:46:01Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:46:03Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T19:46:02Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:46:17Z",
+          "conclusion": "success",
+          "name": "Install dependencies",
+          "number": 4,
+          "started_at": "2026-09-10T19:46:03Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:46:25Z",
+          "conclusion": "success",
+          "name": "Configure",
+          "number": 5,
+          "started_at": "2026-09-10T19:46:17Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:55:59Z",
+          "conclusion": "success",
+          "name": "Build",
+          "number": 6,
+          "started_at": "2026-09-10T19:46:25Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:56:51Z",
+          "conclusion": "success",
+          "name": "Test",
+          "number": 7,
+          "started_at": "2026-09-10T19:55:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:56:51Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 13,
+          "started_at": "2026-09-10T19:56:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:56:51Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 14,
+          "started_at": "2026-09-10T19:56:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:56:51Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 15,
+          "started_at": "2026-09-10T19:56:51Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T19:59:58Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T19:42:53Z",
+      "id": 103021644050,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "mbedtls-enabled / ubuntu-latest / gcc",
+      "runner_group_name": "default",
+      "runner_name": "semantic-reasoning-i401-6-2",
+      "started_at": "2026-09-10T19:49:48Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T19:49:51Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T19:49:39Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:49:52Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T19:49:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:49:52Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T19:49:52Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:49:56Z",
+          "conclusion": "success",
+          "name": "Install dependencies",
+          "number": 4,
+          "started_at": "2026-09-10T19:49:52Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:50:28Z",
+          "conclusion": "success",
+          "name": "Configure with mbedTLS enabled",
+          "number": 5,
+          "started_at": "2026-09-10T19:49:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:55:41Z",
+          "conclusion": "success",
+          "name": "Build with mbedTLS enabled",
+          "number": 6,
+          "started_at": "2026-09-10T19:50:28Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:55:47Z",
+          "conclusion": "success",
+          "name": "Verify enabled compile flag",
+          "number": 7,
+          "started_at": "2026-09-10T19:55:41Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:55:49Z",
+          "conclusion": "success",
+          "name": "Test mbedTLS crypto built-ins",
+          "number": 8,
+          "started_at": "2026-09-10T19:55:47Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:59:40Z",
+          "conclusion": "success",
+          "name": "Test metadata-free mbedTLS prefix discovery",
+          "number": 9,
+          "started_at": "2026-09-10T19:55:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:59:40Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 17,
+          "started_at": "2026-09-10T19:59:40Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:59:41Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 18,
+          "started_at": "2026-09-10T19:59:40Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T19:59:41Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 19,
+          "started_at": "2026-09-10T19:59:41Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T20:23:02Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T19:59:58Z",
+      "id": 103027282661,
+      "labels": [
+        "windows-latest"
+      ],
+      "name": "Build / windows-latest / msvc",
+      "runner_group_name": "default",
+      "runner_name": "B2A1",
+      "started_at": "2026-09-10T20:00:00Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T20:00:06Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T20:00:03Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:00:12Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T20:00:06Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:00:12Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T20:00:12Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:00:12Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-10T20:00:12Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:00:12Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-10T20:00:12Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:00:15Z",
+          "conclusion": "success",
+          "name": "Install dependencies (Windows)",
+          "number": 6,
+          "started_at": "2026-09-10T20:00:12Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:00:15Z",
+          "conclusion": "skipped",
+          "name": "Configure (Linux / macOS)",
+          "number": 7,
+          "started_at": "2026-09-10T20:00:15Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:00:34Z",
+          "conclusion": "success",
+          "name": "Configure (Windows / MSVC)",
+          "number": 8,
+          "started_at": "2026-09-10T20:00:15Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:00:34Z",
+          "conclusion": "skipped",
+          "name": "Build (Linux / macOS)",
+          "number": 9,
+          "started_at": "2026-09-10T20:00:34Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:22:23Z",
+          "conclusion": "success",
+          "name": "Build (Windows / MSVC)",
+          "number": 10,
+          "started_at": "2026-09-10T20:00:34Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:22:23Z",
+          "conclusion": "skipped",
+          "name": "Record bash version",
+          "number": 11,
+          "started_at": "2026-09-10T20:22:23Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:22:23Z",
+          "conclusion": "skipped",
+          "name": "Test (Linux / macOS)",
+          "number": 12,
+          "started_at": "2026-09-10T20:22:23Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:22:56Z",
+          "conclusion": "success",
+          "name": "Test (Windows / MSVC)",
+          "number": 13,
+          "started_at": "2026-09-10T20:22:23Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:22:56Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 25,
+          "started_at": "2026-09-10T20:22:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:22:58Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 26,
+          "started_at": "2026-09-10T20:22:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:22:59Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 27,
+          "started_at": "2026-09-10T20:22:58Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T20:30:56Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T19:59:58Z",
+      "id": 103027282776,
+      "labels": [
+        "macos-latest"
+      ],
+      "name": "Build / macos-latest / clang",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054833",
+      "started_at": "2026-09-10T20:11:11Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T20:11:13Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T20:11:12Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:11:16Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T20:11:13Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:11:18Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T20:11:16Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:11:18Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-10T20:11:18Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:11:23Z",
+          "conclusion": "success",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-10T20:11:18Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:11:23Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (Windows)",
+          "number": 6,
+          "started_at": "2026-09-10T20:11:23Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:11:36Z",
+          "conclusion": "success",
+          "name": "Configure (Linux / macOS)",
+          "number": 7,
+          "started_at": "2026-09-10T20:11:23Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:11:36Z",
+          "conclusion": "skipped",
+          "name": "Configure (Windows / MSVC)",
+          "number": 8,
+          "started_at": "2026-09-10T20:11:36Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:29:59Z",
+          "conclusion": "success",
+          "name": "Build (Linux / macOS)",
+          "number": 9,
+          "started_at": "2026-09-10T20:11:36Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:29:59Z",
+          "conclusion": "skipped",
+          "name": "Build (Windows / MSVC)",
+          "number": 10,
+          "started_at": "2026-09-10T20:29:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:30:00Z",
+          "conclusion": "success",
+          "name": "Record bash version",
+          "number": 11,
+          "started_at": "2026-09-10T20:29:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:30:49Z",
+          "conclusion": "success",
+          "name": "Test (Linux / macOS)",
+          "number": 12,
+          "started_at": "2026-09-10T20:30:00Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:30:49Z",
+          "conclusion": "skipped",
+          "name": "Test (Windows / MSVC)",
+          "number": 13,
+          "started_at": "2026-09-10T20:30:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:30:49Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 25,
+          "started_at": "2026-09-10T20:30:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:30:50Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 26,
+          "started_at": "2026-09-10T20:30:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:30:54Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 27,
+          "started_at": "2026-09-10T20:30:50Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T20:39:02Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T19:59:58Z",
+      "id": 103027282864,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "Build / ubuntu-latest / clang",
+      "runner_group_name": "default",
+      "runner_name": "semantic-reasoning-i401-6",
+      "started_at": "2026-09-10T20:31:06Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T20:30:59Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T20:30:57Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:31:00Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T20:30:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:31:01Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T20:31:00Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:31:09Z",
+          "conclusion": "success",
+          "name": "Install dependencies (Linux)",
+          "number": 4,
+          "started_at": "2026-09-10T20:31:01Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:31:09Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (macOS)",
+          "number": 5,
+          "started_at": "2026-09-10T20:31:09Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:31:09Z",
+          "conclusion": "skipped",
+          "name": "Install dependencies (Windows)",
+          "number": 6,
+          "started_at": "2026-09-10T20:31:09Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:31:43Z",
+          "conclusion": "success",
+          "name": "Configure (Linux / macOS)",
+          "number": 7,
+          "started_at": "2026-09-10T20:31:09Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:31:43Z",
+          "conclusion": "skipped",
+          "name": "Configure (Windows / MSVC)",
+          "number": 8,
+          "started_at": "2026-09-10T20:31:43Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:37:16Z",
+          "conclusion": "success",
+          "name": "Build (Linux / macOS)",
+          "number": 9,
+          "started_at": "2026-09-10T20:31:43Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:37:16Z",
+          "conclusion": "skipped",
+          "name": "Build (Windows / MSVC)",
+          "number": 10,
+          "started_at": "2026-09-10T20:37:16Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:37:16Z",
+          "conclusion": "success",
+          "name": "Record bash version",
+          "number": 11,
+          "started_at": "2026-09-10T20:37:16Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:38:42Z",
+          "conclusion": "success",
+          "name": "Test (Linux / macOS)",
+          "number": 12,
+          "started_at": "2026-09-10T20:37:16Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:38:42Z",
+          "conclusion": "skipped",
+          "name": "Test (Windows / MSVC)",
+          "number": 13,
+          "started_at": "2026-09-10T20:38:42Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:38:43Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 25,
+          "started_at": "2026-09-10T20:38:42Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:38:43Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 26,
+          "started_at": "2026-09-10T20:38:43Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:38:43Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 27,
+          "started_at": "2026-09-10T20:38:43Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T21:16:53Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T20:25:47Z",
+      "id": 103035976181,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "TSan / ubuntu-latest / gcc",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054867",
+      "started_at": "2026-09-10T20:52:56Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T20:52:57Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T20:52:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:52:58Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T20:52:57Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:52:59Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T20:52:58Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:53:10Z",
+          "conclusion": "success",
+          "name": "Install dependencies",
+          "number": 4,
+          "started_at": "2026-09-10T20:52:59Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:53:25Z",
+          "conclusion": "success",
+          "name": "Configure with TSan",
+          "number": 5,
+          "started_at": "2026-09-10T20:53:10Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:13:30Z",
+          "conclusion": "success",
+          "name": "Build with TSan",
+          "number": 6,
+          "started_at": "2026-09-10T20:53:25Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:16:51Z",
+          "conclusion": "success",
+          "name": "Test with TSan",
+          "number": 7,
+          "started_at": "2026-09-10T21:13:30Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:16:51Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 13,
+          "started_at": "2026-09-10T21:16:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:16:51Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 14,
+          "started_at": "2026-09-10T21:16:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:16:51Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 15,
+          "started_at": "2026-09-10T21:16:51Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T21:05:59Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T20:25:47Z",
+      "id": 103035976299,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "TSan-native / ubuntu-latest / gcc",
+      "runner_group_name": "default",
+      "runner_name": "i406-d2",
+      "started_at": "2026-09-10T20:58:46Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T20:58:49Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T20:58:48Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:58:51Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T20:58:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:58:51Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T20:58:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:58:56Z",
+          "conclusion": "success",
+          "name": "Install dependencies",
+          "number": 4,
+          "started_at": "2026-09-10T20:58:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:59:08Z",
+          "conclusion": "success",
+          "name": "Configure with TSan (native threads)",
+          "number": 5,
+          "started_at": "2026-09-10T20:58:56Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:05:49Z",
+          "conclusion": "success",
+          "name": "Build with TSan (native threads)",
+          "number": 6,
+          "started_at": "2026-09-10T20:59:08Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:05:51Z",
+          "conclusion": "success",
+          "name": "Policy smoke (native threads under TSan)",
+          "number": 7,
+          "started_at": "2026-09-10T21:05:49Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:05:51Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 13,
+          "started_at": "2026-09-10T21:05:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:05:51Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 14,
+          "started_at": "2026-09-10T21:05:51Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:05:51Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 15,
+          "started_at": "2026-09-10T21:05:51Z",
+          "status": "completed"
+        }
+      ]
+    },
+    {
+      "completed_at": "2026-09-10T21:19:57Z",
+      "conclusion": "success",
+      "created_at": "2026-09-10T20:25:47Z",
+      "id": 103035976439,
+      "labels": [
+        "ubuntu-latest"
+      ],
+      "name": "TSan / ubuntu-latest / clang",
+      "runner_group_name": "GitHub Actions",
+      "runner_name": "GitHub Actions 1000054868",
+      "started_at": "2026-09-10T20:53:12Z",
+      "status": "completed",
+      "steps": [
+        {
+          "completed_at": "2026-09-10T20:53:14Z",
+          "conclusion": "success",
+          "name": "Set up job",
+          "number": 1,
+          "started_at": "2026-09-10T20:53:13Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:53:16Z",
+          "conclusion": "success",
+          "name": "Run actions/checkout@v5",
+          "number": 2,
+          "started_at": "2026-09-10T20:53:14Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:53:17Z",
+          "conclusion": "success",
+          "name": "Setup sccache",
+          "number": 3,
+          "started_at": "2026-09-10T20:53:16Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:53:39Z",
+          "conclusion": "success",
+          "name": "Install dependencies",
+          "number": 4,
+          "started_at": "2026-09-10T20:53:17Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T20:54:04Z",
+          "conclusion": "success",
+          "name": "Configure with TSan",
+          "number": 5,
+          "started_at": "2026-09-10T20:53:39Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:17:26Z",
+          "conclusion": "success",
+          "name": "Build with TSan",
+          "number": 6,
+          "started_at": "2026-09-10T20:54:04Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:19:54Z",
+          "conclusion": "success",
+          "name": "Test with TSan",
+          "number": 7,
+          "started_at": "2026-09-10T21:17:26Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:19:55Z",
+          "conclusion": "success",
+          "name": "Post Setup sccache",
+          "number": 13,
+          "started_at": "2026-09-10T21:19:54Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:19:55Z",
+          "conclusion": "success",
+          "name": "Post Run actions/checkout@v5",
+          "number": 14,
+          "started_at": "2026-09-10T21:19:55Z",
+          "status": "completed"
+        },
+        {
+          "completed_at": "2026-09-10T21:19:55Z",
+          "conclusion": "success",
+          "name": "Complete job",
+          "number": 15,
+          "started_at": "2026-09-10T21:19:55Z",
+          "status": "completed"
+        }
+      ]
+    }
+  ],
+  "total_count": 18
+}

--- a/scripts/ci/ci-telemetry-fixtures/run-success.json
+++ b/scripts/ci/ci-telemetry-fixtures/run-success.json
@@ -1,0 +1,12 @@
+{
+  "conclusion": "success",
+  "created_at": "2026-09-10T18:27:11Z",
+  "event": "pull_request",
+  "head_branch": "issue-1500-empty-index-lease",
+  "head_sha": "d6b217c29e83e3813a9d138ae3eab4fe81106ead",
+  "id": 34514413925,
+  "name": "CI PR",
+  "run_attempt": 1,
+  "run_started_at": "2026-09-10T18:27:11Z",
+  "status": "completed"
+}

--- a/scripts/ci/test-ci-run-telemetry.py
+++ b/scripts/ci/test-ci-run-telemetry.py
@@ -53,8 +53,9 @@ tool = load_tool()
 
 
 def fixture(name: str):
-    run = json.loads((FIXTURES / f"{name}.json").read_text())
-    jobs = json.loads((FIXTURES / f"{name}-jobs.json").read_text())
+    run = json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+    jobs = json.loads(
+        (FIXTURES / f"{name}-jobs.json").read_text(encoding="utf-8"))
     return run, jobs
 
 
@@ -550,8 +551,10 @@ class ReportPairing(unittest.TestCase):
             (out / "raw").mkdir()
             run, _ = fixture("run-success")
             _, other_jobs = fixture("run-clock-skew")
-            (out / "raw" / "run-999.json").write_text(json.dumps(run))
-            (out / "raw" / "run-999-jobs.json").write_text(json.dumps(other_jobs))
+            (out / "raw" / "run-999.json").write_text(json.dumps(run),
+                                                      encoding="utf-8")
+            (out / "raw" / "run-999-jobs.json").write_text(
+                json.dumps(other_jobs), encoding="utf-8")
             # Without the guard this published a confident 14-hour run wall.
             self.assertEqual(
                 tool.main(["report", "--run-id", "999", "--out", tmp]), 1)
@@ -716,12 +719,14 @@ class DependencyGraph(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             (root / ".github" / "workflows").mkdir(parents=True)
-            source = self.WORKFLOW.read_text().replace(
+            source = self.WORKFLOW.read_text(encoding="utf-8").replace(
                 "    needs: [sanitizer-matrix, build-scope]",
                 "    needs:\n      - sanitizer-matrix\n      - build-scope", 1)
-            (root / ".github" / "workflows" / "ci-pr.yml").write_text(source)
+            (root / ".github" / "workflows" / "ci-pr.yml").write_text(
+                source, encoding="utf-8")
             (root / ".github" / "workflows" / "lint-pr.yml").write_text(
-                (self.WORKFLOW.parent / "lint-pr.yml").read_text())
+                (self.WORKFLOW.parent / "lint-pr.yml").read_text(
+                    encoding="utf-8"), encoding="utf-8")
             with self.assertRaises(tool.WorkflowParseError) as caught:
                 tool.extract_graph(root / ".github" / "workflows" / "ci-pr.yml")
             self.assertIn("sever", str(caught.exception))
@@ -973,6 +978,143 @@ class CriticalPath(unittest.TestCase):
         self.assertEqual(len(path["graph_drift"]["jobs_without_node"]),
                          len(mutated["jobs"]))
 
+    def test_an_untimed_job_on_the_chain_is_not_also_called_off_chain(self):
+        # The two keys mean different things: one says the total is short by
+        # this hop, the other says the chain itself may be wrong.  Collapsing
+        # them would make the second unreadable.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == "lint / uncrustify check":
+                job["started_at"] = None
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        paths = tool.analyze(run, mutated, edges, drift)["critical_path"]
+        for key in ("observed", "graph"):
+            metric = paths[key]
+            self.assertIn("lint / uncrustify check", metric["evidence"]["chain"])
+            self.assertNotIn("untimed_jobs_off_chain", metric["evidence"])
+
+    def test_a_run_with_no_jobs_still_distinguishes_drift_from_no_graph(self):
+        # Only `nodes_without_job` is populated here, so the empty-edges
+        # branch cannot lean on `jobs_without_node` alone.
+        run, _ = fixture("run-success")
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(graph, [])
+        self.assertEqual(drift["jobs_without_node"], [])
+        self.assertTrue(drift["nodes_without_job"])
+        path = tool.analyze(run, {"jobs": []}, edges, drift)["critical_path"]
+        self.assertIn("see drift", path["graph"]["reason"])
+
+    def test_a_job_still_running_is_not_reported_as_missing_data(self):
+        # Every unfinished job in a live run is untimed by definition.
+        # Calling that missing data makes the caveat fire on every live run
+        # with an alarm it does not deserve, which is how a reader learns to
+        # skip it.
+        run, jobs = fixture("run-queued")
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in jobs["jobs"]])
+        paths = tool.analyze(run, jobs, edges, drift)["critical_path"]
+        for key in ("observed", "graph"):
+            metric = paths[key]
+            self.assertEqual(metric["status"], "partial")
+            self.assertIn("have not finished", metric["reason"])
+            self.assertNotIn("were not timed", metric["reason"])
+            self.assertTrue(metric["evidence"]["unfinished_jobs_off_chain"])
+            self.assertNotIn("untimed_jobs_off_chain", metric["evidence"])
+
+    def test_a_job_that_completed_without_a_start_is_not_called_unfinished(self):
+        # run-missing-data ships exactly this shape: status completed, a
+        # completion stamp, no start.  Saying it has not completed puts two
+        # contradictory sentences in one report, and the reader who checks
+        # finds the tool wrong, which costs more than saying nothing.
+        run, jobs = fixture("run-missing-data")
+        report = tool.analyze(run, jobs)
+        victim = next(job for job in report["jobs"]
+                      if job["started_at"] is None)
+        self.assertEqual(victim["status"], "completed")
+        self.assertEqual(victim["metrics"]["job_wall"]["reason"],
+                         "job never started")
+        self.assertNotIn("job has not completed", tool.render_markdown(report))
+
+    def test_a_job_cancelled_before_it_started_is_not_missing_data(self):
+        # It has no duration because it never ran, like a skipped job, and it
+        # will never acquire one.  Both alarms would be false.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == "Sanitizers / ubuntu-latest / clang":
+                job["status"] = "completed"
+                job["conclusion"] = "cancelled"
+                job["started_at"] = None
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        paths = tool.analyze(run, mutated, edges, drift)["critical_path"]
+        for key in ("observed", "graph"):
+            evidence = paths[key]["evidence"]
+            self.assertNotIn("untimed_jobs_off_chain", evidence)
+            self.assertNotIn("unfinished_jobs_off_chain", evidence)
+
+    def test_a_status_the_tool_does_not_know_takes_the_loud_branch(self):
+        # An unreadable status is data the tool cannot interpret.  Presenting
+        # it as an ordinary running job would be a guess in the quiet
+        # direction, which is the one that understates.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == "Sanitizers / ubuntu-latest / clang":
+                job["status"] = "something-new"
+                job["started_at"] = None
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        path = tool.analyze(run, mutated, edges, drift)["critical_path"]["graph"]
+        self.assertIn("Sanitizers / ubuntu-latest / clang",
+                      path["evidence"]["untimed_jobs_off_chain"])
+
+    def test_a_finished_job_with_no_duration_is_still_missing_data(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == "Sanitizers / ubuntu-latest / clang":
+                job["started_at"] = None    # completed, never started
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        path = tool.analyze(run, mutated, edges, drift)["critical_path"]["graph"]
+        self.assertIn("were not timed", path["reason"])
+        self.assertNotIn("have not finished", path["reason"])
+
+    def test_the_observed_reason_names_both_ways_it_can_be_wrong(self):
+        # The walk selects by completion timestamp, so an untimed job can
+        # either sit above the start it chose or sit on a branch it never
+        # entered.  Naming only one leaves the other unstated.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == "TSan / ubuntu-latest / clang":
+                job["started_at"] = None
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        reason = tool.analyze(run, mutated, edges,
+                              drift)["critical_path"]["observed"]["reason"]
+        self.assertIn("below the true end of the path", reason)
+        self.assertIn("longer branch it never entered", reason)
+
+    def test_a_job_is_not_told_the_critical_path_cannot_be_walked(self):
+        # Read against one job, that sentence reverses cause and effect: the
+        # latency is unknown because the job's dependencies are, not because
+        # a path elsewhere could not be walked.
+        report = tool.analyze(*fixture("run-success"))
+        metric = report["jobs"][0]["metrics"]["scheduler_release_latency"]
+        self.assertEqual(metric["status"], "unavailable")
+        self.assertIn("dependencies are unknown", metric["reason"])
+        self.assertNotIn("critical path", metric["reason"])
+
     def test_the_observed_total_says_what_it_omits(self):
         path = self._analyze("run-success")["critical_path"]["observed"]
         self.assertIn("lower bound", path["evidence"]["note"])
@@ -1190,9 +1332,10 @@ class Rendering(unittest.TestCase):
             out = Path(tmp)
             (out / "raw").mkdir()
             run, jobs = fixture("run-success")
-            (out / "raw" / f"run-{run['id']}.json").write_text(json.dumps(run))
+            (out / "raw" / f"run-{run['id']}.json").write_text(
+                json.dumps(run), encoding="utf-8")
             (out / "raw" / f"run-{run['id']}-jobs.json").write_text(
-                json.dumps(jobs))
+                json.dumps(jobs), encoding="utf-8")
             captured = io.StringIO()
             with contextlib.redirect_stderr(captured):
                 self.assertEqual(tool.main(
@@ -1205,13 +1348,226 @@ class Rendering(unittest.TestCase):
             self.assertIn("no dependency graph", text)
             self.assertNotIn("declares no jobs", text)
 
+    def test_the_markdown_says_why_a_number_is_not_final(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == "Sanitizers / ubuntu-latest / clang":
+                job["started_at"] = None
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        text = tool.render_markdown(
+            tool.analyze(run, mutated, edges, drift))
+        # A "(partial)" cell with no reason beside it is a flag a reader
+        # learns to ignore.  The whole point of the degradation is the cause.
+        self.assertIn("Why a number above is not final", text)
+        self.assertIn("routed around", text)
+        self.assertIn("critical_path.graph", text)
+
+    @staticmethod
+    def _row_values(text, job_name):
+        """One job's printed cells, read back out of the rendered table."""
+        table = text.split("Per job, seconds")[1]
+        headings = [part.strip() for part in
+                    table.splitlines()[2].strip().strip("|").split("|")][2:]
+        for line in table.splitlines():
+            if line.startswith(f"| {job_name} |"):
+                cells = [part.strip() for part in
+                         line.strip().strip("|").split("|")][2:]
+                # zip would silently drop a column the header does not
+                # declare, which is the drift this whole reading exists to
+                # catch.
+                if len(cells) != len(headings):
+                    raise AssertionError(
+                        f"{job_name}: {len(cells)} cells under "
+                        f"{len(headings)} headings")
+                return dict(zip(headings, cells))
+        raise AssertionError(f"no row for {job_name}")
+
+    def _degraded_cells(self, report, text):
+        """Every per-job cell the rendered table shows as not a measurement.
+
+        Read out of the markdown rather than out of `job_cells`, because
+        `job_cells` is what is under test: deriving the expectation from it
+        would prove only that the block covers itself."""
+        found = []
+        for job in report["jobs"]:
+            if job["conclusion"] == "skipped":
+                continue
+            for heading, value in self._row_values(text, job["name"]).items():
+                if not value.isdigit():
+                    found.append((job["name"], heading))
+        return found
+
+    def test_every_degraded_cell_in_the_table_is_explained(self):
+        # The block exists to stop `(partial)` being a flag with no cause.
+        # Explaining a metric that has no column while leaving the printed
+        # ones bare would be the same failure wearing a longer report.
+        graph = tool.extract_graph(self.WORKFLOW)
+        for name in ("run-success", "run-skip-cascade", "run-clock-skew",
+                     "run-queued", "run-missing-data", "run-rerun"):
+            run, jobs = fixture(name)
+            edges, drift = tool.match_graph_to_jobs(
+                graph, [j["name"] for j in jobs["jobs"]])
+            for arguments in ((run, jobs), (run, jobs, edges, drift)):
+                report = tool.analyze(*arguments)
+                text = tool.render_markdown(report)
+                block = text.split("Why a number above is not final")[-1]
+                for job_name, heading in self._degraded_cells(report, text):
+                    column = dict((head, key) for key, _, head
+                                  in tool.JOB_COLUMNS)[heading]
+                    self.assertTrue(
+                        f"{job_name} / {column}" in block
+                        or f"`{column}` on " in block,
+                        f"{name}: nothing explains {job_name} / {heading}")
+
+    def test_the_printed_row_is_exactly_what_the_block_reasons_about(self):
+        # The table and the block are built from one declaration precisely so
+        # they cannot drift.  Pin that against the rendered text: add a
+        # seventh cell to the row by hand and this fails, which is the only
+        # way the block can silently stop covering a column.
+        run, jobs = fixture("run-success")
+        report = tool.analyze(run, jobs)
+        text = tool.render_markdown(report)
+        for job in report["jobs"]:
+            printed = self._row_values(text, job["name"])
+            expected = {heading: tool.cell(metric)
+                        for (_, _, heading), (_, metric)
+                        in zip(tool.JOB_COLUMNS, tool.job_cells(job))}
+            self.assertEqual(printed, expected)
+        self.assertEqual(len(tool.JOB_COLUMNS), len(tool.job_cells(
+            report["jobs"][0])))
+
+    def test_a_reason_spanning_more_than_one_column_is_not_collapsed(self):
+        # "4 values are anomalous" names neither a job nor a number.  Four
+        # specific lines are longer and worth more.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"][:2]:
+            job["created_at"] = "2025-01-01T00:01:00Z"
+            job["started_at"] = "2025-01-01T00:00:00Z"
+            job["completed_at"] = "2024-12-31T23:59:00Z"
+        text = tool.render_markdown(tool.analyze(run, mutated))
+        block = text.split("Why a number above is not final")[-1]
+        self.assertNotIn("values are anomalous", block)
+        for name in (job["name"] for job in mutated["jobs"][:2]):
+            self.assertIn(f"`{name} / queue_delay` is anomalous", block)
+            self.assertIn(f"`{name} / job_wall` is anomalous", block)
+
+    def test_a_degraded_number_with_no_recorded_cause_still_appears(self):
+        # The block's whole purpose is that no degraded cell is bare.  A
+        # metric whose reason went missing must say that, not vanish.
+        run, jobs = fixture("run-success")
+        report = tool.analyze(run, jobs)
+        report["jobs"][0]["metrics"]["job_wall"] = {
+            "seconds": 3, "status": "partial", "reason": None, "evidence": {}}
+        text = tool.render_markdown(report)
+        self.assertIn("no cause was recorded", text)
+
+    def test_a_small_group_is_named_job_by_job_not_counted(self):
+        # The collapse threshold is a legibility tradeoff, not an invariant.
+        # Pin both sides of it so it cannot be retuned unnoticed.
+        run, jobs = fixture("run-missing-data")
+        text = tool.render_markdown(tool.analyze(run, jobs))
+        # Three jobs share the configure reason, which is the threshold, so
+        # each is still named.  Five would collapse; run-clock-skew shows it.
+        self.assertEqual(text.count("no step matched phase configure"), 3)
+        self.assertNotIn("on 3 jobs is", text)
+        skewed, skewed_jobs = fixture("run-clock-skew")
+        wide = tool.render_markdown(tool.analyze(skewed, skewed_jobs))
+        self.assertIn("`configure` on 5 jobs is", wide)
+        self.assertEqual(wide.count("no step matched phase configure"), 1)
+
+    def test_the_block_never_explains_a_metric_with_no_column(self):
+        # scheduler_release_latency and upstream_elapsed are computed and
+        # published in the JSON, but the markdown prints neither, so a line
+        # about them explains a number the reader cannot see.
+        run, jobs = fixture("run-success")
+        report = tool.analyze(run, jobs)
+        block = "\n".join(
+            tool.degradation_block(report, report["critical_path"]))
+        for hidden in ("scheduler_release_latency", "upstream_elapsed"):
+            self.assertNotIn(hidden, block)
+
+    def test_the_block_follows_the_table_it_explains(self):
+        text = tool.render_markdown(tool.analyze(*fixture("run-success")))
+        self.assertLess(text.index("Per job, seconds"),
+                        text.index("Why a number above is not final"))
+
+    def test_one_reason_repeated_across_jobs_collapses_to_one_line(self):
+        run, jobs = fixture("run-success")
+        text = tool.render_markdown(tool.analyze(run, jobs))
+        # Eighteen jobs, five without a configure step.  Five identical
+        # sentences would bury every line that is not repeated.
+        self.assertIn("`configure` on 5 jobs is unavailable", text)
+        self.assertEqual(text.count("no step matched phase configure"), 1)
+
+    def test_the_block_carries_the_run_level_rows_too(self):
+        run, jobs = fixture("run-success")
+        text = tool.render_markdown(tool.analyze(run, jobs))
+        self.assertIn("`total_required_check_completion` is unavailable", text)
+        self.assertIn("`first_failure_latency` is unavailable", text)
+
+    def test_the_markdown_does_not_repeat_itself_once_per_skipped_job(self):
+        text = tool.render_markdown(tool.analyze(*fixture("run-skip-cascade")))
+        self.assertEqual(text.count("job skipped; no execution"), 0)
+
+    def test_every_file_the_tool_reads_or_writes_names_its_encoding(self):
+        # Job names come straight from the API and are not ASCII by rule, so
+        # a text call that takes the locale encoding decodes correctly on the
+        # developer's machine and raises on a runner with a different one.
+        # Asserting the discipline is deterministic; asserting the symptom
+        # would need a non-UTF-8 locale the test host may not have.
+        import pathlib
+        read_text, write_text = pathlib.Path.read_text, pathlib.Path.write_text
+        fetch_run = tool.fetch_run
+        seen = []
+
+        def record(kind, original):
+            def wrapper(self, *args, **kwargs):
+                seen.append((kind, str(self), kwargs.get("encoding")))
+                return original(self, *args, **kwargs)
+            return wrapper
+
+        run, jobs = fixture("run-success")
+        jobs = copy.deepcopy(jobs)
+        jobs["jobs"][0]["name"] = "Docs / política ✔ validation"
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                pathlib.Path.read_text = record("read", read_text)
+                pathlib.Path.write_text = record("write", write_text)
+                tool.fetch_run = lambda *a, **k: (run, jobs)
+                # `fetch` writes the raw API payloads, which is where a
+                # non-ASCII job name first reaches the disk.  A test that
+                # skips it does not assert what it claims to.
+                self.assertEqual(tool.main(
+                    ["fetch", "--run-id", str(run["id"]), "--out", tmp,
+                     "--repo", "o/r"]), 0)
+                self.assertEqual(tool.main(
+                    ["report", "--run-id", str(run["id"]), "--out", tmp]), 0)
+                self.assertEqual(tool.main(
+                    ["aggregate", "--out", tmp, "--label", "b"]), 0)
+            finally:
+                pathlib.Path.read_text = read_text
+                pathlib.Path.write_text = write_text
+                tool.fetch_run = fetch_run
+        kinds = {kind for kind, _, _ in seen}
+        self.assertEqual(kinds, {"read", "write"}, seen)
+        written = {name for kind, name, _ in seen if kind == "write"}
+        self.assertTrue(any(name.endswith(".md") for name in written), written)
+        self.assertTrue(any("raw" in name for name in written), written)
+        self.assertEqual([entry for entry in seen if entry[2] != "utf-8"], [])
+
     def test_report_command_writes_both_artifacts(self):
         with tempfile.TemporaryDirectory() as tmp:
             out = Path(tmp)
             (out / "raw").mkdir()
             run, jobs = fixture("run-success")
-            (out / "raw" / f"run-{run['id']}.json").write_text(json.dumps(run))
-            (out / "raw" / f"run-{run['id']}-jobs.json").write_text(json.dumps(jobs))
+            (out / "raw" / f"run-{run['id']}.json").write_text(
+                json.dumps(run), encoding="utf-8")
+            (out / "raw" / f"run-{run['id']}-jobs.json").write_text(
+                json.dumps(jobs), encoding="utf-8")
             self.assertEqual(
                 tool.main(["report", "--run-id", str(run["id"]), "--out", tmp]), 0)
             self.assertTrue((out / f"run-{run['id']}.json").exists())

--- a/scripts/ci/test-ci-run-telemetry.py
+++ b/scripts/ci/test-ci-run-telemetry.py
@@ -487,7 +487,8 @@ class CriticalPathPlaceholder(unittest.TestCase):
         path = tool.analyze(*fixture("run-success"))["critical_path"]
         for key in ("observed", "graph"):
             self.assertEqual(path[key]["status"], "unavailable")
-            self.assertIn("unit 2", path[key]["reason"])
+            self.assertIn("no dependency graph was supplied",
+                          path[key]["reason"])
         # An empty list would read as "compared the graph, found no drift".
         self.assertIsNone(path["graph_drift"])
 
@@ -604,7 +605,8 @@ class GraphAbsence(unittest.TestCase):
             metric = job["metrics"]["scheduler_release_latency"]
             with self.subTest(job=job["name"]):
                 self.assertEqual(metric["status"], "unavailable")
-                self.assertIn("unit 2", metric["reason"])
+                self.assertIn("no dependency graph was supplied",
+                              metric["reason"])
 
     def test_a_root_job_is_named_as_a_root_once_a_graph_exists(self):
         run, jobs = fixture("run-success")
@@ -643,6 +645,355 @@ class GraphAbsence(unittest.TestCase):
                     self.assertIs(
                         job["metrics"]["scheduler_release_latency"]["additive"],
                         True)
+
+
+class DependencyGraph(unittest.TestCase):
+    """The graph is read from the workflow files, never hard-coded: #1574 will
+    change it, and a copy here would drift exactly when that happens."""
+
+    WORKFLOW = SCRIPT_DIR.parent.parent / ".github" / "workflows" / "ci-pr.yml"
+
+    def setUp(self):
+        self.graph = tool.extract_graph(self.WORKFLOW)
+
+    def test_the_reusable_lint_workflow_is_expanded_into_its_jobs(self):
+        # `lint` is `uses: ./.github/workflows/lint-pr.yml`; the API never
+        # reports a job by that name, so an unexpanded node would match
+        # nothing and sever the edge between the freeze gate and every build.
+        self.assertNotIn("lint", self.graph)
+        self.assertIn("lint / EditorConfig check", self.graph)
+        self.assertIn("lint / uncrustify check", self.graph)
+        self.assertEqual(self.graph["lint / uncrustify check"],
+                         ["lint / EditorConfig check"])
+        # The caller's own dependency lands on the callee's root.
+        self.assertEqual(self.graph["lint / EditorConfig check"],
+                         ["RC changelog freeze gate"])
+        # The caller's dependents attach to the callee's sink.
+        self.assertIn("lint / uncrustify check",
+                      self.graph["Build / ubuntu-latest / gcc"])
+
+    def test_every_job_has_an_entry_and_roots_are_explicit(self):
+        # A job missing from the graph must be a gap, never mistaken for a
+        # root, which is why roots carry an explicit empty list.
+        self.assertEqual(len(self.graph), 12)
+        self.assertEqual(self.graph["Detect build-triggering changes"], [])
+        self.assertEqual(self.graph["RC changelog freeze gate"], [])
+
+    def test_the_default_workflow_path_resolves_from_any_directory(self):
+        # It is anchored to the script, not the working directory, because the
+        # tool runs from a build directory under meson.  Asserted explicitly:
+        # report() degrades gracefully when the file is missing, so a wrong
+        # default would otherwise cost the critical path in silence.
+        self.assertTrue(Path(tool.DEFAULT_WORKFLOW).is_file(),
+                        f"{tool.DEFAULT_WORKFLOW} does not exist")
+        self.assertEqual(Path(tool.DEFAULT_WORKFLOW),
+                         self.WORKFLOW.resolve())
+        self.assertEqual(len(tool.extract_graph(tool.DEFAULT_WORKFLOW)), 12)
+
+    def test_the_on_section_is_not_read_as_jobs(self):
+        for spurious in ("pull_request", "workflow_call", "lint / workflow_call"):
+            self.assertNotIn(spurious, self.graph)
+
+    def test_every_node_resolves_against_a_real_run(self):
+        _, jobs = fixture("run-success")
+        names = [j["name"] for j in jobs["jobs"]]
+        edges, drift = tool.match_graph_to_jobs(self.graph, names)
+        self.assertEqual(drift["nodes_without_job"], [])
+        self.assertEqual(drift["jobs_without_node"], [])
+        self.assertEqual(set(edges), set(names))
+
+    def test_matrix_placeholders_match_expanded_names(self):
+        pattern = tool.name_pattern("Build / ${{ matrix.os }} / ${{ m }}")
+        self.assertTrue(pattern.match("Build / windows-latest / msvc"))
+        self.assertFalse(pattern.match("Sanitizers / ubuntu-latest / gcc"))
+
+    def test_an_unreadable_needs_form_is_refused_not_read_as_a_root(self):
+        # Block lists and wrapped flow lists are legal YAML this parser does
+        # not read.  Returning [] would call the job a root and sever its
+        # edges with nothing in the drift report to show for it.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".github" / "workflows").mkdir(parents=True)
+            source = self.WORKFLOW.read_text().replace(
+                "    needs: [sanitizer-matrix, build-scope]",
+                "    needs:\n      - sanitizer-matrix\n      - build-scope", 1)
+            (root / ".github" / "workflows" / "ci-pr.yml").write_text(source)
+            (root / ".github" / "workflows" / "lint-pr.yml").write_text(
+                (self.WORKFLOW.parent / "lint-pr.yml").read_text())
+            with self.assertRaises(tool.WorkflowParseError) as caught:
+                tool.extract_graph(root / ".github" / "workflows" / "ci-pr.yml")
+            self.assertIn("sever", str(caught.exception))
+
+    def test_a_literal_node_wins_over_a_matrix_pattern(self):
+        # Otherwise correctness depends on which job happens to be declared
+        # first, and #1574 reorders jobs.
+        graph = {"Build / ${{ matrix.os }} / ${{ matrix.compiler }}": ["Wide"],
+                 "Build / ubuntu-latest / gcc": ["Narrow"],
+                 "Wide": [], "Narrow": []}
+        jobs = ["Build / ubuntu-latest / gcc", "Build / macos-latest / clang",
+                "Wide", "Narrow"]
+        edges, drift = tool.match_graph_to_jobs(graph, jobs)
+        self.assertEqual(edges["Build / ubuntu-latest / gcc"], ["Narrow"])
+        self.assertEqual(edges["Build / macos-latest / clang"], ["Wide"])
+        self.assertEqual(drift["nodes_without_job"], [])
+
+    def test_placeholder_text_does_not_count_as_specificity(self):
+        # Length alone would let a node whose placeholder name happens to be
+        # long outrank a shorter but more literal one.
+        graph = {"${{ matrix.a_very_long_placeholder_name }}": ["Wide"],
+                 "Build / ${{ os }}": ["Narrow"], "Wide": [], "Narrow": []}
+        edges, _ = tool.match_graph_to_jobs(
+            graph, ["Build / linux", "Wide", "Narrow"])
+        self.assertEqual(edges["Build / linux"], ["Narrow"])
+
+    def test_a_dependency_never_claims_a_job_that_resolved_elsewhere(self):
+        # Expanding a dependency by re-matching its pattern let a node claim
+        # jobs owned by a more specific node, which could make a job its own
+        # dependency and leave a cycle with nothing in the drift report.
+        graph = {"Sanitizers / ${{ matrix.os }} / ${{ matrix.compiler }}": [],
+                 "Sanitizers / tsan / ${{ matrix.compiler }}":
+                     ["Sanitizers / ${{ matrix.os }} / ${{ matrix.compiler }}"]}
+        jobs = ["Sanitizers / ubuntu-latest / gcc", "Sanitizers / tsan / gcc"]
+        edges, _ = tool.match_graph_to_jobs(graph, jobs)
+        for job, deps in edges.items():
+            with self.subTest(job=job):
+                self.assertNotIn(job, deps, "a job cannot depend on itself")
+        self.assertEqual(edges["Sanitizers / tsan / gcc"],
+                         ["Sanitizers / ubuntu-latest / gcc"])
+
+    def test_drift_is_reported_when_the_run_and_the_graph_disagree(self):
+        edges, drift = tool.match_graph_to_jobs(
+            {"A job that never ran": []}, ["Some other job"])
+        self.assertEqual(drift["nodes_without_job"], ["A job that never ran"])
+        self.assertEqual(drift["jobs_without_node"], ["Some other job"])
+
+
+class CriticalPath(unittest.TestCase):
+    WORKFLOW = SCRIPT_DIR.parent.parent / ".github" / "workflows" / "ci-pr.yml"
+
+    def _analyze(self, name):
+        run, jobs = fixture(name)
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in jobs["jobs"]])
+        return tool.analyze(run, jobs, edges, drift)
+
+    def test_the_walk_follows_dependencies_not_the_nearest_finisher(self):
+        path = self._analyze("run-success")["critical_path"]["observed"]
+        chain = path["evidence"]["chain"]
+        self.assertEqual(chain[-1], "TSan / ubuntu-latest / clang")
+        # The nearest job to finish before TSan started was a macOS matrix
+        # build that TSan does not depend on; taking it would have produced a
+        # plausible and wrong path.
+        self.assertNotIn("Build / macos-latest / clang", chain)
+        self.assertIn("Sanitizers / ubuntu-latest / clang", chain)
+        self.assertEqual(chain[0], "RC changelog freeze gate")
+
+    def test_the_observed_path_counts_queueing_and_the_graph_path_does_not(self):
+        paths = self._analyze("run-success")["critical_path"]
+        # The gap between them is the queueing on the path, which is the
+        # measurement #1574 needs before it reorders the graph.
+        self.assertGreater(paths["observed"]["seconds"],
+                           paths["graph"]["seconds"])
+
+    def test_a_skip_cascade_whose_chain_avoids_it_stays_measured(self):
+        # Every edge on the reported chain is known, so the number is final.
+        # Flagging it because some unrelated edge elsewhere was unavailable
+        # would attach a caveat that does not apply to the value shown.
+        paths = self._analyze("run-skip-cascade")["critical_path"]
+        self.assertEqual(paths["graph"]["status"], "measured")
+        self.assertNotIn("Build / ubuntu-24.04-arm / gcc",
+                         paths["graph"]["evidence"]["chain"])
+
+    def _with_skipped(self, job_name):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == job_name:
+                job["conclusion"] = "skipped"
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        return tool.analyze(run, mutated, edges, drift)
+
+    def test_a_chain_through_a_skipped_dependency_degrades_and_names_it(self):
+        paths = self._with_skipped("lint / EditorConfig check")["critical_path"]
+        graph = paths["graph"]
+        self.assertEqual(graph["status"], "partial")
+        self.assertIn("node weights only", graph["reason"])
+        self.assertIsNotNone(graph["seconds"])
+        # The caveat names the edges it applies to, so a reader can see which
+        # part of the number is node weight alone.
+        self.assertIn("RC changelog freeze gate -> lint / EditorConfig check",
+                      graph["evidence"]["unusable_edges"])
+
+    def test_the_observed_walk_stops_rather_than_inventing_a_hop(self):
+        paths = self._with_skipped("lint / EditorConfig check")["critical_path"]
+        observed = paths["observed"]
+        self.assertEqual(observed["status"], "partial")
+        self.assertIn("did not run", observed["reason"])
+        # It stopped at the job whose dependency was skipped instead of
+        # walking through it at zero weight.
+        self.assertEqual(observed["evidence"]["chain"][0],
+                         "lint / uncrustify check")
+
+    def test_a_job_outside_the_graph_stops_the_walk_as_partial(self):
+        run, jobs = fixture("run-success")
+        graph = tool.extract_graph(self.WORKFLOW)
+        del graph["TSan / ubuntu-latest / ${{ matrix.compiler }}"]
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in jobs["jobs"]])
+        report = tool.analyze(run, jobs, edges, drift)
+        observed = report["critical_path"]["observed"]
+        # Before this, a job with no node got an empty edge list, which is
+        # indistinguishable from a root, and the walk reported a confident
+        # one-hop path a third the length of the real one.
+        self.assertEqual(observed["status"], "partial")
+        self.assertIn("not in the dependency graph", observed["reason"])
+        self.assertIn("TSan", drift["jobs_without_node"][0])
+
+    def test_a_run_missing_declared_jobs_is_flagged_not_reported_flat(self):
+        # The one-job rerun fixture walks cleanly to its root, but eleven jobs
+        # the graph declares never appear; a bare number would read as a
+        # complete path over a complete run.
+        report = self._analyze("run-rerun")
+        observed = report["critical_path"]["observed"]
+        self.assertEqual(observed["status"], "partial")
+        self.assertIn("absent from this run", observed["reason"])
+        self.assertEqual(len(report["critical_path"]["graph_drift"]
+                             ["nodes_without_job"]), 11)
+
+    def test_a_hop_the_run_did_not_time_is_not_summed_as_zero(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == "Sanitizers / ubuntu-latest / clang":
+                job["started_at"] = None     # completed, but never started
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        observed = tool.analyze(run, mutated, edges,
+                                drift)["critical_path"]["observed"]
+        # Summing that hop as zero reported 5206 against a true 10362 and
+        # called it measured: a 50 per cent error presented as final.
+        self.assertEqual(observed["status"], "partial")
+        self.assertIn("not timed", observed["reason"])
+        self.assertEqual(observed["evidence"]["unmeasured_hops"],
+                         ["Sanitizers / ubuntu-latest / clang"])
+
+    def test_an_untimed_node_on_the_graph_chain_is_named_too(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            # The lint segment is the only route from the freeze gate to the
+            # builds, so the longest path cannot route around it the way it
+            # routes around a zero-weight leaf.
+            if job["name"] == "lint / uncrustify check":
+                job["started_at"] = None
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        path = tool.analyze(run, mutated, edges, drift)["critical_path"]["graph"]
+        self.assertEqual(path["status"], "partial")
+        self.assertIn("not timed", path["reason"])
+        self.assertIn("lint / uncrustify check",
+                      path["evidence"]["unmeasured_nodes"])
+
+    def test_the_observed_total_says_what_it_omits(self):
+        path = self._analyze("run-success")["critical_path"]["observed"]
+        self.assertIn("lower bound", path["evidence"]["note"])
+        # Per-hop weights are published, not just the chain, so the total can
+        # be checked rather than taken on trust.
+        hops = path["evidence"]["hops"]
+        self.assertEqual(
+            sum((h["queue_delay"] or 0) + (h["job_wall"] or 0) for h in hops),
+            path["seconds"])
+
+    def test_without_a_graph_both_paths_say_so(self):
+        report = tool.analyze(*fixture("run-success"))
+        path = report["critical_path"]
+        for key in ("observed", "graph"):
+            self.assertEqual(path[key]["status"], "unavailable")
+            self.assertIn("no dependency graph was supplied",
+                          path[key]["reason"])
+        self.assertIsNone(path["graph_drift"])
+
+
+class Aggregation(unittest.TestCase):
+    def _reports(self):
+        return [tool.analyze(*fixture(name))
+                for name in ("run-success", "run-skip-cascade")]
+
+    def test_cells_are_job_and_population_never_pooled(self):
+        doc = tool.aggregate_reports(self._reports())
+        self.assertFalse(doc["pooled"])
+        # One run spans both, which is why a run-level filter would refuse
+        # every real input.
+        self.assertIn("hosted", doc["populations"])
+        self.assertIn("self-hosted", doc["populations"])
+        for cell in doc["cells"]:
+            self.assertIn("population", cell)
+            self.assertIn("conclusion", cell)
+
+    def test_a_cell_spanning_several_self_hosted_machines_says_so(self):
+        # Hosted runners are fungible ephemeral VMs, so pooling them is right.
+        # Self-hosted boxes are not, and the fixtures show the same job landing
+        # on different ones between runs.
+        first = tool.analyze(*fixture("run-skip-cascade"))
+        # The clock-skew capture is the same workflow on different machines;
+        # give it the same conclusion so the two land in one cell, which is
+        # what happens across a real baseline window.
+        second = tool.analyze(*fixture("run-clock-skew"))
+        second["conclusion"] = first["conclusion"]
+        doc = tool.aggregate_reports([first, second])
+        mixed = [c for c in doc["cells"] if c["mixed_machines"]]
+        self.assertTrue(mixed, "the fixtures move a job between machines")
+        for cell in mixed:
+            self.assertEqual(cell["population"], "self-hosted")
+            self.assertGreater(len(cell["runner_names"]), 1)
+
+    def test_a_hosted_cell_is_not_flagged_as_mixed(self):
+        doc = tool.aggregate_reports([tool.analyze(*fixture("run-success"))])
+        hosted = [c for c in doc["cells"] if c["population"] == "hosted"]
+        self.assertTrue(hosted)
+        for cell in hosted:
+            self.assertFalse(cell["mixed_machines"])
+
+    def test_failed_and_successful_runs_are_kept_apart(self):
+        doc = tool.aggregate_reports(self._reports())
+        conclusions = {cell["conclusion"] for cell in doc["cells"]}
+        self.assertEqual(conclusions, {"success", "failure"})
+
+    def test_n_is_per_metric_so_a_skipped_job_contributes_to_none(self):
+        doc = tool.aggregate_reports(self._reports())
+        skipped = [c for c in doc["cells"] if c["population"] == "none"]
+        self.assertTrue(skipped, "the failed run skipped five jobs")
+        for cell in skipped:
+            for name, stats in cell["metrics"].items():
+                with self.subTest(job=cell["job"], metric=name):
+                    self.assertEqual(stats["n"], 0)
+                    self.assertIsNone(stats["median"])
+
+    def test_an_unknown_attempt_is_not_called_a_rerun(self):
+        reports = self._reports()
+        reports[0] = dict(reports[0], run_attempt=None)
+        doc = tool.aggregate_reports(reports)
+        self.assertEqual([e["reason"] for e in doc["excluded"]],
+                         ["run_attempt unknown"])
+
+    def test_a_rerun_is_excluded_and_named(self):
+        reports = self._reports() + [tool.analyze(*fixture("run-rerun"))]
+        doc = tool.aggregate_reports(reports)
+        self.assertEqual([e["reason"] for e in doc["excluded"]],
+                         ["run_attempt > 1"])
+
+    def test_percentiles_are_nearest_rank_and_say_when_they_are_the_maximum(self):
+        self.assertEqual(tool.percentile_nearest_rank([1, 2, 3, 4], 0.5), 2)
+        self.assertEqual(tool.percentile_nearest_rank([1, 2, 3, 4], 0.95), 4)
+        self.assertIsNone(tool.percentile_nearest_rank([], 0.5))
+        summary = tool.summarize([5, 1, 3])
+        self.assertEqual(summary["median"], 3)
+        self.assertTrue(summary["p95_is_sample_max"])
 
 
 class Populations(unittest.TestCase):
@@ -744,6 +1095,21 @@ class Rendering(unittest.TestCase):
         self.assertIn("10 executed, 5 skipped", text)
         self.assertIn("first_failure_latency", text)
         self.assertNotIn("| 0 |", text.split("Per job")[0])
+
+    WORKFLOW = SCRIPT_DIR.parent.parent / ".github" / "workflows" / "ci-pr.yml"
+
+    def test_the_summary_says_the_three_totals_are_not_independent(self):
+        run, jobs = fixture("run-success")
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in jobs["jobs"]])
+        report = tool.analyze(run, jobs, edges, drift)
+        text = tool.render_markdown(report)
+        # All three appear adjacent in the table; without this a reader sees
+        # 10366 / 10366 / 10362 and counts three agreeing measurements.
+        self.assertIn("not three independent measurements", text)
+        self.assertIn("by construction", text)
+        self.assertIn("lower bound", text)
 
     def test_report_command_writes_both_artifacts(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/ci/test-ci-run-telemetry.py
+++ b/scripts/ci/test-ci-run-telemetry.py
@@ -223,6 +223,10 @@ class SkipCascade(unittest.TestCase):
         # silently back to the generic sentence or to the raw key.
         self.assertEqual(set(tool.NO_EXECUTION_REASONS),
                          set(tool.NO_RUN_LABELS))
+        # Two conclusions sharing a term would render "1 stale, 1 stale",
+        # which the reader cannot take apart.
+        labels = list(tool.NO_RUN_LABELS.values())
+        self.assertEqual(len(set(labels)), len(labels), labels)
         # And a conclusion neither table has met still gets a true sentence
         # and a term naming itself, rather than borrowing another's.
         self.assertEqual(tool.no_run_label("a_conclusion_from_the_future"),
@@ -235,10 +239,20 @@ class SkipCascade(unittest.TestCase):
     def test_each_no_run_conclusion_says_what_happened_in_its_own_words(self):
         sentences = list(tool.NO_EXECUTION_REASONS.values())
         self.assertEqual(len(set(sentences)), len(sentences), sentences)
-        self.assertEqual(tool.NO_EXECUTION_REASONS["stale"],
-                         "job stale; no execution")
-        self.assertEqual(tool.NO_EXECUTION_REASONS["startup_failure"],
-                         "job failed to start; no execution")
+        self.assertEqual(tool.NO_EXECUTION_REASONS, {
+            "skipped": "job skipped; no execution",
+            "cancelled": "job cancelled before it ran; no execution",
+            "stale": "job stale; no execution",
+            "startup_failure": "job failed to start; no execution",
+            "action_required": "job awaiting approval; no execution",
+        })
+        self.assertEqual(tool.NO_RUN_LABELS, {
+            "skipped": "skipped",
+            "cancelled": "cancelled before running",
+            "stale": "stale",
+            "startup_failure": "failed to start",
+            "action_required": "awaiting approval",
+        })
 
     def test_a_cancellation_still_reaches_the_first_failure_sentence(self):
         # Once a job that did not run leaves the executed list, scanning
@@ -353,6 +367,24 @@ class SkipCascade(unittest.TestCase):
                 entry = next(job for job in tool.analyze(run, mutated)["jobs"]
                              if job["name"] == victim)
                 self.assertTrue(entry["ran"])
+
+    def test_a_run_mixing_no_run_conclusions_names_each_kind_once(self):
+        # One table names every term, skipped included.  A second spelling
+        # beside it would double the skipped term on any run carrying a
+        # skipped job, and a run carrying two kinds pins their order too.
+        run, jobs = fixture("run-skip-cascade")
+        mutated = copy.deepcopy(jobs)
+        victim = next(job["name"] for job in mutated["jobs"]
+                      if job["conclusion"] != "skipped")
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "startup_failure"
+                job["started_at"] = job["created_at"]
+                job["completed_at"] = job["created_at"]
+                job["steps"] = []
+        counts = tool.analyze(run, mutated)["job_counts"]
+        self.assertEqual(tool.job_count_phrase(counts),
+                         "9 executed, 1 failed to start, 5 skipped")
 
     def test_the_summary_terms_do_not_reorder_with_the_job_list(self):
         # Three distinct no-run conclusions in one run.  Without a sort the
@@ -1515,17 +1547,22 @@ class CriticalPath(unittest.TestCase):
         self.assertFalse(entry["ran"])
         self.assertIsNone(entry["metrics"]["queue_delay"]["seconds"])
 
-    def test_a_conclusion_that_never_dispatches_needs_no_stamps(self):
-        # `stale` and `startup_failure` are jobs GitHub never ran.  Stamped
-        # the never-run way they used to report queue 0 and wall 0.
+    def test_a_weighed_conclusion_with_never_run_stamps_reads_as_never_run(
+            self):
+        # The conclusion decides only who is asked.  `skipped` and an
+        # outcome that proves execution settle it without the stamps;
+        # every other conclusion is weighed, and these are the stamps a job
+        # that never ran carries.  None of these subjects is settled by its
+        # conclusion: each of them, stamped a different way, can read as
+        # having run -- which is what the tests below this one show.
         run, jobs = fixture("run-success")
         # Named rather than looped over the constant, which would shrink
         # with it and prove nothing.
         self.assertEqual(tool.NEVER_DISPATCHED, ("skipped",))
         self.assertEqual(tool.CONCLUSIONS_THAT_RAN,
                          ("success", "failure", "timed_out"))
-        for conclusion in ("skipped", "stale", "startup_failure",
-                           "cancelled", "neutral", "action_required",
+        for conclusion in ("stale", "startup_failure", "cancelled",
+                           "neutral", "action_required",
                            "a_conclusion_from_the_future"):
             with self.subTest(conclusion=conclusion):
                 mutated = copy.deepcopy(jobs)

--- a/scripts/ci/test-ci-run-telemetry.py
+++ b/scripts/ci/test-ci-run-telemetry.py
@@ -27,8 +27,10 @@ no step reporting zero seconds, which reads as a phase that ran instantly.
 
 from __future__ import annotations
 
+import contextlib
 import copy
 import importlib.util
+import io
 import json
 import tempfile
 import unittest
@@ -899,6 +901,78 @@ class CriticalPath(unittest.TestCase):
         self.assertIn("lint / uncrustify check",
                       path["evidence"]["unmeasured_nodes"])
 
+    def test_an_untimed_job_off_the_graph_chain_still_qualifies_the_total(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            # A leaf the longest path legitimately routes around.  Weighted at
+            # zero during selection, it is precisely the node that ends up off
+            # the winning chain, so a caveat scoped to the chain never fires.
+            if job["name"] == "Sanitizers / ubuntu-latest / clang":
+                job["started_at"] = None
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        path = tool.analyze(run, mutated, edges, drift)["critical_path"]["graph"]
+        # Previously measured 4431 on a chain that had quietly substituted a
+        # different sanitizer job for the untimed one.
+        self.assertEqual(path["status"], "partial")
+        self.assertIn("routed around", path["reason"])
+        self.assertEqual(path["evidence"]["untimed_jobs_off_chain"],
+                         ["Sanitizers / ubuntu-latest / clang"])
+        self.assertNotIn("Sanitizers / ubuntu-latest / clang",
+                         path["evidence"]["chain"])
+
+    def test_an_untimed_last_finisher_is_not_walked_past_in_silence(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            # The observed walk starts at the last job to finish that was
+            # timed, so untiming the actual last finisher moves the start
+            # down one branch and the job never appears on the result.
+            if job["name"] == "TSan / ubuntu-latest / clang":
+                job["started_at"] = None
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        path = tool.analyze(run, mutated, edges,
+                            drift)["critical_path"]["observed"]
+        self.assertEqual(path["status"], "partial")
+        self.assertEqual(path["evidence"]["untimed_jobs_off_chain"],
+                         ["TSan / ubuntu-latest / clang"])
+        self.assertNotIn("TSan / ubuntu-latest / clang",
+                         path["evidence"]["chain"])
+
+    def test_a_skipped_job_is_never_counted_as_untimed(self):
+        # A skipped job has no duration and that is the right answer, so the
+        # run-wide caveat must not fire on the skip cascade and turn every
+        # such run into a qualified number.
+        report = self._analyze("run-skip-cascade")
+        self.assertGreater(report["job_counts"]["skipped"], 0)
+        for key in ("observed", "graph"):
+            path = report["critical_path"][key]
+            self.assertEqual(path["status"], "measured")
+            self.assertNotIn("untimed_jobs_off_chain", path["evidence"])
+
+    def test_a_graph_that_resolved_to_nothing_is_not_called_a_missing_graph(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            job["name"] = "renamed: " + job["name"]
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        self.assertEqual(edges, {})
+        path = tool.analyze(run, mutated, edges, drift)["critical_path"]
+        # A wholesale rename is the loudest possible drift signal.  Reporting
+        # it as "no graph was supplied" would read as a missing argument.
+        self.assertIn("see drift", path["graph"]["reason"])
+        self.assertNotIn("was supplied", path["graph"]["reason"])
+        self.assertIn("absent from this run", path["observed"]["reason"])
+        self.assertIsNotNone(path["graph_drift"])
+        self.assertEqual(len(path["graph_drift"]["jobs_without_node"]),
+                         len(mutated["jobs"]))
+
     def test_the_observed_total_says_what_it_omits(self):
         path = self._analyze("run-success")["critical_path"]["observed"]
         self.assertIn("lower bound", path["evidence"]["note"])
@@ -1110,6 +1184,26 @@ class Rendering(unittest.TestCase):
         self.assertIn("not three independent measurements", text)
         self.assertIn("by construction", text)
         self.assertIn("lower bound", text)
+
+    def test_an_unreadable_workflow_is_diagnosed_once_not_twice(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / "raw").mkdir()
+            run, jobs = fixture("run-success")
+            (out / "raw" / f"run-{run['id']}.json").write_text(json.dumps(run))
+            (out / "raw" / f"run-{run['id']}-jobs.json").write_text(
+                json.dumps(jobs))
+            captured = io.StringIO()
+            with contextlib.redirect_stderr(captured):
+                self.assertEqual(tool.main(
+                    ["report", "--run-id", str(run["id"]), "--out", tmp,
+                     "--workflow", str(out / "absent.yml")]), 0)
+            text = captured.getvalue()
+            # The file could not be read, so nothing is known about how many
+            # jobs it declares.  Saying it declares none is a second claim,
+            # and a false one.
+            self.assertIn("no dependency graph", text)
+            self.assertNotIn("declares no jobs", text)
 
     def test_report_command_writes_both_artifacts(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/ci/test-ci-run-telemetry.py
+++ b/scripts/ci/test-ci-run-telemetry.py
@@ -135,9 +135,297 @@ class SkipCascade(unittest.TestCase):
     def setUp(self):
         self.report = tool.analyze(*fixture("run-skip-cascade"))
 
+    def _did_not_run_as(self, conclusion, name=None):
+        """A run-success job restamped the way a job that never ran is."""
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = name or "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = conclusion
+                job["started_at"] = job["created_at"]
+                job["completed_at"] = job["created_at"]
+                job["steps"] = []
+        return victim, tool.analyze(run, mutated)
+
+    def test_the_cli_line_names_the_same_division_as_the_report(self):
+        # Two renderings of one fact.  The CLI line is what an operator sees
+        # without opening the artefact, so it cannot be the stale one.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / "raw").mkdir()
+            run, jobs = fixture("run-success")
+            mutated = copy.deepcopy(jobs)
+            for job in mutated["jobs"]:
+                if job["name"] == "Sanitizers / ubuntu-latest / clang":
+                    job["conclusion"] = "startup_failure"
+                    job["started_at"] = job["created_at"]
+                    job["completed_at"] = job["created_at"]
+                    job["steps"] = []
+            (out / "raw" / f"run-{run['id']}.json").write_text(
+                json.dumps(run), encoding="utf-8")
+            (out / "raw" / f"run-{run['id']}-jobs.json").write_text(
+                json.dumps(mutated), encoding="utf-8")
+            captured = io.StringIO()
+            with contextlib.redirect_stdout(captured):
+                self.assertEqual(tool.main(
+                    ["report", "--run-id", str(run["id"]), "--out", tmp]), 0)
+        self.assertIn("17 executed, 1 failed to start", captured.getvalue())
+
+    def test_a_run_where_nothing_ran_still_reads_correctly(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            job["conclusion"] = "cancelled"
+            job["started_at"] = job["created_at"]
+            job["completed_at"] = job["created_at"]
+            job["steps"] = []
+        report = tool.analyze(run, mutated)
+        text = tool.render_markdown(report)
+        self.assertIn(f"0 executed, {len(mutated['jobs'])} cancelled before "
+                      f"running", text)
+        self.assertEqual(report["metrics"]["run_wall_clock"]["status"],
+                         "unavailable")
+
+    def test_the_summary_names_the_conclusion_the_job_actually_had(self):
+        # A runner image that failed to boot means a gate never covered the
+        # change.  Reporting it as somebody hitting cancel sends the reader
+        # to the wrong question, and the table below carries no conclusion
+        # at all, so this line is their only signal.
+        for conclusion, label in (("cancelled", "cancelled before running"),
+                                  ("stale", "stale"),
+                                  ("startup_failure", "failed to start")):
+            with self.subTest(conclusion=conclusion):
+                _, report = self._did_not_run_as(conclusion)
+                text = tool.render_markdown(report)
+                self.assertIn(f"1 {label}", text)
+                # The caption has to cover this conclusion too: the table
+                # row carries six blanks and no conclusion at all.
+                # Scoped to the table it sits under, because the JSON does
+                # carry one duration for such a job: its release latency
+                # ends at the job's creation, not at anything the job did.
+                self.assertIn("has no durations in this table", text)
+                self.assertNotIn("no durations at all", text)
+                self.assertNotIn("A job that was skipped, or cancelled", text)
+                for other in ("cancelled before running", "stale",
+                              "failed to start"):
+                    if other != label:
+                        self.assertNotIn(f"1 {other}", text)
+
+    def test_a_conclusion_with_no_label_is_named_as_itself(self):
+        counts = {"executed": 2, "skipped": 0,
+                  "did_not_run_by_conclusion": {"brand_new": 1}}
+        self.assertEqual(tool.job_count_phrase(counts),
+                         "2 executed, 1 brand_new")
+
+    def test_every_no_run_conclusion_has_a_reason_and_a_label(self):
+        # Adding a conclusion to one table and not the other would fall
+        # silently back to the generic sentence or to the raw key.
+        self.assertEqual(set(tool.NO_EXECUTION_REASONS),
+                         set(tool.NO_RUN_LABELS))
+        # And a conclusion neither table has met still gets a true sentence
+        # and a term naming itself, rather than borrowing another's.
+        self.assertEqual(tool.no_run_label("a_conclusion_from_the_future"),
+                         "a_conclusion_from_the_future")
+        self.assertIn("a_conclusion_from_the_future",
+                      tool.no_execution_reason("a_conclusion_from_the_future"))
+        self.assertIn("no execution",
+                      tool.no_execution_reason("a_conclusion_from_the_future"))
+
+    def test_each_no_run_conclusion_says_what_happened_in_its_own_words(self):
+        sentences = list(tool.NO_EXECUTION_REASONS.values())
+        self.assertEqual(len(set(sentences)), len(sentences), sentences)
+        self.assertEqual(tool.NO_EXECUTION_REASONS["stale"],
+                         "job stale; no execution")
+        self.assertEqual(tool.NO_EXECUTION_REASONS["startup_failure"],
+                         "job failed to start; no execution")
+
+    def test_a_cancellation_still_reaches_the_first_failure_sentence(self):
+        # Once a job that did not run leaves the executed list, scanning
+        # that list for cancellations stops finding them and the reader is
+        # told the run simply had no failure.
+        _, report = self._did_not_run_as("cancelled")
+        metric = report["metrics"]["first_failure_latency"]
+        self.assertEqual(metric["status"], "unavailable")
+        self.assertIn("cancelled jobs were seen", metric["reason"])
+
+    def test_a_job_that_did_not_run_cannot_stretch_the_pr_feedback(self):
+        # Both run-level spans end at the last job that actually ran; a
+        # never-run job's completion stamp is bookkeeping.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["created_at"] = "2030-01-01T00:00:00Z"
+                job["started_at"] = "2030-01-01T00:00:00Z"
+                job["completed_at"] = "2030-01-01T00:00:00Z"
+                job["steps"] = []
+        metrics = tool.analyze(run, mutated)["metrics"]
+        self.assertEqual(metrics["run_wall_clock"]["seconds"], 10366)
+        self.assertEqual(metrics["pr_feedback"]["seconds"], 10366)
+
+    def test_a_job_that_did_not_run_keeps_its_release_latency(self):
+        # Deliberate: that metric ends at the job's *creation*, which
+        # happens whether or not the job then dispatches.  Only the skip
+        # cascade is carved out, because GitHub batches its creation stamps.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["started_at"] = job["created_at"]
+                job["completed_at"] = job["created_at"]
+                job["steps"] = []
+        workflow = SCRIPT_DIR.parent.parent / ".github" / "workflows" / \
+            "ci-pr.yml"
+        graph = tool.extract_graph(workflow)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        entry = next(job for job in tool.analyze(run, mutated, edges,
+                                                 drift)["jobs"]
+                     if job["name"] == victim)
+        self.assertFalse(entry["ran"])
+        self.assertEqual(
+            entry["metrics"]["scheduler_release_latency"]["status"],
+            "measured")
+
+    def test_a_job_level_conclusion_that_may_precede_dispatch_is_weighed(self):
+        # `neutral` and `action_required` are the two GitHub documents on the
+        # job itself, and approval is by definition something that happens
+        # before a dispatch.  Stamped the never-run way they used to publish
+        # queue 0 and wall 0 and count as executed.
+        run, jobs = fixture("run-success")
+        for conclusion in ("neutral", "action_required"):
+            with self.subTest(conclusion=conclusion):
+                mutated = copy.deepcopy(jobs)
+                victim = "Sanitizers / ubuntu-latest / clang"
+                for job in mutated["jobs"]:
+                    if job["name"] == victim:
+                        job["conclusion"] = conclusion
+                        job["started_at"] = job["created_at"]
+                        job["completed_at"] = job["created_at"]
+                        job["steps"] = []
+                report = tool.analyze(run, mutated)
+                entry = next(job for job in report["jobs"]
+                             if job["name"] == victim)
+                self.assertFalse(entry["ran"])
+                self.assertIsNone(entry["metrics"]["job_wall"]["seconds"])
+                self.assertEqual(report["job_counts"]["never_ran"], 1)
+
+    def test_a_conclusion_this_tool_has_not_met_is_weighed_not_assumed(self):
+        # The rule is closed the other way round: only an outcome that proves
+        # execution skips the evidence.  A conclusion GitHub adds after this
+        # was written must not default to "ran" and publish a zero.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "a_conclusion_from_the_future"
+                job["started_at"] = job["created_at"]
+                job["completed_at"] = job["created_at"]
+                job["steps"] = []
+        report = tool.analyze(run, mutated)
+        entry = next(job for job in report["jobs"] if job["name"] == victim)
+        self.assertFalse(entry["ran"])
+        self.assertIn("a_conclusion_from_the_future",
+                      entry["metrics"]["job_wall"]["reason"])
+        self.assertIn("1 a_conclusion_from_the_future",
+                      tool.render_markdown(report))
+
+    def test_an_outcome_only_execution_reaches_is_never_weighed(self):
+        # A successful job ran, whatever its stamps say.  Asking the evidence
+        # there could only erase real seconds.
+        run, jobs = fixture("run-success")
+        for conclusion in tool.CONCLUSIONS_THAT_RAN:
+            with self.subTest(conclusion=conclusion):
+                mutated = copy.deepcopy(jobs)
+                victim = "Sanitizers / ubuntu-latest / clang"
+                for job in mutated["jobs"]:
+                    if job["name"] == victim:
+                        job["conclusion"] = conclusion
+                        job["started_at"] = job["created_at"]
+                        job["completed_at"] = job["created_at"]
+                        job["steps"] = []
+                entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                             if job["name"] == victim)
+                self.assertTrue(entry["ran"])
+
+    def test_the_summary_terms_do_not_reorder_with_the_job_list(self):
+        # Three distinct no-run conclusions in one run.  Without a sort the
+        # phrase follows whatever order the API returned the jobs in.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victims = ["Sanitizers / ubuntu-latest / clang",
+                   "Sanitizers / ubuntu-latest / gcc",
+                   "Sanitizers / macos-latest / clang"]
+        for name, conclusion in zip(victims, ("startup_failure", "stale",
+                                              "cancelled")):
+            for job in mutated["jobs"]:
+                if job["name"] == name:
+                    job["conclusion"] = conclusion
+                    job["started_at"] = job["created_at"]
+                    job["completed_at"] = job["created_at"]
+                    job["steps"] = []
+        forward = tool.job_count_phrase(
+            tool.analyze(run, mutated)["job_counts"])
+        reversed_jobs = {"jobs": list(reversed(mutated["jobs"]))}
+        backward = tool.job_count_phrase(
+            tool.analyze(run, reversed_jobs)["job_counts"])
+        self.assertEqual(forward, backward)
+        self.assertEqual(
+            forward,
+            "15 executed, 1 cancelled before running, 1 failed to start, "
+            "1 stale")
+        # Alphabetical by the term printed, not by GitHub's conclusion name,
+        # which would read as arbitrary order to anyone looking at the line.
+
+    def test_an_evidence_decided_conclusion_keeps_its_evidence(self):
+        # `stale` and `startup_failure` are documented on the run, not the
+        # job.  If one lands on a job that really ran, deciding it from the
+        # conclusion alone would erase its seconds from the run wall clock
+        # with nothing saying so.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "TSan / ubuntu-latest / clang"      # the last to finish
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "stale"
+                self.assertTrue(job["steps"])
+        report = tool.analyze(run, mutated)
+        entry = next(job for job in report["jobs"] if job["name"] == victim)
+        self.assertTrue(entry["ran"])
+        self.assertEqual(report["metrics"]["run_wall_clock"]["seconds"], 10366)
+
+    def test_a_job_that_did_not_run_is_not_counted_as_executed(self):
+        # The header sat directly above a caption excusing the job and a row
+        # of six blanks below it.  One test decides all three.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["started_at"] = job["created_at"]
+                job["completed_at"] = job["created_at"]
+                job["steps"] = []
+        report = tool.analyze(run, mutated)
+        counts = report["job_counts"]
+        self.assertEqual(counts["executed"], len(mutated["jobs"]) - 1)
+        self.assertEqual(counts["never_ran"], 1)
+        self.assertEqual(counts["skipped"], 0)
+        text = tool.render_markdown(report)
+        self.assertIn("17 executed, 1 cancelled before running", text)
+        self.assertNotIn("0 skipped", text)
+
     def test_counts_lead_with_what_actually_ran(self):
         self.assertEqual(self.report["job_counts"],
-                         {"total": 15, "executed": 10, "skipped": 5})
+                         {"total": 15, "executed": 10, "skipped": 5,
+                          "never_ran": 0,
+                          "did_not_run_by_conclusion": {"skipped": 5}})
 
     def test_skipped_jobs_have_no_durations(self):
         skipped = [j for j in self.report["jobs"] if j["conclusion"] == "skipped"]
@@ -1175,6 +1463,84 @@ class CriticalPath(unittest.TestCase):
         self.assertTrue(entry["ran"])
         self.assertFalse(tool.absent_by_design(entry))
         self.assertEqual(entry["metrics"]["job_wall"]["seconds"], 60)
+
+    def test_a_step_that_ran_outranks_a_span_that_says_otherwise(self):
+        # A job cancelled inside its dispatch second is stamped start ==
+        # completion at GitHub's one-second resolution, which the span rule
+        # reads as never-run.  Its step is the only thing that tells the two
+        # apart, so the step has to be asked first.  The zero wall time it
+        # then reports is true: the step evidence establishes it ran.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["completed_at"] = job["started_at"]
+                step = job["steps"][0]
+                job["steps"] = [dict(step,
+                                     completed_at=step["started_at"])]
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertTrue(entry["ran"])
+        self.assertFalse(tool.absent_by_design(entry))
+
+    def test_a_step_of_no_duration_is_still_evidence(self):
+        # Most steps finish inside a second: 100 of the 299 non-skipped steps
+        # in the shipped captures are stamped started == completed.  Reading
+        # those as unusable would discard the commonest shape there is.
+        _, jobs = fixture("run-success")
+        template = next(job["steps"][0] for job in jobs["jobs"]
+                        if job["name"] == "Sanitizers / ubuntu-latest / clang")
+        instant = dict(template, completed_at=template["started_at"])
+        self.assertEqual(tool.first_step_start({"steps": [instant]}),
+                         template["started_at"])
+
+    def test_a_start_stamped_at_creation_is_not_a_dispatch(self):
+        # The equality is the bookkeeping signature itself: a job that never
+        # ran is stamped as starting the moment it was created.  Reading it
+        # as a dispatch publishes queue_delay 0 for a job that never waited
+        # on a runner, and lists it as missing data besides.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["started_at"] = job["created_at"]
+                job["completed_at"] = None
+                job["steps"] = []
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertFalse(entry["ran"])
+        self.assertIsNone(entry["metrics"]["queue_delay"]["seconds"])
+
+    def test_a_conclusion_that_never_dispatches_needs_no_stamps(self):
+        # `stale` and `startup_failure` are jobs GitHub never ran.  Stamped
+        # the never-run way they used to report queue 0 and wall 0.
+        run, jobs = fixture("run-success")
+        # Named rather than looped over the constant, which would shrink
+        # with it and prove nothing.
+        self.assertEqual(tool.NEVER_DISPATCHED, ("skipped",))
+        self.assertEqual(tool.CONCLUSIONS_THAT_RAN,
+                         ("success", "failure", "timed_out"))
+        for conclusion in ("skipped", "stale", "startup_failure",
+                           "cancelled", "neutral", "action_required",
+                           "a_conclusion_from_the_future"):
+            with self.subTest(conclusion=conclusion):
+                mutated = copy.deepcopy(jobs)
+                victim = "Sanitizers / ubuntu-latest / clang"
+                for job in mutated["jobs"]:
+                    if job["name"] == victim:
+                        job["conclusion"] = conclusion
+                        job["started_at"] = job["created_at"]
+                        job["completed_at"] = job["created_at"]
+                        job["steps"] = []
+                entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                             if job["name"] == victim)
+                self.assertFalse(entry["ran"])
+                self.assertIn("no execution",
+                              entry["metrics"]["job_wall"]["reason"])
 
     def test_a_positive_span_alone_proves_the_job_ran(self):
         # Picked up with no queue delay, cancelled, no steps: the span
@@ -2229,7 +2595,7 @@ class Rendering(unittest.TestCase):
         text = tool.render_markdown(tool.analyze(run, mutated))
         block = text.split("Why a number above is not final")[-1]
         self.assertNotIn(victim, block)
-        self.assertIn("cancelled before it", text)
+        self.assertIn("1 cancelled before running", text)
 
     def test_the_block_follows_the_table_it_explains(self):
         text = tool.render_markdown(tool.analyze(*fixture("run-success")))

--- a/scripts/ci/test-ci-run-telemetry.py
+++ b/scripts/ci/test-ci-run-telemetry.py
@@ -834,6 +834,26 @@ class CriticalPath(unittest.TestCase):
         self.assertIn("RC changelog freeze gate -> lint / EditorConfig check",
                       graph["evidence"]["unusable_edges"])
 
+    def test_the_observed_walk_does_not_step_through_a_cancelled_job(self):
+        # A job cancelled before it ran carries a completion stamp and no
+        # duration.  Walking through it at zero weight drops the gap it
+        # represents, which is the same reason a skipped job is excluded.
+        run, jobs = fixture("run-success")
+        victim = "Sanitizers / ubuntu-latest / clang"
+        mutated = self._cancelled_before_starting(jobs, victim)
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        path = tool.analyze(run, mutated, edges,
+                            drift)["critical_path"]["observed"]
+        self.assertNotIn(victim, path["evidence"]["chain"])
+        # The walk routes around it rather than stopping: the same job still
+        # ends the path, reached through a dependency that did run.
+        self.assertEqual(path["evidence"]["chain"][-1],
+                         "TSan / ubuntu-latest / clang")
+        self.assertIn("Sanitizers / macos-latest / clang",
+                      path["evidence"]["chain"])
+
     def test_the_observed_walk_stops_rather_than_inventing_a_hop(self):
         paths = self._with_skipped("lint / EditorConfig check")["critical_path"]
         observed = paths["observed"]
@@ -1021,9 +1041,622 @@ class CriticalPath(unittest.TestCase):
             metric = paths[key]
             self.assertEqual(metric["status"], "partial")
             self.assertIn("have not finished", metric["reason"])
-            self.assertNotIn("were not timed", metric["reason"])
+            self.assertNotIn("reported no duration", metric["reason"])
             self.assertTrue(metric["evidence"]["unfinished_jobs_off_chain"])
             self.assertNotIn("untimed_jobs_off_chain", metric["evidence"])
+
+    def test_a_job_with_no_creation_time_says_that_and_not_something_else(self):
+        # queue_delay measures from creation.  Reporting the missing start
+        # when the creation stamp is what is absent is the same false claim
+        # the job_wall reason was fixed for.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        mutated["jobs"][0]["created_at"] = None
+        report = tool.analyze(run, mutated)
+        self.assertEqual(report["jobs"][0]["metrics"]["queue_delay"]["reason"],
+                         "job has no creation time")
+        self.assertIn("job has no creation time",
+                      tool.render_markdown(report))
+
+    def test_one_job_gets_one_story_about_its_missing_start(self):
+        # queue_delay ends where job_wall begins, so both describe the same
+        # absent stamp.  Two adjacent bullets disagreeing about it is a
+        # contradiction the reader can see without leaving the page.
+        run, jobs = fixture("run-queued")
+        report = tool.analyze(run, jobs)
+        queued = [job for job in report["jobs"]
+                  if job["started_at"] is None
+                  and job["conclusion"] != "skipped"]
+        self.assertTrue(queued)
+        for job in queued:
+            self.assertEqual(job["metrics"]["queue_delay"]["reason"],
+                             job["metrics"]["job_wall"]["reason"])
+            self.assertEqual(job["metrics"]["queue_delay"]["reason"],
+                             "job has not started yet")
+        text = tool.render_markdown(report)
+        self.assertNotIn("job never started", text)
+
+    def test_a_completed_job_is_settled_whatever_the_run_status_says(self):
+        # The run's readability decides nothing about a job that is already
+        # done: it will not start now.
+        run, jobs = fixture("run-success")
+        unreadable = copy.deepcopy(run)
+        unreadable["status"] = "something-new"
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["started_at"] = None
+                job["steps"] = []
+                job["conclusion"] = None   # nothing here says it executed
+        entry = next(job for job in tool.analyze(unreadable, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["metrics"]["job_wall"]["reason"],
+                         "job never started")
+
+    def test_a_started_in_flight_job_in_an_unreadable_run_says_which(self):
+        # Start stamp present, completion absent, job status in flight, run
+        # status unreadable.  The tool knows the job did not report a
+        # completion and does not know whether the run is over, so it says
+        # the second thing rather than asserting the first.
+        run, jobs = fixture("run-queued")
+        unreadable = copy.deepcopy(run)
+        unreadable["status"] = "something-new"
+        mutated = copy.deepcopy(jobs)
+        victim = None
+        for job in mutated["jobs"]:
+            if job["status"] == "in_progress" and job["started_at"]:
+                victim = job["name"]
+                job["completed_at"] = None
+                job["steps"] = []
+                break
+        self.assertIsNotNone(victim)
+        entry = next(job for job in tool.analyze(unreadable, mutated)["jobs"]
+                     if job["name"] == victim)
+        reason = entry["metrics"]["job_wall"]["reason"]
+        self.assertIn("is not one this tool recognises", reason)
+        self.assertNotIn("stopped without reporting", reason)
+        # The start stamp is present and printed two fields away, so the
+        # sentence has to be about the end that is actually missing.
+        self.assertIsNotNone(entry["started_at"])
+        self.assertIn("no completion time", reason)
+        self.assertNotIn("no start stamp", reason)
+
+    def test_an_unreadable_run_status_settles_nothing_about_a_job(self):
+        # The report says twice, at run level, that the run may still be
+        # going.  Telling the reader a queued job in it never started is the
+        # contradiction this whole unit is about, one level up.
+        run, jobs = fixture("run-queued")
+        unreadable = copy.deepcopy(run)
+        unreadable["status"] = "something-new"
+        report = tool.analyze(unreadable, jobs)
+        text = tool.render_markdown(report)
+        self.assertNotIn("job never started", text)
+        self.assertNotIn("job has not started yet", text)
+        waiting = [job for job in report["jobs"]
+                   if job["started_at"] is None and job["ran"]]
+        self.assertTrue(waiting)
+        for job in waiting:
+            for metric in ("queue_delay", "job_wall"):
+                self.assertIn("is not one this tool recognises",
+                              job["metrics"][metric]["reason"])
+
+    def test_a_stalled_job_is_not_told_its_start_may_still_arrive(self):
+        # The walkers already call this job missing data.  A cell telling
+        # the reader it may still start contradicts the caveat above it.
+        run, jobs = fixture("run-queued")
+        finished = copy.deepcopy(run)
+        finished["status"] = "completed"
+        report = tool.analyze(finished, jobs)
+        stalled = [job for job in report["jobs"]
+                   if job["status"] in tool.IN_FLIGHT_STATUSES
+                   and job["started_at"] is None]
+        self.assertTrue(stalled)
+        for job in stalled:
+            for metric in ("queue_delay", "job_wall"):
+                self.assertEqual(job["metrics"][metric]["reason"],
+                                 "job never started")
+
+    def test_a_cancelled_job_that_ran_without_steps_keeps_its_seconds(self):
+        # run-missing-data ships a successful job with sixty seconds of wall
+        # time and an empty step list, so "it reported no steps" cannot mean
+        # "it never ran".  Flip only its conclusion and the seconds must
+        # survive.
+        run, jobs = fixture("run-missing-data")
+        mutated = copy.deepcopy(jobs)
+        victim = "Detect build-triggering changes"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                self.assertEqual(job["steps"], [])
+                job["conclusion"] = "cancelled"
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertTrue(entry["ran"])
+        self.assertFalse(tool.absent_by_design(entry))
+        self.assertEqual(entry["metrics"]["job_wall"]["seconds"], 60)
+
+    def test_a_positive_span_alone_proves_the_job_ran(self):
+        # Picked up with no queue delay, cancelled, no steps: the span
+        # between its own start and completion is the only evidence left.
+        run, jobs = fixture("run-missing-data")
+        mutated = copy.deepcopy(jobs)
+        victim = "Detect build-triggering changes"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["created_at"] = job["started_at"]   # no queue delay
+                job["steps"] = []
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertTrue(entry["ran"])
+        self.assertEqual(entry["metrics"]["job_wall"]["seconds"], 60)
+
+    def test_a_start_later_than_creation_alone_proves_the_job_ran(self):
+        # Cancelled with its completion stamp lost and no steps.  The only
+        # trace left is that the start came after the creation, which a job
+        # that never ran does not have: it is stamped as starting when it
+        # was created.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["completed_at"] = None
+                job["steps"] = []
+                self.assertNotEqual(job["started_at"], job["created_at"])
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertTrue(entry["ran"])
+        self.assertFalse(tool.absent_by_design(entry))
+        self.assertEqual(entry["metrics"]["queue_delay"]["status"], "measured")
+
+    def test_a_job_cancelled_while_it_waited_did_not_run(self):
+        # Stamped start == completion at the moment of cancellation, with a
+        # real queue delay before it.  Counting the later start as dispatch
+        # would publish a measured zero, which reads as a job that ran
+        # instantly -- the misreading this whole rule exists to prevent.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["completed_at"] = job["started_at"]
+                job["steps"] = []
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertFalse(entry["ran"])
+        self.assertTrue(tool.absent_by_design(entry))
+        self.assertIsNone(entry["metrics"]["job_wall"]["seconds"])
+
+    def test_a_step_still_running_is_evidence_the_job_ran(self):
+        # Cancelled mid-step: the step has a start and no completion, which
+        # is exactly the shape a cancellation leaves behind.  Requiring both
+        # stamps would discard the only evidence there is.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["started_at"] = None
+                first = job["steps"][0]
+                job["steps"] = [dict(first, status="in_progress",
+                                     conclusion=None, completed_at=None)]
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertTrue(entry["ran"])
+        self.assertIn("its first step ran at",
+                      entry["metrics"]["job_wall"]["reason"])
+
+    def test_a_step_with_only_a_completion_is_not_evidence(self):
+        # No start stamp to cite, so nothing says when the job began.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["completed_at"] = job["started_at"]
+                job["steps"] = [dict(job["steps"][0], started_at=None)]
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertFalse(entry["ran"])
+
+    def test_a_skipped_or_backwards_step_is_not_evidence(self):
+        # A skipped step is stamped started == completed and never ran, and
+        # a step whose completion precedes its start has stamps the same
+        # report calls unusable.  Citing either would publish a time the
+        # report disowns two sections later.
+        _, jobs = fixture("run-success")
+        template = next(job["steps"][0] for job in jobs["jobs"]
+                        if job["name"] == "Sanitizers / ubuntu-latest / clang")
+        self.assertIsNone(tool.first_step_start(
+            {"steps": [dict(template, conclusion="skipped")]}))
+        self.assertIsNone(tool.first_step_start(
+            {"steps": [dict(template, started_at="2026-09-10T19:30:00Z",
+                            completed_at="2026-09-10T19:20:00Z")]}))
+        self.assertEqual(tool.first_step_start({"steps": [template]}),
+                         template["started_at"])
+
+    def test_the_earliest_step_is_the_one_reported(self):
+        _, jobs = fixture("run-success")
+        steps = next(job["steps"] for job in jobs["jobs"]
+                     if job["name"] == "Sanitizers / ubuntu-latest / clang")
+        self.assertGreater(len(steps), 1)
+        timed = [step["started_at"] for step in steps
+                 if step.get("started_at") and step.get("completed_at")
+                 and step.get("conclusion") != "skipped"]
+        self.assertEqual(
+            tool.first_step_start({"steps": list(reversed(steps))}),
+            min(timed))
+
+    def test_a_cancelled_job_that_never_ran_is_not_saved_by_a_dead_step(self):
+        # The mirror: one step carrying no usable stamps is not evidence the
+        # runner picked the job up, and taking it as evidence prints zeroes
+        # under a caption saying the job has no durations.
+        run, jobs = fixture("run-skip-cascade")
+        mutated = copy.deepcopy(jobs)
+        victim = None
+        for job in mutated["jobs"]:
+            if job["conclusion"] == "skipped" and not (job.get("steps") or []):
+                victim = job["name"]
+                job["conclusion"] = "cancelled"
+                job["steps"] = [{"name": "Set up job", "number": 1,
+                                 "status": "queued", "conclusion": None,
+                                 "started_at": None, "completed_at": None}]
+                break
+        self.assertIsNotNone(victim)
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertFalse(entry["ran"])
+        self.assertTrue(tool.absent_by_design(entry))
+
+    def test_a_report_without_the_ran_flag_is_not_excused(self):
+        # A report written before the flag existed carries no answer.  The
+        # safe reading is that the job ran, so its cells are explained rather
+        # than silently dropped.
+        report = tool.analyze(*fixture("run-success"))
+        entry = copy.deepcopy(report["jobs"][0])
+        entry.pop("ran")
+        self.assertFalse(tool.absent_by_design(entry))
+
+    def test_a_cancelled_job_stamped_the_way_a_skipped_one_is_reports_nothing(
+            self):
+        # The shipped skip cascade shows what GitHub does to a job that did
+        # not run: started_at equal to created_at, and a completion equal to
+        # them or one second earlier.  Flip one such job's conclusion to
+        # cancelled and nothing else, and the old rule printed 0 | 0 | 0
+        # under a caption saying it has no durations.
+        run, jobs = fixture("run-skip-cascade")
+        mutated = copy.deepcopy(jobs)
+        victim = None
+        for job in mutated["jobs"]:
+            if job["conclusion"] == "skipped" and not (job.get("steps") or []):
+                victim = job["name"]
+                self.assertEqual(job["started_at"], job["created_at"])
+                job["conclusion"] = "cancelled"
+                break
+        self.assertIsNotNone(victim)
+        report = tool.analyze(run, mutated)
+        entry = next(job for job in report["jobs"] if job["name"] == victim)
+        self.assertTrue(tool.absent_by_design(entry))
+        self.assertIn("cancelled before it ran",
+                      entry["metrics"]["job_wall"]["reason"])
+        row = next(line for line in tool.render_markdown(report).splitlines()
+                   if line.startswith(f"| {victim} |"))
+        cells = [part.strip() for part in row.strip().strip("|").split("|")][2:]
+        self.assertEqual([value for value in cells if value.isdigit()], [],
+                         row)
+
+    def test_a_cancelled_job_that_ran_still_qualifies_the_critical_path(self):
+        # The predicate has three call sites and the block is only one.  A
+        # job that ran and lost its wall time must still make the path say
+        # so, or a total gets published as final with that job missing.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["started_at"] = None       # ran; the stamp is gone
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        path = tool.analyze(run, mutated, edges, drift)["critical_path"]["graph"]
+        self.assertEqual(path["status"], "partial")
+        self.assertIn(victim, path["evidence"]["untimed_jobs_off_chain"])
+
+    def test_a_cancelled_job_whose_runner_picked_it_up_is_not_excused(self):
+        # Steps are the evidence that the runner executed the job.  A
+        # cancellation that landed after that point leaves real durations,
+        # and the caption does not cover them.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                self.assertTrue(job["steps"])
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertFalse(tool.absent_by_design(entry))
+        self.assertEqual(entry["metrics"]["job_wall"]["status"], "measured")
+
+    def test_a_cancelled_job_that_lost_a_stamp_is_not_excused(self):
+        # A start stamp with no completion is a job that ran and lost a
+        # stamp, not one that never ran.  Excusing it prints seconds in its
+        # own row under a caption saying it has none, and drops its
+        # degraded cells from the block.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["completed_at"] = None
+        report = tool.analyze(run, mutated)
+        entry = next(job for job in report["jobs"]
+                     if job["name"] == victim)
+        self.assertFalse(tool.absent_by_design(entry))
+        self.assertEqual(entry["metrics"]["queue_delay"]["status"], "measured")
+        block = tool.render_markdown(report).split(
+            "Why a number above is not final")[-1]
+        self.assertIn(f"{victim} / job_wall", block)
+
+    def test_a_cancelled_job_whose_steps_ran_is_not_excused(self):
+        # The mirror case: no start stamp, but its steps carry real spans,
+        # so phase seconds are printed for a job the caption would excuse.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["started_at"] = None
+        report = tool.analyze(run, mutated)
+        entry = next(job for job in report["jobs"]
+                     if job["name"] == victim)
+        self.assertEqual(entry["phases"]["compile"]["status"], "measured")
+        self.assertFalse(tool.absent_by_design(entry))
+
+    def test_a_completed_job_with_no_completion_time_says_so(self):
+        # "job has not completed" contradicts the job's own status.  It
+        # completed; what it did not do is say when.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        mutated["jobs"][0]["completed_at"] = None
+        report = tool.analyze(run, mutated)
+        self.assertEqual(report["jobs"][0]["metrics"]["job_wall"]["reason"],
+                         "job reported no completion time")
+
+    def test_a_started_job_in_a_finished_run_is_not_told_it_may_finish(self):
+        # The start stamp is present, so `interval` reports the absent end.
+        # The existing tests all null the start, so this half went unseen.
+        run, jobs = fixture("run-queued")
+        finished = copy.deepcopy(run)
+        finished["status"] = "completed"
+        mutated = copy.deepcopy(jobs)
+        started = [job for job in mutated["jobs"]
+                   if job["status"] == "in_progress" and job["started_at"]]
+        self.assertTrue(started)
+        for job in started:
+            job["completed_at"] = None
+        for job in tool.analyze(finished, mutated)["jobs"]:
+            if job["status"] == "in_progress" and job["started_at"]:
+                self.assertEqual(
+                    job["metrics"]["job_wall"]["reason"],
+                    "job stopped without reporting a completion time")
+
+    def test_a_started_job_with_an_unreadable_status_says_which(self):
+        run, jobs = fixture("run-queued")
+        finished = copy.deepcopy(run)
+        finished["status"] = "completed"
+        mutated = copy.deepcopy(jobs)
+        victim = None
+        for job in mutated["jobs"]:
+            if job["status"] == "in_progress" and job["started_at"]:
+                victim = job["name"]
+                job["status"] = "zzz"
+                job["completed_at"] = None
+                break
+        self.assertIsNotNone(victim)
+        entry = next(job for job in tool.analyze(finished, mutated)["jobs"]
+                     if job["name"] == victim)
+        self.assertIn("is not one this tool recognises",
+                      entry["metrics"]["job_wall"]["reason"])
+
+    def test_an_unreadable_status_is_not_told_it_never_started(self):
+        # The loud branch is right, but the sentence should not assert a
+        # fact about a state the tool has just said it cannot read.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        mutated["jobs"][0]["status"] = "something-new"
+        mutated["jobs"][0]["started_at"] = None
+        reason = tool.analyze(run, mutated)["jobs"][0]["metrics"]["job_wall"][
+            "reason"]
+        self.assertIn("not one this tool recognises", reason)
+        self.assertNotIn("never started", reason)
+
+    def test_a_finished_job_in_a_live_run_is_not_told_it_may_still_start(self):
+        # The run is going, but this job is done.  Only the job's own status
+        # decides whether its start may still arrive.
+        run, jobs = fixture("run-success")
+        live = copy.deepcopy(run)
+        live["status"] = "in_progress"
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["started_at"] = None
+                job["steps"] = []      # no step evidence either
+                job["conclusion"] = None
+        report = tool.analyze(live, mutated)
+        entry = next(job for job in report["jobs"] if job["name"] == victim)
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["metrics"]["job_wall"]["reason"],
+                         "job never started")
+        # And the walkers must file it as missing data, not as work still
+        # going, even though the run around it is going.
+        running, untimed = tool.untimed_executed_jobs(
+            report["jobs"], run_status="in_progress")
+        self.assertIn(victim, untimed)
+        self.assertNotIn(victim, running)
+
+    def test_a_job_whose_steps_ran_is_not_told_it_never_started(self):
+        # The job-level start stamp is gone but its own steps are stamped
+        # and their seconds are printed two columns away.  "Never started"
+        # is refuted by the same row that carries it.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["started_at"] = None
+                self.assertTrue(job["steps"])
+        entry = next(job for job in tool.analyze(run, mutated)["jobs"]
+                     if job["name"] == victim)
+        reason = entry["metrics"]["job_wall"]["reason"]
+        self.assertIn("its first step ran at", reason)
+        self.assertNotIn("never started", reason)
+        self.assertEqual(entry["phases"]["compile"]["status"], "measured")
+
+    def test_a_job_still_queued_has_not_never_started(self):
+        # "never" is a finality claim.  A job waiting in the queue may start
+        # at any moment, and a reader who checks finds the tool overstating.
+        run, jobs = fixture("run-queued")
+        report = tool.analyze(run, jobs)
+        waiting = [job for job in report["jobs"]
+                   if job["status"] in tool.IN_FLIGHT_STATUSES
+                   and job["started_at"] is None]
+        self.assertTrue(waiting)
+        for job in waiting:
+            self.assertEqual(job["metrics"]["job_wall"]["reason"],
+                             "job has not started yet")
+        # A job that did start and has not finished is a different fact, and
+        # the running fixture carries one.
+        running = [job for job in report["jobs"]
+                   if job["status"] == "in_progress" and job["started_at"]]
+        self.assertTrue(running)
+        for job in running:
+            self.assertEqual(job["metrics"]["job_wall"]["reason"],
+                             "job has not completed")
+
+    def _held_for_approval(self, run_status):
+        run, jobs = fixture("run-success")
+        run = copy.deepcopy(run)
+        run["status"] = run_status
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == "Sanitizers / ubuntu-latest / clang":
+                job["status"] = "waiting"
+                job["conclusion"] = None
+                job["started_at"] = None
+                job["completed_at"] = None
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        return tool.analyze(run, mutated, edges, drift)["critical_path"]
+
+    def test_a_job_held_for_approval_is_not_missing_data(self):
+        # `waiting` is an ordinary job at an environment protection rule.
+        # Treating it as missing data would fire on every approval gate.
+        paths = self._held_for_approval("in_progress")
+        # Both walkers, because each asks the question separately and a
+        # one-sided assertion let one of them drift back once already.
+        for key in ("observed", "graph"):
+            evidence = paths[key]["evidence"]
+            self.assertIn("Sanitizers / ubuntu-latest / clang",
+                          evidence["unfinished_jobs_off_chain"], key)
+            self.assertNotIn("untimed_jobs_off_chain", evidence, key)
+
+    def test_a_job_still_waiting_in_a_finished_run_is_missing_data(self):
+        # The same status in a run the API calls completed describes a job
+        # that stopped without saying so.  Quietly calling it work in
+        # progress would promise a number that is never coming.
+        paths = self._held_for_approval("completed")
+        for key in ("observed", "graph"):
+            evidence = paths[key]["evidence"]
+            self.assertIn("Sanitizers / ubuntu-latest / clang",
+                          evidence["untimed_jobs_off_chain"], key)
+            self.assertNotIn("unfinished_jobs_off_chain", evidence, key)
+
+    def test_an_unreadable_run_status_reaches_the_failure_latency_too(self):
+        # The same sentence class one metric over: saying no failure has
+        # happened *yet* asserts the run is going, which the tool declines
+        # to say about a status it cannot read.
+        run, jobs = fixture("run-success")
+        unreadable = copy.deepcopy(run)
+        unreadable["status"] = "something-new"
+        metric = tool.analyze(unreadable, jobs)["metrics"][
+            "first_failure_latency"]
+        self.assertEqual(metric["status"], "unavailable")
+        self.assertIn("is not one this tool recognises", metric["reason"])
+        self.assertNotIn("still in progress", metric["reason"])
+
+    def test_an_unreadable_run_status_still_downgrades_the_run_totals(self):
+        # The two questions about the run pull in opposite directions and
+        # both must err loud.  A status the tool cannot read might mean the
+        # run is unfinished, so the totals become lower bounds; it is not
+        # evidence a stalled job will move, so the walkers call it stopped.
+        run, jobs = fixture("run-success")
+        unreadable = copy.deepcopy(run)
+        unreadable["status"] = "something-new"
+        report = tool.analyze(unreadable, jobs)
+        for key in ("run_wall_clock", "pr_feedback"):
+            metric = report["metrics"][key]
+            self.assertEqual(metric["status"], "partial", key)
+            self.assertIn("may not be final", metric["reason"], key)
+            # ...and it says which of the two it is, rather than claiming a
+            # run is in progress two functions after declining to say so.
+            self.assertNotIn("still in progress", metric["reason"], key)
+
+    def test_a_run_status_the_tool_cannot_read_is_not_read_as_running(self):
+        # An unreadable run status is no evidence that a stalled job will
+        # ever move.  Reporting it as work in progress promises a number
+        # nobody can wait for.
+        paths = self._held_for_approval("something-new")
+        for key in ("observed", "graph"):
+            self.assertIn("Sanitizers / ubuntu-latest / clang",
+                          paths[key]["evidence"]["untimed_jobs_off_chain"],
+                          key)
+
+    def test_the_in_flight_statuses_are_the_ones_github_documents(self):
+        # Looping over the constant would shrink with it.  The list is a
+        # claim about GitHub's job status enum, so assert the claim.
+        self.assertEqual(tool.IN_FLIGHT_STATUSES,
+                         ("queued", "in_progress", "waiting", "requested",
+                          "pending"))
+        # And the readable sets, which decide whether a sentence about a
+        # job's or a run's future is settled.  Widening either by accident
+        # would make the tool assert where it should hedge.
+        self.assertEqual(tool.KNOWN_JOB_STATUSES,
+                         tool.IN_FLIGHT_STATUSES + ("completed",))
+        self.assertEqual(tool.KNOWN_RUN_STATUSES, tool.KNOWN_JOB_STATUSES)
+        self.assertEqual(tool.CONCLUSIONS_THAT_RAN,
+                         ("success", "failure", "timed_out"))
+
+    def test_every_in_flight_status_takes_the_quiet_branch(self):
+        # Dropping any one of them would report an ordinary live job as
+        # missing data, and only `waiting` was pinned before.
+        for status in tool.IN_FLIGHT_STATUSES:
+            with self.subTest(status=status):
+                run, jobs = fixture("run-success")
+                run = copy.deepcopy(run)
+                run["status"] = "in_progress"
+                mutated = copy.deepcopy(jobs)
+                for job in mutated["jobs"]:
+                    if job["name"] == "Sanitizers / ubuntu-latest / clang":
+                        job["status"] = status
+                        job["conclusion"] = None
+                        job["started_at"] = None
+                        job["completed_at"] = None
+                running, untimed = tool.untimed_executed_jobs(
+                    tool.analyze(run, mutated)["jobs"], run_status="in_progress")
+                self.assertIn("Sanitizers / ubuntu-latest / clang", running)
+                self.assertEqual(untimed, [])
 
     def test_a_job_that_completed_without_a_start_is_not_called_unfinished(self):
         # run-missing-data ships exactly this shape: status completed, a
@@ -1035,20 +1668,54 @@ class CriticalPath(unittest.TestCase):
         victim = next(job for job in report["jobs"]
                       if job["started_at"] is None)
         self.assertEqual(victim["status"], "completed")
+        # It concluded successfully, so it ran; the report says which fact
+        # is missing rather than claiming the job never started.
         self.assertEqual(victim["metrics"]["job_wall"]["reason"],
-                         "job never started")
+                         "job reported no start stamp; it concluded 'success'")
         self.assertNotIn("job has not completed", tool.render_markdown(report))
+        self.assertNotIn("job never started", tool.render_markdown(report))
+
+    def test_a_job_that_failed_without_starting_is_still_missing_data(self):
+        # Failure is an outcome, not an excuse from having a duration.  A job
+        # that failed with no start stamp is data the run lost, and widening
+        # the excused list to cover it would hide exactly that.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == "Sanitizers / ubuntu-latest / clang":
+                job["conclusion"] = "failure"
+                job["started_at"] = None
+                # No step evidence, so only the conclusion check can keep
+                # this job out of the excused set.
+                job["steps"] = []
+        graph = tool.extract_graph(self.WORKFLOW)
+        edges, drift = tool.match_graph_to_jobs(
+            graph, [j["name"] for j in mutated["jobs"]])
+        path = tool.analyze(run, mutated, edges, drift)["critical_path"]["graph"]
+        self.assertIn("Sanitizers / ubuntu-latest / clang",
+                      path["evidence"]["untimed_jobs_off_chain"])
+
+    @staticmethod
+    def _cancelled_before_starting(jobs, name):
+        """The shape GitHub actually produces: the job is completed and
+        cancelled, it has no start stamp, and it ran no steps.  Nulling the
+        start alone would leave step durations behind, which describes a job
+        that ran and lost a stamp -- a different thing entirely."""
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            if job["name"] == name:
+                job["status"] = "completed"
+                job["conclusion"] = "cancelled"
+                job["started_at"] = None
+                job["steps"] = []
+        return mutated
 
     def test_a_job_cancelled_before_it_started_is_not_missing_data(self):
         # It has no duration because it never ran, like a skipped job, and it
         # will never acquire one.  Both alarms would be false.
         run, jobs = fixture("run-success")
-        mutated = copy.deepcopy(jobs)
-        for job in mutated["jobs"]:
-            if job["name"] == "Sanitizers / ubuntu-latest / clang":
-                job["status"] = "completed"
-                job["conclusion"] = "cancelled"
-                job["started_at"] = None
+        mutated = self._cancelled_before_starting(
+            jobs, "Sanitizers / ubuntu-latest / clang")
         graph = tool.extract_graph(self.WORKFLOW)
         edges, drift = tool.match_graph_to_jobs(
             graph, [j["name"] for j in mutated["jobs"]])
@@ -1085,7 +1752,7 @@ class CriticalPath(unittest.TestCase):
         edges, drift = tool.match_graph_to_jobs(
             graph, [j["name"] for j in mutated["jobs"]])
         path = tool.analyze(run, mutated, edges, drift)["critical_path"]["graph"]
-        self.assertIn("were not timed", path["reason"])
+        self.assertIn("reported no duration", path["reason"])
         self.assertNotIn("have not finished", path["reason"])
 
     def test_the_observed_reason_names_both_ways_it_can_be_wrong(self):
@@ -1102,6 +1769,10 @@ class CriticalPath(unittest.TestCase):
             graph, [j["name"] for j in mutated["jobs"]])
         reason = tool.analyze(run, mutated, edges,
                               drift)["critical_path"]["observed"]["reason"]
+        # The opening clause matters as much as the tail: the bucket holds
+        # jobs whose status could not be read, which are not finished.
+        self.assertIn("reported no duration", reason)
+        self.assertNotIn("finished job", reason)
         self.assertIn("below the true end of the path", reason)
         self.assertIn("longer branch it never entered", reason)
 
@@ -1202,6 +1873,14 @@ class Aggregation(unittest.TestCase):
         doc = tool.aggregate_reports(reports)
         self.assertEqual([e["reason"] for e in doc["excluded"]],
                          ["run_attempt > 1"])
+
+    def test_the_aggregate_note_covers_every_job_that_did_not_run(self):
+        # The per-job caption was widened to cover cancelled-before-run
+        # jobs; the aggregate note describes the same exclusion and has to
+        # say the same thing.
+        doc = tool.aggregate_reports(self._reports())
+        text = tool.render_aggregate_markdown(doc)
+        self.assertIn("a job that did not run contributes to none", text)
 
     def test_percentiles_are_nearest_rank_and_say_when_they_are_the_maximum(self):
         self.assertEqual(tool.percentile_nearest_rank([1, 2, 3, 4], 0.5), 2)
@@ -1478,6 +2157,16 @@ class Rendering(unittest.TestCase):
         wide = tool.render_markdown(tool.analyze(skewed, skewed_jobs))
         self.assertIn("`configure` on 5 jobs is", wide)
         self.assertEqual(wide.count("no step matched phase configure"), 1)
+        # Four is the other side of the boundary.  Without it the threshold
+        # is pinned only to the interval [3, 4] and can be retuned unseen.
+        four = copy.deepcopy(skewed_jobs)
+        first = four["jobs"][0]
+        first["steps"].append({
+            "name": "Configure", "number": 99, "status": "completed",
+            "conclusion": "success", "started_at": first["started_at"],
+            "completed_at": first["started_at"]})
+        narrow = tool.render_markdown(tool.analyze(skewed, four))
+        self.assertIn("`configure` on 4 jobs is", narrow)
 
     def test_the_block_never_explains_a_metric_with_no_column(self):
         # scheduler_release_latency and upstream_elapsed are computed and
@@ -1489,6 +2178,58 @@ class Rendering(unittest.TestCase):
             tool.degradation_block(report, report["critical_path"]))
         for hidden in ("scheduler_release_latency", "upstream_elapsed"):
             self.assertNotIn(hidden, block)
+
+    def test_the_published_columns_are_the_ones_declared(self):
+        # Header, row and block agreeing with each other says nothing about
+        # which columns exist.  Dropping one shrinks the published report and
+        # every consistency check still passes, so pin the set itself.
+        self.assertEqual(
+            tuple(heading for _, _, heading in tool.JOB_COLUMNS),
+            ("queue", "wall", "configure", "compile", "tests", "unaccounted"))
+        text = tool.render_markdown(tool.analyze(*fixture("run-success")))
+        self.assertIn(
+            "| job | population | queue | wall | configure | compile | "
+            "tests | unaccounted |", text)
+
+    def test_a_job_cancelled_after_it_ran_is_not_excused(self):
+        # It has real durations, so the caption's excuse does not cover it
+        # and its degraded cells still need explaining.  Excusing it also
+        # publishes a count a reader can check against the table and find
+        # one short.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["conclusion"] = "cancelled"
+                job["steps"] = [step for step in job["steps"]
+                                if tool.classify_step(step["name"])
+                                != "compile"]
+        report = tool.analyze(run, mutated)
+        self.assertEqual(
+            report["jobs"][[j["name"] for j in report["jobs"]].index(victim)]
+            ["metrics"]["job_wall"]["status"], "measured")
+        text = tool.render_markdown(report)
+        block = text.split("Why a number above is not final")[-1]
+        self.assertIn("`compile` on 6 jobs is", block)
+
+    def test_a_job_excused_from_durations_is_excused_from_the_block(self):
+        # A job cancelled before it ran has no durations for the same reason
+        # a skipped one does not.  Six true bullets per such job crowd out
+        # the ones that are not absent by design.
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        victim = "Sanitizers / ubuntu-latest / clang"
+        for job in mutated["jobs"]:
+            if job["name"] == victim:
+                job["status"] = "completed"
+                job["conclusion"] = "cancelled"
+                job["started_at"] = None
+                job["steps"] = []
+        text = tool.render_markdown(tool.analyze(run, mutated))
+        block = text.split("Why a number above is not final")[-1]
+        self.assertNotIn(victim, block)
+        self.assertIn("cancelled before it", text)
 
     def test_the_block_follows_the_table_it_explains(self):
         text = tool.render_markdown(tool.analyze(*fixture("run-success")))

--- a/scripts/ci/test-ci-run-telemetry.py
+++ b/scripts/ci/test-ci-run-telemetry.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python3
+"""Self-test for ci-run-telemetry.py (#1570).
+
+Drives the analyzer over committed fixtures, so every verdict is exercised
+without a network, a token, `gh`, or a build directory.  The fixtures under
+`ci-telemetry-fixtures/` are trimmed captures of real runs of this repository's
+`CI PR` workflow plus three hand-written shapes the real captures do not
+contain:
+
+  run-success       run 34514413925, 18 jobs across 16 distinct runners,
+                    hosted and self-hosted mixed in one run -- the ordinary
+                    case, not an edge case
+  run-skip-cascade  run 34571608167: a build failure skips five of fifteen
+                    jobs; three of them are stamped with a completion one
+                    second before their own start
+  run-clock-skew    run 34579784069: a self-hosted runner whose steps start
+                    before the job the server clock says they belong to
+  run-queued        hand-written: a run still in flight
+  run-missing-data  hand-written: a job with no steps, and a job that never
+                    started but carries a completion
+  run-rerun         hand-written: `run_started_at` diverging from `created_at`
+
+The invariants matter more than any single number.  A metric that was not
+measured must say so: the failure this guards against is a phase that matched
+no step reporting zero seconds, which reads as a phase that ran instantly.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TOOL_PATH = SCRIPT_DIR / "ci-run-telemetry.py"
+FIXTURES = SCRIPT_DIR / "ci-telemetry-fixtures"
+
+
+def load_tool():
+    spec = importlib.util.spec_from_file_location("ci_run_telemetry", TOOL_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+tool = load_tool()
+
+
+def fixture(name: str):
+    run = json.loads((FIXTURES / f"{name}.json").read_text())
+    jobs = json.loads((FIXTURES / f"{name}-jobs.json").read_text())
+    return run, jobs
+
+
+def walk_metrics(node, path=""):
+    """Yield every (path, metric object) in a report."""
+    if isinstance(node, dict):
+        if "status" in node and "seconds" in node:
+            yield path, node
+            return
+        for key, value in node.items():
+            yield from walk_metrics(value, f"{path}.{key}" if path else key)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from walk_metrics(value, f"{path}[{index}]")
+
+
+ALL_FIXTURES = ("run-success", "run-skip-cascade", "run-clock-skew",
+                "run-queued", "run-missing-data", "run-rerun")
+
+
+class MetricInvariants(unittest.TestCase):
+    """The rules that hold for every report, whatever the run looked like."""
+
+    def test_no_negative_and_no_unevidenced_zero(self):
+        for name in ALL_FIXTURES:
+            report = tool.analyze(*fixture(name))
+            for path, metric in walk_metrics(report):
+                with self.subTest(fixture=name, metric=path):
+                    seconds = metric["seconds"]
+                    if seconds is not None:
+                        self.assertGreaterEqual(
+                            seconds, 0,
+                            f"{path} reports a negative duration")
+                    if metric["status"] in ("measured", "partial"):
+                        self.assertTrue(
+                            metric["evidence"],
+                            f"{path} claims a measurement with no evidence")
+                    else:
+                        self.assertIsNone(
+                            seconds,
+                            f"{path} is {metric['status']} but carries seconds")
+                        self.assertTrue(
+                            metric["reason"],
+                            f"{path} is {metric['status']} with no reason")
+
+    def test_schema_and_required_keys(self):
+        report = tool.analyze(*fixture("run-success"))
+        self.assertEqual(report["schema"], "wirelog.ci-telemetry/1")
+        for key in ("tool_version", "generated_at", "run_id", "run_attempt",
+                    "workflow", "event", "status", "conclusion", "head_sha",
+                    "head_branch", "t0", "t0_source", "job_counts",
+                    "populations", "jobs", "metrics", "required_checks",
+                    "critical_path", "anomalies", "unmapped_steps",
+                    "unusable_steps"):
+            self.assertIn(key, report)
+        for key in ("skipped_steps", "unusable_steps", "unmapped_steps"):
+            self.assertIn(key, report["jobs"][0])
+
+    def test_unaccounted_closes_the_job_wall(self):
+        report = tool.analyze(*fixture("run-success"))
+        for job in report["jobs"]:
+            wall = job["metrics"]["job_wall"]
+            if wall["status"] != "measured":
+                continue
+            phases = sum(m["seconds"] for m in job["phases"].values()
+                         if m["status"] == "measured")
+            with self.subTest(job=job["name"]):
+                self.assertEqual(
+                    phases + job["unaccounted"]["seconds"], wall["seconds"],
+                    "phase totals plus unaccounted must equal the job wall")
+
+
+class SkipCascade(unittest.TestCase):
+    """A skipped job is stamped with a completion before its own start.  It
+    must produce no durations rather than zeroes or negatives."""
+
+    def setUp(self):
+        self.report = tool.analyze(*fixture("run-skip-cascade"))
+
+    def test_counts_lead_with_what_actually_ran(self):
+        self.assertEqual(self.report["job_counts"],
+                         {"total": 15, "executed": 10, "skipped": 5})
+
+    def test_skipped_jobs_have_no_durations(self):
+        skipped = [j for j in self.report["jobs"] if j["conclusion"] == "skipped"]
+        self.assertEqual(len(skipped), 5)
+        for job in skipped:
+            for key, metric in job["metrics"].items():
+                with self.subTest(job=job["name"], metric=key):
+                    self.assertEqual(metric["status"], "unavailable")
+                    self.assertIn("skipped", metric["reason"])
+            for phase, metric in job["phases"].items():
+                with self.subTest(job=job["name"], phase=phase):
+                    self.assertIsNone(metric["seconds"])
+
+    def test_first_failure_latency_is_measured(self):
+        metric = self.report["metrics"]["first_failure_latency"]
+        self.assertEqual(metric["status"], "measured")
+        self.assertEqual(metric["evidence"]["job"], "Build / ubuntu-latest / gcc")
+        self.assertEqual(metric["seconds"], 1499)
+        # The step matters: a size gate failing at minute 25 is #1573's case,
+        # and the job name alone does not distinguish it from a test failure.
+        self.assertEqual(metric["evidence"]["failed_steps"], ["Check binary size"])
+
+    def test_run_wall_clock_ignores_skipped_completions(self):
+        # The latest completed_at in this run (07:34:52) belongs to a skipped
+        # job that never ran; the latest executed completion is 07:34:51.
+        self.assertEqual(self.report["metrics"]["run_wall_clock"]["seconds"],
+                         2704)
+
+    def test_a_skipped_job_reports_no_release_latency(self):
+        by_name = {j["name"]: j for j in self.report["jobs"]}
+        metric = by_name["Build / ubuntu-24.04-arm / gcc"]["metrics"][
+            "scheduler_release_latency"]
+        self.assertEqual(metric["status"], "unavailable")
+        self.assertIn("skipped", metric["reason"])
+
+
+class ReleaseLatency(unittest.TestCase):
+    """`analyze` takes the dependency graph as a parameter; unit 2 supplies it
+    from the workflow files.  These cases drive it with a literal graph so the
+    branches are exercised now rather than on first contact with real data."""
+
+    def test_latency_is_measured_from_the_last_dependency_to_finish(self):
+        run, jobs = fixture("run-skip-cascade")
+        needs = {"lint / EditorConfig check": ["RC changelog freeze gate"]}
+        report = tool.analyze(run, jobs, needs)
+        by_name = {j["name"]: j for j in report["jobs"]}
+        metric = by_name["lint / EditorConfig check"]["metrics"][
+            "scheduler_release_latency"]
+        # rc-changelog-freeze completed 06:50:17 and released the lint job,
+        # whose creation is stamped the same second.
+        self.assertEqual(metric["seconds"], 0)
+        self.assertEqual(metric["evidence"]["released_by"],
+                         "RC changelog freeze gate")
+
+    def test_the_latest_dependency_wins_when_there_are_several(self):
+        run, jobs = fixture("run-skip-cascade")
+        needs = {"lint / uncrustify check": ["Docs / policy validation",
+                                             "RC changelog freeze gate"]}
+        report = tool.analyze(run, jobs, needs)
+        by_name = {j["name"]: j for j in report["jobs"]}
+        metric = by_name["lint / uncrustify check"]["metrics"][
+            "scheduler_release_latency"]
+        # Docs finished 06:50:04, rc-changelog-freeze 06:50:17; only the later
+        # one can have released the job.
+        self.assertEqual(metric["evidence"]["released_by"],
+                         "RC changelog freeze gate")
+
+    def test_a_skipped_dependency_makes_the_latency_unavailable(self):
+        run, jobs = fixture("run-skip-cascade")
+        needs = {"Build / ubuntu-latest / gcc": [
+            "mbedtls-enabled / ubuntu-latest / gcc"]}
+        report = tool.analyze(run, jobs, needs)
+        by_name = {j["name"]: j for j in report["jobs"]}
+        metric = by_name["Build / ubuntu-latest / gcc"]["metrics"][
+            "scheduler_release_latency"]
+        self.assertEqual(metric["status"], "unavailable")
+        self.assertIn("batched", metric["reason"])
+
+    def test_a_dependency_absent_from_the_run_is_named(self):
+        run, jobs = fixture("run-skip-cascade")
+        needs = {"Build / ubuntu-latest / gcc": ["a job that never ran"]}
+        report = tool.analyze(run, jobs, needs)
+        by_name = {j["name"]: j for j in report["jobs"]}
+        metric = by_name["Build / ubuntu-latest / gcc"]["metrics"][
+            "scheduler_release_latency"]
+        self.assertEqual(metric["status"], "unavailable")
+        self.assertIn("a job that never ran", metric["reason"])
+
+
+class ClockSkew(unittest.TestCase):
+    """Step timestamps come from the runner, job timestamps from the server.
+    The offset is reported; it is never folded into a duration."""
+
+    def setUp(self):
+        self.report = tool.analyze(*fixture("run-clock-skew"))
+        self.by_name = {j["name"]: j for j in self.report["jobs"]}
+
+    def test_offset_is_reported_as_an_anomaly(self):
+        skews = [a for a in self.report["anomalies"]
+                 if a["kind"] == "runner_clock_skew"]
+        self.assertTrue(skews, "a step starting before its job must be reported")
+        for item in skews:
+            self.assertLess(item["offset_seconds"], -tool.CLOCK_SKEW_TOLERANCE_S)
+            self.assertNotRegex(item["runner_name"] or "", r"^GitHub Actions \d+$")
+
+    def test_queue_delay_stays_on_the_server_clock(self):
+        job = self.by_name["lint / uncrustify check"]
+        # created 08:43:11 -> started 08:43:14 on the server clock.  The first
+        # step claims 08:43:04, before the job was created; taking the earlier
+        # value would report a negative queue delay and inflate the wall time.
+        self.assertEqual(job["metrics"]["queue_delay"]["seconds"], 3)
+        self.assertEqual(job["clock_offset_estimate"]["offset_seconds"], -10)
+
+    def test_steps_never_extend_outside_the_corrected_window(self):
+        for job in self.report["jobs"]:
+            offset = job["clock_offset_estimate"]
+            wall = job["metrics"]["job_wall"]
+            if offset["status"] != "measured" or wall["status"] != "measured":
+                continue
+            accounted = sum(m["seconds"] for m in job["phases"].values()
+                            if m["status"] == "measured")
+            with self.subTest(job=job["name"]):
+                self.assertLessEqual(
+                    accounted, wall["seconds"] - offset["offset_seconds"])
+
+
+class InFlightAndMissingData(unittest.TestCase):
+    def test_queued_run_invents_nothing(self):
+        report = tool.analyze(*fixture("run-queued"))
+        by_name = {j["name"]: j for j in report["jobs"]}
+        queued = by_name["TSan / ubuntu-latest / gcc"]
+        self.assertEqual(queued["metrics"]["queue_delay"]["status"], "unavailable")
+        self.assertEqual(queued["metrics"]["job_wall"]["status"], "unavailable")
+        running = by_name["Build / ubuntu-latest / gcc"]
+        self.assertEqual(running["metrics"]["queue_delay"]["seconds"], 12)
+        self.assertEqual(running["metrics"]["job_wall"]["status"], "unavailable")
+        self.assertEqual(report["metrics"]["run_wall_clock"]["status"], "partial")
+
+    def test_missing_fields_are_reported_not_guessed(self):
+        report = tool.analyze(*fixture("run-missing-data"))
+        by_name = {j["name"]: j for j in report["jobs"]}
+        no_steps = by_name["Detect build-triggering changes"]
+        for phase, metric in no_steps["phases"].items():
+            with self.subTest(phase=phase):
+                self.assertEqual(metric["status"], "unavailable")
+        self.assertEqual(no_steps["clock_offset_estimate"]["status"], "unavailable")
+        never_started = by_name["Build / ubuntu-latest / gcc"]
+        self.assertEqual(never_started["metrics"]["queue_delay"]["status"],
+                         "unavailable")
+        self.assertEqual(report["t0_source"], "created_at")
+
+    def test_rerun_anchors_on_run_started_at(self):
+        report = tool.analyze(*fixture("run-rerun"))
+        self.assertEqual(report["t0_source"], "run_started_at")
+        self.assertEqual(report["t0"], "2026-09-10T10:00:00Z")
+        job = report["jobs"][0]
+        # Anchoring on created_at would have reported an hour of upstream wait.
+        self.assertEqual(job["metrics"]["upstream_elapsed"]["seconds"], 1)
+
+
+class PhaseAttribution(unittest.TestCase):
+    def test_every_fixture_step_name_is_classified_deliberately(self):
+        unmapped = set()
+        for name in ALL_FIXTURES:
+            _, jobs = fixture(name)
+            for job in jobs["jobs"]:
+                for step in job.get("steps") or []:
+                    step_name = step["name"]
+                    if (tool.classify_step(step_name) == "other"
+                            and step_name not in tool.KNOWN_UNMAPPED):
+                        unmapped.add(step_name)
+        self.assertEqual(
+            unmapped, set(),
+            "every observed step name must map to a phase or be listed in "
+            "KNOWN_UNMAPPED; a new one landing in `other` is a silent gap")
+
+    def test_tool_specific_installs_belong_to_their_gate(self):
+        # Downloading a gate's own tool is that gate's cost.  Pooling it into
+        # deps_install would overstate what #1571 reads as dependency setup.
+        for step, phase in (("Install clang-tidy (pinned major)", "tidy"),
+                            ("Install syft", "sbom"),
+                            ("Install editorconfig-checker", "lint"),
+                            ("Install uncrustify", "lint")):
+            with self.subTest(step=step):
+                self.assertEqual(tool.classify_step(step), phase)
+        self.assertEqual(tool.classify_step("Install dependencies (Linux)"),
+                         "deps_install")
+
+    def test_post_steps_are_not_merged_into_the_phase_they_clean_up(self):
+        self.assertEqual(tool.classify_step("Setup sccache"), "cache_setup")
+        self.assertEqual(tool.classify_step("Post Setup sccache"), "post_cleanup")
+        self.assertEqual(tool.classify_step("Run actions/checkout@v5"), "checkout")
+        self.assertEqual(tool.classify_step("Post Run actions/checkout@v5"),
+                         "post_cleanup")
+
+    def test_tsan_native_test_step_is_not_lost(self):
+        self.assertEqual(
+            tool.classify_step("Policy smoke (native threads under TSan)"),
+            "tests")
+
+    def test_a_renamed_step_reports_unavailable_not_zero(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        renamed = 0
+        for job in mutated["jobs"]:
+            if job["name"] != "Build / ubuntu-latest / gcc":
+                continue
+            for step in job["steps"]:
+                if step["name"] == "Test":
+                    step["name"] = "Verify build outputs"
+                    renamed += 1
+        self.assertEqual(renamed, 1, "fixture must contain the step to rename")
+        report = tool.analyze(run, mutated)
+        job = next(j for j in report["jobs"]
+                   if j["name"] == "Build / ubuntu-latest / gcc")
+        self.assertEqual(job["phases"]["tests"]["status"], "unavailable")
+        self.assertIn("Verify build outputs", report["unmapped_steps"])
+
+
+class SkewedRunners(unittest.TestCase):
+    """The residual between the job window and the steps inside it is the one
+    place a clock offset can still surface as a duration.  It must not."""
+
+    STEP_START = "2026-09-11T08:34:54Z"
+
+    def _job_with_step_span(self, span_seconds):
+        run, jobs = fixture("run-clock-skew")
+        mutated = copy.deepcopy(jobs)
+        job = next(j for j in mutated["jobs"]
+                   if j["name"] == "RC changelog freeze gate")
+        # created 08:33:37, started 08:35:04, completed 08:35:14: a ten-second
+        # server-clock window on a runner whose clock trails by ten seconds,
+        # so its steps can span more than the window they sit in.
+        end = (datetime.fromisoformat(self.STEP_START.replace("Z", "+00:00"))
+               + timedelta(seconds=span_seconds))
+        job["steps"] = [{"name": "Set up job", "number": 1,
+                         "status": "completed", "conclusion": "success",
+                         "started_at": self.STEP_START,
+                         "completed_at": end.isoformat().replace("+00:00", "Z")}]
+        return tool.analyze(run, mutated), job
+
+    def test_a_step_span_inside_the_window_is_an_ordinary_residual(self):
+        report, _ = self._job_with_step_span(5)
+        job = next(j for j in report["jobs"]
+                   if j["name"] == "RC changelog freeze gate")
+        self.assertEqual(job["unaccounted"]["status"], "measured")
+        self.assertEqual(job["unaccounted"]["seconds"], 5)
+
+    def test_steps_spanning_more_than_the_window_are_not_a_duration(self):
+        report, _ = self._job_with_step_span(11)
+        job = next(j for j in report["jobs"]
+                   if j["name"] == "RC changelog freeze gate")
+        residual = job["unaccounted"]
+        self.assertEqual(residual["status"], "anomalous")
+        self.assertIsNone(residual["seconds"])
+        self.assertEqual(residual["raw_seconds"], -1)
+        # A reader scanning the summary must see it, not only the JSON.
+        kinds = {a["kind"] for a in report["anomalies"]}
+        self.assertIn("steps_exceed_job_wall", kinds)
+        self.assertIn("steps_exceed_job_wall", tool.render_markdown(report))
+
+    def test_a_negative_duration_can_never_be_constructed(self):
+        with self.assertRaises(ValueError):
+            tool.measured(-1, {"from": "a", "to": "b"})
+        with self.assertRaises(ValueError):
+            tool.measured(1, {})
+
+
+class UnusableSteps(unittest.TestCase):
+    """A step that matched a phase but carried no usable interval must not be
+    reported as a phase no step matched; that reason would be false."""
+
+    def _with_broken_test_step(self, started, completed):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        job = next(j for j in mutated["jobs"]
+                   if j["name"] == "Build / ubuntu-latest / gcc")
+        for step in job["steps"]:
+            if step["name"] == "Test":
+                step["started_at"], step["completed_at"] = started, completed
+        report = tool.analyze(run, mutated)
+        return next(j for j in report["jobs"]
+                    if j["name"] == "Build / ubuntu-latest / gcc")
+
+    def test_a_backwards_step_is_named_not_silently_dropped(self):
+        job = self._with_broken_test_step("2026-09-10T19:50:00Z",
+                                          "2026-09-10T19:49:00Z")
+        self.assertEqual(job["phases"]["tests"]["status"], "unavailable")
+        self.assertIn("no usable interval", job["phases"]["tests"]["reason"])
+        self.assertEqual([u["step"] for u in job["unusable_steps"]], ["Test"])
+        self.assertEqual(job["unusable_steps"][0]["raw_seconds"], -60)
+
+    def test_a_step_without_timestamps_is_named_too(self):
+        job = self._with_broken_test_step(None, None)
+        self.assertIn("no usable interval", job["phases"]["tests"]["reason"])
+        self.assertEqual([u["step"] for u in job["unusable_steps"]], ["Test"])
+
+    def test_an_unusable_step_reaches_the_run_summary(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        job = next(j for j in mutated["jobs"]
+                   if j["name"] == "Build / ubuntu-latest / gcc")
+        for step in job["steps"]:
+            if step["name"] == "Test":
+                step["completed_at"] = step["started_at"]
+                step["started_at"] = "2026-09-10T23:59:59Z"
+        report = tool.analyze(run, mutated)
+        self.assertIn("Test", report["unusable_steps"])
+        kinds = {a["kind"] for a in report["anomalies"]}
+        self.assertIn("unusable_step", kinds)
+        self.assertIn("Test", tool.render_markdown(report))
+
+
+class InFlightRunLevelMetrics(unittest.TestCase):
+    def test_every_run_level_figure_is_a_lower_bound_until_the_run_ends(self):
+        report = tool.analyze(*fixture("run-clock-skew"))
+        self.assertEqual(report["status"], "in_progress")
+        for key in ("run_wall_clock", "pr_feedback"):
+            with self.subTest(metric=key):
+                metric = report["metrics"][key]
+                self.assertEqual(metric["status"], "partial")
+                self.assertIn("lower bound", metric["reason"])
+        failure = report["metrics"]["first_failure_latency"]
+        self.assertEqual(failure["status"], "unavailable")
+        self.assertIn("still in progress", failure["reason"])
+
+    def test_a_completed_failure_is_final_even_mid_run(self):
+        run, jobs = fixture("run-skip-cascade")
+        in_flight = copy.deepcopy(run)
+        in_flight["status"], in_flight["conclusion"] = "in_progress", None
+        report = tool.analyze(in_flight, jobs)
+        # A job still running can only complete later, so it can never produce
+        # an earlier first failure: this value does not move.
+        self.assertEqual(report["metrics"]["first_failure_latency"]["status"],
+                         "measured")
+        self.assertEqual(report["metrics"]["run_wall_clock"]["status"],
+                         "partial")
+
+    def test_a_finished_run_reports_final_figures(self):
+        report = tool.analyze(*fixture("run-success"))
+        self.assertEqual(report["metrics"]["run_wall_clock"]["status"],
+                         "measured")
+        self.assertEqual(report["metrics"]["pr_feedback"]["status"], "measured")
+
+
+class CriticalPathPlaceholder(unittest.TestCase):
+    """Unit 2 fills this in.  Until then it must not look like a result."""
+
+    def test_placeholder_names_the_missing_work_and_drift_is_not_empty(self):
+        path = tool.analyze(*fixture("run-success"))["critical_path"]
+        for key in ("observed", "graph"):
+            self.assertEqual(path[key]["status"], "unavailable")
+            self.assertIn("unit 2", path[key]["reason"])
+        # An empty list would read as "compared the graph, found no drift".
+        self.assertIsNone(path["graph_drift"])
+
+
+class SkippedSteps(unittest.TestCase):
+    """An `if:`-skipped step is stamped started == completed.  Counted, it adds
+    a 0 to its phase and its name to the evidence; a phase whose steps were all
+    skipped would then report a measured zero -- a phase that never ran,
+    presented as instant.  The success fixture carries twenty of them."""
+
+    def test_a_skipped_step_does_not_feed_the_phase_it_matched(self):
+        report = tool.analyze(*fixture("run-success"))
+        job = next(j for j in report["jobs"]
+                   if j["name"] == "Sanitizers / ubuntu-latest / gcc")
+        phase = job["phases"]["deps_install"]
+        # The macOS install is skipped on a Linux runner; only the Linux one
+        # actually installed anything.
+        self.assertEqual(phase["evidence"]["matched_steps"],
+                         ["Install dependencies (Linux)"])
+        self.assertIn("Install dependencies (macOS)",
+                      [item["step"] for item in job["skipped_steps"]])
+
+    def test_a_wholly_skipped_phase_is_unavailable_not_zero(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        job = next(j for j in mutated["jobs"]
+                   if j["name"] == "Build / windows-latest / msvc")
+        renamed = 0
+        for step in job["steps"]:
+            if step["name"].startswith("Test"):
+                step["conclusion"] = "skipped"
+                step["completed_at"] = step["started_at"]
+                renamed += 1
+        self.assertGreater(renamed, 0, "fixture must contain Test steps")
+        report = tool.analyze(run, mutated)
+        entry = next(j for j in report["jobs"]
+                     if j["name"] == "Build / windows-latest / msvc")
+        phase = entry["phases"]["tests"]
+        self.assertEqual(phase["status"], "unavailable")
+        self.assertIn("skipped", phase["reason"])
+        row = next(line for line in tool.render_markdown(report).splitlines()
+                   if line.startswith("| Build / windows-latest / msvc |"))
+        self.assertNotIn("| 0 |", row)
+        self.assertIn("| unavailable |", row)
+
+    def test_skipped_steps_are_not_anomalies(self):
+        report = tool.analyze(*fixture("run-success"))
+        kinds = {a["kind"] for a in report["anomalies"]}
+        self.assertNotIn("unusable_step", kinds)
+        self.assertNotIn("skipped_step", kinds)
+
+
+class ReportPairing(unittest.TestCase):
+    def test_a_mismatched_saved_pair_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / "raw").mkdir()
+            run, _ = fixture("run-success")
+            _, other_jobs = fixture("run-clock-skew")
+            (out / "raw" / "run-999.json").write_text(json.dumps(run))
+            (out / "raw" / "run-999-jobs.json").write_text(json.dumps(other_jobs))
+            # Without the guard this published a confident 14-hour run wall.
+            self.assertEqual(
+                tool.main(["report", "--run-id", "999", "--out", tmp]), 1)
+            self.assertFalse((out / "run-999.json").exists())
+
+
+class FailureConclusions(unittest.TestCase):
+    def test_a_timed_out_job_counts_as_the_first_failure(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        job = next(j for j in mutated["jobs"]
+                   if j["name"] == "Build / ubuntu-latest / gcc")
+        job["conclusion"] = "timed_out"
+        report = tool.analyze(run, mutated)
+        metric = report["metrics"]["first_failure_latency"]
+        self.assertEqual(metric["status"], "measured")
+        self.assertEqual(metric["evidence"]["job"], "Build / ubuntu-latest / gcc")
+
+    def test_a_cancelled_job_is_not_a_failure_but_is_acknowledged(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        for job in mutated["jobs"]:
+            job["conclusion"] = "cancelled"
+        report = tool.analyze(run, mutated)
+        # A run cancelled by concurrency did not fail; counting it would put
+        # scheduling noise into a failure metric.  But "no failed job" alone
+        # would hide that cancellations were seen at all.
+        metric = report["metrics"]["first_failure_latency"]
+        self.assertEqual(metric["status"], "unavailable")
+        self.assertIn("cancelled", metric["reason"])
+
+    def test_a_timeout_says_why_no_step_is_named(self):
+        run, jobs = fixture("run-success")
+        mutated = copy.deepcopy(jobs)
+        job = next(j for j in mutated["jobs"]
+                   if j["name"] == "Build / ubuntu-latest / gcc")
+        job["conclusion"] = "timed_out"
+        for step in job["steps"]:
+            step["conclusion"] = "cancelled"
+        report = tool.analyze(run, mutated)
+        evidence = report["metrics"]["first_failure_latency"]["evidence"]
+        # A timed-out job stamps its steps cancelled, so an empty step list is
+        # expected; the conclusion says so instead of reading as a job that
+        # failed with no failing step.
+        self.assertEqual(evidence["failed_steps"], [])
+        self.assertEqual(evidence["conclusion"], "timed_out")
+
+
+class GraphAbsence(unittest.TestCase):
+    def test_the_missing_graph_is_named_and_not_confused_with_a_root(self):
+        report = tool.analyze(*fixture("run-success"))
+        for job in report["jobs"]:
+            metric = job["metrics"]["scheduler_release_latency"]
+            with self.subTest(job=job["name"]):
+                self.assertEqual(metric["status"], "unavailable")
+                self.assertIn("unit 2", metric["reason"])
+
+    def test_a_root_job_is_named_as_a_root_once_a_graph_exists(self):
+        run, jobs = fixture("run-success")
+        # A genuine root is named in the graph with an empty dependency list.
+        report = tool.analyze(run, jobs, {
+            "Detect build-triggering changes": [],
+            "lint / uncrustify check": ["lint / EditorConfig check"]})
+        by_name = {j["name"]: j for j in report["jobs"]}
+        root = by_name["Detect build-triggering changes"]["metrics"][
+            "scheduler_release_latency"]
+        self.assertIn("root job", root["reason"])
+
+    def test_a_job_missing_from_the_graph_is_not_called_a_root(self):
+        run, jobs = fixture("run-success")
+        report = tool.analyze(run, jobs, {"lint / uncrustify check":
+                                          ["lint / EditorConfig check"]})
+        by_name = {j["name"]: j for j in report["jobs"]}
+        # Absence from a partial graph is an extractor gap, not rootness; the
+        # two were conflated and 17 of 18 jobs claimed to be roots.
+        absent = by_name["Sanitizers / ubuntu-latest / gcc"]["metrics"][
+            "scheduler_release_latency"]
+        self.assertIn("absent from the supplied dependency graph",
+                      absent["reason"])
+        self.assertNotIn("root job", absent["reason"])
+
+    def test_summability_is_stated_on_every_job_in_every_state(self):
+        # The flag must never be absent: a missing key would have to be
+        # interpreted, and on a skipped job there is nothing to interpret it
+        # from.  run-skip-cascade carries five skipped jobs.
+        for name in ("run-success", "run-skip-cascade"):
+            report = tool.analyze(*fixture(name))
+            for job in report["jobs"]:
+                with self.subTest(fixture=name, job=job["name"]):
+                    self.assertIs(
+                        job["metrics"]["upstream_elapsed"]["additive"], False)
+                    self.assertIs(
+                        job["metrics"]["scheduler_release_latency"]["additive"],
+                        True)
+
+
+class Populations(unittest.TestCase):
+    def test_one_run_spans_several_runner_populations(self):
+        report = tool.analyze(*fixture("run-success"))
+        self.assertEqual(set(report["populations"]), {"hosted", "self-hosted"})
+        self.assertTrue(report["populations"]["self-hosted"])
+
+    def test_labels_are_not_a_source_of_truth(self):
+        _, jobs = fixture("run-success")
+        disguised = [j for j in jobs["jobs"]
+                     if j.get("runner_name") == "semantic-reasoning-i401-6-2"]
+        self.assertTrue(disguised, "fixture must keep the disguised runner")
+        self.assertIn("ubuntu-latest", disguised[0]["labels"])
+        self.assertEqual(tool.population_of(disguised[0]), "self-hosted")
+
+    def test_windows_runner_is_self_hosted(self):
+        self.assertEqual(
+            tool.population_of({"runner_name": "B2A1"}), "self-hosted")
+        self.assertEqual(
+            tool.population_of({"runner_name": "GitHub Actions 1000054606"}),
+            "hosted")
+
+
+class RequiredChecks(unittest.TestCase):
+    def test_unqueryable_required_set_is_recorded_not_faked(self):
+        report = tool.analyze(*fixture("run-success"))
+        metric = report["metrics"]["total_required_check_completion"]
+        self.assertEqual(metric["status"], "unavailable")
+        self.assertIn("404", metric["reason"])
+        self.assertEqual(report["required_checks"]["surrogate"], "pr_feedback")
+        evidence = report["metrics"]["pr_feedback"]["evidence"]
+        self.assertEqual(evidence["source"], "pinned-list")
+        # On this workflow every executed job is a pinned check, so pr_feedback
+        # and run_wall_clock coincide by construction.  The count says so, so a
+        # reader does not mistake the agreement for corroboration.
+        self.assertEqual(evidence["non_pinned_executed"], 0)
+        self.assertEqual(report["metrics"]["pr_feedback"]["seconds"],
+                         report["metrics"]["run_wall_clock"]["seconds"])
+
+
+class FetchBudget(unittest.TestCase):
+    """`fetch` is the only networked path.  Its transport is injectable, so
+    these cases assert the request list and the retry policy offline."""
+
+    def test_two_requests_for_a_single_page_run(self):
+        calls = []
+
+        def transport(args):
+            calls.append(args[-1])
+            if "/jobs" in args[-1]:
+                return json.dumps({"total_count": 1, "jobs": [{"name": "a"}]}).encode()
+            return json.dumps({"id": 7}).encode()
+
+        budget = tool.Budget(tool.DEFAULT_MAX_REQUESTS)
+        run, jobs = tool.fetch_run("o/r", 7, budget, transport, lambda _s: None)
+        self.assertEqual(budget.used, 2)
+        self.assertEqual(run["id"], 7)
+        self.assertEqual(jobs["total_count"], 1)
+        self.assertEqual(calls[0], "repos/o/r/actions/runs/7")
+        self.assertIn("filter=latest", calls[1])
+
+    def test_budget_is_a_hard_stop(self):
+        def transport(args):
+            return json.dumps({"id": 1, "total_count": 0, "jobs": []}).encode()
+
+        budget = tool.Budget(1)
+        with self.assertRaises(RuntimeError) as caught:
+            tool.fetch_run("o/r", 7, budget, transport, lambda _s: None)
+        self.assertIn("budget exhausted", str(caught.exception))
+
+    def test_rate_limit_is_retried_and_other_errors_are_not(self):
+        attempts = {"n": 0}
+        slept = []
+
+        def flaky(args):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise RuntimeError("HTTP 403: API rate limit exceeded")
+            return json.dumps({"id": 1}).encode()
+
+        budget = tool.Budget(10)
+        self.assertEqual(
+            tool.api_get("p", budget, flaky, slept.append)["id"], 1)
+        self.assertEqual(slept, [1])
+
+        def fatal(args):
+            raise RuntimeError("HTTP 404: Not Found")
+
+        with self.assertRaises(RuntimeError):
+            tool.api_get("p", tool.Budget(10), fatal, slept.append)
+        self.assertEqual(slept, [1], "a 404 must not be retried")
+
+
+class Rendering(unittest.TestCase):
+    def test_markdown_names_skipped_jobs_and_survives_a_failed_run(self):
+        report = tool.analyze(*fixture("run-skip-cascade"))
+        text = tool.render_markdown(report)
+        self.assertIn("10 executed, 5 skipped", text)
+        self.assertIn("first_failure_latency", text)
+        self.assertNotIn("| 0 |", text.split("Per job")[0])
+
+    def test_report_command_writes_both_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / "raw").mkdir()
+            run, jobs = fixture("run-success")
+            (out / "raw" / f"run-{run['id']}.json").write_text(json.dumps(run))
+            (out / "raw" / f"run-{run['id']}-jobs.json").write_text(json.dumps(jobs))
+            self.assertEqual(
+                tool.main(["report", "--run-id", str(run["id"]), "--out", tmp]), 0)
+            self.assertTrue((out / f"run-{run['id']}.json").exists())
+            self.assertTrue((out / f"run-{run['id']}.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -776,6 +776,18 @@ test('shell_gate_timeouts_selftest', py3,
      env: ['WIRELOG_SHELL_GATE_BUILD=' + meson.project_build_root()],
      suite: 'abi')
 
+# Issue #1570: self-test for scripts/ci/ci-run-telemetry.py, the offline
+# analyzer that separates CI queue delay from execution time.  Only the
+# self-test is registered: the analyzer itself is a measurement instrument, not
+# a gate, and never runs in CI.  It drives committed fixtures, so it needs no
+# network, no `gh`, no token and no build directory.  Python-seeded, so outside
+# the #1464 shell-gate timeout rule by construction; the explicit timeout
+# anticipates #1488 and costs nothing.
+test('ci_run_telemetry_selftest', py3,
+     args: [meson.project_source_root() / 'scripts/ci/test-ci-run-telemetry.py'],
+     suite: 'abi',
+     timeout: 60)
+
 # Issue #1464: the pre-commit hook installer must never leave an empty,
 # non-executable hook behind on a console whose locale cannot encode its
 # output; meson.build runs it with check: false, so only a test can see that.


### PR DESCRIPTION
Advances #1570. **Does not close it.** Several of its criteria are not met
by this branch, each with an owner:

- "Capture slow tests and cold/warm cache context" needs job logs, which
  this tool deliberately does not read. #1580.
- "Publish machine-readable timing and a concise job summary" and
  "preserve reports after failures" are produced, but only for an operator
  running the script by hand; nothing puts them in front of a pull request
  author. #1577 carries the publication path and already records this.
- "Failed runs preserve useful timing evidence; missing telemetry never
  silently represents successful validation" -- the first half holds, but
  gap 4 in `docs/CI_TELEMETRY.md` is a defect in which the tool can publish
  a wrong number as final with nothing in the artefact saying so. It does
  not fire on `ci-pr.yml` as it stands. #1582.
- "Collect comparable before-change baseline runs on hosted runners" -- the
  baseline is 96 hosted and 30 self-hosted jobs and nothing in the workflow
  chose that split. #1581.
- "...plus first-failure latency", from the same bullet -- all seven runs
  succeeded, so there is none to time. #1583 item 23.
- "Deliver a reproducible measurement procedure and results in this issue"
  -- the results half is the issue comment; the procedure half is partly
  short, since `aggregate` pools no run-level statistics and six of the seven
  published tables are hand-derived. #1583 item 17.

That list is what the review found, not a guarantee of completeness.

Adds `scripts/ci/ci-run-telemetry.py`, an offline analyzer that separates
the time a PR CI job spends waiting for a runner from the time it spends
running, attributes the running part to named phases, and walks each
run's critical path two ways so scheduling delay can be told apart from
work the dependency graph forces.

It is wired into no workflow. It reads saved GitHub REST responses from
disk and needs no build directory; only its self-test runs in CI, under
`meson test --suite abi`.

## What it measures

Per job: `queue_delay`, `job_wall`, `upstream_elapsed`,
`scheduler_release_latency`, `unaccounted`, and fourteen named phases.
Per run: `run_wall_clock`, `pr_feedback`, `first_failure_latency`,
`total_required_check_completion`, job counts by conclusion, and two
critical paths -- `observed` (walked back from the last job to finish
through its declared dependencies, queueing included) and `graph` (the
longest path over the declared graph, queueing excluded).

Every metric is an object carrying `status`, `reason` and `evidence`,
never a bare number. A `measured` metric cannot be constructed without
evidence and cannot be negative; both are enforced in the constructor.
The tool never substitutes zero for something it could not measure --
most of the design follows from that one rule, including the part that
took the most revision: deciding whether a job ran at all, when GitHub
stamps a job that never dispatched as starting the moment it was created.

## Baseline

Seven successful `CI PR` runs, 126 jobs -- the last seven of the
twenty-eight that succeeded on a first attempt out of sixty-five `CI PR`
runs that day, so a recency sample rather than a random draw. Headline
figures, with the full derivation, provenance and caveats in
`docs/CI_TELEMETRY.md`:

- `run_wall_clock` median 7414 s, max 10366 s.
- Queueing is 18 percent of summed job lifetime, concentrated in a tail:
  median job waits 29 s, worst waits 1979 s, and 35 of 126 jobs waited
  longer than they ran. The sample cannot separate that tail from three
  runs that started within three and a half minutes of each other.
- Compilation is 87 percent of summed job wall time, and a median 72
  percent of the observed critical path. The two denominators answer
  different questions; a lever sized against the wrong one is sized wrong.
- The same job's duration differs by 2.4x to 4.5x between the two runner
  pools. Both pools answer `ubuntu-latest` and `windows-latest` and nothing
  chooses, so the same job lands on either from run to run. The cause of the difference is not
  established: sccache routes both pools through the same
  GitHub Actions backend, so machine persistence does not explain it.
- `total_required_check_completion` is unavailable: this repository pins
  no required status checks.

## Commits

Nine atomic units, each approved by three independent gates before it was
committed: the measurement, the critical-path walk and aggregation, then
four correctness fixes found in review, then the wording and rule-naming
pass over the tests, then this documentation, then a correctness pass over
the documentation's claims about the issues it cites. 171 self-tests
over committed fixtures, using no network, no `gh` and no build
directory.

## Validation

`meson test --suite abi`: 67 Ok, 0 Fail, 2 Skipped, run in this
worktree's own build directory on the rebased branch.
