### PR TITLE
ci: pin Meson 1.12.0 across workflows

### DIFF
--- a/.github/actions/setup-meson/action.yml
+++ b/.github/actions/setup-meson/action.yml
@@ -1,0 +1,56 @@
+name: Set up pinned Meson
+description: Install Meson 1.12.0 and Windows Ninja in an isolated uv environment
+
+runs:
+  using: composite
+  steps:
+    - name: Set up uv
+      uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
+      with:
+        version: 0.12.13
+        enable-cache: false
+
+    - name: Install Meson 1.12.0 (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        tool_venv="$RUNNER_TEMP/wirelog-ci-tools"
+        uv venv --system-site-packages "$tool_venv"
+        uv pip install --python "$tool_venv/bin/python" 'meson==1.12.0'
+        export PATH="$tool_venv/bin:$PATH"
+        echo "$tool_venv/bin" >> "$GITHUB_PATH"
+        test "$(command -v meson)" = "$tool_venv/bin/meson"
+        test "$(meson --version)" = '1.12.0'
+        command -v python
+        python --version
+        command -v ninja
+        ninja --version
+
+    - name: Install Meson 1.12.0 and Ninja (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $toolVenv = Join-Path $env:RUNNER_TEMP 'wirelog-ci-tools'
+        $toolScripts = Join-Path $toolVenv 'Scripts'
+        $toolPython = Join-Path $toolScripts 'python.exe'
+        uv venv --system-site-packages $toolVenv
+        uv pip install --python $toolPython 'meson==1.12.0' ninja
+        $env:PATH = "$toolScripts;$env:PATH"
+        Add-Content -Path $env:GITHUB_PATH -Value $toolScripts
+        $mesonPath = (Get-Command meson).Source
+        if ($mesonPath -ne (Join-Path $toolScripts 'meson.exe')) {
+          throw "Expected Meson from $toolScripts, got $mesonPath"
+        }
+        $mesonVersion = (& meson --version).Trim()
+        if ($mesonVersion -ne '1.12.0') {
+          throw "Expected Meson 1.12.0, got $mesonVersion"
+        }
+        Get-Command python
+        python --version
+        $ninjaPath = (Get-Command ninja).Source
+        if ($ninjaPath -ne (Join-Path $toolScripts 'ninja.exe')) {
+          throw "Expected Ninja from $toolScripts, got $ninjaPath"
+        }
+        Get-Command ninja
+        ninja --version

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,6 +50,7 @@ on:
       - 'cross/**'
       - 'scripts/ci/check-android-alignment.sh'
       - '.github/workflows/android.yml'
+      - '.github/actions/setup-meson/action.yml'
   push:
     branches:
       - main
@@ -62,6 +63,7 @@ on:
       - 'cross/**'
       - 'scripts/ci/check-android-alignment.sh'
       - '.github/workflows/android.yml'
+      - '.github/actions/setup-meson/action.yml'
 
 permissions:
   contents: read
@@ -80,7 +82,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build binutils file
+          sudo apt-get install -y ninja-build binutils file
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Install NDK r27c
         id: setup-ndk
@@ -190,7 +195,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build binutils
+          sudo apt-get install -y ninja-build binutils
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Build host Linux .so (no -Dandroid; expect 4 KB alignment)
         run: |
@@ -225,7 +233,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build binutils
+          sudo apt-get install -y ninja-build binutils
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Install NDK r27c
         id: setup-ndk

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -76,7 +76,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build abigail-tools
+          sudo apt-get install -y ninja-build abigail-tools
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             sudo apt-get install -y clang
           fi
@@ -97,18 +97,20 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install meson ninja coreutils gnu-tar
+          brew install ninja coreutils gnu-tar
           echo "$(brew --prefix coreutils)/libexec/gnubin" >> "$GITHUB_PATH"
           echo "$(brew --prefix gnu-tar)/libexec/gnubin" >> "$GITHUB_PATH"
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          pip install meson ninja
           # pkgconfiglite ships from a SourceForge mirror without a
           # checksum; chocolatey's default policy now blocks empty
           # checksums for non-secure sources, so opt in explicitly.
           choco install pkgconfiglite -y --allow-empty-checksums
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure (Linux / macOS)
         if: runner.os != 'Windows'
@@ -231,7 +233,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build pkg-config libmbedtls-dev
+          sudo apt-get install -y ninja-build pkg-config libmbedtls-dev
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure with mbedTLS enabled
         run: meson setup builddir-mbedtls -Dtests=true -DmbedTLS=enabled
@@ -299,7 +304,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build abigail-tools
+          sudo apt-get install -y ninja-build abigail-tools
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             sudo apt-get install -y clang
           fi
@@ -307,9 +312,12 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install meson ninja coreutils gnu-tar
+          brew install ninja coreutils gnu-tar
           echo "$(brew --prefix coreutils)/libexec/gnubin" >> "$GITHUB_PATH"
           echo "$(brew --prefix gnu-tar)/libexec/gnubin" >> "$GITHUB_PATH"
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure with sanitizers
         run: >
@@ -369,10 +377,13 @@ jobs:
       - name: Install dependencies (Linux)
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build abigail-tools
+          sudo apt-get install -y ninja-build abigail-tools
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             sudo apt-get install -y clang
           fi
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       # Force POSIX pthreads for TSan (C11 threads.h is uninstrumented)
       - name: Configure with TSan

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -152,7 +152,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev uncrustify abigail-tools b3sum
+          sudo apt-get install -y ninja-build libmbedtls-dev uncrustify abigail-tools b3sum
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure
         run: meson setup builddir -Dtests=true -DmbedTLS=disabled
@@ -300,7 +303,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev uncrustify abigail-tools b3sum
+          sudo apt-get install -y ninja-build libmbedtls-dev uncrustify abigail-tools b3sum
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure
         run: meson setup builddir -Dtests=true -DmbedTLS=disabled
@@ -359,7 +365,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev uncrustify abigail-tools b3sum
+          sudo apt-get install -y ninja-build libmbedtls-dev uncrustify abigail-tools b3sum
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             sudo apt-get install -y clang
           fi
@@ -367,18 +373,20 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install meson ninja mbedtls uncrustify coreutils gnu-tar
+          brew install ninja mbedtls uncrustify coreutils gnu-tar
           echo "$(brew --prefix coreutils)/libexec/gnubin" >> "$GITHUB_PATH"
           echo "$(brew --prefix gnu-tar)/libexec/gnubin" >> "$GITHUB_PATH"
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          pip install meson ninja
           # pkgconfiglite ships from a SourceForge mirror without a
           # checksum; chocolatey's default policy now blocks empty
           # checksums for non-secure sources, so opt in explicitly.
           choco install pkgconfiglite uncrustify -y --allow-empty-checksums
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure (Linux / macOS)
         if: runner.os != 'Windows'
@@ -486,7 +494,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build pkg-config libmbedtls-dev
+          sudo apt-get install -y ninja-build pkg-config libmbedtls-dev
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure with mbedTLS enabled
         run: meson setup builddir-mbedtls -Dtests=true -DmbedTLS=enabled
@@ -553,7 +564,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev abigail-tools
+          sudo apt-get install -y ninja-build libmbedtls-dev abigail-tools
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             sudo apt-get install -y clang
           fi
@@ -561,9 +572,12 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install meson ninja mbedtls coreutils gnu-tar
+          brew install ninja mbedtls coreutils gnu-tar
           echo "$(brew --prefix coreutils)/libexec/gnubin" >> "$GITHUB_PATH"
           echo "$(brew --prefix gnu-tar)/libexec/gnubin" >> "$GITHUB_PATH"
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure with sanitizers
         run: >
@@ -625,10 +639,13 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev
+          sudo apt-get install -y ninja-build libmbedtls-dev
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             sudo apt-get install -y clang
           fi
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure with TSan
         run: |
@@ -691,7 +708,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build libmbedtls-dev
+          sudo apt-get install -y ninja-build libmbedtls-dev
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure with TSan (native threads)
         run: |

--- a/.github/workflows/diagnose-1575-arm.yml
+++ b/.github/workflows/diagnose-1575-arm.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/diagnose-1575-arm.yml'
       - 'scripts/ci/diagnose-arm-sanitizer-timeouts.py'
       - 'scripts/ci/test-diagnose-arm-sanitizer-timeouts.py'
+      - '.github/actions/setup-meson/action.yml'
 
 permissions:
   contents: read
@@ -27,17 +28,17 @@ jobs:
             uname -a
             cat /etc/os-release
           } > diagnostics-1575/host.log 2>&1
-      - uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
-        with:
-          enable-cache: false
       - name: Install tools
         run: |
           set -o pipefail
           {
             sudo apt-get update
-            sudo apt-get install -y meson ninja-build gdb procps libmbedtls-dev
-            uv venv .venv-diagnose
+            sudo apt-get install -y ninja-build gdb procps libmbedtls-dev
           } 2>&1 | tee diagnostics-1575/setup.log
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
+      - name: Create diagnostic Python environment
+        run: uv venv .venv-diagnose
       - name: Record tool versions
         run: |
           {

--- a/.github/workflows/fuzz-evidence.yml
+++ b/.github/workflows/fuzz-evidence.yml
@@ -97,10 +97,11 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang meson ninja-build
+          sudo apt-get install -y clang ninja-build
           clang --version
-          meson --version
-          ninja --version
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure fuzz build
         shell: bash

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -25,8 +25,11 @@ jobs:
           xcodebuild -version
           xcrun --sdk iphoneos --show-sdk-path
 
-      - name: Install dependencies
-        run: brew install meson ninja
+      - name: Install Ninja
+        run: brew install ninja
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure iOS arm64
         run: >

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -72,13 +72,15 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build linux-tools-common linux-tools-generic
+          sudo apt-get install -y ninja-build linux-tools-common linux-tools-generic
 
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
-          pip install meson ninja
           choco install pkgconfiglite -y
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       # Best-effort: request the 'performance' cpufreq governor. On
       # GitHub's ubuntu-latest the governor is usually already
@@ -307,7 +309,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl meson ninja-build unzip linux-tools-common linux-tools-generic
+          sudo apt-get install -y ninja-build curl unzip linux-tools-common linux-tools-generic
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Verify stable timing host
         shell: bash
@@ -432,10 +437,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install dependencies
+      - name: Install Ninja
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build
+          sudo apt-get install -y ninja-build
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure debug + TSan
         run: >

--- a/.github/workflows/perf-suite-required.yml
+++ b/.github/workflows/perf-suite-required.yml
@@ -58,7 +58,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build linux-tools-common linux-tools-generic
+          sudo apt-get install -y ninja-build linux-tools-common linux-tools-generic
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       # Best-effort: request the 'performance' cpufreq governor. If
       # the governor cannot be set (no permission / no governor

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -68,10 +68,22 @@ jobs:
           fetch-depth: 0
       - name: Verify tagged commit
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+      # Keep helper code tied to this workflow revision. The source checkout
+      # above may be an older immutable tag without the shared setup action.
+      - name: Checkout workflow tools
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-tools
+          fetch-depth: 1
+          persist-credentials: false
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build b3sum
+          sudo apt-get install -y ninja-build b3sum
+
+      - name: Set up Meson 1.12.0
+        uses: ./workflow-tools/.github/actions/setup-meson
       - name: Build and test default suite
         run: |
           meson setup build-default -Dtests=true --buildtype=debug
@@ -89,10 +101,19 @@ jobs:
           fetch-depth: 0
       - name: Verify tagged commit
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+      - name: Checkout workflow tools
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-tools
+          fetch-depth: 1
+          persist-credentials: false
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build abigail-tools b3sum
+          sudo apt-get install -y ninja-build abigail-tools b3sum
+      - name: Set up Meson 1.12.0
+        uses: ./workflow-tools/.github/actions/setup-meson
       # WIRELOG_ABI_REQUIRED=1: this is the GA ABI gate, and a gate that skips
       # asserts nothing. abigail-tools is installed above, so abidiff is present
       # here and a skip means something is wrong rather than unavailable.
@@ -118,10 +139,19 @@ jobs:
           fetch-depth: 0
       - name: Verify tagged commit
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+      - name: Checkout workflow tools
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-tools
+          fetch-depth: 1
+          persist-credentials: false
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang meson ninja-build
+          sudo apt-get install -y clang ninja-build
+      - name: Set up Meson 1.12.0
+        uses: ./workflow-tools/.github/actions/setup-meson
       - name: Build fuzz targets
         run: |
           CC=clang meson setup build-fuzz -Denable_fuzz=true -Db_sanitize=address -Db_lundef=false -Dtests=true
@@ -150,8 +180,17 @@ jobs:
           fetch-depth: 0
       - name: Verify tagged commit
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+      - name: Checkout workflow tools
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-tools
+          fetch-depth: 1
+          persist-credentials: false
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y meson ninja-build libmbedtls-dev
+        run: sudo apt-get update && sudo apt-get install -y ninja-build libmbedtls-dev
+      - name: Set up Meson 1.12.0
+        uses: ./workflow-tools/.github/actions/setup-meson
       - name: Build and test enabled crypto validation
         run: |
           meson setup build-mbedtls -Dtests=true -DmbedTLS=enabled --buildtype=debug
@@ -174,12 +213,22 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build b3sum
-      - name: Verify tagged commit and hosted runner prerequisites
+          sudo apt-get install -y ninja-build b3sum
+      - name: Verify tagged commit
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+      - name: Checkout workflow tools
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-tools
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Set up Meson 1.12.0
+        uses: ./workflow-tools/.github/actions/setup-meson
+      - name: Verify hosted runner prerequisites
         shell: bash
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
           test "$WIRELOG_GA_ISOLATION_CONTROL" = github-hosted-runner
           test "$WIRELOG_GA_ISOLATION_ASSERTION" = hosted-runner
           command -v meson
@@ -248,10 +297,17 @@ jobs:
           fetch-depth: 0
       - name: Verify tagged commit
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+      - name: Checkout workflow tools
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: workflow-tools
+          fetch-depth: 1
+          persist-credentials: false
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build jq
+          sudo apt-get install -y ninja-build jq
           # Must match ci-pr.yml's pin: sbom/snapshot.txt is sensitive to the
           # syft cataloger set, so two versions would disagree about the
           # baseline. test-required-gates.sh asserts they are equal.
@@ -259,6 +315,8 @@ jobs:
           curl -sSfL \
             "https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin syft
+      - name: Set up Meson 1.12.0
+        uses: ./workflow-tools/.github/actions/setup-meson
       # WIRELOG_SBOM_REQUIRED=1 for the same reason the ABI job sets its own:
       # syft is installed directly above, so a skip here means something is
       # wrong rather than unavailable, and a gate that skips asserts nothing.

--- a/.github/workflows/tier1-sanitizers.yml
+++ b/.github/workflows/tier1-sanitizers.yml
@@ -57,7 +57,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y meson ninja-build abigail-tools
+          sudo apt-get install -y ninja-build abigail-tools
           if [ "${{ matrix.compiler }}" = "clang" ]; then
             sudo apt-get install -y clang
           fi
@@ -65,9 +65,12 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install meson ninja coreutils gnu-tar
+          brew install ninja coreutils gnu-tar
           echo "$(brew --prefix coreutils)/libexec/gnubin" >> "$GITHUB_PATH"
           echo "$(brew --prefix gnu-tar)/libexec/gnubin" >> "$GITHUB_PATH"
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure ASan/UBSan
         run: >
@@ -133,15 +136,18 @@ jobs:
         run: |
           if [ "${{ matrix.platform }}" = "linux" ]; then
             sudo apt-get update
-            sudo apt-get install -y meson ninja-build libmbedtls-dev
+            sudo apt-get install -y ninja-build libmbedtls-dev
             if [ "${{ matrix.compiler }}" = "clang" ]; then
               sudo apt-get install -y clang
             fi
           else
-            brew install meson ninja mbedtls coreutils gnu-tar
+            brew install ninja mbedtls coreutils gnu-tar
             echo "$(brew --prefix coreutils)/libexec/gnubin" >> "$GITHUB_PATH"
             echo "$(brew --prefix gnu-tar)/libexec/gnubin" >> "$GITHUB_PATH"
           fi
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure TSan
         run: |
@@ -185,7 +191,10 @@ jobs:
       - name: Install MSan fuzz dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang meson ninja-build
+          sudo apt-get install -y clang ninja-build
+
+      - name: Set up Meson 1.12.0
+        uses: ./.github/actions/setup-meson
 
       - name: Configure MSan fuzz build
         env:

--- a/sbom/snapshot.txt
+++ b/sbom/snapshot.txt
@@ -11,6 +11,8 @@
 ./.github/workflows/lint-main.yml@UNKNOWN:NOASSERTION
 ./.github/workflows/lint-pr.yml@UNKNOWN:NOASSERTION
 ./.github/workflows/tier1-sanitizers.yml@UNKNOWN:NOASSERTION
+# The release workflow's helper-action declaration remains a discovered dependency.
+./workflow-tools/.github/actions/setup-meson@UNKNOWN:NOASSERTION
 actions/attest-build-provenance@v2:NOASSERTION
 actions/cache@v4:NOASSERTION
 actions/cache@v6:NOASSERTION

--- a/sbom/snapshot.txt
+++ b/sbom/snapshot.txt
@@ -1,3 +1,13 @@
+# Local Meson setup action references introduced by the 1.12.0 CI pin.
+./.github/actions/setup-meson@UNKNOWN:NOASSERTION
+./.github/actions/setup-meson@UNKNOWN:NOASSERTION
+./.github/actions/setup-meson@UNKNOWN:NOASSERTION
+./.github/actions/setup-meson@UNKNOWN:NOASSERTION
+./.github/actions/setup-meson@UNKNOWN:NOASSERTION
+./.github/actions/setup-meson@UNKNOWN:NOASSERTION
+./.github/actions/setup-meson@UNKNOWN:NOASSERTION
+./.github/actions/setup-meson@UNKNOWN:NOASSERTION
+./.github/actions/setup-meson@UNKNOWN:NOASSERTION
 ./.github/workflows/lint-main.yml@UNKNOWN:NOASSERTION
 ./.github/workflows/lint-pr.yml@UNKNOWN:NOASSERTION
 ./.github/workflows/tier1-sanitizers.yml@UNKNOWN:NOASSERTION

--- a/scripts/ci/check-sbom-snapshot.sh
+++ b/scripts/ci/check-sbom-snapshot.sh
@@ -62,7 +62,7 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 # Extract current dependency list as "name@version:license"
 # Release verification checks out workflow helpers under this nested directory;
-# they are not part of the tagged source inventory.
+# exclude those files while retaining local-action declarations in workflows.
 syft dir:"$repo_root" --exclude '**/workflow-tools/**' -o syft-json 2>/dev/null \
   | jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' \
   | LC_ALL=C sort > "$tmpdir/current.txt"

--- a/scripts/ci/check-sbom-snapshot.sh
+++ b/scripts/ci/check-sbom-snapshot.sh
@@ -61,7 +61,9 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
 # Extract current dependency list as "name@version:license"
-syft dir:"$repo_root" -o syft-json 2>/dev/null \
+# Release verification checks out workflow helpers under this nested directory;
+# they are not part of the tagged source inventory.
+syft dir:"$repo_root" --exclude '**/workflow-tools/**' -o syft-json 2>/dev/null \
   | jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' \
   | LC_ALL=C sort > "$tmpdir/current.txt"
 

--- a/scripts/ci/test-generate-sbom.sh
+++ b/scripts/ci/test-generate-sbom.sh
@@ -93,8 +93,9 @@ refute() {
 # A fixture repo_root holding a copy of the real script. Nothing here can reach
 # the working tree: repo_root is derived from the script's own directory.
 repo="$tmp/repo"
-mkdir -p "$repo/scripts/release" "$repo/subprojects/nanoarrow" "$repo/bin"
+mkdir -p "$repo/scripts/release" "$repo/scripts/ci" "$repo/subprojects/nanoarrow" "$repo/bin"
 cp "$root/scripts/release/generate-sbom.sh" "$repo/scripts/release/"
+cp "$root/scripts/ci/check-sbom-snapshot.sh" "$repo/scripts/ci/"
 printf "project('wirelog', 'c',\n  version: '9.9.9-dev',\n)\n" > "$repo/meson.build"
 
 # Entries chosen so C and en_US collation disagree: glibc's en_US ignores the
@@ -113,18 +114,30 @@ cat > "$repo/bin/syft" <<'EOS'
 # as unused.
 outfile=""
 prev=""
+exclude_workflow_tools=0
 for a in "$@"; do
     case "$a" in dir:*) printf '%s\n' "${a#dir:}" >> "$SYFT_SCANNED" ;; esac
+    case "$prev" in
+        --exclude)
+            printf '%s\n' "$a" >> "$SYFT_EXCLUDES"
+            [[ "$a" == '**/workflow-tools/**' ]] && exclude_workflow_tools=1
+            ;;
+    esac
     case "$prev" in -o) case "$a" in *=*) outfile=${a#*=} ;; esac ;; esac
     prev=$a
 done
 emit() {
-cat <<'JSON'
+    local workflow_tools_artifact=""
+    if [[ "$exclude_workflow_tools" != 1 || "${SYFT_IGNORE_EXCLUDE:-0}" == 1 ]]; then
+        workflow_tools_artifact='{"name":"./workflow-tools/.github/actions/setup-meson","version":"UNKNOWN","licenses":[]},'
+    fi
+cat <<JSON
 {"artifacts":[
   {"name":"zlib","version":"1.3","licenses":[{"value":"Zlib"}]},
   {"name":"./.github/workflows/lint-pr.yml","version":"UNKNOWN","licenses":[]},
   {"name":"actions/checkout","version":"v5","licenses":[]},
   {"name":"./.github/workflows/lint-main.yml","version":"UNKNOWN","licenses":[]},
+  $workflow_tools_artifact
   {"name":"r-lib/actions","version":"v2","licenses":[]}
 ]}
 JSON
@@ -134,7 +147,10 @@ EOS
 chmod +x "$repo/bin/syft"
 
 scanned="$tmp/scanned.txt"
-gen() { SYFT_SCANNED="$scanned" PATH="$repo/bin:$PATH" \
+excludes="$tmp/excludes.txt"
+: > "$scanned"
+: > "$excludes"
+gen() { SYFT_SCANNED="$scanned" SYFT_EXCLUDES="$excludes" PATH="$repo/bin:$PATH" \
         "$repo/scripts/release/generate-sbom.sh" "$@"; }
 
 # --- the parameter, which is the point of the issue ------------------------
@@ -144,6 +160,39 @@ assert 'the snapshot lands in the given directory' test -f "$out/snapshot.txt"
 assert 'the SPDX document lands there too' test -f "$out/wirelog-9.9.9.spdx.json"
 assert 'the CycloneDX document lands there too' test -f "$out/wirelog-9.9.9.cdx.json"
 refute 'the default directory is not touched when one is given' test -e "$repo/sbom"
+
+all_scans_exclude_workflow_tools() {
+    [[ $(wc -l < "$scanned") -eq 3 && $(wc -l < "$excludes") -eq 3 ]] || return 1
+    ! grep -qvxF '**/workflow-tools/**' "$excludes"
+}
+assert 'every generated SBOM excludes nested workflow-tools checkouts' \
+    all_scans_exclude_workflow_tools
+refute 'the generated baseline omits the non-product workflow-tools checkout' \
+    grep -Fq './workflow-tools/.github/actions/setup-meson' "$out/snapshot.txt"
+refute 'the committed baseline omits the non-product workflow-tools checkout' \
+    grep -Fq './workflow-tools/' "$root/sbom/snapshot.txt"
+
+# The gate must use the same scan boundary as the generator. A full helper
+# checkout lives below repo_root during release verification and is not part
+# of the tagged source inventory.
+mkdir -p "$repo/sbom"
+cp "$out/snapshot.txt" "$repo/sbom/snapshot.txt"
+check_excludes="$tmp/check-excludes.txt"
+check_snapshot() {
+    SYFT_EXCLUDES="$check_excludes" PATH="$repo/bin:$PATH" \
+        "$repo/scripts/ci/check-sbom-snapshot.sh"
+}
+expect_status 'the snapshot gate accepts its generated baseline' 0 check_snapshot
+assert 'the snapshot gate passes the exact workflow-tools exclusion' \
+    test "$(wc -l < "$check_excludes")" -eq 1
+assert 'the snapshot gate passes the exact workflow-tools exclusion' \
+    grep -Fxq '**/workflow-tools/**' "$check_excludes"
+check_snapshot_with_unexcluded_checkout() {
+    SYFT_IGNORE_EXCLUDE=1 SYFT_EXCLUDES="$tmp/ignored-excludes.txt" \
+        PATH="$repo/bin:$PATH" "$repo/scripts/ci/check-sbom-snapshot.sh"
+}
+expect_status 'the snapshot gate rejects an unexcluded helper checkout' \
+    1 check_snapshot_with_unexcluded_checkout
 
 # What the generator SCANS, not just where it writes. The script takes a
 # build_root it does not read; if that ever changes the SBOM would describe a

--- a/scripts/ci/test-generate-sbom.sh
+++ b/scripts/ci/test-generate-sbom.sh
@@ -127,9 +127,10 @@ for a in "$@"; do
     prev=$a
 done
 emit() {
-    local workflow_tools_artifact=""
+    local workflow_tools_artifact='{"name":"./workflow-tools/.github/actions/setup-meson","version":"UNKNOWN","licenses":[]},'
+    local nested_workflow_tools_artifact=""
     if [[ "$exclude_workflow_tools" != 1 || "${SYFT_IGNORE_EXCLUDE:-0}" == 1 ]]; then
-        workflow_tools_artifact='{"name":"./workflow-tools/.github/actions/setup-meson","version":"UNKNOWN","licenses":[]},'
+        nested_workflow_tools_artifact='{"name":"./workflow-tools/.github/workflows/release-tag.yml","version":"UNKNOWN","licenses":[]},'
     fi
 cat <<JSON
 {"artifacts":[
@@ -138,6 +139,7 @@ cat <<JSON
   {"name":"actions/checkout","version":"v5","licenses":[]},
   {"name":"./.github/workflows/lint-main.yml","version":"UNKNOWN","licenses":[]},
   $workflow_tools_artifact
+  $nested_workflow_tools_artifact
   {"name":"r-lib/actions","version":"v2","licenses":[]}
 ]}
 JSON
@@ -167,10 +169,14 @@ all_scans_exclude_workflow_tools() {
 }
 assert 'every generated SBOM excludes nested workflow-tools checkouts' \
     all_scans_exclude_workflow_tools
-refute 'the generated baseline omits the non-product workflow-tools checkout' \
-    grep -Fq './workflow-tools/.github/actions/setup-meson' "$out/snapshot.txt"
-refute 'the committed baseline omits the non-product workflow-tools checkout' \
-    grep -Fq './workflow-tools/' "$root/sbom/snapshot.txt"
+assert 'the generated baseline retains the declared workflow-tools action reference once' \
+    test "$(grep -Fxc './workflow-tools/.github/actions/setup-meson@UNKNOWN:NOASSERTION' "$out/snapshot.txt")" -eq 1
+refute 'the generated baseline excludes nested workflow-tools workflow files' \
+    grep -Fq './workflow-tools/.github/workflows/' "$out/snapshot.txt"
+assert 'the committed baseline retains the declared workflow-tools action reference once' \
+    test "$(grep -Fxc './workflow-tools/.github/actions/setup-meson@UNKNOWN:NOASSERTION' "$root/sbom/snapshot.txt")" -eq 1
+refute 'the committed baseline excludes nested workflow-tools workflow files' \
+    grep -Fq './workflow-tools/.github/workflows/' "$root/sbom/snapshot.txt"
 
 # The gate must use the same scan boundary as the generator. A full helper
 # checkout lives below repo_root during release verification and is not part

--- a/scripts/release/generate-sbom.sh
+++ b/scripts/release/generate-sbom.sh
@@ -64,11 +64,18 @@ mkdir -p "$out_dir"
 
 output_prefix="$out_dir/wirelog-${version}"
 
+# Release verification checks out the workflow revision under a nested
+# workflow-tools/ directory. It is CI tooling, not part of the tagged source
+# inventory, so keep that checkout out of every generated SBOM format.
+syft_scan() {
+    syft dir:"$repo_root" --exclude '**/workflow-tools/**' "$@"
+}
+
 echo "generate-sbom: Generating SPDX 2.3..."
-syft dir:"$repo_root" -o spdx-json@2.3="${output_prefix}.spdx.json"
+syft_scan -o spdx-json@2.3="${output_prefix}.spdx.json"
 
 echo "generate-sbom: Generating CycloneDX 1.5..."
-syft dir:"$repo_root" -o cyclonedx-json@1.5="${output_prefix}.cdx.json"
+syft_scan -o cyclonedx-json@1.5="${output_prefix}.cdx.json"
 
 echo "generate-sbom: Updating snapshot baseline..."
 # Extract normalized dependency list: name@version:license.
@@ -76,7 +83,7 @@ echo "generate-sbom: Updating snapshot baseline..."
 # operator's locale: glibc's en_US collation ignores leading punctuation, so
 # regenerating under it reorders the "./.github/workflows/..." entries and
 # buries the real dependency change in unrelated diff noise.
-syft dir:"$repo_root" -o syft-json 2>/dev/null \
+syft_scan -o syft-json 2>/dev/null \
   | jq -r '.artifacts[] | "\(.name)@\(.version // "unknown"):\((.licenses // [{}])[0].value // "NOASSERTION")"' \
   | LC_ALL=C sort > "$out_dir/snapshot.txt"
 

--- a/scripts/release/generate-sbom.sh
+++ b/scripts/release/generate-sbom.sh
@@ -65,8 +65,9 @@ mkdir -p "$out_dir"
 output_prefix="$out_dir/wirelog-${version}"
 
 # Release verification checks out the workflow revision under a nested
-# workflow-tools/ directory. It is CI tooling, not part of the tagged source
-# inventory, so keep that checkout out of every generated SBOM format.
+# workflow-tools/ directory. Exclude that checkout's files from the tagged
+# source inventory. The workflow cataloger still reports the local-action
+# declaration in release-tag.yml, which remains a legitimate snapshot entry.
 syft_scan() {
     syft dir:"$repo_root" --exclude '**/workflow-tools/**' "$@"
 }


### PR DESCRIPTION
## Summary

The CI runners currently obtain Meson from different sources and versions. Pin Meson to 1.12.0 across every workflow that invokes it, using one shared composite action and an isolated `uv` environment.

- Add `.github/actions/setup-meson`: install Meson 1.12.0, assert its version and resolved path, and log Python/Ninja resolution.
- Update all 29 Meson-consuming jobs across the CI, sanitizer, Android/iOS, fuzz, performance, release, and diagnostic workflows.
- Keep native apt/Homebrew Ninja packages on Unix; Windows installs Ninja in the tool venv.
- In release-tag jobs, load the composite action from the workflow revision while keeping the release source checkout at `TAG_REF`, so older tags can still be manually re-verified.

No build or test scopes/durations were reduced.

## Validation

- `actionlint` on all workflow files (ignoring the unchanged `ci-main.yml:39` diagnostic, reproduced on base).
- Parsed all workflow and action YAML; verified setup precedes Meson in all 29 jobs.
- Confirmed no workflow installs Meson with apt, Homebrew, or pip; no global pip Ninja install remains.
- Created an isolated uv venv locally and confirmed Meson resolves from it at exactly 1.12.0; native Linux Ninja remains on system PATH.
- `bash -n` for the Unix composite-action script and `git diff --check`.

Windows PowerShell execution and hosted runner behavior will be validated by CI.
