### PR TITLE
fix(ci): decode localized ninja output with utf-8 encoding on windows

### DIFF
--- a/scripts/ci/test-arm-asan-strict-align-selection.py
+++ b/scripts/ci/test-arm-asan-strict-align-selection.py
@@ -18,7 +18,7 @@ class SelectionTest(unittest.TestCase):
     def configure(self, compiler="gcc", version="13.3.0", cpu="aarch64",
                   sanitizer="address,undefined", compile_support=True,
                   link_support=True, selected=True):
-        source = (ROOT / "meson.build").read_text()
+        source = (ROOT / "meson.build").read_text(encoding="utf-8")
         self.assertEqual(source.count(BEGIN), 1)
         self.assertEqual(source.count(END), 1)
         block = source.split(BEGIN, 1)[1].split(END, 1)[0]
@@ -41,23 +41,26 @@ class SelectionTest(unittest.TestCase):
             root = Path(tmp)
             (root / "meson.build").write_text(
                 "project('selection', 'c', default_options: ['b_lto=true'])\n"
-                + block + "\nexecutable('probe', 'probe.c')\n")
-            (root / "probe.c").write_text("int main(void) { return 0; }\n")
+                + block + "\nexecutable('probe', 'probe.c')\n",
+                encoding="utf-8")
+            (root / "probe.c").write_text("int main(void) { return 0; }\n",
+                                          encoding="utf-8")
             # Do not inherit a parent's target compiler or cross-file choice.
             env = os.environ.copy()
             env.pop("CC", None)
             result = subprocess.run(
                 [meson, "setup", str(root / "build"), str(root), "--backend=ninja"],
-                env=env, capture_output=True, text=True, timeout=30)
+                env=env, capture_output=True, text=True, encoding="utf-8",
+                errors="replace", timeout=30)
             output = result.stdout + result.stderr
             if selected and not (compile_support and link_support):
                 self.assertNotEqual(result.returncode, 0, output)
                 self.assertIn("requires compiler and linker support for -mstrict-align", output)
                 return
             self.assertEqual(result.returncode, 0, output)
-            commands = json.loads((root / "build/compile_commands.json").read_text())
+            commands = json.loads((root / "build/compile_commands.json").read_text(encoding="utf-8"))
             self.assertEqual("-mstrict-align" in commands[0]["command"], selected)
-            ninja = (root / "build/build.ninja").read_text()
+            ninja = (root / "build/build.ninja").read_text(encoding="utf-8", errors="replace")
             link_lines = [line for line in ninja.splitlines()
                           if line.strip().startswith("LINK_ARGS =")]
             self.assertTrue(link_lines)
@@ -85,6 +88,26 @@ class SelectionTest(unittest.TestCase):
             with self.subTest(compile=compile_support, link=link_support):
                 self.configure(compile_support=compile_support,
                                link_support=link_support)
+
+    def test_ninja_localized_utf8_decoding(self):
+        """Ensure build.ninja with multi-byte localized MSVC prefixes decodes without error."""
+        with tempfile.TemporaryDirectory(prefix="ninja-utf8-") as tmp:
+            ninja_file = Path(tmp) / "build.ninja"
+            # Korean MSVC /showIncludes prefix contains byte 0xed in '포' (\xed\x8f\xac)
+            # which raises UnicodeDecodeError under default CP949 on Windows.
+            content = (
+                "ninja_required_version = 1.8.2\n"
+                "msvc_deps_prefix = 참고: 포함 파일: \n"
+                "build probe.exe: c_LINKER probe.obj\n"
+                "  LINK_ARGS = -mstrict-align\n"
+            )
+            ninja_file.write_text(content, encoding="utf-8")
+            decoded = ninja_file.read_text(encoding="utf-8", errors="replace")
+            self.assertIn("LINK_ARGS =", decoded)
+            link_lines = [line for line in decoded.splitlines()
+                          if line.strip().startswith("LINK_ARGS =")]
+            self.assertTrue(link_lines)
+            self.assertIn("-mstrict-align", link_lines[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Resolves the Windows CI failure in `CI Main` on the `main` branch (`wirelog:abi / arm_asan_strict_align_selection`):
```
UnicodeDecodeError: 'cp949' codec can't decode byte 0xed in position 187: illegal multibyte sequence
```

### Root Cause
In `scripts/ci/test-arm-asan-strict-align-selection.py`, `(root / "build/build.ninja").read_text()` (and associated fixture I/O and subprocess execution) did not specify `encoding="utf-8"`.
On Windows runners where the system ANSI code page is not UTF-8 (such as CP949 on Korean Windows), Python defaults to that code page. When Meson runs with MSVC on localized installations, Meson outputs `msvc_deps_prefix = 참고: 포함 파일: ` in UTF-8 into `build.ninja`. Byte `0xed` (the first byte of `포` in UTF-8: `\xed\x8f\xac`) is an invalid sequence in CP949 at that position, causing the test to fail.

### Changes
- In `scripts/ci/test-arm-asan-strict-align-selection.py`:
  - Added `encoding="utf-8"` to all `read_text()` and `write_text()` calls.
  - Added `encoding="utf-8", errors="replace"` to `subprocess.run()`.
  - Added `errors="replace"` to `build.ninja` reading for defensive handling of mixed-encoding outputs.
  - Added a dedicated regression test `test_ninja_localized_utf8_decoding` testing multi-byte localized Korean MSVC strings (containing byte `0xed`).

## Validation
- Ran `python scripts/ci/test-arm-asan-strict-align-selection.py SelectionTest.test_ninja_localized_utf8_decoding` (PASS).
- Ran all 4 tests in `scripts/ci/test-arm-asan-strict-align-selection.py` (all 4 PASS).
- Confirmed reproduction of the CP949 decoding error when reading unencoded UTF-8 `build.ninja`.
- Verified clean git diff, whitespace checks (`git diff --check`), and atomic commit tree.
