### PR TITLE
Measure shell-gate wall time against its timeout after the suite

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -461,6 +461,27 @@ jobs:
           $env:CXX = 'cl'
           meson test -C builddir --print-errorlogs
 
+      # Issue #1487: a shell gate that drifts from 3s to 110s still passes its
+      # timeout (a hang detector, not a drift detector). Post-suite, this step
+      # reads the testlog Meson just wrote and fails every shell-seeded test
+      # whose duration exceeded 50% of its own timeout, by name with both
+      # numbers. WIRELOG_WALLTIME_REQUIRED=1 turns every would-be skip into a
+      # failure so a gate that asserts nothing is loud, not green. Bash is
+      # present on all three runners, so shell gates register and run here; the
+      # gate measures exactly the ones that ran.
+      - name: Shell gate walltime budget (Linux / macOS)
+        if: runner.os != 'Windows'
+        run: python3 scripts/ci/check-shell-gate-walltime.py builddir --fraction 0.5
+        env:
+          WIRELOG_WALLTIME_REQUIRED: "1"
+
+      - name: Shell gate walltime budget (Windows / MSVC)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: python scripts/ci/check-shell-gate-walltime.py builddir --fraction 0.5
+        env:
+          WIRELOG_WALLTIME_REQUIRED: "1"
+
   # ==========================================================================
   # Phase: Build mbedTLS (gated by build-primary)
   # Optional crypto coverage; must pass before build-matrix proceeds.

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -77,6 +77,14 @@ jobs:
           meson setup build-default -Dtests=true --buildtype=debug
           meson compile -C build-default
           meson test -C build-default --print-errorlogs
+      # Issue #1487: post-suite walltime budget for the shell gates, measured
+      # from the testlog Meson just wrote. WIRELOG_WALLTIME_REQUIRED=1 turns a
+      # would-be skip (no shell gates measured) into a failure, so a green tag
+      # cannot hide a gate that asserted nothing.
+      - name: Shell gate walltime budget
+        run: python3 scripts/ci/check-shell-gate-walltime.py build-default --fraction 0.5
+        env:
+          WIRELOG_WALLTIME_REQUIRED: "1"
 
   abi:
     name: Tag / ABI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to wirelog are documented in this file.
 
 ### Added
 
+- **Shell-gate walltime budget gate** (#1487):
+  `scripts/ci/check-shell-gate-walltime.py` reads
+  `builddir/meson-logs/testlog.json` after the suite and fails when
+  any shell-seeded test (same classifier as the #1464 timeout gate)
+  took more than 50% of its Meson timeout (`--fraction` overrides
+  the default).  Runs post-suite in `ci-pr.yml` on all three matrix
+  OSes and in the `release-tag.yml` default job;
+  `WIRELOG_WALLTIME_REQUIRED=1` escalates the advisory skip to a
+  hard failure.  The self-test
+  (`scripts/ci/test-check-shell-gate-walltime.py`,
+  `meson test --suite abi:shell_gate_walltime_selftest`) covers the
+  pass / over-budget / worst-run / non-positive-timeout /
+  command-join / missing-input / corrupt-testlog / escalation /
+  fraction-override / usage-error paths.  `CONTRIBUTING.md` records
+  the Linux baseline for calibration (worst: `doop_validation`
+  26.96s of 90s = 30.0%; 37 of 43 registered shell-seeded tests
+  measured; all others within 13.5%).
+
 ### Changed
 
 ### Deprecated
@@ -36,6 +54,25 @@ All notable changes to wirelog are documented in this file.
 - **Built-in CSV fact loading streams input in bounded batches** and admits
   its transient staging buffers before allocation; custom I/O adapters and
   their public ABI are unchanged (#1402, #1405, #1429).
+
+- **Shell-gate walltime budget gate** (#1487):
+  `scripts/ci/check-shell-gate-walltime.py` reads
+  `builddir/meson-logs/testlog.json` after the suite and fails when
+  any shell-seeded test (same classifier as the #1464 timeout gate)
+  took more than 50% of its Meson timeout (`--fraction` overrides
+  the default).  Runs post-suite in `ci-pr.yml` on all three matrix
+  OSes and in the `release-tag.yml` default job;
+  `WIRELOG_WALLTIME_REQUIRED=1` escalates the advisory skip to a
+  hard failure.  The self-test
+  (`scripts/ci/test-check-shell-gate-walltime.py`,
+  `meson test --suite abi:shell_gate_walltime_selftest`) covers the
+  pass / over-budget / worst-run / non-positive-timeout /
+  command-join / missing-input / corrupt-testlog / escalation /
+  fraction-override / usage-error paths.  `CONTRIBUTING.md` records
+  the Linux baseline for calibration (worst: `doop_validation`
+  26.96s of 90s = 30.0%; 37 of 43 registered shell-seeded tests
+  measured; all others within 13.5%).
+
 - **Per-stratum TDD execution diagnostics** distinguish admission, selected
   worker width, submitted work, completed barriers, and serial replay. Exact
   result controls cover fused and unfused execution (#1378).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,52 @@ sudo cpupower frequency-set -g performance     # if available
 taskset -c 0 WIRELOG_PERF_GATE=1 meson test -C build-perf --suite perf --print-errorlogs
 ```
 
+### Shell-gate walltime budget
+
+Every shell-seeded test (a test whose command runs a `.sh` script) carries an
+explicit `timeout:` enforced by the *timeout* gate
+(`scripts/ci/check-shell-gate-timeouts.py`, #1464). A timeout is a hang
+detector, not a drift detector: a gate that quietly goes from 3s to 110s still
+passes everything. The *walltime budget* gate closes that gap.
+
+Because its measurement input (`build/meson-logs/testlog.json`) exists only
+after `meson test`, it runs as a **post-suite CI step** in
+`ci-pr.yml` (`build-matrix`, all three OSes) and `release-tag.yml` (the
+`default` job), not as a suite member -- a suite-registered gate would always
+see an empty log and skip (the #1301 always-skip shape).
+
+* The step fails any shell-seeded test whose measured duration exceeds
+  **50%** of its own `timeout`, by name, printing both numbers.
+* `WIRELOG_WALLTIME_REQUIRED=1` (set on every step) turns a would-be skip --
+  no shell gates measured -- into a failure, so a green run cannot hide a gate
+  that asserted nothing. `scripts/ci/test-required-gates.sh` pins the wiring.
+* `scripts/ci/check-shell-gate-walltime.py` is the gate;
+  `scripts/ci/test-check-shell-gate-walltime.py` is its self-test (registered
+  as `meson test --suite abi:shell_gate_walltime_selftest`, pure Python so it
+  asserts on every matrix OS).
+
+The 50% budget is calibrated against a measured Linux baseline (ubuntu-latest,
+`meson test`, `build/meson-logs/testlog.json`), 43 shell-seeded tests
+registered, 37 executed in the default suite. Worst observed shares of their
+own timeout:
+
+| test | timeout | duration (s) | % of timeout |
+|---|---|---|---|
+| doop_validation | 90s | 26.96 | 30.0% |
+| bash_construct_ratchet_selftest | 120s | 16.20 | 13.5% |
+| memory_pressure_contract | 120s | 14.34 | 12.0% |
+| log_abi_compile_erasure | 180s | 19.40 | 10.8% |
+| threading_doc | 120s | 3.72 | 3.1% |
+
+The next 32 gates all sit at 3.1% or below, the remainder under 1%. So the
+50% budget is ~1.7x the single worst case and an order of magnitude above the
+next cluster: it flags a genuine drift without tripping on the slow-but-stable
+gates above. Regenerate the table from any Linux build with:
+
+```sh
+python3 scripts/ci/check-shell-gate-walltime.py build --fraction 0.5
+```
+
 ### Internal commit-series labels in source comments
 
 Internal commit-series labels (such as `Phase 2A`, `Phase 3C-001`,

--- a/scripts/ci/check-shell-gate-walltime.py
+++ b/scripts/ci/check-shell-gate-walltime.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Measure shell-gate wall time against its own timeout after the suite (#1487).
+
+Every shell-seeded test carries an explicit timeout (check-shell-gate-timeouts.py,
+#1464), but a timeout is a hang detector and is deliberately useless for
+detecting drift: a gate that quietly goes from 3 s to 110 s passes everything.
+This gate closes that gap.  It runs as a POST-SUITE CI step -- after
+``meson test`` -- and it fails every shell-seeded test whose measured duration
+exceeds a fraction of its own timeout (50% by default, ``--fraction`` to
+override).  Both numbers are printed for every offender so a drift is visible
+at a glance.
+
+Why a CI step and not a meson test: the measurement input,
+``<builddir>/meson-logs/testlog.json``, exists only after ``meson test``
+finishes, so a suite-registered gate would always skip in a fresh CI job (the
+#1301 always-skip shape).  Hence the workflow step in ci-pr.yml and
+release-tag.yml.  ``WIRELOG_WALLTIME_REQUIRED=1`` (which CI sets on the jobs
+where shell gates are expected) turns every would-be skip into a failure, so a
+gate that asserts nothing is loud instead of green.
+
+Two inputs are joined, and the join key matters:
+
+* ``meson-info/intro-tests.json`` gives the population -- the shell-seeded
+  tests (same ``shell_seed_from_cmd`` classifier as the timeout gate, shared
+  with check-bash-constructs.py) and each one's registered ``timeout``.
+* ``meson-logs/testlog.json`` gives the measured ``duration`` for the tests
+  that actually ran.  Meson writes it as JSON Lines: one object per line, not
+  a single document.
+
+The join is on the test ``command`` (``cmd`` in the introspection, ``command``
+in the log) -- identical in both files and stable across Meson versions.  It
+deliberately is NOT the ``name`` field: Meson 1.12 records a *pretty* name in
+the log (``abi - wirelog:source_access_contract``) that never equals the plain
+introspection name (``source_access_contract``), so a name join silently
+measures nothing and the gate would pass on every drifted gate.
+
+Verdicts:
+  * no shell seeds in the introspection          -> SKIP (escalatable)
+  * shell seeds exist but none were measured     -> SKIP (escalatable)
+  * a measured gate exceeds the budget           -> FAIL, by name, both numbers
+  * otherwise                                    -> PASS
+Corrupt/unreadable input is a failure -- the gate cannot decide, so it must
+not pass.
+
+Usage: check-shell-gate-walltime.py <builddir> [--fraction 0.5]
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_FRACTION = 0.5
+REQUIRED_ENV = "WIRELOG_WALLTIME_REQUIRED"
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def fail(message: str) -> int:
+    print(f"check-shell-gate-walltime: FAIL: {message}", file=sys.stderr)
+    return 1
+
+
+def skip(message: str) -> int:
+    if os.environ.get(REQUIRED_ENV) == "1":
+        return fail(f"gate required but would skip: {message}")
+    print(f"check-shell-gate-walltime: SKIP: {message}")
+    return 77
+
+
+def load_classifier():
+    """importlib-load the shared gate for ``shell_seed_from_cmd``.
+
+    Same dance as check-shell-gate-timeouts.py: the hyphenated filename cannot
+    be imported by name, and one classifier must serve both gates so the
+    measured set cannot drift from the timeout rule."""
+    path = SCRIPT_DIR / "check-bash-constructs.py"
+    spec = importlib.util.spec_from_file_location("_bash_constructs", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load sibling gate {path}")
+    module = importlib.util.module_from_spec(spec)
+    # Register before executing: the sibling declares a dataclass, which
+    # resolves its module through sys.modules at class-creation time.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.shell_seed_from_cmd
+
+
+def _cmd_key(cmd: object) -> tuple[str, ...] | None:
+    """Normalise a test command to a hashable join key, or None."""
+    if not isinstance(cmd, list) or not cmd:
+        return None
+    return tuple(str(c) for c in cmd)
+
+
+def shell_seeds(intro: Path) -> list[tuple[str, str, object, tuple[str, ...]]]:
+    """Return (name, suite, timeout, cmd_key) for every shell-seeded test."""
+    data = json.loads(intro.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("introspection is not a list of tests")
+    classify = load_classifier()
+    seeds: list[tuple[str, str, object, tuple[str, ...]]] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        if classify(item.get("cmd")) is None:
+            continue
+        name = str(item.get("name", "?"))
+        suites = item.get("suite")
+        suite = ",".join(str(s) for s in suites) if isinstance(suites, list) else "?"
+        key = _cmd_key(item.get("cmd"))
+        seeds.append((name, suite, item.get("timeout"), key))
+    return seeds
+
+
+def durations_from_testlog(testlog: Path) -> dict[tuple[str, ...], list[float]]:
+    """Map command key -> measured durations from Meson's JSON-Lines log.
+
+    testlog.json holds one object per line for the tests that RAN in this
+    build directory; a registered test absent here was not executed by the
+    suite and therefore has no runtime to budget.  A command that ran more
+    than once keeps every duration so the worst run is the one that is judged."""
+    durations: dict[tuple[str, ...], list[float]] = {}
+    with testlog.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            entry = json.loads(line)
+            if not isinstance(entry, dict):
+                continue
+            key = _cmd_key(entry.get("command"))
+            duration = entry.get("duration")
+            if key is None or not isinstance(duration, (int, float)) or duration < 0:
+                continue
+            durations.setdefault(key, []).append(float(duration))
+    return durations
+
+
+def budget_offenders(
+    seeds: list[tuple[str, str, object, tuple[str, ...]]],
+    durations: dict[tuple[str, ...], list[float]],
+    fraction: float,
+) -> tuple[int, list[str]]:
+    """Return (measured shell-gate count, offender lines) over the budget."""
+    measured = 0
+    offenders: list[str] = []
+    for name, suite, timeout, key in seeds:
+        runs = durations.get(key) if key is not None else None
+        if not runs:
+            continue  # registered but not executed in this suite
+        measured += 1
+        try:
+            limit = float(timeout)
+        except (TypeError, ValueError):
+            offenders.append(
+                f"{name} (suite {suite}): timeout {timeout!r} is not a number;"
+                " its runtime cannot be bounded")
+            continue
+        if limit <= 0:
+            offenders.append(
+                f"{name} (suite {suite}): timeout {limit} disables the walltime"
+                " budget; set a positive timeout: in tests/meson.build")
+            continue
+        worst = max(runs)
+        ratio = worst / limit
+        if ratio > fraction:
+            offenders.append(
+                f"{name} (suite {suite}): duration {worst:.2f}s is"
+                f" {ratio * 100:.1f}% of its {limit:.0f}s timeout"
+                f" (budget {fraction * 100:.0f}%)")
+    return measured, offenders
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="check-shell-gate-walltime")
+    parser.add_argument("builddir")
+    parser.add_argument("--fraction", type=float, default=DEFAULT_FRACTION,
+                        help=f"fail when a duration exceeds this fraction of the"
+                             f" timeout (default {DEFAULT_FRACTION})")
+    args = parser.parse_args(argv[1:])
+    if not (0 < args.fraction <= 1):
+        return fail(f"--fraction must be in (0, 1], got {args.fraction}")
+    build = Path(args.builddir).resolve()
+    if not build.is_dir():
+        return skip(f"meson build directory missing: {build}")
+    testlog = build / "meson-logs" / "testlog.json"
+    intro = build / "meson-info" / "intro-tests.json"
+    if not testlog.is_file():
+        return skip(f"testlog missing: {testlog} (post-suite gate; `meson test`"
+                    " has not produced it)")
+    if not intro.is_file():
+        return skip(f"meson introspection unavailable: {intro} missing")
+    try:
+        seeds = shell_seeds(intro)
+        durations = durations_from_testlog(testlog)
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        return fail(f"cannot evaluate the walltime budget: {exc}")
+    if not seeds:
+        return skip("introspection contained no shell-seeded tests; nothing to"
+                    " measure (the classifier or tests/meson.build changed shape)")
+    measured, offenders = budget_offenders(seeds, durations, args.fraction)
+    if measured == 0:
+        return skip(f"{len(seeds)} shell-seeded tests are registered but none"
+                    " ran in this suite; nothing to measure")
+    if offenders:
+        return fail("\n".join(offenders))
+    print(f"check-shell-gate-walltime: ok {measured} executed shell-seeded tests"
+          f" are within {args.fraction * 100:.0f}% of their timeout budgets")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/ci/test-check-shell-gate-walltime.py
+++ b/scripts/ci/test-check-shell-gate-walltime.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Self-test for check-shell-gate-walltime.py (#1487).
+
+Drives the gate over a synthetic introspection file and a synthetic Meson
+testlog (JSON Lines) in a temporary build directory, so every verdict --
+pass, over-budget fail, missing-log skip, required escalation, vacuity floor,
+and fraction handling -- is exercised without a real ``meson test`` run.
+
+The join key is the test ``command``, so one case pins the gate to the
+command-join and not the ``name`` join: a testlog whose ``name`` disagrees
+with the introspection name (exactly what Meson 1.12 writes: a *pretty* name)
+must still be measured, and a testlog that only matches by name must not be.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+GATE = SCRIPT_DIR / "check-shell-gate-walltime.py"
+
+
+def load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, path
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module  # dataclasses resolve their module here
+    spec.loader.exec_module(module)
+    return module
+
+
+def shell_test(name: str, timeout: int, suite: str = "wirelog:abi",
+               shape: str = "find_program") -> dict:
+    script = f"/src/scripts/ci/{name}.sh"
+    cmd = [script] if shape == "find_program" else ["/usr/bin/bash", script]
+    return {"name": name, "suite": [suite], "timeout": timeout, "cmd": cmd}
+
+
+def py_test(name: str, timeout: int) -> dict:
+    return {"name": name, "suite": ["wirelog:abi"], "timeout": timeout,
+            "cmd": ["/usr/bin/python3", f"/src/scripts/ci/{name}.py"]}
+
+
+def testlog_entry(cmd: list[str], duration: float,
+                  name: str | None = None) -> dict:
+    """A Meson testlog line. ``name`` is the *pretty* name unless given."""
+    return {"name": name if name is not None else "pretty - " + cmd[-1].split("/")[-1],
+            "result": "OK", "is_fail": False, "duration": duration,
+            "returncode": 0, "command": cmd}
+
+
+class GateCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gate = load(GATE, "_shell_gate_walltime")
+        self.tmp = tempfile.TemporaryDirectory()
+        self.build = Path(self.tmp.name) / "build"
+        (self.build / "meson-info").mkdir(parents=True)
+        (self.build / "meson-logs").mkdir(parents=True)
+        self.environ = dict(os.environ)
+        os.environ.pop("WIRELOG_WALLTIME_REQUIRED", None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self.environ)
+        self.tmp.cleanup()
+
+    def write_intro(self, tests: list[dict]) -> None:
+        (self.build / "meson-info" / "intro-tests.json").write_text(
+            json.dumps(tests), encoding="utf-8")
+
+    def write_testlog(self, entries: list[dict]) -> None:
+        lines = "".join(json.dumps(e) + "\n" for e in entries)
+        (self.build / "meson-logs" / "testlog.json").write_text(
+            lines, encoding="utf-8")
+
+    def run_gate(self, build: Path | None = None,
+                 fraction: float | None = None) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        argv = ["gate", str(build or self.build)]
+        if fraction is not None:
+            argv += ["--fraction", str(fraction)]
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = self.gate.main(argv)
+        return rc, out.getvalue(), err.getvalue()
+
+    # -- pass ---------------------------------------------------------------
+    def test_within_budget_passes(self) -> None:
+        self.write_intro([shell_test("check-fast", 120)])
+        self.write_testlog([testlog_entry(shell_test("check-fast", 120)["cmd"], 3.0)])
+        rc, out, _ = self.run_gate()
+        self.assertEqual(rc, 0)
+        self.assertIn("ok 1 executed shell-seeded tests", out)
+
+    def test_non_shell_tests_are_ignored(self) -> None:
+        self.write_intro([py_test("gate-py", 120), shell_test("check-ok", 120)])
+        self.write_testlog([
+            testlog_entry(shell_test("check-ok", 120)["cmd"], 60.0),
+            testlog_entry(py_test("gate-py", 120)["cmd"], 999.0),
+        ])
+        rc, out, _ = self.run_gate()
+        self.assertEqual(rc, 0)
+        self.assertIn("ok 1 executed shell-seeded tests", out)
+
+    # -- fail ---------------------------------------------------------------
+    def test_over_budget_fails_by_name_with_both_numbers(self) -> None:
+        self.write_intro([shell_test("check-slow", 120), shell_test("check-fast", 120)])
+        self.write_testlog([
+            testlog_entry(shell_test("check-slow", 120)["cmd"], 80.0),
+            testlog_entry(shell_test("check-fast", 120)["cmd"], 2.0),
+        ])
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("check-slow (suite wirelog:abi): duration 80.00s", err)
+        self.assertIn("66.7% of its 120s timeout", err)
+        self.assertNotIn("check-fast", err)
+
+    def test_worst_run_is_judged(self) -> None:
+        self.write_intro([shell_test("check-spike", 120)])
+        cmd = shell_test("check-spike", 120)["cmd"]
+        self.write_testlog([
+            testlog_entry(cmd, 2.0),
+            testlog_entry(cmd, 90.0),
+        ])
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("check-spike", err)
+        self.assertIn("90.00s", err)
+
+    def test_non_positive_timeout_fails(self) -> None:
+        self.write_intro([shell_test("check-neg", 0)])
+        self.write_testlog([testlog_entry(shell_test("check-neg", 0)["cmd"], 1.0)])
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("check-neg", err)
+        self.assertIn("disables the walltime budget", err)
+
+    # -- join key -----------------------------------------------------------
+    def test_command_join_not_name(self) -> None:
+        """The testlog's pretty name does not equal the introspection name,
+        yet the duration must still be attributed (Meson 1.12 behaviour)."""
+        self.write_intro([shell_test("check-pretty", 120)])
+        self.write_testlog([
+            testlog_entry(shell_test("check-pretty", 120)["cmd"], 90.0,
+                          name="abi - wirelog:check-pretty")])
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("check-pretty", err)
+
+    def test_name_only_match_is_not_measured(self) -> None:
+        """A testlog line whose command is a different seed but whose name
+        happens to equal the registered name must NOT be attributed: a
+        name-join would silently measure the wrong test."""
+        self.write_intro([shell_test("check-real", 120)])
+        other_cmd = ["/usr/bin/bash", "/src/scripts/ci/check-other.sh"]
+        self.write_testlog([testlog_entry(other_cmd, 90.0, name="check-real")])
+        rc, out, _ = self.run_gate()
+        # No seed command was measured -> vacuity skip, not a false pass.
+        self.assertEqual(rc, 77)
+        self.assertIn("registered but none ran", out)
+
+    # -- skip routes --------------------------------------------------------
+    def test_missing_testlog_skips(self) -> None:
+        self.write_intro([shell_test("check-any", 120)])
+        rc, out, _ = self.run_gate()
+        self.assertEqual(rc, 77)
+        self.assertIn("SKIP", out)
+
+    def test_missing_build_dir_skips(self) -> None:
+        rc, out, _ = self.run_gate(build=Path(self.tmp.name) / "absent")
+        self.assertEqual(rc, 77)
+        self.assertIn("build directory missing", out)
+
+    def test_no_shell_seeds_skips(self) -> None:
+        self.write_intro([py_test("only-python", 120)])
+        self.write_testlog([testlog_entry(py_test("only-python", 120)["cmd"], 1.0)])
+        rc, out, _ = self.run_gate()
+        self.assertEqual(rc, 77)
+        self.assertIn("no shell-seeded tests", out)
+
+    def test_seeds_registered_but_none_ran_skips(self) -> None:
+        self.write_intro([shell_test("check-idle", 120)])
+        self.write_testlog([])
+        rc, out, _ = self.run_gate()
+        self.assertEqual(rc, 77)
+        self.assertIn("registered but none ran", out)
+
+    def test_corrupt_testlog_fails(self) -> None:
+        self.write_intro([shell_test("check-any", 120)])
+        (self.build / "meson-logs" / "testlog.json").write_text(
+            "{not valid json\n", encoding="utf-8")
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("cannot evaluate", err)
+
+    # -- required escalation -----------------------------------------------
+    def test_required_turns_skip_into_failure(self) -> None:
+        self.write_intro([shell_test("check-any", 120)])
+        os.environ["WIRELOG_WALLTIME_REQUIRED"] = "1"
+        rc, _, err = self.run_gate()
+        self.assertEqual(rc, 1)
+        self.assertIn("gate required but would skip", err)
+
+    # -- fraction handling --------------------------------------------------
+    def test_fraction_override(self) -> None:
+        self.write_intro([shell_test("check-edge", 120)])
+        self.write_testlog([testlog_entry(shell_test("check-edge", 120)["cmd"], 70.0)])
+        # 70/120 = 58.3%: over the 50% default, within a 75% budget.
+        rc_fail, _, _ = self.run_gate()
+        self.assertEqual(rc_fail, 1)
+        rc_pass, out, _ = self.run_gate(fraction=0.75)
+        self.assertEqual(rc_pass, 0)
+        self.assertIn("75%", out)
+
+    def test_invalid_fraction_fails(self) -> None:
+        self.write_intro([shell_test("check-any", 120)])
+        self.write_testlog([testlog_entry(shell_test("check-any", 120)["cmd"], 1.0)])
+        for bad in (0.0, 1.5, -1.0):
+            rc, _, err = self.run_gate(fraction=bad)
+            self.assertEqual(rc, 1)
+            self.assertIn("--fraction must be in (0, 1]", err)
+
+    def test_fraction_one_is_allowed(self) -> None:
+        self.write_intro([shell_test("check-at", 120)])
+        self.write_testlog([testlog_entry(shell_test("check-at", 120)["cmd"], 119.0)])
+        rc, out, _ = self.run_gate(fraction=1.0)
+        self.assertEqual(rc, 0)
+        self.assertIn("ok 1 executed", out)
+
+    def test_usage(self) -> None:
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            try:
+                self.gate.main(["gate"])
+                rc = 0
+            except SystemExit as exc:  # argparse exits on a missing positional
+                rc = exc.code if isinstance(exc.code, int) else 2
+        self.assertEqual(rc, 2)
+        self.assertIn("usage", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test-required-gates.sh
+++ b/scripts/ci/test-required-gates.sh
@@ -92,6 +92,26 @@ sbom_fails_when_required() {
 assert 'check-sbom-snapshot.sh skips when advisory' sbom_skips_when_advisory
 assert 'check-sbom-snapshot.sh fails when WIRELOG_SBOM_REQUIRED=1' sbom_fails_when_required
 
+# The walltime budget gate (#1487) is a POST-SUITE Python gate: it reads
+# meson-logs/testlog.json, which $empty does not have, so it reaches its
+# genuine missing-log skip route. Python is launched explicitly (the gate is a
+# .py, not a .sh); same advisory-skip / required-fail contract as the rest.
+walltime_skips_when_advisory() {
+    local st=0
+    ( unset WIRELOG_WALLTIME_REQUIRED
+      python3 "$root/scripts/ci/check-shell-gate-walltime.py" "$empty" ) >/dev/null 2>&1 || st=$?
+    [ "$st" = 77 ]
+}
+walltime_fails_when_required() {
+    local st=0
+    ( export WIRELOG_WALLTIME_REQUIRED=1
+      python3 "$root/scripts/ci/check-shell-gate-walltime.py" "$empty" ) >/dev/null 2>&1 || st=$?
+    [ "$st" = 1 ]
+}
+assert 'check-shell-gate-walltime.py skips when advisory' walltime_skips_when_advisory
+assert 'check-shell-gate-walltime.py fails when WIRELOG_WALLTIME_REQUIRED=1' \
+    walltime_fails_when_required
+
 # --- 2. wiring --------------------------------------------------------------
 # Assert on the job/step that must carry it, not merely on the file: the
 # variable appearing anywhere in a workflow would satisfy a bare grep while
@@ -129,6 +149,16 @@ assert 'ci-pr.yml SBOM step sets WIRELOG_SBOM_REQUIRED' \
     sets_in_step ci-pr.yml 'SBOM snapshot gate' WIRELOG_SBOM_REQUIRED
 assert 'release-tag.yml Tag/SBOM sets WIRELOG_SBOM_REQUIRED' \
     sets_in_step release-tag.yml 'Build and test SBOM suite' WIRELOG_SBOM_REQUIRED
+
+# #1487: the walltime budget is a post-suite step, so it has two OS-split steps
+# in the PR matrix and one in the release default job. Each must carry the
+# escalation, else the required contract above is unenforced in CI.
+assert 'ci-pr.yml walltime step (Linux/macOS) sets WIRELOG_WALLTIME_REQUIRED' \
+    sets_in_step ci-pr.yml 'Shell gate walltime budget (Linux / macOS)' WIRELOG_WALLTIME_REQUIRED
+assert 'ci-pr.yml walltime step (Windows) sets WIRELOG_WALLTIME_REQUIRED' \
+    sets_in_step ci-pr.yml 'Shell gate walltime budget (Windows / MSVC)' WIRELOG_WALLTIME_REQUIRED
+assert 'release-tag.yml default job sets WIRELOG_WALLTIME_REQUIRED' \
+    sets_in_step release-tag.yml 'Shell gate walltime budget' WIRELOG_WALLTIME_REQUIRED
 
 # release-verification must WAIT ON every verification job, not merely agree
 # with itself about how many there are. Comparing counts caught drift between

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -787,6 +787,15 @@ test('ci_run_telemetry_selftest', py3,
      args: [meson.project_source_root() / 'scripts/ci/test-ci-run-telemetry.py'],
      suite: 'abi',
      timeout: 60)
+# Issue #1487: the shell-gate walltime budget is a POST-SUITE gate -- it reads
+# meson-logs/testlog.json, which exists only after `meson test` -- so it runs
+# as a CI step in ci-pr.yml and release-tag.yml, not as a suite member.  Only
+# its self-test lives in the suite: pure Python over synthetic testlog +
+# introspection, so it asserts on every matrix OS (Linux/macOS/Windows) with no
+# bash and no prior `meson test`.
+test('shell_gate_walltime_selftest', py3,
+     args: [meson.project_source_root() / 'scripts/ci/test-check-shell-gate-walltime.py'],
+     suite: 'abi')
 
 # Issue #1464: the pre-commit hook installer must never leave an empty,
 # non-executable hook behind on a console whose locale cannot encode its


### PR DESCRIPTION
Fixes #1487.

A Meson timeout is a hang detector, not a drift detector: a shell gate that quietly goes from 3 s to 110 s still passes everything. This adds a post-suite gate that closes the gap.

## What

- `scripts/ci/check-shell-gate-walltime.py` — post-suite gate: joins the registered shell-seeded tests (`meson-info/intro-tests.json`, same `shell_seed_from_cmd` classifier as the #1464 timeout gate) with the durations Meson recorded in `meson-logs/testlog.json` (JSON Lines; joined on the test **command** — Meson 1.12 writes a pretty name into the log that never equals the introspection name, so a name join silently measures nothing). Fails any shell gate whose worst run exceeded 50% of its own timeout (`--fraction` overrides), by name, printing both numbers. Missing/corrupt input cannot pass; a no-seed or none-ran verdict skips, and `WIRELOG_WALLTIME_REQUIRED=1` escalates every would-be skip to a failure so a gate that asserts nothing is loud instead of green.
- `scripts/ci/test-check-shell-gate-walltime.py` — 17 unittest cases over synthetic introspection + testlog: pass, over-budget (name + both numbers), worst-run judged, non-positive timeout, command-join regression guard, name-only-match not measured, missing testlog/build dir, no seeds, seeds-registered-but-none-ran, corrupt testlog, required-escalation, fraction override (0.75 passes where 0.5 fails), invalid fractions (0.0/1.5/-1), fraction 1.0, and usage error (exit 2). Registered as `meson test --suite abi:shell_gate_walltime_selftest`; pure Python so it asserts on all three matrix OSes.
- CI wiring: post-suite steps in `ci-pr.yml` `build-matrix` (Linux/macOS + Windows/MSVC) and the `release-tag.yml` `default` job, each with `WIRELOG_WALLTIME_REQUIRED=1`. `scripts/ci/test-required-gates.sh` pins both the advisory-skip / required-fail behaviour and the step wiring.
- `CONTRIBUTING.md` — new "Shell-gate walltime budget" section documenting the gate, the 50% rule, the escalation contract, and the Linux baseline that calibrates it.
- `CHANGELOG.md` — Unreleased/Added entry (#1487).

## Linux baseline (calibration)

43 shell-seeded tests registered, 37 executed in the default suite. Worst observed shares of their own timeout:

| test | timeout | duration (s) | % of timeout |
|---|---|---|---|
| doop_validation | 90 s | 26.96 | 30.0% |
| bash_construct_ratchet_selftest | 120 s | 16.20 | 13.5% |
| memory_pressure_contract | 120 s | 14.34 | 12.0% |
| log_abi_compile_erasure | 180 s | 19.40 | 10.8% |
| threading_doc | 120 s | 3.72 | 3.1% |

The next 32 gates all sit at 3.1% or below; the remainder under 1%. The 50% budget is ~1.7× the single worst case and an order of magnitude above the next cluster.

## Validation

- `check-shell-gate-walltime.py build --fraction 0.5` → ok 37 executed shell-seeded tests within 50%
- `test-check-shell-gate-walltime.py` → 17/17 OK
- `meson test -C build shell_gate_walltime_selftest` → OK
- `check-changelog-format.py` → OK
- `test-required-gates.sh` → all pass (incl. 2 new behaviour + 3 wiring assertions)
- both workflow YAMLs parse; `bash -n` clean
